### PR TITLE
Add export tray fills feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -191,6 +192,7 @@
                 </details>
                 <button id="export-csv-btn">Download Route Data (XLSX)</button>
                 <button id="open-fill-btn">Open Tray Fill Tool</button>
+                <button id="export-tray-fills-btn">Export Tray Fills</button>
             </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- add jsPDF library to page
- add *Export Tray Fills* button in results section
- implement renderTrayToPNG and exportTrayFills functions
- trigger tray fill export from new button

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687694aceb3883248266b7b3fef37cbc