### PR TITLE
Add manual tray rebalance step

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
                 <button id="export-csv-btn">Download Route Data (XLSX)</button>
                 <button id="open-fill-btn">Open Tray Fill Tool</button>
                 <button id="export-tray-fills-btn">Export Tray Fills</button>
+                <button id="rebalance-btn">Rebalance Tray Fill</button>
             </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- add a button in the results section to rebalance overfilled trays
- track routing system and routes in state for later use
- implement `rebalanceTrayFill` and hook it to the button

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687802b47dc883248f4154412f2a66f6