### PR TITLE
Add tray fill rebalance function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # CableTrayRoute
 Designed to find the optimal cable route for your cable.
 
+## New Feature: Rebalance Tray Fill
+
+After running the standard routing process, click **Rebalance Tray Fill** to
+automatically reroute cables in trays that exceed the allowed fill percentage.
+The script tries alternative paths for those cables until each tray is back
+under its limit.
+
 ## New Feature: Cable Tag Input
 
 You can now specify a **Cable Tag** when routing cables. Use the text field in the

--- a/index.html
+++ b/index.html
@@ -191,6 +191,7 @@
                     <div id="updated-utilization-container"></div>
                 </details>
                 <button id="export-csv-btn">Download Route Data (XLSX)</button>
+                <button id="rebalance-btn">Rebalance Tray Fill</button>
                 <button id="open-fill-btn">Open Tray Fill Tool</button>
                 <button id="export-tray-fills-btn">Export Tray Fills</button>
             </section>


### PR DESCRIPTION
## Summary
- add new **Rebalance Tray Fill** button
- implement `rebalanceTrayFill` logic to reroute cables in overfilled trays
- keep updated tray data after routing for rebalancing
- document new feature

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687908005d2c8324be7a3116d50f51b9