### PR TITLE
Fix insulation check and sample cables loading

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -1307,7 +1307,8 @@ function checkInsulationThickness(){
     const td=tr.children[5];
     const inp=td?.querySelector('input');
     if(!inp) return;
-    if(isNaN(parseFloat(inp.value))){
+    const val=parseFloat(inp.value);
+    if(!isFinite(val) || val<=0){
       td.classList.add('missing-value');
       missing=true;
     }else{
@@ -1786,7 +1787,13 @@ document.getElementById('sampleCables').addEventListener('click',()=>{
     });
   });
   samples.forEach(addCableRow);
+  const search=document.getElementById('cable-search');
+  if(search){
+    search.value='';
+    filterTable(document.getElementById('cableTable'), '');
+  }
   updateInsulationOptions();
+  checkInsulationThickness();
   drawGrid();
   updateAmpacityReport();
   saveDuctbankSession();


### PR DESCRIPTION
## Summary
- ensure sample cable search filter is cleared when loading sample data
- validate insulation thickness properly and flag zero/invalid values

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6887e64cd2f48324824d952b819aae3a