### PR TITLE
Fix heat map overlay

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -239,10 +239,10 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
 <div id="warning-area" style="display:none;"></div>
 
 <div id="gridContainer" style="position:relative;display:inline-block;">
- <svg id="grid" width="500" height="500" style="position:relative;z-index:1;"></svg>
- <canvas id="tempCanvas" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:0;display:none;"></canvas>
- <canvas id="tempOverlay" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:2;display:none;"></canvas>
-</div>
+    <svg id="grid" width="500" height="500" style="position:relative;z-index:1;"></svg>
+    <canvas id="tempCanvas" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:2;display:none;opacity:0.7;"></canvas>
+    <canvas id="tempOverlay" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:3;display:none;"></canvas>
+  </div>
 <label style="display:block;margin-top:4px;"><input type="checkbox" id="hideDrawing"> Hide Drawing</label>
 
 <details id="ampacityDetails" open style="margin-top:8px;">
@@ -1697,11 +1697,11 @@ let minT=Infinity;
      for(let dy=0;dy<stepY;dy++){
        for(let dx=0;dx<stepX;dx++){
          const idx=((j*stepY+dy)*width+(i*stepX+dx))*4;
-         img.data[idx]=r;
-         img.data[idx+1]=g;
-         img.data[idx+2]=b;
-         img.data[idx+3]=200;
-       }
+        img.data[idx]=r;
+        img.data[idx+1]=g;
+        img.data[idx+2]=b;
+        img.data[idx+3]=160;
+      }
      }
    }
  }


### PR DESCRIPTION
## Summary
- raise heat map canvas z-index so it appears above the SVG grid
- make heat map semi-transparent for better visibility

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6888cb5b5a7c832483339ef35368f57e