### PR TITLE
Fix Shared Field Route grouping and collapsible utilization

### DIFF
--- a/app.js
+++ b/app.js
@@ -227,23 +227,24 @@ document.addEventListener('DOMContentLoaded', () => {
 
         findCommonFieldRoutes(routes, tolerance = 1) {
             const map = {};
-            const keyFor = (s, e) => {
+            const keyFor = (s, e, group) => {
                 const rounded = arr => arr.map(v => v.toFixed(2)).join(',');
-                return `${rounded(s)}|${rounded(e)}`;
+                return `${rounded(s)}|${rounded(e)}|${group || ''}`;
             };
             for (let i = 0; i < routes.length; i++) {
                 const a = routes[i];
                 for (let j = i + 1; j < routes.length; j++) {
                     const b = routes[j];
+                    if (a.allowed_cable_group && b.allowed_cable_group && a.allowed_cable_group !== b.allowed_cable_group) continue;
                     for (const segA of a.segments) {
                         if (segA.type !== 'field') continue;
                         for (const segB of b.segments) {
                             if (segB.type !== 'field') continue;
                             const ov = this._segmentsOverlap(segA, segB, tolerance);
                             if (ov) {
-                                const key = keyFor(ov.start, ov.end);
+                                const key = keyFor(ov.start, ov.end, a.allowed_cable_group);
                                 if (!map[key]) {
-                                    map[key] = { start: ov.start, end: ov.end, cables: new Set() };
+                                    map[key] = { start: ov.start, end: ov.end, group: a.allowed_cable_group, cables: new Set() };
                                 }
                                 map[key].cables.add(a.label || a.name);
                                 map[key].cables.add(b.label || b.name);
@@ -257,6 +258,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 name: `Route ${count++}`,
                 start: r.start,
                 end: r.end,
+                allowed_cable_group: r.group,
                 cables: Array.from(r.cables)
             }));
         }
@@ -1296,7 +1298,8 @@ document.addEventListener('DOMContentLoaded', () => {
                                 startPoint: cable.start,
                                 endPoint: cable.end,
                                 startTag: cable.start_tag,
-                                endTag: cable.end_tag
+                                endTag: cable.end_tag,
+                                allowed_cable_group: cable.allowed_cable_group
                             });
                         }
                         batchResults[index] = {
@@ -1335,7 +1338,8 @@ document.addEventListener('DOMContentLoaded', () => {
             if (common.length > 0) {
                 let html = '<h4>Potential Shared Field Routes</h4><ul>';
                 common.forEach(c => {
-                    html += `<li>${c.name}: ${formatPoint(c.start)} to ${formatPoint(c.end)} - ${c.cables.join(', ')}</li>`;
+                    const group = c.allowed_cable_group ? ` (Group ${c.allowed_cable_group})` : '';
+                    html += `<li>${c.name}${group}: ${formatPoint(c.start)} to ${formatPoint(c.end)} - ${c.cables.join(', ')}</li>`;
                 });
                 html += '</ul>';
                 elements.metrics.innerHTML = html;

--- a/index.html
+++ b/index.html
@@ -140,8 +140,10 @@
                 <h3>3D Route Visualization</h3>
                 <div id="plot-3d"></div>
                 <button id="popout-plot-btn">Open Full Screen</button>
-                <h3>Updated Tray Utilization</h3>
-                <div id="updated-utilization-container"></div>
+                <details id="updated-utilization-details">
+                    <summary>Updated Tray Utilization</summary>
+                    <div id="updated-utilization-container"></div>
+                </details>
                 <button id="export-csv-btn">Download Route Data (XLSX)</button>
             </section>
         </main>

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -157,23 +157,24 @@ class CableRoutingSystem {
 
     findCommonFieldRoutes(routes, tolerance = 1) {
         const map = {};
-        const keyFor = (s, e) => {
+        const keyFor = (s, e, group) => {
             const rounded = arr => arr.map(v => v.toFixed(2)).join(',');
-            return `${rounded(s)}|${rounded(e)}`;
+            return `${rounded(s)}|${rounded(e)}|${group || ''}`;
         };
         for (let i = 0; i < routes.length; i++) {
             const a = routes[i];
             for (let j = i + 1; j < routes.length; j++) {
                 const b = routes[j];
+                if (a.allowed_cable_group && b.allowed_cable_group && a.allowed_cable_group !== b.allowed_cable_group) continue;
                 for (const segA of a.segments) {
                     if (segA.type !== 'field') continue;
                     for (const segB of b.segments) {
                         if (segB.type !== 'field') continue;
                         const ov = this._segmentsOverlap(segA, segB, tolerance);
                         if (ov) {
-                            const key = keyFor(ov.start, ov.end);
+                            const key = keyFor(ov.start, ov.end, a.allowed_cable_group);
                             if (!map[key]) {
-                                map[key] = { start: ov.start, end: ov.end, cables: new Set() };
+                                map[key] = { start: ov.start, end: ov.end, group: a.allowed_cable_group, cables: new Set() };
                             }
                             map[key].cables.add(a.label || a.name);
                             map[key].cables.add(b.label || b.name);
@@ -187,6 +188,7 @@ class CableRoutingSystem {
             name: `Route ${count++}`,
             start: r.start,
             end: r.end,
+            allowed_cable_group: r.group,
             cables: Array.from(r.cables)
         }));
     }


### PR DESCRIPTION
## Summary
- filter potential shared routes by allowed cable group and preserve group in result
- include cable group when building route data
- show cable group info in shared route list
- collapse updated tray utilization table under a dropdown header

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687117c4c7348324a9c6baf46e15b5bf