### PR TITLE
Fix invisible edit icon in table

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,6 +102,7 @@ button:hover {
     padding: 0 4px;
     cursor: pointer;
     font-size: 1rem;
+    color: var(--text-color); /* Ensure icons are visible */
 }
 .icon-delete {
     color: red;


### PR DESCRIPTION
## Summary
- make table edit icon visible without hover

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fbf478cb083249739a3b1ae8103e8