### PR TITLE
Remove automatic tray rebalancing

### DIFF
--- a/app.js
+++ b/app.js
@@ -2376,21 +2376,7 @@ const openConduitFill = (cables) => {
         state.updatedUtilData = utilData;
         renderUpdatedUtilizationTable();
 
-        finalUtilization = await rerouteOverfilledTrays(routingSystem, allRoutesForPlotting);
         state.routeObjs = allRoutesForPlotting;
-        fillLimit = parseFloat(elements.fillLimitIn.value) / 100;
-        utilData = Object.entries(finalUtilization).map(([id, data]) => {
-            const fullPct = (data.current_fill * fillLimit / data.max_fill) * 100;
-            return {
-                tray_id: id,
-                full_pct: fullPct,
-                utilization: data.utilization_percentage.toFixed(1),
-                available: data.available_capacity.toFixed(2),
-                fill: `<button class="fill-btn" data-tray="${id}">Open</button>`
-            };
-        });
-        state.updatedUtilData = utilData;
-        renderUpdatedUtilizationTable();
         visualize(trayDataForRun, allRoutesForPlotting, "Batch Route Visualization");
 
         elements.progressLabel.textContent = 'Complete';


### PR DESCRIPTION
## Summary
- don't rebalance trays during the main routing pass
- keep rebalancing as a separate user action

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6878088417708324a2007321c903a4a0