### PR TITLE
Sort legend, include allowed group in XLSX export

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ coordinates for that cable.
 - CSV export no longer includes the **Status** column.
 - Route data download now generates an **XLSX** file with an additional
   worksheet mapping trays to the cables routed through them.
+- The **Tray Cable Map** worksheet now also lists the tray's **Allowed Cable Group**.
 - Start and end tags are displayed in the 3D view (duplicates shown once).
 - Cable specification fields are now located in the **Cable Routing Options** panel.
 - Manual tray entry now has a single **Import Trays CSV** button. Clicking it opens a file dialog and loads trays immediately after you choose a file.

--- a/app.js
+++ b/app.js
@@ -1222,8 +1222,10 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
+        const groupMap = new Map(state.trayData.map(t => [t.tray_id, t.allowed_cable_group || '']));
         const trayList = Array.from(trayMap.entries()).map(([tray_id, cables]) => ({
             tray_id,
+            allowed_cable_group: groupMap.get(tray_id) || '',
             cables: Array.from(cables).join(', ')
         }));
 
@@ -1473,6 +1475,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         if (routes && routes.length > 0) {
+            // Sort routes alphanumerically by label so the legend order is predictable
+            routes = routes.slice().sort((a, b) => {
+                const la = a.label || '';
+                const lb = b.label || '';
+                return la.localeCompare(lb, undefined, { numeric: true, sensitivity: 'base' });
+            });
+
             const palette = ['blue', 'green', 'orange', 'purple', 'brown', 'cyan', 'magenta', 'olive'];
             const seenTags = new Set();
 


### PR DESCRIPTION
## Summary
- keep route legend alphabetical for easier reading
- include allowed cable group info when exporting Tray Cable Map
- document new Tray Cable Map column in README

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68711ed049308324bae33fd3abea0171