### PR TITLE
Enhance routing UI and data export

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,12 +29,14 @@
                         <input type="number" id="start-x" placeholder="X (ft)" value="5">
                         <input type="number" id="start-y" placeholder="Y (ft)" value="2">
                         <input type="number" id="start-z" placeholder="Z (ft)" value="4">
+                        <input type="text" id="start-tag" placeholder="Start Tag">
                     </div>
                     <div class="column">
                         <label>Point B (End)</label>
                         <input type="number" id="end-x" placeholder="X (ft)" value="45">
                         <input type="number" id="end-y" placeholder="Y (ft)" value="14">
                         <input type="number" id="end-z" placeholder="Z (ft)" value="4">
+                        <input type="text" id="end-tag" placeholder="End Tag">
                     </div>
                 </div>
             </section>
@@ -133,11 +135,10 @@
                 <h3>Updated Tray Utilization</h3>
                 <div id="updated-utilization-container"></div>
                 <div id="plot-utilization"></div>
-                <button id="export-json-btn">Download Route Data (JSON)</button>
+                <button id="export-csv-btn">Download Route Data (CSV)</button>
             </section>
         </main>
     </div>
 
     <script src="app.js"></script>
-</body>
-</html>
+</body></html>


### PR DESCRIPTION
## Summary
- add text tags for start/end points
- move Tray ID earlier in the results table and mark field routes
- export route data as CSV

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_686d81aee0e88324a684c9e132a61b71