### PR TITLE
Improve tray routing to avoid backtracking

### DIFF
--- a/routeWorker.js
+++ b/routeWorker.js
@@ -200,6 +200,41 @@ class CableRoutingSystem {
         return false;
     }
 
+    _removeTrayBacktracking(segments) {
+        const result = [];
+        let i = 0;
+        while (i < segments.length) {
+            const curr = { ...segments[i] };
+            if (curr.type === 'tray' && i + 1 < segments.length) {
+                const next = { ...segments[i + 1] };
+                if (next.type === 'field') {
+                    const oTray = this._segmentOrientation(curr);
+                    const oField = this._segmentOrientation(next);
+                    if (oTray.axis === oField.axis) {
+                        const trayDir = Math.sign(curr.end[oTray.axis] - curr.start[oTray.axis]);
+                        const fieldDir = Math.sign(next.end[oField.axis] - next.start[oField.axis]);
+                        if (trayDir !== 0 && fieldDir !== 0 && trayDir !== fieldDir) {
+                            const overshoot = Math.min(Math.abs(next.end[oField.axis] - next.start[oField.axis]), curr.length);
+                            curr.end[oTray.axis] -= trayDir * overshoot;
+                            curr.length -= overshoot;
+                            next.start[oField.axis] -= trayDir * overshoot;
+                            next.length -= overshoot;
+                            if (curr.length > 0.0001) result.push(curr);
+                            if (next.length > 0.0001) {
+                                result.push(next);
+                            }
+                            i += 2;
+                            continue;
+                        }
+                    }
+                }
+            }
+            result.push(curr);
+            i++;
+        }
+        return result;
+    }
+
     prepareBaseGraph() {
         const graph = { nodes: {}, edges: {} };
         const addNode = (id, point, type = 'generic') => {
@@ -476,11 +511,13 @@ class CableRoutingSystem {
             }
         }
 
+        const cleaned = this._removeTrayBacktracking(routeSegments);
+
         return {
             success: true,
             total_length: totalLength,
             field_routed_length: fieldRoutedLength,
-            route_segments: this._consolidateSegments(routeSegments), // Use the new consolidation method
+            route_segments: this._consolidateSegments(cleaned),
             tray_segments: Array.from(traySegments),
             warnings: [],
         };

--- a/test.js
+++ b/test.js
@@ -162,6 +162,41 @@ class CableRoutingSystem {
     return false;
   }
 
+  _removeTrayBacktracking(segments) {
+    const result = [];
+    let i = 0;
+    while (i < segments.length) {
+      const curr = { ...segments[i] };
+      if (curr.type === 'tray' && i + 1 < segments.length) {
+        const next = { ...segments[i + 1] };
+        if (next.type === 'field') {
+          const oTray = this._segmentOrientation(curr);
+          const oField = this._segmentOrientation(next);
+          if (oTray.axis === oField.axis) {
+            const trayDir = Math.sign(curr.end[oTray.axis] - curr.start[oTray.axis]);
+            const fieldDir = Math.sign(next.end[oField.axis] - next.start[oField.axis]);
+            if (trayDir !== 0 && fieldDir !== 0 && trayDir !== fieldDir) {
+              const overshoot = Math.min(Math.abs(next.end[oField.axis] - next.start[oField.axis]), curr.length);
+              curr.end[oTray.axis] -= trayDir * overshoot;
+              curr.length -= overshoot;
+              next.start[oField.axis] -= trayDir * overshoot;
+              next.length -= overshoot;
+              if (curr.length > 0.0001) result.push(curr);
+              if (next.length > 0.0001) {
+                result.push(next);
+              }
+              i += 2;
+              continue;
+            }
+          }
+        }
+      }
+      result.push(curr);
+      i++;
+    }
+    return result;
+  }
+
   recordSharedFieldSegments(segments) {
     segments.forEach(s => {
       if (s.type === 'field') {
@@ -309,7 +344,8 @@ class CableRoutingSystem {
         routeSegments.push({type,start:p1,end:p2,length,tray_id});
       }
     }
-    return {success:true,total_length:totalLength,field_routed_length:fieldLen,route_segments:this._consolidateSegments(routeSegments),tray_segments:Array.from(traySegments)};
+    const cleaned = this._removeTrayBacktracking(routeSegments);
+    return {success:true,total_length:totalLength,field_routed_length:fieldLen,route_segments:this._consolidateSegments(cleaned),tray_segments:Array.from(traySegments)};
   }
 }
 


### PR DESCRIPTION
## Summary
- add `_removeTrayBacktracking` to clean up routes that overshoot tray ends
- apply this cleanup in `calculateRoute` for routeWorker, app, and tests

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687119cda5ac83248dc0efedb6babffb