### PR TITLE
Sync utilization coloring in PDF

### DIFF
--- a/app.js
+++ b/app.js
@@ -1871,8 +1871,9 @@ const openConduitFill = (cables) => {
 
             const trayText = String(row.tray_id);
             const pageNum = pageMap && pageMap[row.tray_id] ? pageMap[row.tray_id] : '';
+            const utilColorVal = parseFloat(row.utilization || row.utilization_pct || row.full_pct);
+            const colors = colorForUtil(utilColorVal);
             const utilPct = parseFloat(row.full_pct);
-            const colors = colorForUtil(utilPct);
 
             doc.setFillColor(...colors.fill);
             doc.setDrawColor(0);


### PR DESCRIPTION
## Summary
- match PDF color logic to web table by basing row colors on the same utilization value

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6877b9092f2c83249a62023b83e3cb2e