### PR TITLE
Update routing options and CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ Points fields. After filling in the details, click **Add Cable to List** and the
 cable will appear in the table for batch routing. Each row in the table allows
 you to edit not only the cable tag, but also the diameter and the start/end
 coordinates for that cable.
+
+## Updates
+
+- Default *Tray Proximity Threshold* is now **72 in**.
+- Each cable row in batch mode includes **Duplicate** and **Delete** controls.
+- Tray utilization tables show **Available Space** to two decimal places.
+- CSV export flattens the breakdown so each segment is a separate row.

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
                         <span class="tooltip">The maximum distance a cable can jump from its start or end point to connect to a nearby tray segment.</span>
                     </span>
                  </label>
-                 <input type="number" id="proximity-threshold" value="6.0" step="0.5">
+                 <input type="number" id="proximity-threshold" value="72" step="1">
 
                  <label for="field-route-penalty">Field Route Cost Multiplier
                     <span class="help-icon" tabindex="0">?


### PR DESCRIPTION
## Summary
- default proximity threshold is 72in
- show duplicate/delete buttons for batch cable rows
- show available tray space with two decimals
- flatten CSV export for easier consumption
- document recent updates

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_686e61ed0b848324ac3a97a0d2522ea6