### PR TITLE
Add Allowed Cable Group constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ You can now specify a **Cable Tag** when routing cables. Use the text field in t
 "Cable Specifications" section to assign a tag for a single cable. In batch mode
 the tag can be edited for each cable in the table.
 
+## New Feature: Allowed Cable Group
+
+Cable trays and cables now include an **Allowed Cable Group** property. During routing, a cable will only use trays whose allowed group matches the cable's group. This helps ensure voltage-rated cables are routed appropriately.
+
 ## New Feature: Manual Batch Cable Entry
 
 When batch mode is selected, you can now use the **Add Cable to List** button to

--- a/app.js
+++ b/app.js
@@ -364,7 +364,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
 
-        calculateRoute(startPoint, endPoint, cableArea) {
+        calculateRoute(startPoint, endPoint, cableArea, allowedGroup) {
             if (!this.baseGraph) this.prepareBaseGraph();
             // 1. Start from the precomputed graph
             const cloneGraph = (base) => {
@@ -384,7 +384,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             // Remove trays without remaining capacity
             this.trays.forEach(tray => {
-                if (tray.current_fill + cableArea > tray.maxFill) {
+                if (tray.current_fill + cableArea > tray.maxFill || tray.allowed_cable_group !== allowedGroup) {
                     const remove = Object.keys(graph.nodes).filter(n => n.includes(tray.tray_id));
                     remove.forEach(n => {
                         delete graph.nodes[n];
@@ -558,23 +558,23 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- EVENT HANDLERS & UI LOGIC (This part remains the same) ---
     
     const getSampleTrays = () => [
-        {"tray_id": "H1-A", "start_x": 0, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 9.30},
-        {"tray_id": "H1-B", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 6.98},
-        {"tray_id": "H1-C", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 12.71},
-        {"tray_id": "H2-A", "start_x": 0, "start_y": 0, "start_z": 30, "end_x": 40, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 4.96},
-        {"tray_id": "H2-B", "start_x": 40, "start_y": 0, "start_z": 30, "end_x": 80, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 8.99},
-        {"tray_id": "H2-C", "start_x": 80, "start_y": 0, "start_z": 30, "end_x": 120, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 3.26},
-        {"tray_id": "V1", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 2.79},
-        {"tray_id": "V2", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 3.41},
-        {"tray_id": "C1", "start_x": 60, "start_y": 0, "start_z": 10, "end_x": 60, "end_y": 40, "end_z": 10, "width": 9, "height": 2.95, "current_fill": 5.43},
-        {"tray_id": "C2", "start_x": 100, "start_y": 0, "start_z": 30, "end_x": 100, "end_y": 60, "end_z": 30, "width": 9, "height": 2.95, "current_fill": 6.36},
-        {"tray_id": "B1", "start_x": 60, "start_y": 40, "start_z": 10, "end_x": 60, "end_y": 80, "end_z": 10, "width": 6, "height": 1.97, "current_fill": 1.86},
-        {"tray_id": "B2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 100, "end_y": 100, "end_z": 30, "width": 6, "height": 1.97, "current_fill": 1.40},
-        {"tray_id": "TRUNK", "start_x": 0, "start_y": 20, "start_z": 50, "end_x": 120, "end_y": 20, "end_z": 50, "width": 24, "height": 5.91, "current_fill": 27.90},
-        {"tray_id": "EQ1", "start_x": 20, "start_y": 0, "start_z": 10, "end_x": 20, "end_y": 15, "end_z": 5, "width": 4, "height": 1.57, "current_fill": 1.24},
-        {"tray_id": "EQ2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 110, "end_y": 90, "end_z": 20, "width": 4, "height": 1.57, "current_fill": 0.93},
-        {"tray_id": "CONN1", "start_x": 120, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 20, "end_z": 25, "width": 8, "height": 2.95, "current_fill": 3.10},
-        {"tray_id": "CONN2", "start_x": 120, "start_y": 20, "start_z": 25, "end_x": 120, "end_y": 20, "end_z": 50, "width": 8, "height": 2.95, "current_fill": 2.33}
+        {"tray_id": "H1-A", "start_x": 0, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 9.30,"allowed_cable_group": "HV"},
+        {"tray_id": "H1-B", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 6.98,"allowed_cable_group": "HV"},
+        {"tray_id": "H1-C", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 12.71,"allowed_cable_group": "HV"},
+        {"tray_id": "H2-A", "start_x": 0, "start_y": 0, "start_z": 30, "end_x": 40, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 4.96,"allowed_cable_group": "LV"},
+        {"tray_id": "H2-B", "start_x": 40, "start_y": 0, "start_z": 30, "end_x": 80, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 8.99,"allowed_cable_group": "LV"},
+        {"tray_id": "H2-C", "start_x": 80, "start_y": 0, "start_z": 30, "end_x": 120, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 3.26,"allowed_cable_group": "LV"},
+        {"tray_id": "V1", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 2.79,"allowed_cable_group": "HV"},
+        {"tray_id": "V2", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 3.41,"allowed_cable_group": "LV"},
+        {"tray_id": "C1", "start_x": 60, "start_y": 0, "start_z": 10, "end_x": 60, "end_y": 40, "end_z": 10, "width": 9, "height": 2.95, "current_fill": 5.43,"allowed_cable_group": "HV"},
+        {"tray_id": "C2", "start_x": 100, "start_y": 0, "start_z": 30, "end_x": 100, "end_y": 60, "end_z": 30, "width": 9, "height": 2.95, "current_fill": 6.36,"allowed_cable_group": "LV"},
+        {"tray_id": "B1", "start_x": 60, "start_y": 40, "start_z": 10, "end_x": 60, "end_y": 80, "end_z": 10, "width": 6, "height": 1.97, "current_fill": 1.86,"allowed_cable_group": "HV"},
+        {"tray_id": "B2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 100, "end_y": 100, "end_z": 30, "width": 6, "height": 1.97, "current_fill": 1.40,"allowed_cable_group": "LV"},
+        {"tray_id": "TRUNK", "start_x": 0, "start_y": 20, "start_z": 50, "end_x": 120, "end_y": 20, "end_z": 50, "width": 24, "height": 5.91, "current_fill": 27.90,"allowed_cable_group": "HV"},
+        {"tray_id": "EQ1", "start_x": 20, "start_y": 0, "start_z": 10, "end_x": 20, "end_y": 15, "end_z": 5, "width": 4, "height": 1.57, "current_fill": 1.24,"allowed_cable_group": "HV"},
+        {"tray_id": "EQ2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 110, "end_y": 90, "end_z": 20, "width": 4, "height": 1.57, "current_fill": 0.93,"allowed_cable_group": "LV"},
+        {"tray_id": "CONN1", "start_x": 120, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 20, "end_z": 25, "width": 8, "height": 2.95, "current_fill": 3.10,"allowed_cable_group": "HV"},
+        {"tray_id": "CONN2", "start_x": 120, "start_y": 20, "start_z": 25, "end_x": 120, "end_y": 20, "end_z": 50, "width": 8, "height": 2.95, "current_fill": 2.33,"allowed_cable_group": "HV"}
     ];
     
     const getSampleCables = () => [
@@ -584,7 +584,8 @@ document.addEventListener('DOMContentLoaded', () => {
             start: [5, 5, 5],
             end: [110, 95, 45],
             start_tag: "ST1",
-            end_tag: "ET1"
+            end_tag: "ET1",
+            allowed_cable_group: "HV"
         },
         {
             name: "Control Cable 1",
@@ -592,7 +593,8 @@ document.addEventListener('DOMContentLoaded', () => {
             start: [10, 0, 10],
             end: [100, 80, 25],
             start_tag: "ST2",
-            end_tag: "ET2"
+            end_tag: "ET2",
+            allowed_cable_group: "LV"
         },
         {
             name: "Data Cable 1",
@@ -600,7 +602,8 @@ document.addEventListener('DOMContentLoaded', () => {
             start: [15, 5, 15],
             end: [105, 85, 30],
             start_tag: "ST3",
-            end_tag: "ET3"
+            end_tag: "ET3",
+            allowed_cable_group: "LV"
         },
         {
             name: "Power Cable 2",
@@ -608,7 +611,8 @@ document.addEventListener('DOMContentLoaded', () => {
             start: [20, 10, 8],
             end: [115, 90, 35],
             start_tag: "ST4",
-            end_tag: "ET4"
+            end_tag: "ET4",
+            allowed_cable_group: "HV"
         },
         {
             name: "Control Cable 2",
@@ -616,7 +620,8 @@ document.addEventListener('DOMContentLoaded', () => {
             start: [25, 15, 12],
             end: [95, 75, 28],
             start_tag: "ST5",
-            end_tag: "ET5"
+            end_tag: "ET5",
+            allowed_cable_group: "LV"
         },
     ];
 
@@ -725,6 +730,7 @@ document.addEventListener('DOMContentLoaded', () => {
             width: parseFloat(document.getElementById('t-w').value),
             height: parseFloat(document.getElementById('t-h').value),
             current_fill: parseFloat(document.getElementById('t-fill').value),
+            allowed_cable_group: document.getElementById('t-group').value
         };
         if (!newTray.tray_id || isNaN(newTray.width)) {
             alert("Please fill in at least Tray ID and Width.");
@@ -751,7 +757,7 @@ document.addEventListener('DOMContentLoaded', () => {
             updateTableCounts();
             return;
         }
-        let table = '<table><thead><tr><th>Tray ID</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th><th>Width</th><th>Height</th><th>Current Fill</th><th></th><th></th></tr></thead><tbody>';
+        let table = '<table><thead><tr><th>Tray ID</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th><th>Width</th><th>Height</th><th>Current Fill</th><th>Allowed Group</th><th></th><th></th></tr></thead><tbody>';
         state.manualTrays.forEach((t, idx) => {
             table += `<tr data-idx="${idx}">
                         <td><input type="text" class="tray-id-input" data-idx="${idx}" value="${t.tray_id}" style="width:80px;"></td>
@@ -768,6 +774,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         <td><input type="number" class="tray-width-input" data-idx="${idx}" value="${t.width}" style="width:60px;"></td>
                         <td><input type="number" class="tray-height-input" data-idx="${idx}" value="${t.height}" style="width:60px;"></td>
                         <td><input type="number" class="tray-fill-input" data-idx="${idx}" value="${t.current_fill}" style="width:80px;"></td>
+                        <td><input type="text" class="tray-group-input" data-idx="${idx}" value="${t.allowed_cable_group || ''}" style="width:100px;"></td>
                         <td><button class="icon-button dup-tray" data-idx="${idx}" title="Duplicate">📋</button></td>
                         <td><button class="icon-button delete-tray icon-delete" data-idx="${idx}" title="Delete">\u274C</button></td>
                      </tr>`;
@@ -827,6 +834,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 updateTrayData();
             });
         });
+        elements.manualTrayTableContainer.querySelectorAll('.tray-group-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.manualTrays[i].allowed_cable_group = e.target.value;
+                updateTrayData();
+            });
+        });
         elements.manualTrayTableContainer.querySelectorAll('.delete-tray').forEach(btn => {
             btn.addEventListener('click', e => {
                 const i = parseInt(e.target.dataset.idx, 10);
@@ -850,7 +864,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const exportManualTraysCSV = () => {
-        const headers = ['tray_id','start_x','start_y','start_z','end_x','end_y','end_z','width','height','current_fill'];
+        const headers = ['tray_id','start_x','start_y','start_z','end_x','end_y','end_z','width','height','current_fill','allowed_cable_group'];
         const rows = state.manualTrays;
         let csv = headers.join(',') + '\n';
         if (rows.length > 0) {
@@ -895,7 +909,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     end_z: parseFloat(t.end_z) || 0,
                     width: parseFloat(t.width) || 0,
                     height: parseFloat(t.height) || 0,
-                    current_fill: parseFloat(t.current_fill) || 0
+                    current_fill: parseFloat(t.current_fill) || 0,
+                    allowed_cable_group: t.allowed_cable_group || ''
                 });
             }
             state.manualTrays = newTrays;
@@ -910,7 +925,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const exportCableOptionsCSV = () => {
-        const headers = ['tag','start_tag','end_tag','diameter','start_x','start_y','start_z','end_x','end_y','end_z'];
+        const headers = ['tag','start_tag','end_tag','diameter','allowed_cable_group','start_x','start_y','start_z','end_x','end_y','end_z'];
         const rows = state.cableList;
         let csv = headers.join(',') + '\n';
         if (rows.length > 0) {
@@ -920,6 +935,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     c.start_tag || '',
                     c.end_tag || '',
                     c.diameter !== undefined ? c.diameter : '',
+                    c.allowed_cable_group || '',
                     c.start[0], c.start[1], c.start[2],
                     c.end[0], c.end[1], c.end[2]
                 ];
@@ -956,6 +972,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     start_tag: t.start_tag || '',
                     end_tag: t.end_tag || '',
                     diameter: parseFloat(t.diameter) || 0,
+                    allowed_cable_group: t.allowed_cable_group || '',
                     start: [parseFloat(t.start_x) || 0, parseFloat(t.start_y) || 0, parseFloat(t.start_z) || 0],
                     end: [parseFloat(t.end_x) || 0, parseFloat(t.end_y) || 0, parseFloat(t.end_z) || 0]
                 });
@@ -991,13 +1008,14 @@ document.addEventListener('DOMContentLoaded', () => {
             updateTableCounts();
             return;
         }
-        let html = '<h4>Cables to Route:</h4><table><thead><tr><th>Tag</th><th>Start Tag</th><th>End Tag</th><th>Diameter (in)</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th><th></th><th></th></tr></thead><tbody>';
+        let html = '<h4>Cables to Route:</h4><table><thead><tr><th>Tag</th><th>Start Tag</th><th>End Tag</th><th>Diameter (in)</th><th>Allowed Group</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th><th></th><th></th></tr></thead><tbody>';
         state.cableList.forEach((c, idx) => {
             html += `<tr>
                         <td><input type="text" class="cable-tag-input" data-idx="${idx}" value="${c.name}"></td>
                         <td><input type="text" class="cable-start-tag-input" data-idx="${idx}" value="${c.start_tag || ''}" style="width:240px;"></td>
                         <td><input type="text" class="cable-end-tag-input" data-idx="${idx}" value="${c.end_tag || ''}" style="width:240px;"></td>
                         <td><input type="number" class="cable-diameter-input" data-idx="${idx}" value="${c.diameter}" step="0.01" style="width:60px;"></td>
+                        <td><input type="text" class="cable-group-input" data-idx="${idx}" value="${c.allowed_cable_group || ''}" style="width:120px;"></td>
                         <td>
                             <input type="number" class="cable-start-input" data-idx="${idx}" data-coord="0" value="${c.start[0]}" step="0.1" style="width:80px;">
                             <input type="number" class="cable-start-input" data-idx="${idx}" data-coord="1" value="${c.start[1]}" step="0.1" style="width:80px;">
@@ -1036,6 +1054,12 @@ document.addEventListener('DOMContentLoaded', () => {
             input.addEventListener('input', e => {
                 const i = parseInt(e.target.dataset.idx, 10);
                 state.cableList[i].diameter = parseFloat(e.target.value);
+            });
+        });
+        elements.cableListContainer.querySelectorAll('.cable-group-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.cableList[i].allowed_cable_group = e.target.value;
             });
         });
         elements.cableListContainer.querySelectorAll('.cable-start-input').forEach(input => {
@@ -1083,7 +1107,8 @@ document.addEventListener('DOMContentLoaded', () => {
             start: [0, 0, 0],
             end: [0, 0, 0],
             start_tag: '',
-            end_tag: ''
+            end_tag: '',
+            allowed_cable_group: ''
         };
         state.cableList.push(newCable);
         updateCableListDisplay();

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
                              <input type="number" id="t-w" placeholder="Width (in)">
                              <input type="number" id="t-h" placeholder="Height (in)">
                              <input type="number" id="t-fill" placeholder="Current Fill (in²)">
+                             <input type="text" id="t-group" placeholder="Allowed Cable Group">
                              <button id="add-tray-btn">Add Tray</button>
                         </div>
                     </details>

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -294,7 +294,7 @@ class CableRoutingSystem {
         });
     }
 
-    calculateRoute(startPoint, endPoint, cableArea) {
+    calculateRoute(startPoint, endPoint, cableArea, allowedGroup) {
         if (!this.baseGraph) this.prepareBaseGraph();
         // 1. Start from the precomputed graph
         const cloneGraph = (base) => {
@@ -314,7 +314,7 @@ class CableRoutingSystem {
 
         // Remove trays without remaining capacity
         this.trays.forEach(tray => {
-            if (tray.current_fill + cableArea > tray.maxFill) {
+            if (tray.current_fill + cableArea > tray.maxFill || tray.allowed_cable_group !== allowedGroup) {
                 const remove = Object.keys(graph.nodes).filter(n => n.includes(tray.tray_id));
                 remove.forEach(n => {
                     delete graph.nodes[n];
@@ -491,6 +491,6 @@ self.onmessage = function(e) {
     const system = new CableRoutingSystem(options);
     trays.forEach(t => system.addTraySegment(t));
     system.baseGraph = baseGraph;
-    const result = system.calculateRoute(cable.start, cable.end, cableArea);
+    const result = system.calculateRoute(cable.start, cable.end, cableArea, cable.allowed_cable_group);
     self.postMessage(result);
 };

--- a/test.js
+++ b/test.js
@@ -314,7 +314,7 @@ class CableRoutingSystem {
 }
 
 const getSampleTrays = () => [
-  {"tray_id": "H1-A", "start_x": 0, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 9.30},
+  {"tray_id": "H1-A", "start_x": 0, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 9.30, "allowed_cable_group": "HV"},
   {"tray_id": "H1-B", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 6.98},
   {"tray_id": "H1-C", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 12.71},
   {"tray_id": "H2-A", "start_x": 0, "start_y": 0, "start_z": 30, "end_x": 40, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 4.96},


### PR DESCRIPTION
## Summary
- add `allowed_cable_group` field for trays and cables
- ensure routing only uses trays matching cable group
- update manual entry forms, tables, CSV import/export
- include allowed group in sample data and README

## Testing
- `node test.js | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6871041f35b48324a24ab3ba741437a2