### PR TITLE
Add cable rerouting for overfilled trays

### DIFF
--- a/routeWorker.js
+++ b/routeWorker.js
@@ -68,6 +68,16 @@ class CableRoutingSystem {
             }
          });
     }
+
+    removeTrayFill(trayIds, cableArea) {
+         if (!Array.isArray(trayIds)) return;
+         trayIds.forEach(trayId => {
+            if (this.trays.has(trayId)) {
+                const t = this.trays.get(trayId);
+                t.current_fill = Math.max(0, t.current_fill - cableArea);
+            }
+         });
+    }
     
     getTrayUtilization() {
         const utilization = {};


### PR DESCRIPTION
## Summary
- add `removeTrayFill` helper on `CableRoutingSystem`
- post-process results with `rerouteOverfilledTrays` to move cables from trays that exceed capacity
- reroute cables then recompute utilization and replot

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6877e8512a88832494b6a5395e7abf2e