### PR TITLE
Improve shared route highlight behaviour

### DIFF
--- a/app.js
+++ b/app.js
@@ -1851,7 +1851,7 @@ const openTrayFill = (trayId) => {
             y: [route.start[1], route.end[1]],
             z: [route.start[2], route.end[2]],
             mode: 'lines', type: 'scatter3d',
-            line: { color: 'red', width: 8, dash: 'dot' },
+            line: { color: 'yellow', width: 12 },
             name: '__shared_highlight__', showlegend: false
         });
         const layout = window.current3DPlot.layout;
@@ -1859,17 +1859,31 @@ const openTrayFill = (trayId) => {
         const cy = (route.start[1] + route.end[1]) / 2;
         const cz = (route.start[2] + route.end[2]) / 2;
 
-        const xr = layout.scene.xaxis.range || [layout.scene.xaxis.min, layout.scene.xaxis.max];
-        const yr = layout.scene.yaxis.range || [layout.scene.yaxis.min, layout.scene.yaxis.max];
-        const zr = layout.scene.zaxis.range || [layout.scene.zaxis.min, layout.scene.zaxis.max];
+        const xr = layout.scene.xaxis.range;
+        const yr = layout.scene.yaxis.range;
+        const zr = layout.scene.zaxis.range;
 
-        const xw = xr[1] - xr[0];
-        const yw = yr[1] - yr[0];
-        const zw = zr[1] - zr[0];
+        const def = (a, b) => (Array.isArray(a) && a[0] != null && a[1] != null) ? a : b;
 
-        layout.scene.xaxis.range = [cx - xw/2, cx + xw/2];
-        layout.scene.yaxis.range = [cy - yw/2, cy + yw/2];
-        layout.scene.zaxis.range = [cz - zw/2, cz + zw/2];
+        const dx = Math.abs(route.start[0] - route.end[0]);
+        const dy = Math.abs(route.start[1] - route.end[1]);
+        const dz = Math.abs(route.start[2] - route.end[2]);
+
+        const defaultX = [cx - Math.max(dx * 2, 10), cx + Math.max(dx * 2, 10)];
+        const defaultY = [cy - Math.max(dy * 2, 10), cy + Math.max(dy * 2, 10)];
+        const defaultZ = [cz - Math.max(dz * 2, 10), cz + Math.max(dz * 2, 10)];
+
+        const xrFinal = def(xr, defaultX);
+        const yrFinal = def(yr, defaultY);
+        const zrFinal = def(zr, defaultZ);
+
+        const xw = xrFinal[1] - xrFinal[0];
+        const yw = yrFinal[1] - yrFinal[0];
+        const zw = zrFinal[1] - zrFinal[0];
+
+        layout.scene.xaxis.range = [cx - xw / 2, cx + xw / 2];
+        layout.scene.yaxis.range = [cy - yw / 2, cy + yw / 2];
+        layout.scene.zaxis.range = [cz - zw / 2, cz + zw / 2];
 
         Plotly.react(elements.plot3d, traces, layout);
         window.current3DPlot.traces = traces;


### PR DESCRIPTION
## Summary
- enhance highlight color and width for shared routes
- default ranges when panning to a highlighted route so the plot camera always moves

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6872ae243f688324a386cb9e1c5251c1