### PR TITLE
Add batch-only routing and network import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ coordinates for that cable.
 - CSV export no longer includes the **Status** column.
 - Start and end tags are displayed in the 3D view (duplicates shown once).
 - Cable specification fields are now located in the **Cable Routing Options** panel.
+- Cable routing always uses the batch list. Add a single cable by adding one row.
+- Tray network tables can now be **imported** or **exported** as CSV.
+- Updated tray utilization table shows a progress bar with a marker for the maximum allowed fill.

--- a/app.js
+++ b/app.js
@@ -24,7 +24,6 @@ document.addEventListener('DOMContentLoaded', () => {
         endTagIn: document.getElementById('end-tag'),
         calculateBtn: document.getElementById('calculate-route-btn'),
         inputMethodRadios: document.querySelectorAll('input[name="input-method"]'),
-        routingModeRadios: document.querySelectorAll('input[name="routing-mode"]'),
         manualEntrySection: document.getElementById('manual-entry-section'),
         batchSection: document.getElementById('batch-section'),
         addTrayBtn: document.getElementById('add-tray-btn'),
@@ -41,8 +40,10 @@ document.addEventListener('DOMContentLoaded', () => {
         routeBreakdownContainer: document.getElementById('route-breakdown-container'),
         plot3d: document.getElementById('plot-3d'),
         updatedUtilizationContainer: document.getElementById('updated-utilization-container'),
-        plotUtilization: document.getElementById('plot-utilization'),
         exportCsvBtn: document.getElementById('export-csv-btn'),
+        importTraysBtn: document.getElementById('import-trays-btn'),
+        importTraysFile: document.getElementById('import-trays-file'),
+        exportTraysBtn: document.getElementById('export-trays-btn'),
     };
     
     // --- CORE ROUTING LOGIC (JavaScript implementation of your Python backend) ---
@@ -388,6 +389,19 @@ document.addEventListener('DOMContentLoaded', () => {
         table += '</tbody></table>';
         container.innerHTML = table;
     };
+
+    const renderUtilizationTable = (container, data, limit) => {
+        let table = '<table><thead><tr><th>Tray ID</th><th>Utilization</th><th>Available (in²)</th></tr></thead><tbody>';
+        data.forEach(row => {
+            const cls = utilizationStyle(row);
+            table += `<tr class="${cls}"><td>${row.tray_id}</td><td>` +
+                `<div class="progress-bar"><div class="progress-fill" style="width:${row.utilization}%"></div>` +
+                `<div class="progress-marker" style="left:${limit}%"></div></div> ${row.utilization}%` +
+                `</td><td>${row.available}</td></tr>`;
+        });
+        table += '</tbody></table>';
+        container.innerHTML = table;
+    };
     
     const utilizationStyle = (row) => {
         const util = row.utilization_pct || row.utilization;
@@ -447,13 +461,6 @@ document.addEventListener('DOMContentLoaded', () => {
         updateTrayDisplay();
     };
     
-    const handleRoutingModeChange = () => {
-        if(document.getElementById('batch-mode').checked) {
-            elements.batchSection.style.display = 'block';
-        } else {
-            elements.batchSection.style.display = 'none';
-        }
-    };
 
     const addManualTray = () => {
         const newTray = {
@@ -483,6 +490,58 @@ document.addEventListener('DOMContentLoaded', () => {
         state.trayData = [];
         elements.manualTrayTableContainer.innerHTML = '';
         updateTrayDisplay();
+    };
+
+    const exportTrayCSV = () => {
+        const trays = state.trayData.length > 0 ? state.trayData : state.manualTrays;
+        if (trays.length === 0) {
+            alert('No tray data to export.');
+            return;
+        }
+        const headers = ['tray_id','start_x','start_y','start_z','end_x','end_y','end_z','width','height','current_fill'];
+        let csv = headers.join(',') + '\n';
+        trays.forEach(t => {
+            csv += headers.map(h => t[h]).join(',') + '\n';
+        });
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'tray_network.csv';
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const importTrayCSV = (file) => {
+        const reader = new FileReader();
+        reader.onload = e => {
+            const lines = e.target.result.trim().split(/\r?\n/);
+            if (lines.length < 2) return;
+            const headers = lines[0].split(',');
+            const idx = h => headers.indexOf(h);
+            const trays = lines.slice(1).filter(l=>l.trim()).map(line => {
+                const parts = line.split(',');
+                return {
+                    tray_id: parts[idx('tray_id')],
+                    start_x: parseFloat(parts[idx('start_x')]),
+                    start_y: parseFloat(parts[idx('start_y')]),
+                    start_z: parseFloat(parts[idx('start_z')]),
+                    end_x: parseFloat(parts[idx('end_x')]),
+                    end_y: parseFloat(parts[idx('end_y')]),
+                    end_z: parseFloat(parts[idx('end_z')]),
+                    width: parseFloat(parts[idx('width')]),
+                    height: parseFloat(parts[idx('height')]),
+                    current_fill: parseFloat(parts[idx('current_fill')])
+                };
+            });
+            state.manualTrays = trays;
+            if (document.getElementById('manual-entry').checked) {
+                state.trayData = state.manualTrays;
+                renderManualTrayTable();
+            }
+            updateTrayDisplay();
+        };
+        reader.readAsText(file);
     };
 
     const renderManualTrayTable = () => {
@@ -767,9 +826,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const trayDataForRun = JSON.parse(JSON.stringify(state.trayData));
         trayDataForRun.forEach(tray => routingSystem.addTraySegment(tray));
         
-        const isBatchMode = document.getElementById('batch-mode').checked;
-
-        if (isBatchMode && state.cableList.length > 0) {
+        if (state.cableList.length > 0) {
             const batchResults = [];
             const allRoutesForPlotting = [];
 
@@ -811,73 +868,9 @@ document.addEventListener('DOMContentLoaded', () => {
             state.latestRouteData = batchResults;
             elements.metrics.innerHTML = '';
             visualize(trayDataForRun, allRoutesForPlotting, "Batch Route Visualization");
-
         } else {
-            const startPoint = [
-                parseFloat(document.getElementById('start-x').value),
-                parseFloat(document.getElementById('start-y').value),
-                parseFloat(document.getElementById('start-z').value),
-            ];
-            const endPoint = [
-                parseFloat(document.getElementById('end-x').value),
-                parseFloat(document.getElementById('end-y').value),
-                parseFloat(document.getElementById('end-z').value),
-            ];
-            state.startTag = elements.startTagIn.value;
-            state.endTag = elements.endTagIn.value;
-            state.cableTag = elements.cableTagIn.value;
-            const cableArea = parseFloat(elements.cableAreaOut.textContent);
-            
-            const result = routingSystem.calculateRoute(startPoint, endPoint, cableArea);
-
-            if (result.success) {
-                showMessage('success', 'Route calculated successfully!');
-                elements.metrics.innerHTML = `
-                    <div class="column"><strong>Total Length:</strong> ${result.total_length.toFixed(2)}</div>
-                    <div class="column"><strong>Field-Routed:</strong> ${result.field_routed_length.toFixed(2)}</div>
-                    <div class="column"><strong>Trays Used:</strong> ${result.tray_segments.length}</div>
-                `;
-                const breakdownData = result.route_segments.map((seg, i) => ({
-                    cable: state.cableTag || '',
-                    segment: i + 1,
-                    tray_id: seg.type === 'field' ? 'Field Route' : (seg.tray_id || 'N/A'),
-                    type: seg.type,
-                    from: formatPoint(seg.start),
-                    to: formatPoint(seg.end),
-                    length: seg.length.toFixed(2)
-                }));
-                renderTable(
-                    elements.routeBreakdownContainer,
-                    [
-                        { label: 'Cable Tag', key: 'cable' },
-                        { label: 'Segment', key: 'segment' },
-                        { label: 'Tray ID', key: 'tray_id' },
-                        { label: 'Type', key: 'type' },
-                        { label: 'From', key: 'from' },
-                        { label: 'To', key: 'to' },
-                        { label: 'Length', key: 'length' }
-                    ],
-                    breakdownData
-                );
-                state.latestRouteData = breakdownData;
-                visualize(
-                    trayDataForRun,
-                    [{
-                        label: state.cableTag || state.startTag || 'Cable Route',
-                        segments: result.route_segments,
-                        startPoint,
-                        endPoint,
-                        startTag: state.startTag,
-                        endTag: state.endTag
-                    }],
-                    "3D Route Visualization"
-                );
-            } else {
-                showMessage('error', `Route calculation failed: ${result.error}`);
-                elements.metrics.innerHTML = '';
-                elements.routeBreakdownContainer.innerHTML = '';
-                elements.plot3d.innerHTML = '';
-            }
+            alert('Please add at least one cable to the list.');
+            return;
         }
         
         const finalUtilization = routingSystem.getTrayUtilization();
@@ -886,17 +879,11 @@ document.addEventListener('DOMContentLoaded', () => {
             utilization: data.utilization_percentage.toFixed(1),
             available: data.available_capacity.toFixed(2),
         }));
-        renderTable(
+        renderUtilizationTable(
             elements.updatedUtilizationContainer,
-            [
-                { label: 'Tray ID', key: 'tray_id' },
-                { label: 'Utilization (%)', key: 'utilization' },
-                { label: 'Available (in²)', key: 'available' }
-            ],
             utilData,
-            (row) => utilizationStyle(row)
+            parseFloat(elements.fillLimitIn.value)
         );
-        plotUtilization(finalUtilization);
     };
     
     // --- VISUALIZATION ---
@@ -991,29 +978,26 @@ document.addEventListener('DOMContentLoaded', () => {
         Plotly.newPlot(elements.plot3d, traces, layout);
     };
     
-    const plotUtilization = (utilizationData) => {
-        const ids = Object.keys(utilizationData);
-        const percentages = ids.map(id => utilizationData[id].utilization_percentage);
-        const data = [{
-            x: ids, y: percentages, type: 'bar',
-            marker: { color: percentages.map(p => p > 80 ? 'red' : p > 60 ? 'orange' : 'green') }
-        }];
-        const layout = { title: 'Tray Utilization After Routing', yaxis: { title: 'Utilization (%)' } };
-        Plotly.newPlot(elements.plotUtilization, data, layout);
-    }
     
     // --- INITIALIZATION & EVENT LISTENERS ---
     elements.cableDiameterIn.addEventListener('input', updateCableArea);
     elements.fillLimitIn.addEventListener('input', updateFillLimitDisplay);
     elements.calculateBtn.addEventListener('click', mainCalculation);
     elements.inputMethodRadios.forEach(radio => radio.addEventListener('change', handleInputMethodChange));
-    elements.routingModeRadios.forEach(radio => radio.addEventListener('change', handleRoutingModeChange));
     elements.addTrayBtn.addEventListener('click', addManualTray);
     elements.clearTraysBtn.addEventListener('click', clearManualTrays);
     elements.loadSampleCablesBtn.addEventListener('click', loadSampleCables);
     elements.addCableBtn.addEventListener('click', addCableToBatch);
     elements.clearCablesBtn.addEventListener('click', clearCableList);
     elements.exportCsvBtn.addEventListener('click', exportRouteCSV);
+    elements.exportTraysBtn.addEventListener('click', exportTrayCSV);
+    elements.importTraysBtn.addEventListener('click', () => elements.importTraysFile.click());
+    elements.importTraysFile.addEventListener('change', e => {
+        if (e.target.files[0]) importTrayCSV(e.target.files[0]);
+    });
+
+    handleInputMethodChange();
     
-    // Initial setup
-    updateCableArea();    handleInputMethodChange();});
+    // Initial setup    updateCableArea();    handleInputMethodChange();});
+
+    handleInputMethodChange();});

--- a/index.html
+++ b/index.html
@@ -78,6 +78,9 @@
                     </details>
                     <div id="manual-tray-table-container"></div>
                     <button id="clear-trays-btn">Clear All Trays</button>
+                    <input type="file" id="import-trays-file" accept=".csv" style="display:none">
+                    <button id="import-trays-btn">Import Network CSV</button>
+                    <button id="export-trays-btn">Export Network CSV</button>
                 </div>
 
                  <div id="tray-utilization-container"></div>
@@ -85,12 +88,6 @@
 
             <section class="card">
                 <h2>Cable Routing Options</h2>
-                <div class="input-methods">
-                    <input type="radio" id="single-cable-mode" name="routing-mode" value="single" checked>
-                    <label for="single-cable-mode">Single Cable</label>
-                    <input type="radio" id="batch-mode" name="routing-mode" value="batch">
-                    <label for="batch-mode">Multiple Cables (Batch)</label>
-                </div>
 
                 <section>
                     <h3>Cable Specifications</h3>
@@ -121,7 +118,7 @@
                     </div>
                 </section>
 
-                <div id="batch-section" style="display:none;">
+                <div id="batch-section">
                     <button id="add-cable-btn">Add Cable to List</button>
                     <button id="load-sample-cables-btn">Load Sample Cable List</button>
                     <div id="cable-list-container"></div>
@@ -139,10 +136,8 @@
                 <div id="plot-3d"></div>
                 <h3>Updated Tray Utilization</h3>
                 <div id="updated-utilization-container"></div>
-                <div id="plot-utilization"></div>
                 <button id="export-csv-btn">Download Route Data (CSV)</button>
             </section>
         </main>
     </div>
-
-    <script src="app.js"></script></body></html>
+    <script src="app.js"></script></body></html>

--- a/style.css
+++ b/style.css
@@ -213,3 +213,23 @@ th {
     width: 100%;
     min-height: 450px;
 }
+
+/* Progress Bar for Tray Utilization */
+.progress-bar {
+    position: relative;
+    width: 100%;
+    height: 16px;
+    background-color: #e9ecef;
+    border-radius: 8px;
+    overflow: hidden;
+}
+.progress-fill {
+    height: 100%;
+    background-color: var(--primary-color);
+}
+.progress-marker {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background-color: #000;}


### PR DESCRIPTION
## Summary
- switch routing UI to always use batch list
- add import/export buttons for tray networks
- replace utilization chart with progress bars
- document new workflow

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686e6ab2dde48324999962d27f392d71