### PR TITLE
Add tray shape field and visualization

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,27 @@ const CONTAINMENT_RULES = {
     thresholds: { conduit: 3, channel: 6 } // 1-3 cables conduit, 4-6 channel, >6 tray
 };
 
+const SHAPE_CODES = [
+    'STR','90B','45B','30B/60B','TEE','X','VI','VO','45VI','45VO','RED-C','RED-S','Z','OFFSET','SPIRAL'
+];
+
+const SHAPE_COLORS = {
+    '90B': '#1f77b4',
+    '45B': '#ff7f0e',
+    '30B/60B': '#2ca02c',
+    'TEE': '#d62728',
+    'X': '#9467bd',
+    'VI': '#17becf',
+    'VO': '#17becf',
+    '45VI': '#8c564b',
+    '45VO': '#8c564b',
+    'RED-C': '#e377c2',
+    'RED-S': '#e377c2',
+    'Z': '#bcbd22',
+    'OFFSET': '#7f7f7f',
+    'SPIRAL': '#17becf'
+};
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- STATE MANAGEMENT ---
     let state = {
@@ -797,23 +818,23 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- EVENT HANDLERS & UI LOGIC (This part remains the same) ---
     
     const getSampleTrays = () => [
-        {"tray_id": "H1-A", "start_x": 0, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 9.30,"allowed_cable_group": "HV"},
-        {"tray_id": "H1-B", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 6.98,"allowed_cable_group": "HV"},
-        {"tray_id": "H1-C", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 12.71,"allowed_cable_group": "HV"},
-        {"tray_id": "H2-A", "start_x": 0, "start_y": 0, "start_z": 30, "end_x": 40, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 4.96,"allowed_cable_group": "LV"},
-        {"tray_id": "H2-B", "start_x": 40, "start_y": 0, "start_z": 30, "end_x": 80, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 8.99,"allowed_cable_group": "LV"},
-        {"tray_id": "H2-C", "start_x": 80, "start_y": 0, "start_z": 30, "end_x": 120, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 3.26,"allowed_cable_group": "LV"},
-        {"tray_id": "V1", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 2.79,"allowed_cable_group": "HV"},
-        {"tray_id": "V2", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 3.41,"allowed_cable_group": "LV"},
-        {"tray_id": "C1", "start_x": 60, "start_y": 0, "start_z": 10, "end_x": 60, "end_y": 40, "end_z": 10, "width": 9, "height": 2.95, "current_fill": 5.43,"allowed_cable_group": "HV"},
-        {"tray_id": "C2", "start_x": 100, "start_y": 0, "start_z": 30, "end_x": 100, "end_y": 60, "end_z": 30, "width": 9, "height": 2.95, "current_fill": 6.36,"allowed_cable_group": "LV"},
-        {"tray_id": "B1", "start_x": 60, "start_y": 40, "start_z": 10, "end_x": 60, "end_y": 80, "end_z": 10, "width": 6, "height": 1.97, "current_fill": 1.86,"allowed_cable_group": "HV"},
-        {"tray_id": "B2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 100, "end_y": 100, "end_z": 30, "width": 6, "height": 1.97, "current_fill": 1.40,"allowed_cable_group": "LV"},
-        {"tray_id": "TRUNK", "start_x": 0, "start_y": 20, "start_z": 50, "end_x": 120, "end_y": 20, "end_z": 50, "width": 24, "height": 5.91, "current_fill": 27.90,"allowed_cable_group": "HV"},
-        {"tray_id": "EQ1", "start_x": 20, "start_y": 0, "start_z": 10, "end_x": 20, "end_y": 15, "end_z": 5, "width": 4, "height": 1.57, "current_fill": 1.24,"allowed_cable_group": "HV"},
-        {"tray_id": "EQ2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 110, "end_y": 90, "end_z": 20, "width": 4, "height": 1.57, "current_fill": 0.93,"allowed_cable_group": "LV"},
-        {"tray_id": "CONN1", "start_x": 120, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 20, "end_z": 25, "width": 8, "height": 2.95, "current_fill": 3.10,"allowed_cable_group": "HV"},
-        {"tray_id": "CONN2", "start_x": 120, "start_y": 20, "start_z": 25, "end_x": 120, "end_y": 20, "end_z": 50, "width": 8, "height": 2.95, "current_fill": 2.33,"allowed_cable_group": "HV"}
+        {"tray_id": "H1-A", "start_x": 0, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 9.30,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "H1-B", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 6.98,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "H1-C", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 12.71,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "H2-A", "start_x": 0, "start_y": 0, "start_z": 30, "end_x": 40, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 4.96,"allowed_cable_group": "LV", "shape": "STR"},
+        {"tray_id": "H2-B", "start_x": 40, "start_y": 0, "start_z": 30, "end_x": 80, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 8.99,"allowed_cable_group": "LV", "shape": "STR"},
+        {"tray_id": "H2-C", "start_x": 80, "start_y": 0, "start_z": 30, "end_x": 120, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 3.26,"allowed_cable_group": "LV", "shape": "STR"},
+        {"tray_id": "V1", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 2.79,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "V2", "start_x": 80, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 3.41,"allowed_cable_group": "LV", "shape": "STR"},
+        {"tray_id": "C1", "start_x": 60, "start_y": 0, "start_z": 10, "end_x": 60, "end_y": 40, "end_z": 10, "width": 9, "height": 2.95, "current_fill": 5.43,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "C2", "start_x": 100, "start_y": 0, "start_z": 30, "end_x": 100, "end_y": 60, "end_z": 30, "width": 9, "height": 2.95, "current_fill": 6.36,"allowed_cable_group": "LV", "shape": "STR"},
+        {"tray_id": "B1", "start_x": 60, "start_y": 40, "start_z": 10, "end_x": 60, "end_y": 80, "end_z": 10, "width": 6, "height": 1.97, "current_fill": 1.86,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "B2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 100, "end_y": 100, "end_z": 30, "width": 6, "height": 1.97, "current_fill": 1.40,"allowed_cable_group": "LV", "shape": "STR"},
+        {"tray_id": "TRUNK", "start_x": 0, "start_y": 20, "start_z": 50, "end_x": 120, "end_y": 20, "end_z": 50, "width": 24, "height": 5.91, "current_fill": 27.90,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "EQ1", "start_x": 20, "start_y": 0, "start_z": 10, "end_x": 20, "end_y": 15, "end_z": 5, "width": 4, "height": 1.57, "current_fill": 1.24,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "EQ2", "start_x": 100, "start_y": 60, "start_z": 30, "end_x": 110, "end_y": 90, "end_z": 20, "width": 4, "height": 1.57, "current_fill": 0.93,"allowed_cable_group": "LV", "shape": "STR"},
+        {"tray_id": "CONN1", "start_x": 120, "start_y": 0, "start_z": 10, "end_x": 120, "end_y": 20, "end_z": 25, "width": 8, "height": 2.95, "current_fill": 3.10,"allowed_cable_group": "HV", "shape": "STR"},
+        {"tray_id": "CONN2", "start_x": 120, "start_y": 20, "start_z": 25, "end_x": 120, "end_y": 20, "end_z": 50, "width": 8, "height": 2.95, "current_fill": 2.33,"allowed_cable_group": "HV", "shape": "STR"}
     ];
     
     const getSampleCables = () => [
@@ -1076,7 +1097,8 @@ const openConduitFill = (cables) => {
             width: parseFloat(document.getElementById('t-w').value),
             height: parseFloat(document.getElementById('t-h').value),
             current_fill: parseFloat(document.getElementById('t-fill').value),
-            allowed_cable_group: document.getElementById('t-group').value
+            allowed_cable_group: document.getElementById('t-group').value,
+            shape: document.getElementById('t-shape').value || 'STR'
         };
         state.manualTrays.push(newTray);
         state.trayData = state.manualTrays;
@@ -1118,6 +1140,7 @@ const openConduitFill = (cables) => {
             '<th data-key="height">Height</th>' +
             '<th data-key="current_fill">Current Fill</th>' +
             '<th data-key="allowed_cable_group">Allowed Group</th>' +
+            '<th data-key="shape">Shape</th>' +
             '<th></th><th></th></tr></thead><tbody>';
         state.manualTrays.forEach((t, idx) => {
             table += `<tr data-idx="${idx}">
@@ -1136,6 +1159,11 @@ const openConduitFill = (cables) => {
                         <td><input type="number" class="tray-height-input" data-idx="${idx}" value="${t.height}" style="width:60px;"></td>
                         <td><input type="number" class="tray-fill-input" data-idx="${idx}" value="${t.current_fill}" style="width:80px;"></td>
                         <td><input type="text" class="tray-group-input" data-idx="${idx}" value="${t.allowed_cable_group || ''}" style="width:100px;"></td>
+                        <td>
+                            <select class="tray-shape-select" data-idx="${idx}" style="width:100px;">
+                                ${SHAPE_CODES.map(s => `<option value="${s}" ${t.shape === s ? 'selected' : ''}>${s}</option>`).join('')}
+                            </select>
+                        </td>
                         <td><button class="icon-button dup-tray" data-idx="${idx}" title="Duplicate">📋</button></td>
                         <td><button class="icon-button delete-tray icon-delete" data-idx="${idx}" title="Delete">\u274C</button></td>
                      </tr>`;
@@ -1210,6 +1238,14 @@ const openConduitFill = (cables) => {
                 saveSession();
             });
         });
+        elements.manualTrayTableContainer.querySelectorAll('.tray-shape-select').forEach(sel => {
+            sel.addEventListener('change', e => {
+                const i = parseInt(e.target.dataset.idx, 10);
+                state.manualTrays[i].shape = e.target.value;
+                updateTrayData();
+                saveSession();
+            });
+        });
         elements.manualTrayTableContainer.querySelectorAll('.delete-tray').forEach(btn => {
             btn.addEventListener('click', e => {
                 const i = parseInt(e.target.dataset.idx, 10);
@@ -1237,7 +1273,7 @@ const openConduitFill = (cables) => {
     };
 
     const exportManualTraysCSV = () => {
-        const headers = ['tray_id','start_x','start_y','start_z','end_x','end_y','end_z','width','height','current_fill','allowed_cable_group'];
+        const headers = ['tray_id','start_x','start_y','start_z','end_x','end_y','end_z','width','height','current_fill','allowed_cable_group','shape'];
         const rows = state.manualTrays;
         let csv = headers.join(',') + '\n';
         if (rows.length > 0) {
@@ -1283,7 +1319,8 @@ const openConduitFill = (cables) => {
                     width: parseFloat(t.width) || 0,
                     height: parseFloat(t.height) || 0,
                     current_fill: parseFloat(t.current_fill) || 0,
-                    allowed_cable_group: t.allowed_cable_group || ''
+                    allowed_cable_group: t.allowed_cable_group || '',
+                    shape: t.shape || 'STR'
                 });
             }
             state.manualTrays = newTrays;
@@ -1987,21 +2024,21 @@ const openConduitFill = (cables) => {
     const visualize = (trays, routes, title) => {
         const traces = [];
 
-        const trayMesh = (tray) => {
-            const w = tray.width / 12; // inches to ft
+        const meshForSegment = (s, e, tray) => {
+            const w = tray.width / 12;
             const h = tray.height / 12;
-            const sx = tray.start_x, sy = tray.start_y, sz = tray.start_z;
-            const ex = tray.end_x, ey = tray.end_y, ez = tray.end_z;
+            const sx = s[0], sy = s[1], sz = s[2];
+            const ex = e[0], ey = e[1], ez = e[2];
             let verts;
-            if (sx !== ex) { // along X
+            if (sx !== ex) {
                 const y1 = sy - w / 2, y2 = sy + w / 2;
                 const z1 = sz - h / 2, z2 = sz + h / 2;
                 verts = [[sx,y1,z1],[sx,y2,z1],[sx,y2,z2],[sx,y1,z2],[ex,y1,z1],[ex,y2,z1],[ex,y2,z2],[ex,y1,z2]];
-            } else if (sy !== ey) { // along Y
+            } else if (sy !== ey) {
                 const x1 = sx - w / 2, x2 = sx + w / 2;
                 const z1 = sz - h / 2, z2 = sz + h / 2;
                 verts = [[x1,sy,z1],[x2,sy,z1],[x2,sy,z2],[x1,sy,z2],[x1,ey,z1],[x2,ey,z1],[x2,ey,z2],[x1,ey,z2]];
-            } else { // along Z
+            } else {
                 const x1 = sx - w / 2, x2 = sx + w / 2;
                 const y1 = sy - h / 2, y2 = sy + h / 2;
                 verts = [[x1,y1,sz],[x2,y1,sz],[x2,y2,sz],[x1,y2,sz],[x1,y1,ez],[x2,y1,ez],[x2,y2,ez],[x1,y2,ez]];
@@ -2012,11 +2049,25 @@ const openConduitFill = (cables) => {
             const i = [0,0,4,4,3,3,0,0,0,0,1,1];
             const j = [1,2,5,6,2,6,1,5,3,7,2,6];
             const k = [2,3,6,7,6,7,5,4,7,4,6,5];
-            return {type:'mesh3d', x, y, z, i, j, k, opacity:0.3, color:'lightgrey', name: tray.tray_id, hoverinfo:'name'};
+            const color = SHAPE_COLORS[tray.shape] || 'lightgrey';
+            const text = `${tray.tray_id} (${tray.shape || 'STR'})`;
+            return {type:'mesh3d', x, y, z, i, j, k, opacity:0.3, color, name: tray.tray_id, hoverinfo:'text', text:[text]};
+        };
+
+        const trayMesh = (tray) => {
+            const start = [tray.start_x, tray.start_y, tray.start_z];
+            const end = [tray.end_x, tray.end_y, tray.end_z];
+            const segments = [];
+            let cur = start.slice();
+            if (cur[0] !== end[0]) { const n=[end[0],cur[1],cur[2]]; segments.push([cur,n]); cur=n; }
+            if (cur[1] !== end[1]) { const n=[cur[0],end[1],cur[2]]; segments.push([cur,n]); cur=n; }
+            if (cur[2] !== end[2]) { const n=[cur[0],cur[1],end[2]]; segments.push([cur,n]); cur=n; }
+            if (segments.length === 0) segments.push([start,end]);
+            return segments.map(seg => meshForSegment(seg[0], seg[1], tray));
         };
 
         trays.forEach(tray => {
-            traces.push(trayMesh(tray));
+            trayMesh(tray).forEach(t => traces.push(t));
             const midX = (tray.start_x + tray.end_x) / 2;
             const midY = (tray.start_y + tray.end_y) / 2;
             const midZ = (tray.start_z + tray.end_z) / 2 + (tray.height / 12) / 2 + 0.5;

--- a/index.html
+++ b/index.html
@@ -111,6 +111,23 @@
                              <input type="number" id="t-w" placeholder="Width (in)">
                              <input type="number" id="t-h" placeholder="Height (in)">
                              <input type="number" id="t-fill" placeholder="Current Fill (in²)">
+                             <select id="t-shape">
+                                 <option value="STR">Straight</option>
+                                 <option value="90B">90° Bend</option>
+                                 <option value="45B">45° Bend</option>
+                                 <option value="30B/60B">30°/60° Bend</option>
+                                 <option value="TEE">Tee</option>
+                                 <option value="X">Cross</option>
+                                 <option value="VI">Vertical Inside</option>
+                                 <option value="VO">Vertical Outside</option>
+                                 <option value="45VI">45° Vertical Inside</option>
+                                 <option value="45VO">45° Vertical Outside</option>
+                                 <option value="RED-C">Center Reducer</option>
+                                 <option value="RED-S">Side Reducer</option>
+                                 <option value="Z">Z-Bend</option>
+                                 <option value="OFFSET">Offset</option>
+                                 <option value="SPIRAL">Spiral</option>
+                             </select>
                              <input type="text" id="t-group" placeholder="Allowed Cable Group">
                              <button id="add-tray-btn">Add Tray</button>
                              <span class="help-icon" tabindex="0" aria-describedby="add-tray-help">?</span>


### PR DESCRIPTION
## Summary
- add component shape dropdown for tray input
- persist shape in tray list and CSV import/export
- color-code tray shapes in 3D visualization

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6875bff390e883248df597dda9ffda70