### PR TITLE
Fix CSV re-import

### DIFF
--- a/app.js
+++ b/app.js
@@ -621,6 +621,8 @@ document.addEventListener('DOMContentLoaded', () => {
             updateTrayDisplay();
         };
         reader.readAsText(file);
+        // Reset the file input so importing the same file again triggers the change event
+        elements.importTraysFile.value = '';
     };
 
     const exportCableOptionsCSV = () => {
@@ -678,6 +680,8 @@ document.addEventListener('DOMContentLoaded', () => {
             updateCableListDisplay();
         };
         reader.readAsText(file);
+        // Reset the file input so importing the same file again triggers the change event
+        elements.importCablesFile.value = '';
     };
 
     const renderBatchResults = (results) => {


### PR DESCRIPTION
## Summary
- reset import file fields to allow re-importing the same CSV

## Testing
- `node --version`
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_686ead764b308324af725db61d172d40