### PR TITLE
Add collapsible tray utilization table

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,10 @@
                     <button id="clear-trays-btn">Clear All Trays</button>
                 </div>
 
-                 <div id="tray-utilization-container"></div>
+                <details id="tray-utilization-details">
+                    <summary>Tray Utilization</summary>
+                    <div id="tray-utilization-container"></div>
+                </details>
             </section>
 
             <section class="card">


### PR DESCRIPTION
## Summary
- collapse tray utilization table by default for easier scrolling

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68700371fe2083249eeca4363d1bd7d3