### PR TITLE
Fix 3D plot missing after initial route

### DIFF
--- a/app.js
+++ b/app.js
@@ -2508,7 +2508,10 @@ const openConduitFill = (cables) => {
         autosize: true,
         margin: { l: 0, r: 0, t: 0, b: 0 }
     };
-    Plotly.newPlot(elements.plot3d, traces, layout, {responsive: true});
+    elements.plot3d.innerHTML = '';
+    Plotly.newPlot(elements.plot3d, traces, layout, {responsive: true}).then(() => {
+        Plotly.Plots.resize(elements.plot3d);
+    });
     window.current3DPlot = { traces: traces, layout: layout };
     window.base3DPlot = {
         traces: JSON.parse(JSON.stringify(traces)),


### PR DESCRIPTION
## Summary
- clear and resize the plot before rendering

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6878378cf22c83249a085ec1b4efe8fc