### PR TITLE
Fix legend overlap in 3D view

### DIFF
--- a/app.js
+++ b/app.js
@@ -1137,7 +1137,13 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
 
-    const layout = { title: title, scene: { aspectmode: 'data' }, autosize: true, margin: {l:0, r:0, t:0, b:0} };
+    const layout = {
+        title: title,
+        scene: { aspectmode: 'data' },
+        legend: { x: 1, y: 0, xanchor: 'right', yanchor: 'bottom' },
+        autosize: true,
+        margin: { l: 0, r: 0, t: 0, b: 0 }
+    };
     Plotly.newPlot(elements.plot3d, traces, layout, {responsive: true});
     window.current3DPlot = { traces: traces, layout: layout };
     };


### PR DESCRIPTION
## Summary
- position Plotly legend at the bottom-right so it no longer overlaps the modebar controls

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ee63d67848324884ac53e921abfd0