### PR TITLE
Add continuous load input for ductbank cables

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -86,6 +86,7 @@ body.dark-mode #helpPopup{background:#2c3034;color:#f8f9fa;}
     <th>Cond.</th>
     <th>Size</th>
     <th>Weight</th>
+    <th>Est. Load (A)</th>
     <th>Conduit</th>
     <th>Conductor Material</th>
     <th>Insulation Type</th>
@@ -248,6 +249,7 @@ SAMPLE_CABLES.forEach(c=>{
  c.insulation_type='THHN';
  c.voltage_rating='600V';
  c.shielding_jacket='';
+ c.est_load=250;
 });
 
 const CONDUIT_SPECS={
@@ -314,11 +316,11 @@ function addConduitRow(data={}){
 
 function addCableRow(data={}){
  const tr=document.createElement('tr');
- const cols=['tag','cable_type','diameter','conductors','conductor_size','weight','conduit_id','conductor_material','insulation_type','voltage_rating','shielding_jacket'];
+ const cols=['tag','cable_type','diameter','conductors','conductor_size','weight','est_load','conduit_id','conductor_material','insulation_type','voltage_rating','shielding_jacket'];
  cols.forEach(c=>{
   const td=document.createElement('td');
   const inp=document.createElement('input');
-  if(c==='diameter'||c==='weight') inp.type='number';
+  if(c==='diameter'||c==='weight'||c==='est_load') inp.type='number';
   else if(c==='conductors') inp.type='number';
   else inp.type='text';
   if(c==='conductor_size') inp.setAttribute('list','sizeList');
@@ -339,21 +341,22 @@ function rowToConduit(tr){
 }
 
 function rowToCable(tr){
- const vals=Array.from(tr.children).slice(0,11).map(td=>td.querySelector('input').value);
- const [tag,cable_type,diameter,conductors,conductor_size,weight,conduit_id,conductor_material,insulation_type,voltage_rating,shielding_jacket]=vals;
- return {
-  tag,
-  cable_type,
-  diameter:parseFloat(diameter),
-  conductors:parseInt(conductors||0),
-  conductor_size,
-  weight:parseFloat(weight)||0,
-  conduit_id,
-  conductor_material,
-  insulation_type,
-  voltage_rating,
-  shielding_jacket
- };
+ const vals=Array.from(tr.children).slice(0,12).map(td=>td.querySelector('input').value);
+ const [tag,cable_type,diameter,conductors,conductor_size,weight,est_load,conduit_id,conductor_material,insulation_type,voltage_rating,shielding_jacket]=vals;
+  return {
+   tag,
+   cable_type,
+   diameter:parseFloat(diameter),
+   conductors:parseInt(conductors||0),
+   conductor_size,
+   weight:parseFloat(weight)||0,
+   est_load:parseFloat(est_load)||0,
+   conduit_id,
+   conductor_material,
+   insulation_type,
+   voltage_rating,
+   shielding_jacket
+  };
 }
 
 function getAllConduits(){
@@ -731,7 +734,8 @@ const ctx=canvas.getContext('2d');
    const volt=parseFloat(c.voltage_rating)||600;
    if(volt>2000)Rth*=1.1;else if(volt<600)Rth*=0.95;
    if(c.shielding_jacket)Rth*=1.05;
-   const heat=5*Rth*countMap[c.conduit_id];
+   const load=parseFloat(c.est_load)||0;
+   const heat=load*0.05*Rth;
    return {cx,cy,heat,conduit:c.conduit_id,cable:c};
   }).filter(Boolean);
   let minCy=Infinity,maxCy=-Infinity;
@@ -883,7 +887,7 @@ function exportConduits(){
 
 function exportCables(){
  const rows=getAllCables();
- const headers=['tag','cable_type','diameter','conductors','conductor_size','weight','conduit_id','conductor_material','insulation_type','voltage_rating','shielding_jacket'];
+ const headers=['tag','cable_type','diameter','conductors','conductor_size','weight','est_load','conduit_id','conductor_material','insulation_type','voltage_rating','shielding_jacket'];
  exportCSV('ductbank_cables.csv',headers,rows);
 }
 


### PR DESCRIPTION
## Summary
- allow setting estimated continuous load for each ductbank cable
- use the new load value when estimating heat generation
- include the new field when exporting ductbank cable data

## Testing
- `node test.js > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68810dcc47388324af4d2f73ac071352