### PR TITLE
Add cable type and weight columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ coordinates for that cable.
 - Manual tray entry now has a single **Import Trays CSV** button. Clicking it opens a file dialog and loads trays immediately after you choose a file.
 - Cable Routing Options now has **Import Cables CSV** and **Export Cables CSV** buttons for managing the cable list.
 - New **Shared Field Route Cost Multiplier** input lets successive cables reuse existing field runs at a reduced cost.
+- The **Cables to Route** table now includes a **Cable Type** drop-down (Power, Control, Signal) and a **Weight (lbs/ft)** column.

--- a/app.js
+++ b/app.js
@@ -619,7 +619,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const getSampleCables = () => [
         {
             name: "Power Cable 1",
+            cable_type: "Power",
             diameter: 1.26,
+            weight: 1.5,
             start: [5, 5, 5],
             end: [110, 95, 45],
             start_tag: "ST1",
@@ -628,7 +630,9 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         {
             name: "Control Cable 1",
+            cable_type: "Control",
             diameter: 0.47,
+            weight: 0.8,
             start: [10, 0, 10],
             end: [100, 80, 25],
             start_tag: "ST2",
@@ -637,7 +641,9 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         {
             name: "Data Cable 1",
+            cable_type: "Signal",
             diameter: 0.31,
+            weight: 0.5,
             start: [15, 5, 15],
             end: [105, 85, 30],
             start_tag: "ST3",
@@ -646,7 +652,9 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         {
             name: "Power Cable 2",
+            cable_type: "Power",
             diameter: 1.10,
+            weight: 1.3,
             start: [20, 10, 8],
             end: [115, 90, 35],
             start_tag: "ST4",
@@ -655,7 +663,9 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         {
             name: "Control Cable 2",
+            cable_type: "Control",
             diameter: 0.59,
+            weight: 0.9,
             start: [25, 15, 12],
             end: [95, 75, 28],
             start_tag: "ST5",
@@ -981,7 +991,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const exportCableOptionsCSV = () => {
-        const headers = ['tag','start_tag','end_tag','diameter','allowed_cable_group','start_x','start_y','start_z','end_x','end_y','end_z'];
+        const headers = ['tag','start_tag','end_tag','cable_type','diameter','weight','allowed_cable_group','start_x','start_y','start_z','end_x','end_y','end_z'];
         const rows = state.cableList;
         let csv = headers.join(',') + '\n';
         if (rows.length > 0) {
@@ -990,7 +1000,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     c.name || '',
                     c.start_tag || '',
                     c.end_tag || '',
+                    c.cable_type || '',
                     c.diameter !== undefined ? c.diameter : '',
+                    c.weight !== undefined ? c.weight : '',
                     c.allowed_cable_group || '',
                     c.start[0], c.start[1], c.start[2],
                     c.end[0], c.end[1], c.end[2]
@@ -1027,7 +1039,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     name: t.tag || '',
                     start_tag: t.start_tag || '',
                     end_tag: t.end_tag || '',
+                    cable_type: t.cable_type || 'Power',
                     diameter: parseFloat(t.diameter) || 0,
+                    weight: parseFloat(t.weight) || 0,
                     allowed_cable_group: t.allowed_cable_group || '',
                     start: [parseFloat(t.start_x) || 0, parseFloat(t.start_y) || 0, parseFloat(t.start_z) || 0],
                     end: [parseFloat(t.end_x) || 0, parseFloat(t.end_y) || 0, parseFloat(t.end_z) || 0]
@@ -1064,13 +1078,21 @@ document.addEventListener('DOMContentLoaded', () => {
             updateTableCounts();
             return;
         }
-        let html = '<h4>Cables to Route:</h4><table class="sticky-table"><thead><tr><th>Tag</th><th>Start Tag</th><th>End Tag</th><th>Diameter (in)</th><th>Allowed Group</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th><th></th><th></th></tr></thead><tbody>';
+        let html = '<h4>Cables to Route:</h4><table class="sticky-table"><thead><tr><th>Tag</th><th>Start Tag</th><th>End Tag</th><th>Cable Type</th><th>Diameter (in)</th><th>Weight (lbs/ft)</th><th>Allowed Group</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th><th></th><th></th></tr></thead><tbody>';
         state.cableList.forEach((c, idx) => {
             html += `<tr>
                         <td><input type="text" class="cable-tag-input" data-idx="${idx}" value="${c.name}"></td>
                         <td><input type="text" class="cable-start-tag-input" data-idx="${idx}" value="${c.start_tag || ''}" style="width:240px;"></td>
                         <td><input type="text" class="cable-end-tag-input" data-idx="${idx}" value="${c.end_tag || ''}" style="width:240px;"></td>
+                        <td>
+                            <select class="cable-type-select" data-idx="${idx}">
+                                <option value="Power" ${c.cable_type === 'Power' ? 'selected' : ''}>Power</option>
+                                <option value="Control" ${c.cable_type === 'Control' ? 'selected' : ''}>Control</option>
+                                <option value="Signal" ${c.cable_type === 'Signal' ? 'selected' : ''}>Signal</option>
+                            </select>
+                        </td>
                         <td><input type="number" class="cable-diameter-input" data-idx="${idx}" value="${c.diameter}" step="0.01" style="width:60px;"></td>
+                        <td><input type="number" class="cable-weight-input" data-idx="${idx}" value="${c.weight || 0}" step="0.01" style="width:80px;"></td>
                         <td><input type="text" class="cable-group-input" data-idx="${idx}" value="${c.allowed_cable_group || ''}" style="width:120px;"></td>
                         <td>
                             <input type="number" class="cable-start-input" data-idx="${idx}" data-coord="0" value="${c.start[0]}" step="0.1" style="width:80px;">
@@ -1111,6 +1133,18 @@ document.addEventListener('DOMContentLoaded', () => {
             input.addEventListener('input', e => {
                 const i = parseInt(e.target.dataset.idx, 10);
                 state.cableList[i].diameter = parseFloat(e.target.value);
+            });
+        });
+        elements.cableListContainer.querySelectorAll('.cable-weight-input').forEach(input => {
+            input.addEventListener('input', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.cableList[i].weight = parseFloat(e.target.value);
+            });
+        });
+        elements.cableListContainer.querySelectorAll('.cable-type-select').forEach(sel => {
+            sel.addEventListener('change', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.cableList[i].cable_type = e.target.value;
             });
         });
         elements.cableListContainer.querySelectorAll('.cable-group-input').forEach(input => {
@@ -1160,7 +1194,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const addCableToBatch = () => {
         const newCable = {
             name: `Cable ${state.cableList.length + 1}`,
+            cable_type: 'Power',
             diameter: 1.0,
+            weight: 0,
             start: [0, 0, 0],
             end: [0, 0, 0],
             start_tag: '',


### PR DESCRIPTION
## Summary
- add Cable Type dropdown and numeric Weight field to cable table
- include new fields in CSV import/export and sample cables
- document new columns in README

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6871544178108324aca2c60adeaa53bc