### PR TITLE
Add ampacity module with calibration tests

### DIFF
--- a/ampacity.js
+++ b/ampacity.js
@@ -1,0 +1,141 @@
+const conductorProps = require('./data/conductor_properties.json');
+
+const AWG_AREA = {"18":1624,"16":2583,"14":4107,"12":6530,"10":10380,"8":16510,"6":26240,"4":41740,"3":52620,"2":66360,"1":83690,"1/0":105600,"2/0":133100,"3/0":167800,"4/0":211600};
+const BASE_RESISTIVITY = { cu: 0.017241, al: 0.028264 };
+const TEMP_COEFF = { cu: 0.00393, al: 0.00403 };
+const RESISTANCE_TABLE = { cu: {}, al: {} };
+for (const sz in AWG_AREA) {
+  const areaMM2 = AWG_AREA[sz] * 0.0005067;
+  RESISTANCE_TABLE.cu[sz] = BASE_RESISTIVITY.cu / areaMM2;
+  RESISTANCE_TABLE.al[sz] = BASE_RESISTIVITY.al / areaMM2;
+}
+
+function sizeToArea(size) {
+  if (!size) return 0;
+  const s = size.toString().trim();
+  if (conductorProps[s]) return conductorProps[s].area_cm;
+  if (/kcmil/i.test(s)) return parseFloat(s) * 1000;
+  const m = s.match(/#?(\d+(?:\/0)?)/);
+  if (!m) return 0;
+  return AWG_AREA[m[1]] || 0;
+}
+
+function dcResistance(size, material, temp = 20) {
+  const key = size ? size.toString().trim() : '';
+  const mat = material && material.toLowerCase().includes('al') ? 'al' : 'cu';
+  let base;
+  const props = conductorProps[key];
+  if (props) {
+    base = mat === 'al' ? props.rdc_al : props.rdc_cu;
+  } else {
+    base = RESISTANCE_TABLE[mat][key];
+    if (base === undefined) {
+      const areaCM = sizeToArea(size);
+      if (!areaCM) return 0;
+      const areaMM2 = areaCM * 0.0005067;
+      base = BASE_RESISTIVITY[mat] / areaMM2;
+    }
+  }
+  return base * (1 + TEMP_COEFF[mat] * (temp - 20));
+}
+
+function skinEffect(size) {
+  const area = sizeToArea(size) / 1000;
+  if (!area) return 0;
+  const table = [
+    [0, 0], [100, 0], [250, 0.05], [500, 0.1],
+    [1000, 0.15], [2000, 0.2]
+  ];
+  for (let i = 1; i < table.length; i++) {
+    const a = table[i - 1];
+    const b = table[i];
+    if (area <= b[0]) {
+      const t = (area - a[0]) / (b[0] - a[0]);
+      return a[1] + t * (b[1] - a[1]);
+    }
+  }
+  return table[table.length - 1][1];
+}
+
+function dielectricRise(voltage) {
+  const v = (parseFloat(voltage) || 0) / 1000;
+  const table = [
+    [0, 0], [2, 0], [5, 5], [15, 10], [25, 15], [35, 20]
+  ];
+  if (v <= table[0][0]) return table[0][1];
+  for (let i = 1; i < table.length; i++) {
+    const a = table[i - 1];
+    const b = table[i];
+    if (v <= b[0]) {
+      const t = (v - a[0]) / (b[0] - a[0]);
+      return a[1] + t * (b[1] - a[1]);
+    }
+  }
+  return table[table.length - 1][1];
+}
+
+function conductorThermalResistance(cable) {
+  const props = conductorProps[cable.conductor_size];
+  if (!props) throw new Error('Invalid conductor size: ' + cable.conductor_size);
+  const areaM2 = props.area_cm * 5.067e-10;
+  const r = Math.sqrt(areaM2 / Math.PI);
+  const t = (parseFloat(cable.insulation_thickness) || props.insulation_thickness || 0) * 0.0254;
+  const r_i = r;
+  const r_o = r + t;
+  const r_ie = r * 0.001;
+  const kCond = cable.conductor_material && cable.conductor_material.toLowerCase().includes('al') ? 237 : 401;
+  const kIns = parseFloat(cable.insulation_k) || 0.3;
+  const Rcond = Math.log(r_i / r_ie) / (2 * Math.PI * kCond);
+  const Rins = Math.log(r_o / r_i) / (2 * Math.PI * kIns);
+  return { Rcond, Rins };
+}
+
+const AIR_RTH = 3.4; // calibrated air thermal resistance (°C·m/W)
+
+function calcRcaComponents(cable, params = {}) {
+  const { Rcond, Rins } = conductorThermalResistance(cable);
+  let Rduct = 0;
+  let Rsoil = 0;
+  if (params.medium === 'air') {
+    Rduct = AIR_RTH;
+  } else {
+    const mat = (params.conduit_type || '').includes('PVC') ? 'PVC' : 'steel';
+    const tables = {
+      PVC: { "4": 0.08 },
+      steel: { "4": 0.055 }
+    };
+    const base = tables[mat] && tables[mat][params.trade_size];
+    Rduct = base !== undefined ? base : (mat === 'PVC' ? 0.1 : 0.08);
+    let rho = params.soilResistivity || 90;
+    rho = Math.min(150, Math.max(40, rho));
+    const rho_m = rho / 100;
+    const burial = (params.ductbankDepth || 0) * 0.0254;
+    const D = params.conduit_diameter || 0.1;
+    if (burial > 0 && D > 0) {
+      Rsoil = (rho_m / (2 * Math.PI)) * Math.log(4 * burial / D);
+    }
+  }
+  const Rca = Rcond + Rins + Rduct + Rsoil;
+  return { Rcond, Rins, Rduct, Rsoil, Rca };
+}
+
+function ampacity(cable, params = {}) {
+  const Tc = parseFloat(cable.insulation_rating || 90);
+  const Ta = params.ambient || 30;
+  const Rdc = dcResistance(cable.conductor_size, cable.conductor_material, Tc);
+  const Yc = skinEffect(cable.conductor_size);
+  const dTd = dielectricRise(cable.voltage_rating || 600);
+  const comps = calcRcaComponents(cable, params);
+  const I = Math.sqrt((Tc - (Ta + dTd)) / (Rdc * (1 + Yc) * comps.Rca));
+  return { ampacity: I, components: comps };
+}
+
+module.exports = {
+  sizeToArea,
+  dcResistance,
+  skinEffect,
+  dielectricRise,
+  conductorThermalResistance,
+  calcRcaComponents,
+  ampacity
+};

--- a/docs/AMPACITY_METHOD.md
+++ b/docs/AMPACITY_METHOD.md
@@ -53,6 +53,11 @@ Typical soil resistivity values per IEEE Std 835 Table 1:
 - **120 °C·cm/W** – dry sand
 - **150 °C·cm/W** – dry sand and gravel
 
+## Calibration
+
+The resistance constants were tuned so that calculated ampacities match IEEE 835 tables.
+Using a baseline of 500 kcmil Cu THHN (90 °C) and 2/0 Al (75 °C) in air, a fixed air thermal resistance of 3.4 °C·m/W yields results within ±5 % of the published values.
+
 The original Neher‑McGrath paper provides additional discussion on how soil conditions influence ampacity.
 
 ## References

--- a/tests/ampacity.test.js
+++ b/tests/ampacity.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+const {
+  dcResistance,
+  conductorThermalResistance,
+  calcRcaComponents,
+  skinEffect,
+  dielectricRise,
+  ampacity
+} = require('../ampacity');
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  \u2713', name);
+  } catch (err) {
+    console.error('  \u2717', name, err.message || err);
+    process.exitCode = 1;
+  }
+}
+
+describe('core thermal functions', () => {
+  it('dcResistance matches expected value', () => {
+    const r = dcResistance('500 kcmil', 'Copper', 90);
+    assert(Math.abs(r - 0.0000893) < 5e-7);
+  });
+
+  it('skinEffect interpolates correctly', () => {
+    const y = skinEffect('500 kcmil');
+    assert(Math.abs(y - 0.1) < 0.001);
+  });
+
+  it('dielectricRise gives 0 at 600V', () => {
+    const d = dielectricRise(600);
+    assert.strictEqual(d, 0);
+  });
+
+  it('conductorThermalResistance returns reasonable values', () => {
+    const res = conductorThermalResistance({
+      conductor_size: '500 kcmil',
+      conductor_material: 'Copper'
+    });
+    assert(Math.abs(res.Rcond - 0.00274) < 1e-4);
+    assert(Math.abs(res.Rins - 0.12626) < 1e-4);
+  });
+
+  it('calcRcaComponents includes air resistance', () => {
+    const comps = calcRcaComponents({
+      conductor_size: '500 kcmil',
+      conductor_material: 'Copper'
+    }, { medium: 'air' });
+    assert(Math.abs(comps.Rca - 3.529) < 0.01);
+  });
+});
+
+describe('ampacity calibration', () => {
+  it('500 kcmil Cu THHN at 90C ~430A', () => {
+    const cable = {
+      conductor_size: '500 kcmil',
+      conductor_material: 'Copper',
+      insulation_rating: 90,
+      voltage_rating: 600
+    };
+    const I = ampacity(cable, { medium: 'air' }).ampacity;
+    assert(Math.abs(I - 430) / 430 < 0.05);
+  });
+
+  it('2/0 Al at 75C ~150A', () => {
+    const cable = {
+      conductor_size: '2/0 AWG',
+      conductor_material: 'Aluminum',
+      insulation_rating: 75,
+      voltage_rating: 600
+    };
+    const I = ampacity(cable, { medium: 'air' }).ampacity;
+    assert(Math.abs(I - 150) / 150 < 0.05);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ampacity.js` containing Neher‑McGrath calculations
- create `tests/ampacity.test.js` with unit tests
- document calibration of air thermal resistance in `AMPACITY_METHOD.md`

## Testing
- `node tests/ampacity.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6887a5b103f88324b63c6bde6ceecb41