### PR TITLE
Adjust 3D plot height and popout sizing

### DIFF
--- a/app.js
+++ b/app.js
@@ -1146,8 +1146,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!window.current3DPlot) return;
         const html = `<!DOCTYPE html>
 <html><head><title>3D Route Visualization</title>
-<meta charset="UTF-8"><script src="https://cdn.plot.ly/plotly-latest.min.js"><\/script>
-</head><body style="margin:0;"><div id="plot" style="width:100vw;height:100vh;"></div>
+<meta charset="UTF-8">
+<script src="https://cdn.plot.ly/plotly-latest.min.js"><\/script>
+<style>html,body{margin:0;height:100%;overflow:hidden;}#plot{width:100%;height:100%;}</style>
+</head><body>
+<div id="plot"></div>
 <script>const data = ${JSON.stringify(window.current3DPlot.traces)};
 const layout = ${JSON.stringify(window.current3DPlot.layout)};
 Plotly.newPlot(document.getElementById('plot'), data, layout);<\/script>

--- a/style.css
+++ b/style.css
@@ -254,7 +254,7 @@ th {
 /* --- Plots --- */
 #plot-3d {
     width: 100%;
-    min-height: 1800px;
+    height: 600px;
 }
 
 #popout-plot-btn {


### PR DESCRIPTION
## Summary
- make the embedded 3D visualization shorter
- ensure the pop-out window fits the screen without scrolling

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686edeb5cb388324a301a5d43ba2094d