### PR TITLE
Center view on shared route

### DIFF
--- a/app.js
+++ b/app.js
@@ -1854,6 +1854,13 @@ const openTrayFill = (trayId) => {
             line: { color: 'red', width: 8, dash: 'dot' },
             name: '__shared_highlight__', showlegend: false
         });
+        const cam = window.current3DPlot.layout.scene.camera || {};
+        const center = {
+            x: (route.start[0] + route.end[0]) / 2,
+            y: (route.start[1] + route.end[1]) / 2,
+            z: (route.start[2] + route.end[2]) / 2
+        };
+        window.current3DPlot.layout.scene.camera = { ...cam, center };
         Plotly.react(elements.plot3d, traces, window.current3DPlot.layout);
         window.current3DPlot.traces = traces;
     };


### PR DESCRIPTION
## Summary
- when clicking a shared field route item, pan the 3D viewer to its center

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687276cb0c948324892e34ba495fdbc4