### PR TITLE
Increase 3D plot height

### DIFF
--- a/style.css
+++ b/style.css
@@ -254,7 +254,8 @@ th {
 /* --- Plots --- */
 #plot-3d {
     width: 100%;
-    min-height: 450px;}
+    min-height: 900px;
+}
 
 /* Progress Bar */
 #progress-container {


### PR DESCRIPTION
## Summary
- increase the minimum height of the plotly container for 3D visualization

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ec5cec940832486fa7c54660b1e2d