### PR TITLE
Improve heat map toggle

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -238,8 +238,8 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
 <div id="warning-area" style="display:none;"></div>
 
 <div id="gridContainer" style="position:relative;display:inline-block;">
- <svg id="grid" width="500" height="500"></svg>
- <canvas id="tempCanvas" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:10;"></canvas>
+ <svg id="grid" width="500" height="500" style="position:relative;z-index:1;"></svg>
+ <canvas id="tempCanvas" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:0;"></canvas>
 </div>
 
 <details id="ampacityDetails" open style="margin-top:8px;">
@@ -295,6 +295,9 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
 
 <script>
 let heatVisible=true;
+window.lastHeatGrid=null;
+window.lastConduitTemps=null;
+window.lastAmbient=0;
 let GRID_SIZE = 20; // number of grid nodes across the ductbank for thermal solver
 const SAMPLE_CONDUITS=[
  {conduit_id:"C1",conduit_type:"PVC Sch 40",trade_size:"4",x:0,y:0},
@@ -1235,6 +1238,9 @@ svg.appendChild(widthText);
 svg.setAttribute('width',maxX*scale+2*margin+80);
 
 svg.setAttribute('height',maxY*scale+2*margin+20);
+ if(heatVisible && window.lastHeatGrid){
+   drawHeatMap(window.lastHeatGrid, window.lastConduitTemps || {}, conduits, window.lastAmbient||0);
+ }
 }
 
 function validateThermalInputs(){
@@ -1513,9 +1519,12 @@ const ctx=canvas.getContext('2d');
  pc.style.display='none';
  document.getElementById('solver-info').textContent=
   `Iterations: ${result.iter}  Residual: ${result.residual.toFixed(3)}`;
- const grid=result.grid;
- const conduitTemps=result.conduitTemps;
- drawHeatMap(grid,conduitTemps,conduits,ambient);
+const grid=result.grid;
+const conduitTemps=result.conduitTemps;
+window.lastHeatGrid=grid;
+window.lastConduitTemps=conduitTemps;
+window.lastAmbient=ambient;
+if(heatVisible) drawHeatMap(grid,conduitTemps,conduits,ambient);
 
  window.finiteAmpacity = {};
  window.cableOverLimit = {};
@@ -1544,12 +1553,21 @@ function drawHeatMap(grid, conduitTemps, conduits, ambient){
  const step=Math.ceil(Math.max(width,height)/GRID_SIZE);
  const img=ctx.createImageData(width,height);
  let maxT=-Infinity,maxPx=0,maxPy=0;
+ let minT=Infinity;
  for(let j=0;j<grid.length;j++){
    for(let i=0;i<grid[j].length;i++){
      const T=grid[j][i];
      if(T>maxT){maxT=T;maxPx=i*step;maxPy=j*step;}
-     const r=Math.min(255,Math.max(0,Math.round(255*Math.min(1,(T-ambient)/30))));
-     const b=255-r;
+     if(T<minT)minT=T;
+   }
+ }
+ const range=maxT-minT||1;
+ for(let j=0;j<grid.length;j++){
+   for(let i=0;i<grid[j].length;i++){
+     const T=grid[j][i];
+     const frac=(T-minT)/range;
+     const r=Math.round(255*frac);
+     const b=Math.round(255*(1-frac));
      for(let dy=0;dy<step;dy++){
        for(let dx=0;dx<step;dx++){
          const idx=((j*step+dy)*width+(i*step+dx))*4;
@@ -1563,6 +1581,22 @@ function drawHeatMap(grid, conduitTemps, conduits, ambient){
  }
  ctx.clearRect(0,0,width,height);
  ctx.putImageData(img,0,0);
+
+ // legend
+ const legendH=80, legendW=12;
+ const legendX=width-legendW-10;
+ const legendY=10;
+ for(let y=0;y<legendH;y++){
+   const frac=1-y/(legendH-1);
+   const r=Math.round(255*frac);
+   const b=Math.round(255*(1-frac));
+   ctx.fillStyle=`rgb(${r},0,${b})`;
+   ctx.fillRect(legendX,legendY+y,legendW,1);
+ }
+ ctx.fillStyle='black';
+ ctx.font='10px sans-serif';
+ ctx.fillText((maxT*9/5+32).toFixed(0)+'\u00B0F',legendX-4,legendY+8);
+ ctx.fillText((minT*9/5+32).toFixed(0)+'\u00B0F',legendX-4,legendY+legendH-2);
  const maxTF=maxT*9/5+32;
  const Tc=getConductorRating();
  if(maxT>Tc){
@@ -1803,9 +1837,12 @@ document.getElementById('thermalBtn').addEventListener('click',()=>{
   runFiniteThermalAnalysis();
 });
 document.getElementById('heatToggleBtn').addEventListener('click',()=>{
- heatVisible=!heatVisible;
- const canvas=document.getElementById('tempCanvas');
- canvas.style.display=heatVisible?'block':'none';
+  heatVisible=!heatVisible;
+  const canvas=document.getElementById('tempCanvas');
+  canvas.style.display=heatVisible?'block':'none';
+  if(heatVisible && window.lastHeatGrid){
+    drawHeatMap(window.lastHeatGrid, window.lastConduitTemps||{}, getAllConduits(), window.lastAmbient||0);
+  }
 });
 
 const darkToggle = document.getElementById('dark-toggle');


### PR DESCRIPTION
## Summary
- place temperature canvas behind SVG drawing
- store finite-element results globally and redraw heat map when toggled
- scale heat map from blue to red and add a simple legend

## Testing
- `node tests/ampacity.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6887abef3e6c8324a275c9ad8dcde023