### PR TITLE
Add import guide and session reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,28 @@ a cross-sectional view of a cable tray. After calculating routes, click
 **Download Route Data (XLSX)** and then **Open Tray Fill Tool** to launch the
 viewer. Import the exported `route_data.xlsx` file to display the tray fill
 diagram with the cables placed according to their properties.
+
+## Import and Export Guide
+
+### Tray CSV Format
+A tray CSV used for import must include the following headers:
+
+```
+tray_id,start_x,start_y,start_z,end_x,end_y,end_z,width,height,current_fill,allowed_cable_group
+```
+
+All coordinates are in **feet**. Width and height are in **inches** and `current_fill` is the occupied area in square inches. A sample file is available at `examples/trays_template.csv`.
+
+### Cable CSV Format
+Cables can be imported with these column headers:
+
+```
+tag,start_tag,end_tag,cable_type,conductors,conductor_size,diameter,weight,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
+```
+
+Start and end coordinates use **feet**. Diameter is in **inches** and weight is in **lbs/ft**. See `examples/cables_template.csv` for a template.
+
+Exported routing results are written to `route_data.xlsx`. Load this file in `cabletrayfill.html` to view tray utilization.
+
+## Clearing Saved Sessions
+The application stores your trays, cables and theme preference in browser storage. Open the settings menu (⚙) and click **Delete Saved Data** to clear this information.

--- a/app.js
+++ b/app.js
@@ -55,6 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
         settingsBtn: document.getElementById('settings-btn'),
         settingsMenu: document.getElementById('settings-menu'),
         helpBtn: document.getElementById('help-btn'),
+        deleteDataBtn: document.getElementById('delete-data-btn'),
         traySearch: document.getElementById('tray-search'),
         cableSearch: document.getElementById('cable-search'),
     };
@@ -1450,6 +1451,19 @@ const openTrayFill = (trayId) => {
         saveSession();
     };
 
+    const deleteSavedData = () => {
+        localStorage.removeItem('ctrSession');
+        state.manualTrays = [];
+        state.cableList = [];
+        if (elements.manualTrayTableContainer) {
+            elements.manualTrayTableContainer.innerHTML = '';
+        }
+        updateCableListDisplay();
+        updateTrayDisplay();
+        updateTableCounts();
+        alert('Saved session data cleared.');
+    };
+
     const showMessage = (type, text) => {
         elements.messages.innerHTML += `<div class="message ${type}">${text}</div>`;
     };
@@ -1979,6 +1993,9 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
         elements.helpBtn.addEventListener('click', () => {
             window.open('README.md', '_blank');
         });
+    }
+    if (elements.deleteDataBtn) {
+        elements.deleteDataBtn.addEventListener('click', deleteSavedData);
     }
     if (elements.traySearch) {
         elements.traySearch.addEventListener('input', () => filterTable(elements.manualTrayTableContainer, elements.traySearch.value));

--- a/examples/cables_template.csv
+++ b/examples/cables_template.csv
@@ -1,0 +1,3 @@
+tag,start_tag,end_tag,cable_type,conductors,conductor_size,diameter,weight,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
+CBL-001,EQ1,EQ2,Power,3,#12 AWG,1.26,1.50,HV,20,0,10,100,80,25
+CBL-002,EQ1,EQ2,Control,4,#18 AWG,0.47,0.40,,10,0,10,100,80,25

--- a/examples/trays_template.csv
+++ b/examples/trays_template.csv
@@ -1,0 +1,3 @@
+tray_id,start_x,start_y,start_z,end_x,end_y,end_z,width,height,current_fill,allowed_cable_group
+H1-A,0,0,10,40,0,10,16,3.94,9.30,HV
+H1-B,40,0,10,80,0,10,16,3.94,6.98,

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
                 <div id="settings-menu" class="settings-menu">
                     <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
                     <button id="help-btn">Site Help</button>
+                    <button id="delete-data-btn">Delete Saved Data</button>
                 </div>
             </header>
 


### PR DESCRIPTION
## Summary
- document CSV import formats and session clearing
- add example tray and cable CSV templates
- add delete saved data option in settings menu

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6872b90e4dc08324820e657a1c3ae55b