### PR TITLE
Add XLSX report with tray/cable map

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ coordinates for that cable.
 - Tray utilization tables show **Available Space** to two decimal places.
 - CSV export flattens the breakdown so each segment is a separate row.
 - CSV export no longer includes the **Status** column.
+- Route data download now generates an **XLSX** file with an additional
+  worksheet mapping trays to the cables routed through them.
 - Start and end tags are displayed in the 3D view (duplicates shown once).
 - Cable specification fields are now located in the **Cable Routing Options** panel.
 - Manual tray entry now has a single **Import Trays CSV** button. Clicking it opens a file dialog and loads trays immediately after you choose a file.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Optimal 3D Cable Routing System</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -140,7 +141,7 @@
                 <button id="popout-plot-btn">Open Full Screen</button>
                 <h3>Updated Tray Utilization</h3>
                 <div id="updated-utilization-container"></div>
-                <button id="export-csv-btn">Download Route Data (CSV)</button>
+                <button id="export-csv-btn">Download Route Data (XLSX)</button>
             </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- load `xlsx` library from CDN
- switch route data export to produce an XLSX file
- include a second worksheet mapping each tray to routed cables
- update README to describe new export format

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68701e3aa2908324ba97a564bcdf39b5