### PR TITLE
Move soil resistivity values to config

### DIFF
--- a/data/soil_resistivity.json
+++ b/data/soil_resistivity.json
@@ -1,0 +1,7 @@
+{
+  "Very Wet Clay": 40,
+  "Moist Clay/Sand": 60,
+  "Average Soil": 90,
+  "Dry Sand": 120,
+  "Dry Sand & Gravel": 150
+}

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -142,13 +142,7 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
   <thead>
    <tr><th>Soil Type</th><th>Thermal Resistivity (°C·cm/W)</th></tr>
   </thead>
-  <tbody>
-   <tr><td>Very Wet Clay</td><td>40</td></tr>
-   <tr><td>Moist Clay / Sand</td><td>60</td></tr>
-   <tr><td>Average Soil</td><td>90</td></tr>
-   <tr><td>Dry Sand</td><td>120</td></tr>
-   <tr><td>Dry Sand &amp; Gravel</td><td>150</td></tr>
-  </tbody>
+  <tbody id="soilTableBody"></tbody>
  </table>
  <table class="db-table" style="margin-top:8px;width:auto;">
   <thead>
@@ -237,7 +231,7 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
            (R<sub>dc</sub> &times; (1 + Y<sub>c</sub>) &times; R<sub>ca</sub>)</pre>
   <p>Here T<sub>c</sub> is the allowable conductor temperature from the rating selection, T<sub>a</sub> is the higher of earth or air temperature, and &Delta;T<sub>d</sub> is the dielectric-loss rise (0 when voltage is below 2&nbsp;kV). Y<sub>c</sub> corrects for AC skin and proximity effects. R<sub>ca</sub> is the sum R<sub>cond</sub> + R<sub>ins</sub> + R<sub>duct</sub> + R<sub>soil</sub>.</p>
   <p>&#x3c1; is the soil resistivity, N is the cables in the conduit, D is ductbank depth (in), <em>moistureAdj</em> reduces resistance for wetter soil, <em>adjCableFactor</em> accounts for heat from neighboring conduits, and <em>spacingAdj</em>=3/spacing. <em>insulationAdj</em>, <em>voltageAdj</em> and <em>jacketAdj</em> adjust for cable construction. The DC resistance R<sub>dc</sub> depends on conductor material and size.</p>
-  <p>Lower soil resistivity allows heat to dissipate more easily and therefore increases cable ampacity. See <a href="docs/soil_resistivity.md" target="_blank">soil resistivity reference</a> for typical IEEE&nbsp;835 values.</p>
+  <p>Soil resistivity (&#x3c1;) influences the R<sub>soil</sub> term of the equation. Lower values dissipate heat more easily and raise cable ampacity. Typical IEEE&nbsp;835 values (40–150&nbsp;&deg;C·cm/W) populate the drop-down. See <a href="docs/soil_resistivity.md" target="_blank">soil resistivity reference</a> for details.</p>
   <h3>Thermal Analysis</h3>
   <p>The <em>Thermal Analysis</em> button overlays a heat map on the drawing. Each conduit center is marked with a yellow dot labeled with the estimated earth temperature in Fahrenheit and the hottest point is highlighted in red.</p>
   <p>Inputs are validated before running the analysis. Ductbank depth is limited to 0–120&nbsp;in, spacing between 1–24&nbsp;in and cable estimated load up to 2000&nbsp;A. Values outside these ranges will be clamped.</p>
@@ -1065,9 +1059,12 @@ function validateThermalInputs(){
   const warnings=[];
   const soilEl=document.getElementById('soilResistivity');
   let soil=parseFloat(soilEl.value);
-  if(isFinite(soil) && Array.isArray(window.SOIL_RESISTIVITY_OPTIONS)){
-    const min=Math.min(...SOIL_RESISTIVITY_OPTIONS);
-    const max=Math.max(...SOIL_RESISTIVITY_OPTIONS);
+  if(isFinite(soil)){
+    let min=40, max=150;
+    if(Array.isArray(window.SOIL_RESISTIVITY_OPTIONS) && window.SOIL_RESISTIVITY_OPTIONS.length){
+      min=Math.min(...SOIL_RESISTIVITY_OPTIONS);
+      max=Math.max(...SOIL_RESISTIVITY_OPTIONS);
+    }
     if(soil<min||soil>max){
       warnings.push(`Soil resistivity ${soil} is outside ${min}-${max} \xB0C\xB7cm/W typical range.`);
     }
@@ -1666,12 +1663,28 @@ function updateHeatSourceVisibility(){
 }
 heatSourcesCheck.addEventListener('change',updateHeatSourceVisibility);
 addHeatBtn.addEventListener('click',()=>addHeatSourceRow());
+
+function populateSoilReferences(data){
+  const list=document.getElementById('soilResList');
+  const table=document.getElementById('soilTableBody');
+  if(list){
+    list.innerHTML=Object.values(data).map(v=>`<option value="${v}"></option>`).join('');
+  }
+  if(table){
+    table.innerHTML='';
+    Object.entries(data).forEach(([type,val])=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${type}</td><td>${val}</td>`;
+      table.appendChild(tr);
+    });
+  }
+}
 updateHeatSourceVisibility();
 loadDuctbankSession();
-if(window.SOIL_RESISTIVITY_OPTIONS){
-  const list=document.getElementById('soilResList');
-  list.innerHTML=SOIL_RESISTIVITY_OPTIONS.map(v=>`<option value="${v}"></option>`).join('');
-}
+loadSoilResistivityData().then(data=>{
+  populateSoilReferences(data);
+  validateThermalInputs();
+});
 document.getElementById('soilResistivity').addEventListener('change',validateThermalInputs);
 </script>
   <p class="legalDisclaimer">

--- a/soilResistivityConfig.js
+++ b/soilResistivityConfig.js
@@ -1,2 +1,19 @@
-// Typical soil thermal resistivity values from IEEE Std 835 (\u00b0C\u00b7cm/W)
-const SOIL_RESISTIVITY_OPTIONS = [60, 90, 120, 150];
+// Load typical soil thermal resistivity values (\u00b0C\u00b7cm/W) from JSON
+// This exposes two globals:
+//   SOIL_RESISTIVITY_DATA    - map of soil description -> resistivity
+//   SOIL_RESISTIVITY_OPTIONS - array of resistivity values
+function loadSoilResistivityData(){
+  return fetch('data/soil_resistivity.json')
+    .then(r => r.json())
+    .then(data => {
+      window.SOIL_RESISTIVITY_DATA = data;
+      window.SOIL_RESISTIVITY_OPTIONS = Object.values(data);
+      return data;
+    })
+    .catch(err => {
+      console.error('Failed to load soil resistivity data', err);
+      window.SOIL_RESISTIVITY_DATA = {};
+      window.SOIL_RESISTIVITY_OPTIONS = [];
+      return {};
+    });
+}


### PR DESCRIPTION
## Summary
- move soil resistivity values to `data/soil_resistivity.json`
- fetch JSON config on ductbank page load
- populate soil table and datalist from config
- warn if soil resistivity is outside 40-150 range
- clarify help text about soil resistivity

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68877148621083248af5ef3bcea5aab6