### PR TITLE
Fix CSV export for multiple cable routing

### DIFF
--- a/app.js
+++ b/app.js
@@ -548,16 +548,32 @@ document.addEventListener('DOMContentLoaded', () => {
             alert('No route data to export.');
             return;
         }
+
         const headers = Object.keys(state.latestRouteData[0]);
-        const rows = state.latestRouteData.map(row => headers.map(h => row[h]));
         let csv = headers.join(',') + '\n';
-        rows.forEach(r => {
-            const line = r.map(val => {
-                const str = String(val);
-                return str.includes(',') ? `"${str}"` : str;
+
+        state.latestRouteData.forEach(row => {
+            const line = headers.map(h => {
+                let val = row[h];
+                if (typeof val === 'object') {
+                    try {
+                        val = JSON.stringify(val);
+                    } catch (e) {
+                        val = '';
+                    }
+                }
+                let str = String(val);
+                if (str.includes('"')) {
+                    str = str.replace(/"/g, '""');
+                }
+                if (str.includes(',') || str.includes('\n')) {
+                    str = `"${str}"`;
+                }
+                return str;
             }).join(',');
             csv += line + '\n';
         });
+
         const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- fix CSV export for batch cable routing results
- JSON stringify objects and escape commas for CSV download

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d891ff55083249ed302b08362cd6b