### PR TITLE
Add shared field route multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ coordinates for that cable.
 - Cable specification fields are now located in the **Cable Routing Options** panel.
 - Manual tray entry now has a single **Import Trays CSV** button. Clicking it opens a file dialog and loads trays immediately after you choose a file.
 - Cable Routing Options now has **Import Cables CSV** and **Export Cables CSV** buttons for managing the cable list.
+- New **Shared Field Route Cost Multiplier** input lets successive cables reuse existing field runs at a reduced cost.

--- a/index.html
+++ b/index.html
@@ -39,6 +39,13 @@
                     </span>
                  </label>
                  <input type="number" id="field-route-penalty" value="3.0" step="0.1">
+
+                 <label for="shared-field-penalty">Shared Field Route Cost Multiplier
+                    <span class="help-icon" tabindex="0">?
+                        <span class="tooltip">Multiplier applied when a cable uses an existing field-routed path from a previous cable. Use a value less than 1 to make shared field routes cheaper than new field routes.</span>
+                    </span>
+                 </label>
+                 <input type="number" id="shared-field-penalty" value="0.5" step="0.1">
                  
                  <button id="calculate-route-btn" class="primary-btn">▶ Calculate Optimal Route</button>
                  <div id="progress-container" style="display:none;">


### PR DESCRIPTION
## Summary
- let successive cables reuse previous field routes
- add **Shared Field Route Cost Multiplier** input
- account for shared field cost in routing logic
- track shared field segments during batch runs
- document new option

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ef2a2d88883248ca5d1196a060a7a