### PR TITLE
Improve ductbank layout and controls

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -20,7 +20,8 @@ th{background:#f0f0f0;}
 body.dark-mode th{background:#343a40;color:#f8f9fa;}
 body.dark-mode td{background:#2c3034;}
 button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
-#grid{border:1px solid #aaa;margin-top:12px;}
+#grid{border:1px solid #aaa;margin-top:12px;display:block;margin:auto;}
+.db-button-panel{margin-top:8px;display:flex;flex-wrap:wrap;gap:4px;}
 .removeBtn{background:#e74c3c;color:#fff;border:none;}
 .duplicateBtn{background:#95a5a6;color:#fff;border:none;}
 #helpOverlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:none;justify-content:center;align-items:center;z-index:1000;}
@@ -38,10 +39,13 @@ body.dark-mode #helpPopup{background:#2c3034;color:#f8f9fa;}
   <button id="helpBtn">Help</button>
  </div>
 </header>
-<label style="margin-left:8px;">Ductbank Tag<input type="text" id="ductbankTag" style="margin-left:4px;"></label>
-
 <fieldset>
- <legend><strong>Ductbank Conduits</strong></legend>
+ <legend><strong>Ductbank Information</strong></legend>
+ <label>Ductbank Tag<input type="text" id="ductbankTag" style="margin-left:4px;"></label>
+</fieldset>
+
+<details open>
+ <summary><strong>Ductbank Conduits</strong></summary>
  <input type="file" id="importConduits" accept=".csv"/>
  <button type="button" id="addConduit">Add Conduit</button>
  <button type="button" id="sampleConduits">Load Sample Data</button>
@@ -61,10 +65,10 @@ body.dark-mode #helpPopup{background:#2c3034;color:#f8f9fa;}
   </thead>
   <tbody></tbody>
  </table>
-</fieldset>
+</details>
 
-<fieldset>
- <legend><strong>Cables</strong></legend>
+<details open>
+ <summary><strong>Cables</strong></summary>
  <input type="file" id="importCables" accept=".csv"/>
  <button type="button" id="addCable">Add Cable</button>
  <button type="button" id="sampleCables">Load Sample Data</button>
@@ -85,7 +89,7 @@ body.dark-mode #helpPopup{background:#2c3034;color:#f8f9fa;}
   </thead>
   <tbody></tbody>
  </table>
-</fieldset>
+</details>
 
 <div style="margin-top:8px;">
   <label>Horiz Spacing (in)<input type="number" id="hSpacing" value="3" style="width:60px;"></label>
@@ -99,11 +103,13 @@ body.dark-mode #helpPopup{background:#2c3034;color:#f8f9fa;}
 
 <svg id="grid" width="500" height="500"></svg>
 
-<button id="calc">Calculate Fill</button>
-<button id="exportBtn">Download Ductbank Data</button>
-<button id="exportConduitsBtn">Export Ductbank Conduits</button>
-<button id="exportCablesBtn">Export Ductbank Cables</button>
-<button id="exportImgBtn">Export Image</button>
+<div class="db-button-panel">
+ <button id="calc">Calculate Fill</button>
+ <button id="exportBtn">Download Ductbank Data</button>
+ <button id="exportConduitsBtn">Export Ductbank Conduits</button>
+ <button id="exportCablesBtn">Export Ductbank Cables</button>
+ <button id="exportImgBtn">Export Image</button>
+</div>
 
 <div id="helpOverlay">
  <div id="helpPopup">
@@ -495,14 +501,14 @@ svg.appendChild(widthText);
   svg.appendChild(circle);
   const cidText=document.createElementNS('http://www.w3.org/2000/svg','text');
   cidText.setAttribute('x',cx);
-  cidText.setAttribute('y',cy-R-10);
+  cidText.setAttribute('y',cy-R-22);
   cidText.setAttribute('font-size','10');
   cidText.setAttribute('text-anchor','middle');
   cidText.textContent=c.conduit_id;
   svg.appendChild(cidText);
   const typeText=document.createElementNS('http://www.w3.org/2000/svg','text');
   typeText.setAttribute('x',cx);
-  typeText.setAttribute('y',cy-R-22);
+  typeText.setAttribute('y',cy-R-10);
   typeText.setAttribute('font-size','8');
   typeText.setAttribute('text-anchor','middle');
   typeText.textContent=`${c.conduit_type} ${c.trade_size}\"`;


### PR DESCRIPTION
## Summary
- place Ductbank Tag field inside a new *Ductbank Information* container
- make conduit and cable sections collapsible via `<details>`
- ensure SVG displays as a block and group action buttons below it
- position conduit info text below the conduit id

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687fcc98ca7c83248b0e2d7822fbddd4