### PR TITLE
Add settings menu and sample tray button

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,8 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fillLimitIn: document.getElementById('fill-limit'),
         fillLimitOut: document.getElementById('fill-limit-value'),
         calculateBtn: document.getElementById('calculate-route-btn'),
-        inputMethodRadios: document.querySelectorAll('input[name="input-method"]'),
-        manualEntrySection: document.getElementById('manual-entry-section'),
+        loadSampleTraysBtn: document.getElementById('load-sample-trays-btn'),
         batchSection: document.getElementById('batch-section'),
         addTrayBtn: document.getElementById('add-tray-btn'),
         clearTraysBtn: document.getElementById('clear-trays-btn'),
@@ -50,6 +49,9 @@ document.addEventListener('DOMContentLoaded', () => {
         manualTraySummary: document.getElementById('manual-tray-summary'),
         cableListSummary: document.getElementById('cable-list-summary'),
         darkToggle: document.getElementById('dark-toggle'),
+        settingsBtn: document.getElementById('settings-btn'),
+        settingsMenu: document.getElementById('settings-menu'),
+        helpBtn: document.getElementById('help-btn'),
         traySearch: document.getElementById('tray-search'),
         cableSearch: document.getElementById('cable-search'),
     };
@@ -847,19 +849,6 @@ document.addEventListener('DOMContentLoaded', () => {
         window.open('cabletrayfill.html', '_blank');
     };
     
-    const handleInputMethodChange = () => {
-        if (document.getElementById('sample-data').checked) {
-            elements.manualEntrySection.style.display = 'none';
-            state.trayData = getSampleTrays();
-            elements.manualTrayTableContainer.innerHTML = '';
-        } else {
-            elements.manualEntrySection.style.display = 'block';
-            state.trayData = state.manualTrays;
-            renderManualTrayTable();
-        }
-        updateTrayDisplay();
-        updateTableCounts();
-    };
     
 
     const addManualTray = () => {
@@ -908,6 +897,15 @@ document.addEventListener('DOMContentLoaded', () => {
         state.manualTrays = [];
         state.trayData = [];
         elements.manualTrayTableContainer.innerHTML = '';
+        updateTrayDisplay();
+        updateTableCounts();
+        saveSession();
+    };
+
+    const loadSampleTrays = () => {
+        state.manualTrays = getSampleTrays();
+        state.trayData = state.manualTrays;
+        renderManualTrayTable();
         updateTrayDisplay();
         updateTableCounts();
         saveSession();
@@ -1843,7 +1841,9 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
     // --- INITIALIZATION & EVENT LISTENERS ---
     elements.fillLimitIn.addEventListener('input', updateFillLimitDisplay);
     elements.calculateBtn.addEventListener('click', mainCalculation);
-    elements.inputMethodRadios.forEach(radio => radio.addEventListener('change', handleInputMethodChange));
+    if (elements.loadSampleTraysBtn) {
+        elements.loadSampleTraysBtn.addEventListener('click', loadSampleTrays);
+    }
     elements.addTrayBtn.addEventListener('click', addManualTray);
     elements.clearTraysBtn.addEventListener('click', clearManualTrays);
     elements.exportTraysBtn.addEventListener('click', exportManualTraysCSV);
@@ -1875,6 +1875,21 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
         if (document.body.classList.contains('dark-mode')) {
             elements.darkToggle.checked = true;
         }
+    }
+    if (elements.settingsBtn && elements.settingsMenu) {
+        elements.settingsBtn.addEventListener('click', () => {
+            elements.settingsMenu.style.display = elements.settingsMenu.style.display === 'block' ? 'none' : 'block';
+        });
+        document.addEventListener('click', (e) => {
+            if (!elements.settingsMenu.contains(e.target) && e.target !== elements.settingsBtn) {
+                elements.settingsMenu.style.display = 'none';
+            }
+        });
+    }
+    if (elements.helpBtn) {
+        elements.helpBtn.addEventListener('click', () => {
+            alert('Refer to the README for help.');
+        });
     }
     if (elements.traySearch) {
         elements.traySearch.addEventListener('input', () => filterTable(elements.manualTrayTableContainer, elements.traySearch.value));
@@ -1912,5 +1927,5 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
         saveSession();
     }
 
-    handleInputMethodChange();
+    updateTrayDisplay();
 });

--- a/index.html
+++ b/index.html
@@ -13,9 +13,6 @@
         <aside class="sidebar">
             <header>
                 <h2>Input Parameters</h2>
-                <div class="dark-toggle">
-                    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-                </div>
             </header>
             
             <!-- Cable specification fields moved to the routing options card -->
@@ -61,20 +58,20 @@
         </aside>
 
         <main class="main-content">
-            <header>
+            <header class="page-header">
                 <h1>Optimal 3D Cable Routing System</h1>
+                <button id="settings-btn" class="settings-btn" aria-label="Settings">⚙</button>
                 <p>Find the most efficient path for routing cables through tray networks with capacity constraints.</p>
+                <div id="settings-menu" class="settings-menu">
+                    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+                    <button id="help-btn">Site Help</button>
+                </div>
             </header>
 
             <section class="card">
                 <h2>Cable Tray Network</h2>
                 <div class="tray-controls">
-                    <div class="input-methods">
-                        <input type="radio" id="manual-entry" name="input-method" value="manual" checked>
-                        <label for="manual-entry">Manual Entry</label>
-                        <input type="radio" id="sample-data" name="input-method" value="sample">
-                        <label for="sample-data">Use Sample Data</label>
-                    </div>
+                    <button id="load-sample-trays-btn">Load Sample Tray Network</button>
                     <div class="tray-import-export">
                         <button id="export-trays-btn">Export Trays CSV</button>
                         <input type="file" id="import-trays-file" accept=".csv" style="display:none;">

--- a/style.css
+++ b/style.css
@@ -20,17 +20,43 @@ body.dark-mode {
     background-color: #212529;
 }
 
+.page-header {
+    position: relative;
+}
+
+.settings-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: none;
+    border: none;
+    font-size: 1.4rem;
+    cursor: pointer;
+    color: var(--text-color);
+}
+
+.settings-menu {
+    position: absolute;
+    top: 2.2rem;
+    right: 0;
+    background: var(--secondary-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 0.5rem 1rem;
+    display: none;
+    z-index: 100;
+}
+
+body.dark-mode .settings-menu {
+    background: var(--secondary-color);
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     margin: 0;
     background-color: #f0f2f5;
     color: var(--text-color);
 }
-
-.dark-toggle {
-    margin-top: 8px;
-}
-
 
 .container {
     display: flex;
@@ -75,6 +101,16 @@ header h1, header h2 {
     padding: 1.5rem;
     margin-top: 1.5rem;
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+body.dark-mode .card {
+    background: #2c3034;
+}
+
+body.dark-mode h2,
+body.dark-mode h3,
+body.dark-mode h4 {
+    color: var(--primary-color);
 }
 
 .columns {


### PR DESCRIPTION
## Summary
- replace tray input radio buttons with `Load Sample Tray Network` button
- add gear icon to open a new settings menu with dark mode toggle and help
- improve dark mode by darkening card background and coloring headers
- update JavaScript for new controls and remove old input method logic

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68726abe694883249334e86e3c5a3bec