### PR TITLE
Fix ampacity limits for cable insulation

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -581,7 +581,9 @@ function sizeToArea(size){
 function estimateAmpacity(cable,params,count=1,total=0){
  const areaCM=sizeToArea(cable.conductor_size);
  if(!areaCM)return {ampacity:0};
- const Rdc=dcResistance(cable.conductor_size,cable.conductor_material,90);
+ const insType=(cable.insulation_type||'').toUpperCase();
+ const rating=INSULATION_TEMP_LIMIT[insType]||90;
+ const Rdc=dcResistance(cable.conductor_size,cable.conductor_material,rating);
  const spacing=(params.hSpacing+params.vSpacing)/2||3;
  const spacingAdj=3/spacing; // tighter spacing -> higher thermal resistance
  let Rth=(params.soilResistivity||90)/90*0.5;
@@ -593,8 +595,7 @@ function estimateAmpacity(cable,params,count=1,total=0){
  if(params.concreteEncasement)Rth*=0.8;
  Rth*=(1+(params.ductbankDepth||0)/100);
 
- const ins=(cable.insulation_type||'').toUpperCase();
- if(ins.includes('XLPE'))Rth*=0.95;else if(ins.includes('PVC'))Rth*=1.05;
+ if(insType.includes('XLPE'))Rth*=0.95;else if(insType.includes('PVC'))Rth*=1.05;
  const volt=parseFloat(cable.voltage_rating)||600;
  if(volt>2000)Rth*=1.1;else if(volt<600)Rth*=0.95;
  if(cable.shielding_jacket)Rth*=1.05;
@@ -602,7 +603,7 @@ function estimateAmpacity(cable,params,count=1,total=0){
  Rth*=count;
  const amb=Math.max(params.earthTemp||20,
                    isNaN(params.airTemp)?-Infinity:params.airTemp);
- const dT=90-amb;
+ const dT=rating-amb;
  const ampacity=Math.sqrt(dT/(Rdc*Rth));
  return {ampacity};
 }
@@ -630,9 +631,10 @@ function updateAmpacityReport(){
   const neher=isFinite(res.ampacity)?res.ampacity.toFixed(0):'N/A';
   const finite=window.finiteAmpacity?window.finiteAmpacity[c.tag]||'N/A':'N/A';
   const overObj=window.conduitOverLimit&&window.conduitOverLimit[c.conduit_id];
-  const over=overObj&&overObj.over;
+  const rating=INSULATION_TEMP_LIMIT[(c.insulation_type||'').toUpperCase()]||90;
+  const over=overObj?overObj.temp>rating:false;
   return `<tr><td>${c.tag}</td><td>${neher}</td><td>${finite}</td><td>${over?'Yes':''}</td></tr>`;
- }).join('');
+}).join('');
  document.getElementById('ampacityReport').innerHTML=
    `<h3>Ampacity Estimates</h3><table><thead><tr><th>Cable</th><th>Ampacity (A) - Neher McGrath</th><th>Ampacity (A) - Finite Element</th><th>Over Limit</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
@@ -1101,16 +1103,18 @@ const ctx=canvas.getContext('2d');
      return;
    }
    const T = conduitTemps[cd.conduit_id]??ambient;
-   const Rdc = dcResistance(c.conductor_size,c.conductor_material,T);
+  const insType=(c.insulation_type||'').toUpperCase();
+  const rating=INSULATION_TEMP_LIMIT[insType]||90;
+  const Rdc = dcResistance(c.conductor_size,c.conductor_material,T);
    const current=parseFloat(c.est_load)||0;
    if(current<=0){
      window.finiteAmpacity[c.tag]='N/A';
      return;
    }
    const Rth = (T - ambient) / (current*current*Rdc);
-   const amp = Math.sqrt((90 - ambient) / (Rdc * Rth));
-   window.finiteAmpacity[c.tag] = isFinite(amp) ? amp.toFixed(0) : 'N/A';
- });
+  const amp = Math.sqrt((rating - ambient) / (Rdc * Rth));
+  window.finiteAmpacity[c.tag] = isFinite(amp) ? amp.toFixed(0) : 'N/A';
+});
  updateAmpacityReport();
 }
 


### PR DESCRIPTION
## Summary
- reference insulation rating for each cable
- use rating instead of 90°C delta in Neher‑McGrath ampacity estimates
- apply cable rating in finite‑element ampacity calc
- determine over‑limit per cable based on its rating

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6882edea63d08324a66f7a770f2072ac