### PR TITLE
Fix conduit fill checks and spacing

### DIFF
--- a/conduitfill.html
+++ b/conduitfill.html
@@ -429,11 +429,12 @@
         const center = margin + R*SCALE;
         let svg = `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">`;
         svg += `<circle cx="${center}" cy="${center}" r="${R*SCALE}" fill="none" stroke="black" stroke-width="2"/>`;
-        svg += `<text x="${center}" y="${center - R*SCALE + 12}" font-size="12" text-anchor="middle">ID: ${(2*R).toFixed(2)}\"</text>`;
+        svg += `<text x="${center}" y="${center - R*SCALE + 16}" font-size="12" text-anchor="middle">ID: ${(2*R).toFixed(2)}\"</text>`;
         placed.forEach(p=>{
           svg += `<circle cx="${center + p.x*SCALE}" cy="${center + p.y*SCALE}" r="${p.r*SCALE}" fill="lightblue" stroke="black" stroke-width="1"/>`;
           if(p.tag){
-            const fs = calcFont(p.tag, p.r, SCALE, 8);
+            let fs = calcFont(p.tag, p.r, SCALE, 8);
+            fs = Math.min(fs, p.r * SCALE * 0.9);
             const cx = center + p.x*SCALE;
             const cy = center + p.y*SCALE;
             svg += `<text x="${cx}" y="${cy}" font-size="${fs}" text-anchor="middle" dominant-baseline="middle">${p.tag}</text>`;
@@ -474,9 +475,11 @@
         }
 
         let jamRatioVal = null;
-        for(const c of cables){
-          const jr = R / c.r;
-          if(jr >= 2.8 && jr <= 3.2){ jamRatioVal = jr; break; }
+        if(cables.length === 3){
+          for(const c of cables){
+            const jr = R / c.r;
+            if(jr >= 2.8 && jr <= 3.2){ jamRatioVal = jr; break; }
+          }
         }
         if(jamRatioVal!==null){
           results += `<p class="warning">WARNING: Jam ratio ${jamRatioVal.toFixed(2)} (between 2.8 and 3.2) for one or more cables.</p>`;


### PR DESCRIPTION
## Summary
- adjust jam ratio check to only run when exactly three cables are present
- tweak inner diameter label position so it does not touch the conduit wall in the small preview
- limit cable tag font size in small preview to stay inside cable circle

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687573d7a33083249d673145885c2d00