### PR TITLE
Add shared field routes export

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ coordinates for that cable.
 - Route data download now generates an **XLSX** file with an additional
   worksheet mapping trays to the cables routed through them.
 - The **Tray Cable Map** worksheet now also lists the tray's **Allowed Cable Group**.
+- The XLSX export includes a **Shared Field Routes** worksheet showing
+  potential field runs shared between cables.
 - Start and end tags are displayed in the 3D view (duplicates shown once).
 - Cable specification fields are now located in the **Cable Routing Options** panel.
 - Manual tray entry now has a single **Import Trays CSV** button. Clicking it opens a file dialog and loads trays immediately after you choose a file.

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
         cableList: [],
         trayData: [],
         latestRouteData: [],
+        sharedFieldRoutes: [],
     };
 
     // --- ELEMENT REFERENCES ---
@@ -1247,11 +1248,23 @@ document.addEventListener('DOMContentLoaded', () => {
             cables: Array.from(cables).join(', ')
         }));
 
+        const sharedRoutes = (state.sharedFieldRoutes || []).map(r => ({
+            route_name: r.name,
+            allowed_cable_group: r.allowed_cable_group || '',
+            start: formatPoint(r.start),
+            end: formatPoint(r.end),
+            cables: r.cables.join(', ')
+        }));
+
         const wb = XLSX.utils.book_new();
         const ws1 = XLSX.utils.json_to_sheet(data);
         XLSX.utils.book_append_sheet(wb, ws1, 'Route Data');
         const ws2 = XLSX.utils.json_to_sheet(trayList);
         XLSX.utils.book_append_sheet(wb, ws2, 'Tray Cable Map');
+        if (sharedRoutes.length > 0) {
+            const ws3 = XLSX.utils.json_to_sheet(sharedRoutes);
+            XLSX.utils.book_append_sheet(wb, ws3, 'Shared Field Routes');
+        }
         XLSX.writeFile(wb, 'route_data.xlsx');
     };
 
@@ -1394,6 +1407,7 @@ document.addEventListener('DOMContentLoaded', () => {
             renderBatchResults(batchResults);
             state.latestRouteData = batchResults;
             const common = routingSystem.findCommonFieldRoutes(allRoutesForPlotting, 6);
+            state.sharedFieldRoutes = common;
             if (common.length > 0) {
                 let html = '<h4>Potential Shared Field Routes</h4><ul>';
                 common.forEach(c => {


### PR DESCRIPTION
## Summary
- store potential shared field routes in state
- include shared routes sheet when exporting route data
- document the new worksheet in README

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687134d81fa48324945e82bbc17ab4f0