### PR TITLE
Add CSS tooltip support for help icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,18 +42,24 @@
             <section>
                 <h3>Routing Parameters</h3>
                  <label for="fill-limit">Max Tray Fill (%)
-                    <span class="help-icon" title="The maximum allowed fill capacity for a cable tray, based on standards like the NEC 40% rule.">?</span>
+                    <span class="help-icon" tabindex="0">?
+                        <span class="tooltip">The maximum allowed fill capacity for a cable tray, based on standards like the NEC 40% rule.</span>
+                    </span>
                  </label>
                  <input type="range" id="fill-limit" min="20" max="80" value="40" step="5">
                  <span id="fill-limit-value">40%</span>
 
                  <label for="proximity-threshold">Tray Proximity Threshold (in)
-                    <span class="help-icon" title="The maximum distance a cable can jump from its start/end point to connect to a nearby tray segment.">?</span>
+                    <span class="help-icon" tabindex="0">?
+                        <span class="tooltip">The maximum distance a cable can jump from its start or end point to connect to a nearby tray segment.</span>
+                    </span>
                  </label>
                  <input type="number" id="proximity-threshold" value="6.0" step="0.5">
 
                  <label for="field-route-penalty">Field Route Cost Multiplier
-                    <span class="help-icon" title="This makes field routing (not in a tray) more 'expensive' than routing within a tray. A value of 3 means every inch of field routing costs as much as 3 inches of tray routing. This encourages the algorithm to use trays whenever possible.">?</span>
+                    <span class="help-icon" tabindex="0">?
+                        <span class="tooltip">This makes field routing (not in a tray) more expensive than routing within a tray. A value of 3 means every inch of field routing costs as much as 3 inches of tray routing, encouraging the algorithm to use trays whenever possible.</span>
+                    </span>
                  </label>
                  <input type="number" id="field-route-penalty" value="3.0" step="0.1">
                  

--- a/style.css
+++ b/style.css
@@ -129,11 +129,12 @@ details > summary {
 
 /* --- Help Icon --- */
 .help-icon {
+    position: relative;
     display: inline-block;
     width: 16px;
     height: 16px;
     background-color: #aaa;
-    color: white;
+    color: #fff;
     border-radius: 50%;
     text-align: center;
     font-size: 12px;
@@ -141,6 +142,40 @@ details > summary {
     cursor: help;
     margin-left: 8px;
     font-weight: bold;
+}
+
+.help-icon .tooltip {
+    visibility: hidden;
+    width: 220px;
+    background-color: #333;
+    color: #fff;
+    text-align: left;
+    border-radius: 4px;
+    padding: 6px 8px;
+    position: absolute;
+    z-index: 10;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    line-height: 1.2;
+    white-space: normal;
+}
+
+.help-icon .tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 5px;
+    border-style: solid;
+    border-color: #333 transparent transparent transparent;
+}
+
+.help-icon:hover .tooltip,
+.help-icon:focus .tooltip {
+    visibility: visible;
 }
 
 /* --- Tables --- */


### PR DESCRIPTION
## Summary
- add accessible tooltips via CSS
- clarify help icon markup in HTML, including Field Route Cost Multiplier explanation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d789b1ce48324a484c5ce3daeabbf