### PR TITLE
Add tray fill viewer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ coordinates for that cable.
 - The **Cables to Route** table now includes a **Cable Type** drop-down (Power, Control, Signal) and a **Weight (lbs/ft)** column.
 - A new **Conductors** column lets you specify the number of conductors for each cable.
 - A new **Conductor Size** column lets you choose an AWG or kcmil size for each cable.
+
+## Tray Fill Visualization
+
+The repository now includes `cabletrayfill.html`, a standalone page that draws
+a cross-sectional view of a cable tray. After calculating routes, click
+**Download Route Data (XLSX)** and then **Open Tray Fill Tool** to launch the
+viewer. Import the exported `route_data.xlsx` file to display the tray fill
+diagram with the cables placed according to their properties.

--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
         popoutPlotBtn: document.getElementById('popout-plot-btn'),
         updatedUtilizationContainer: document.getElementById('updated-utilization-container'),
         exportCsvBtn: document.getElementById('export-csv-btn'),
+        openFillBtn: document.getElementById('open-fill-btn'),
         progressContainer: document.getElementById('progress-container'),
         progressBar: document.getElementById('progress-bar'),
         progressLabel: document.getElementById('progress-label'),
@@ -1699,6 +1700,11 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
     elements.importCablesBtn.addEventListener('click', () => elements.importCablesFile.click());
     elements.importCablesFile.addEventListener('change', importCableOptionsCSV);
     elements.exportCsvBtn.addEventListener('click', exportRouteXLSX);
+    if (elements.openFillBtn) {
+        elements.openFillBtn.addEventListener('click', () => {
+            window.open('cabletrayfill.html', '_blank');
+        });
+    }
     elements.popoutPlotBtn.addEventListener('click', popOutPlot);
     elements.cancelRoutingBtn.addEventListener('click', cancelCurrentRouting);
 

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
                     <div id="updated-utilization-container"></div>
                 </details>
                 <button id="export-csv-btn">Download Route Data (XLSX)</button>
+                <button id="open-fill-btn">Open Tray Fill Tool</button>
             </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- add "Open Tray Fill Tool" button to `index.html`
- hook up button in `app.js` to open `cabletrayfill.html`
- document new tray fill viewer in README

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6871d6da31f08324a1c19f85fa5856ec