### PR TITLE
Ensure heatmap canvas overlays match SVG size

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -238,10 +238,10 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
 
 <div id="warning-area" style="display:none;"></div>
 
-<div id="gridContainer" style="position:relative;display:inline-block;">
- <svg id="grid" width="500" height="500" style="position:relative;z-index:1;"></svg>
- <canvas id="tempCanvas" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:0;"></canvas>
- <canvas id="tempOverlay" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:2;"></canvas>
+<div id="gridContainer">
+ <svg id="grid" width="500" height="500"></svg>
+ <canvas id="tempCanvas"></canvas>
+ <canvas id="tempOverlay"></canvas>
 </div>
 <label style="display:block;margin-top:4px;"><input type="checkbox" id="hideDrawing"> Hide Drawing</label>
 
@@ -1101,8 +1101,11 @@ function drawGrid(){
  const svg=document.getElementById('grid');
  const heat=document.getElementById('tempCanvas');
  const overlay=document.getElementById('tempOverlay');
- if(heat){const ctx=heat.getContext('2d');ctx.clearRect(0,0,heat.width,heat.height);} 
- if(overlay){const octx=overlay.getContext('2d');octx.clearRect(0,0,overlay.width,overlay.height);} 
+ const width=parseFloat(svg.getAttribute('width'))||svg.clientWidth;
+ const height=parseFloat(svg.getAttribute('height'))||svg.clientHeight;
+ [heat,overlay].forEach(cv=>{if(!cv)return;cv.width=width;cv.height=height;cv.style.width='100%';cv.style.height='100%';});
+ if(heat){const ctx=heat.getContext('2d');ctx.clearRect(0,0,heat.width,heat.height);}
+ if(overlay){const octx=overlay.getContext('2d');octx.clearRect(0,0,overlay.width,overlay.height);}
  svg.innerHTML='';
  autoPlaceConduits();
  const conduits=getAllConduits();
@@ -1569,7 +1572,7 @@ async function runFiniteThermalAnalysis(){
  const svg=document.getElementById('grid');
  const width=parseFloat(svg.getAttribute('width')) || svg.clientWidth;
  const height=parseFloat(svg.getAttribute('height')) || svg.clientHeight;
- [canvas,overlay].forEach(cv=>{if(!cv)return;cv.width=width;cv.height=height;cv.style.width=width+'px';cv.style.height=height+'px';cv.style.display=heatVisible?'block':'none';});
+ [canvas,overlay].forEach(cv=>{if(!cv)return;cv.width=width;cv.height=height;cv.style.width='100%';cv.style.height='100%';cv.style.display=heatVisible?'block':'none';});
  const ctx=canvas.getContext('2d');
  ctx.clearRect(0,0,width,height);
  const octx=overlay.getContext('2d');
@@ -1644,6 +1647,7 @@ function drawHeatMap(grid, conduitTemps, conduits, ambient){
  const svg=document.getElementById('grid');
  const width=parseFloat(svg.getAttribute('width'))||svg.clientWidth;
  const height=parseFloat(svg.getAttribute('height'))||svg.clientHeight;
+ [canvas,overlay].forEach(cv=>{cv.width=width;cv.height=height;cv.style.width='100%';cv.style.height='100%';});
  const stepX=Math.ceil(width/(grid[0]?.length||1));
  const stepY=Math.ceil(height/(grid.length||1));
  const img=ctx.createImageData(Math.round(width),Math.round(height));

--- a/style.css
+++ b/style.css
@@ -554,10 +554,14 @@ body.dark-mode .db-table td {
     margin-top: 12px;
     display: block;
     margin: auto;
+    position: relative;
+    z-index: 1;
 }
 
 #gridContainer {
-    overflow-x: auto;
+    position: relative;
+    display: inline-block;
+    overflow: visible;
 }
 
 #gridContainer::-webkit-scrollbar {
@@ -577,6 +581,19 @@ body.dark-mode .db-table td {
     height: 0;
     overflow: hidden;
 }
+
+#tempCanvas,
+#tempOverlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+#tempCanvas { z-index: 2; }
+#tempOverlay { z-index: 3; }
 
 .db-button-panel {
     margin-top: 8px;


### PR DESCRIPTION
## Summary
- let the heatmap canvases automatically size with the SVG
- layer the canvases so the heat map appears under temperature labels
- keep canvases from being clipped by grid container

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6887d4049b108324badc8f42bb97d98f