### PR TITLE
Inline editing for tray network

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
         cableList: [],
         trayData: [],
         latestRouteData: [],
-        editingTrayIndex: null,
     };
 
     // --- ELEMENT REFERENCES ---
@@ -735,31 +734,82 @@ document.addEventListener('DOMContentLoaded', () => {
             elements.manualTrayTableContainer.innerHTML = '';
             return;
         }
-        let table = '<table><thead><tr><th>Tray ID</th><th>Start X</th><th>End X</th><th>Width</th><th>Height</th><th>Current Fill</th><th>Actions</th></tr></thead><tbody>';
+        let table = '<table><thead><tr><th>Tray ID</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th><th>Width</th><th>Height</th><th>Current Fill</th><th></th><th></th></tr></thead><tbody>';
         state.manualTrays.forEach((t, idx) => {
-            if (state.editingTrayIndex === idx) {
-                table += `<tr data-idx="${idx}">
-                            <td><input type="text" class="edit-tray-id" value="${t.tray_id}" style="width:80px;"></td>
-                            <td><input type="number" class="edit-start-x" value="${t.start_x}" style="width:80px;"></td>
-                            <td><input type="number" class="edit-end-x" value="${t.end_x}" style="width:80px;"></td>
-                            <td><input type="number" class="edit-width" value="${t.width}" style="width:60px;"></td>
-                            <td><input type="number" class="edit-height" value="${t.height}" style="width:60px;"></td>
-                            <td><input type="number" class="edit-fill" value="${t.current_fill}" style="width:80px;"></td>
-                            <td>
-                                <button class="icon-button save-tray" data-idx="${idx}" title="Save">\u2714</button>
-                                <button class="icon-button cancel-tray" data-idx="${idx}" title="Cancel">\u274C</button>
-                            </td>
-                         </tr>`;
-            } else {
-                table += `<tr><td>${t.tray_id}</td><td>${t.start_x}</td><td>${t.end_x}</td><td>${t.width}</td><td>${t.height}</td><td>${t.current_fill}</td>` +
-                         `<td><button class="icon-button edit-tray" data-idx="${idx}" title="Edit">\u270F</button>` +
-                         `<button class="icon-button delete-tray icon-delete" data-idx="${idx}" title="Delete">\u274C</button>` +
-                         `<button class="icon-button dup-tray" data-idx="${idx}" title="Duplicate">📋</button></td></tr>`;
-            }
+            table += `<tr data-idx="${idx}">
+                        <td><input type="text" class="tray-id-input" data-idx="${idx}" value="${t.tray_id}" style="width:80px;"></td>
+                        <td>
+                            <input type="number" class="tray-start-input" data-idx="${idx}" data-coord="0" value="${t.start_x}" style="width:70px;">
+                            <input type="number" class="tray-start-input" data-idx="${idx}" data-coord="1" value="${t.start_y}" style="width:70px;">
+                            <input type="number" class="tray-start-input" data-idx="${idx}" data-coord="2" value="${t.start_z}" style="width:70px;">
+                        </td>
+                        <td>
+                            <input type="number" class="tray-end-input" data-idx="${idx}" data-coord="0" value="${t.end_x}" style="width:70px;">
+                            <input type="number" class="tray-end-input" data-idx="${idx}" data-coord="1" value="${t.end_y}" style="width:70px;">
+                            <input type="number" class="tray-end-input" data-idx="${idx}" data-coord="2" value="${t.end_z}" style="width:70px;">
+                        </td>
+                        <td><input type="number" class="tray-width-input" data-idx="${idx}" value="${t.width}" style="width:60px;"></td>
+                        <td><input type="number" class="tray-height-input" data-idx="${idx}" value="${t.height}" style="width:60px;"></td>
+                        <td><input type="number" class="tray-fill-input" data-idx="${idx}" value="${t.current_fill}" style="width:80px;"></td>
+                        <td><button class="icon-button dup-tray" data-idx="${idx}" title="Duplicate">📋</button></td>
+                        <td><button class="icon-button delete-tray icon-delete" data-idx="${idx}" title="Delete">\u274C</button></td>
+                     </tr>`;
         });
         table += '</tbody></table>';
         elements.manualTrayTableContainer.innerHTML = table;
 
+        const updateTrayData = () => { state.trayData = state.manualTrays; updateTrayDisplay(); };
+
+        elements.manualTrayTableContainer.querySelectorAll('.tray-id-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.manualTrays[i].tray_id = e.target.value;
+                updateTrayData();
+            });
+        });
+        elements.manualTrayTableContainer.querySelectorAll('.tray-start-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                const c = parseInt(e.target.dataset.coord, 10);
+                const val = parseFloat(e.target.value);
+                if (c === 0) state.manualTrays[i].start_x = val;
+                if (c === 1) state.manualTrays[i].start_y = val;
+                if (c === 2) state.manualTrays[i].start_z = val;
+                updateTrayData();
+            });
+        });
+        elements.manualTrayTableContainer.querySelectorAll('.tray-end-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                const c = parseInt(e.target.dataset.coord, 10);
+                const val = parseFloat(e.target.value);
+                if (c === 0) state.manualTrays[i].end_x = val;
+                if (c === 1) state.manualTrays[i].end_y = val;
+                if (c === 2) state.manualTrays[i].end_z = val;
+                updateTrayData();
+            });
+        });
+        elements.manualTrayTableContainer.querySelectorAll('.tray-width-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.manualTrays[i].width = parseFloat(e.target.value);
+                updateTrayData();
+            });
+        });
+        elements.manualTrayTableContainer.querySelectorAll('.tray-height-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.manualTrays[i].height = parseFloat(e.target.value);
+                updateTrayData();
+            });
+        });
+        elements.manualTrayTableContainer.querySelectorAll('.tray-fill-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.manualTrays[i].current_fill = parseFloat(e.target.value);
+                updateTrayData();
+            });
+        });
         elements.manualTrayTableContainer.querySelectorAll('.delete-tray').forEach(btn => {
             btn.addEventListener('click', e => {
                 const i = parseInt(e.target.dataset.idx, 10);
@@ -769,47 +819,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 updateTrayDisplay();
             });
         });
