### PR TITLE
Add tray utilization progress bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,9 +104,7 @@
                 <div id="plot-3d"></div>
                 <h3>Updated Tray Utilization</h3>
                 <div id="updated-utilization-container"></div>
-                <div id="plot-utilization"></div>
                 <button id="export-csv-btn">Download Route Data (CSV)</button>
             </section>
         </main>
-    </div>
-    <script src="app.js"></script></body></html>
+    </div>    <script src="app.js"></script></body></html>

--- a/style.css
+++ b/style.css
@@ -196,6 +196,30 @@ th {
 .util-medium { background-color: var(--warning-bg); color: var(--warning-text); }
 .util-low { background-color: var(--success-bg); color: var(--success-text); }
 
+/* Utilization Bars */
+.util-bar {
+    position: relative;
+    width: 100%;
+    height: 16px;
+    background-color: #e9ecef;
+    border-radius: 8px;
+    overflow: hidden;
+}
+.util-bar-fill {
+    height: 100%;
+}
+.util-bar-marker {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background-color: #000;
+}
+.util-label {
+    margin-left: 4px;
+    font-size: 0.8rem;
+}
+
 
 /* --- Messages --- */
 .message {
@@ -209,7 +233,6 @@ th {
 .message.error { background-color: var(--error-bg); border-color: var(--error-text); color: var(--error-text); }
 
 /* --- Plots --- */
-#plot-3d, #plot-utilization {
+#plot-3d {
     width: 100%;
-    min-height: 450px;
-}
+    min-height: 450px;}


### PR DESCRIPTION
## Summary
- render tables with custom cell formatting
- show tray utilization with an inline progress bar and remove column chart
- clean up unused elements and styles

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686e84b748d8832490bd27bd845ee6ae