### PR TITLE
Adjust tag field width

### DIFF
--- a/app.js
+++ b/app.js
@@ -838,8 +838,8 @@ document.addEventListener('DOMContentLoaded', () => {
         state.cableList.forEach((c, idx) => {
             html += `<tr>
                         <td><input type="text" class="cable-tag-input" data-idx="${idx}" value="${c.name}"></td>
-                        <td><input type="text" class="cable-start-tag-input" data-idx="${idx}" value="${c.start_tag || ''}" style="width:80px;"></td>
-                        <td><input type="text" class="cable-end-tag-input" data-idx="${idx}" value="${c.end_tag || ''}" style="width:80px;"></td>
+                        <td><input type="text" class="cable-start-tag-input" data-idx="${idx}" value="${c.start_tag || ''}" style="width:240px;"></td>
+                        <td><input type="text" class="cable-end-tag-input" data-idx="${idx}" value="${c.end_tag || ''}" style="width:240px;"></td>
                         <td><input type="number" class="cable-diameter-input" data-idx="${idx}" value="${c.diameter}" step="0.01" style="width:60px;"></td>
                         <td>
                             <input type="number" class="cable-start-input" data-idx="${idx}" data-coord="0" value="${c.start[0]}" step="0.1" style="width:80px;">


### PR DESCRIPTION
## Summary
- widen the `start_tag` and `end_tag` fields in the cable list table

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686fbddf1d9c8324a77b1e6b79c21a5b