### PR TITLE
Improve route breakdown display

### DIFF
--- a/app.js
+++ b/app.js
@@ -1046,11 +1046,11 @@ document.addEventListener('DOMContentLoaded', () => {
         results.forEach(res => {
             html += `<details><summary>${res.cable} | ${res.status} | Total ${res.total_length} | Field ${res.field_length} | Segments ${res.segments_count}</summary>`;
             if (res.breakdown && res.breakdown.length > 0) {
-                html += '<table><thead><tr><th>Segment</th><th>Tray ID</th><th>Type</th><th>From</th><th>To</th><th>Length</th></tr></thead><tbody>';
+                html += '<div class="table-scroll"><table class="sticky-table"><thead><tr><th>Segment</th><th>Tray ID</th><th>Type</th><th>From</th><th>To</th><th>Length</th></tr></thead><tbody>';
                 res.breakdown.forEach(b => {
                     html += `<tr><td>${b.segment}</td><td>${b.tray_id}</td><td>${b.type}</td><td>${b.from}</td><td>${b.to}</td><td>${b.length}</td></tr>`;
                 });
-                html += '</tbody></table>';
+                html += '</tbody></table></div>';
             }
             html += '</details>';
         });

--- a/index.html
+++ b/index.html
@@ -135,8 +135,10 @@
                 <h2>Routing Results</h2>
                 <div id="messages"></div>
                 <div id="metrics" class="columns"></div>
-                <h3>Route Breakdown</h3>
-                <div id="route-breakdown-container"></div>
+                <details id="route-breakdown-details">
+                    <summary>Route Breakdown</summary>
+                    <div id="route-breakdown-container"></div>
+                </details>
                 <h3>3D Route Visualization</h3>
                 <div id="plot-3d"></div>
                 <button id="popout-plot-btn">Open Full Screen</button>


### PR DESCRIPTION
## Summary
- wrap Route Breakdown section in a `<details>` element so the entire section can be collapsed
- make each Route Breakdown table scrollable with sticky headers

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68712f64908c8324a3cb889f2f6068ac