-
-        elements.manualTrayTableContainer.querySelectorAll('.edit-tray').forEach(btn => {
-            btn.addEventListener('click', e => {
-                const i = parseInt(e.target.dataset.idx, 10);
-                state.editingTrayIndex = i;
-                renderManualTrayTable();
-            });
-        });
-
-        elements.manualTrayTableContainer.querySelectorAll('.save-tray').forEach(btn => {
-            btn.addEventListener('click', e => {
-                const i = parseInt(e.target.dataset.idx, 10);
-                const row = elements.manualTrayTableContainer.querySelector(`tr[data-idx="${i}"]`);
-                const updated = {
-                    tray_id: row.querySelector('.edit-tray-id').value,
-                    start_x: parseFloat(row.querySelector('.edit-start-x').value),
-                    end_x: parseFloat(row.querySelector('.edit-end-x').value),
-                    width: parseFloat(row.querySelector('.edit-width').value),
-                    height: parseFloat(row.querySelector('.edit-height').value),
-                    current_fill: parseFloat(row.querySelector('.edit-fill').value),
-                    start_y: state.manualTrays[i].start_y,
-                    start_z: state.manualTrays[i].start_z,
-                    end_y: state.manualTrays[i].end_y,
-                    end_z: state.manualTrays[i].end_z
-                };
-                // Preserve y/z values from existing row (not editable here)
-                state.manualTrays[i] = { ...state.manualTrays[i], ...updated };
-                state.trayData = state.manualTrays;
-                state.editingTrayIndex = null;
-                renderManualTrayTable();
-                updateTrayDisplay();
-            });
-        });
-
-        elements.manualTrayTableContainer.querySelectorAll('.cancel-tray').forEach(btn => {
-            btn.addEventListener('click', () => {
-                state.editingTrayIndex = null;
-                renderManualTrayTable();
-            });
-        });
-
         elements.manualTrayTableContainer.querySelectorAll('.dup-tray').forEach(btn => {
             btn.addEventListener('click', e => {
                 const i = parseInt(e.target.dataset.idx, 10);


### PR DESCRIPTION
## Summary
- simplify tray editing by removing edit/save state
- display tray fields as inputs like cable list
- update event handlers to save changes immediately

## Testing
- `node test.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870100ded7c8324b18ac239a0394090