### PR TITLE
Revise UI and add tag visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ coordinates for that cable.
 - Each cable row in batch mode includes **Duplicate** and **Delete** controls.
 - Tray utilization tables show **Available Space** to two decimal places.
 - CSV export flattens the breakdown so each segment is a separate row.
+- CSV export no longer includes the **Status** column.
+- Start and end tags are displayed in the 3D view (duplicates shown once).
+- Cable specification fields are now located in the **Cable Routing Options** panel.

--- a/index.html
+++ b/index.html
@@ -14,34 +14,7 @@
                 <h2>Input Parameters</h2>
             </header>
             
-            <section>
-                <h3>Cable Specifications</h3>
-                <label for="cable-tag">Cable Tag</label>
-                <input type="text" id="cable-tag" placeholder="Cable Tag">
-                <label for="cable-diameter">Cable Outer Diameter (in)</label>
-                <input type="number" id="cable-diameter" value="1.0" step="0.1">
-                <p class="info-text">Cable Area: <span id="cable-area"></span> in²</p>
-            </section>
-
-            <section>
-                <h3>Route Points</h3>
-                <div class="columns">
-                    <div class="column">
-                        <label>Point A (Start)</label>
-                        <input type="text" id="start-tag" placeholder="Start Tag">
-                        <input type="number" id="start-x" placeholder="X (ft)" value="5">
-                        <input type="number" id="start-y" placeholder="Y (ft)" value="2">
-                        <input type="number" id="start-z" placeholder="Z (ft)" value="4">
-                    </div>
-                    <div class="column">
-                        <label>Point B (End)</label>
-                        <input type="text" id="end-tag" placeholder="End Tag">
-                        <input type="number" id="end-x" placeholder="X (ft)" value="45">
-                        <input type="number" id="end-y" placeholder="Y (ft)" value="14">
-                        <input type="number" id="end-z" placeholder="Z (ft)" value="4">
-                    </div>
-                </div>
-            </section>
+            <!-- Cable specification fields moved to the routing options card -->
             
             <section>
                 <h3>Routing Parameters</h3>
@@ -118,6 +91,35 @@
                     <input type="radio" id="batch-mode" name="routing-mode" value="batch">
                     <label for="batch-mode">Multiple Cables (Batch)</label>
                 </div>
+
+                <section>
+                    <h3>Cable Specifications</h3>
+                    <label for="cable-tag">Cable Tag</label>
+                    <input type="text" id="cable-tag" placeholder="Cable Tag">
+                    <label for="cable-diameter">Cable Outer Diameter (in)</label>
+                    <input type="number" id="cable-diameter" value="1.0" step="0.1">
+                    <p class="info-text">Cable Area: <span id="cable-area"></span> in²</p>
+                </section>
+
+                <section>
+                    <h3>Route Points</h3>
+                    <div class="columns">
+                        <div class="column">
+                            <label>Point A (Start)</label>
+                            <input type="text" id="start-tag" placeholder="Start Tag">
+                            <input type="number" id="start-x" placeholder="X (ft)" value="5">
+                            <input type="number" id="start-y" placeholder="Y (ft)" value="2">
+                            <input type="number" id="start-z" placeholder="Z (ft)" value="4">
+                        </div>
+                        <div class="column">
+                            <label>Point B (End)</label>
+                            <input type="text" id="end-tag" placeholder="End Tag">
+                            <input type="number" id="end-x" placeholder="X (ft)" value="45">
+                            <input type="number" id="end-y" placeholder="Y (ft)" value="14">
+                            <input type="number" id="end-z" placeholder="Z (ft)" value="4">
+                        </div>
+                    </div>
+                </section>
 
                 <div id="batch-section" style="display:none;">
                     <button id="add-cable-btn">Add Cable to List</button>


### PR DESCRIPTION
## Summary
- move cable entry fields into the Cable Routing Options card
- remove `status` column from the CSV export
- show start/end tags in the 3D route view and avoid duplicate labels

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686e660097708324bd8258fef7877bfe