### PR TITLE
Finite-difference heat solver

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -247,6 +247,7 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
 
 <script>
 let heatVisible=true;
+const GRID_SIZE = 20; // number of grid nodes across the ductbank for thermal solver
 const SAMPLE_CONDUITS=[
  {conduit_id:"C1",conduit_type:"PVC Sch 40",trade_size:"4",x:0,y:0},
  {conduit_id:"C2",conduit_type:"PVC Sch 40",trade_size:"4",x:2,y:0},
@@ -1138,7 +1139,7 @@ function solveDuctbankTemperatures(conduits,cables,params,progress){
   const width=parseFloat(svg.getAttribute('width'))||svg.clientWidth;
   const height=parseFloat(svg.getAttribute('height'))||svg.clientHeight;
   const scale=40,margin=20;
-  const step=4; // pixel step for solver grid
+  const step=Math.ceil(Math.max(width,height)/GRID_SIZE); // pixel step for solver grid
   const dx=(0.0254/scale)*step;
   const nx=Math.ceil(width/step);
   const ny=Math.ceil(height/step);
@@ -1298,7 +1299,7 @@ const ctx=canvas.getContext('2d');
  const grid=result.grid;
  const conduitTemps=result.conduitTemps;
 
- const step=4; // same as solver
+ const step=Math.ceil(Math.max(width,height)/GRID_SIZE); // match solver grid
  const img=ctx.createImageData(width,height);
  let maxT=-Infinity,maxPx=0,maxPy=0;
  for(let j=0;j<grid.length;j++){

--- a/thermalWorker.js
+++ b/thermalWorker.js
@@ -1,4 +1,5 @@
 // Worker for finite-difference ductbank thermal solver
+const GRID_SIZE = 20; // number of grid nodes across the ductbank
 const CONDUIT_SPECS={
  "EMT":{"1/2":0.304,"3/4":0.533,"1":0.864,"1-1/4":1.496,"1-1/2":2.036,"2":3.356,"2-1/2":5.858,"3":8.846,"3-1/2":11.545,"4":14.753},
  "RMC":{"1/2":0.314,"3/4":0.549,"1":0.887,"1-1/4":1.526,"1-1/2":2.071,"2":3.408,"2-1/2":4.866,"3":7.499,"3-1/2":10.01,"4":12.882,"5":20.212,"6":29.158},
@@ -36,7 +37,7 @@ function dcResistance(size,material,temp=20){
 
 function solve(conduits,cables,params,width,height,progressCb){
   const scale=40,margin=20;
-  const step=4;
+  const step=Math.ceil(Math.max(width,height)/GRID_SIZE);
   const dx=(0.0254/scale)*step;
   const nx=Math.ceil(width/step);
   const ny=Math.ceil(height/step);


### PR DESCRIPTION
## Summary
- add GRID_SIZE constant for solver resolution
- compute grid spacing from GRID_SIZE instead of fixed 4px
- mirror updated spacing when rendering the heat map
- run solver with same logic inside `thermalWorker.js`

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_688770fa2474832496410f35839819c2