### PR TITLE
Add CSV import/export for manual trays

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ coordinates for that cable.
 - CSV export no longer includes the **Status** column.
 - Start and end tags are displayed in the 3D view (duplicates shown once).
 - Cable specification fields are now located in the **Cable Routing Options** panel.
+- Manual tray entry includes **Import** and **Export** buttons for working with CSV files.

--- a/index.html
+++ b/index.html
@@ -77,6 +77,11 @@
                         </div>
                     </details>
                     <div id="manual-tray-table-container"></div>
+                    <div class="tray-import-export">
+                        <button id="export-trays-btn">Export Trays CSV</button>
+                        <input type="file" id="import-trays-file" accept=".csv">
+                        <button id="import-trays-btn">Import Trays CSV</button>
+                    </div>
                     <button id="clear-trays-btn">Clear All Trays</button>
                 </div>
 

--- a/style.css
+++ b/style.css
@@ -127,6 +127,14 @@ details > summary {
     padding: 1rem 0;
 }
 
+.tray-import-export {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    margin-top: 10px;
+}
+
 /* --- Help Icon --- */
 .help-icon {
     position: relative;


### PR DESCRIPTION
## Summary
- support exporting manual tray data or a template CSV
- add ability to import trays from a CSV file
- expose new buttons in UI and basic styles
- document tray import/export controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e87b1de5c8324890aabe92c1d145e