### PR TITLE
Fix '#500 kcmil' parsing

### DIFF
--- a/ampacity.js
+++ b/ampacity.js
@@ -24,18 +24,27 @@ for (const sz in AWG_AREA) {
   RESISTANCE_TABLE.al[sz] = BASE_RESISTIVITY.al / areaMM2;
 }
 
+function normalizeSizeKey(size) {
+  const s = size ? size.toString().trim() : '';
+  if (conductorProps[s]) return s;
+  const alt = s.replace(/^#/, '');
+  if (conductorProps[alt]) return alt;
+  return s;
+}
+
 function sizeToArea(size) {
   if (!size) return 0;
-  const s = size.toString().trim();
+  let s = size.toString().trim();
   if (conductorProps[s]) return conductorProps[s].area_cm;
+  s = s.replace(/^#/, '');
   if (/kcmil/i.test(s)) return parseFloat(s) * 1000;
-  const m = s.match(/#?(\d+(?:\/0)?)/);
+  const m = s.match(/(\d+(?:\/0)?)/);
   if (!m) return 0;
   return AWG_AREA[m[1]] || 0;
 }
 
 function dcResistance(size, material, temp = 20) {
-  const key = size ? size.toString().trim() : '';
+  const key = normalizeSizeKey(size);
   const mat = material && material.toLowerCase().includes('al') ? 'al' : 'cu';
   let base;
   const props = conductorProps[key];
@@ -89,7 +98,8 @@ function dielectricRise(voltage) {
 }
 
 function conductorThermalResistance(cable) {
-  const props = conductorProps[cable.conductor_size];
+  const key = normalizeSizeKey(cable.conductor_size);
+  const props = conductorProps[key];
   if (!props) throw new Error('Invalid conductor size: ' + cable.conductor_size);
   const areaM2 = props.area_cm * 5.067e-10;
   const r = Math.sqrt(areaM2 / Math.PI);

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -846,8 +846,16 @@ for(const sz in AWG_AREA){
   RESISTANCE_TABLE.al[sz]=BASE_RESISTIVITY.al/areaMM2;
 }
 
+function normalizeSizeKey(size){
+  const s=size?size.toString().trim():'';
+  if(CONDUCTOR_PROPS[s]) return s;
+  const alt=s.replace(/^#/, '');
+  if(CONDUCTOR_PROPS[alt]) return alt;
+  return s;
+}
+
 function dcResistance(size,material,temp=20){
-  const key=size?size.toString().trim():'';
+  const key=normalizeSizeKey(size);
   const mat=material&&material.toLowerCase().includes('al')?'al':'cu';
   let base;
   const props=CONDUCTOR_PROPS[key];
@@ -867,10 +875,11 @@ function dcResistance(size,material,temp=20){
 
 function sizeToArea(size){
  if(!size)return 0;
- const s=size.toString().trim();
+ let s=size.toString().trim();
  if(CONDUCTOR_PROPS[s]) return CONDUCTOR_PROPS[s].area_cm;
+ s=s.replace(/^#/, '');
  if(/kcmil/i.test(s))return parseFloat(s)*1000;
- const m=s.match(/#?(\d+(?:\/0)?)/);
+ const m=s.match(/(\d+(?:\/0)?)/);
  if(!m)return 0;
  return AWG_AREA[m[1]]||0;
 }
@@ -914,7 +923,8 @@ function dielectricRise(voltage){
 }
 
 function conductorThermalResistance(cable){
-  const props=CONDUCTOR_PROPS[cable.conductor_size];
+  const key=normalizeSizeKey(cable.conductor_size);
+  const props=CONDUCTOR_PROPS[key];
   if(!props){
     throw new Error('Invalid conductor size: '+cable.conductor_size);
   }

--- a/thermalWorker.js
+++ b/thermalWorker.js
@@ -20,17 +20,26 @@ for(const sz in AWG_AREA){
   RESISTANCE_TABLE.cu[sz]=BASE_RESISTIVITY.cu/areaMM2;
   RESISTANCE_TABLE.al[sz]=BASE_RESISTIVITY.al/areaMM2;
 }
+
+function normalizeSizeKey(size){
+  const s=size?size.toString().trim():'';
+  if(CONDUCTOR_PROPS[s]) return s;
+  const alt=s.replace(/^#/, '');
+  if(CONDUCTOR_PROPS[alt]) return alt;
+  return s;
+}
 function sizeToArea(size){
   if(!size) return 0;
-  const s=size.toString().trim();
+  let s=size.toString().trim();
   if(CONDUCTOR_PROPS[s]) return CONDUCTOR_PROPS[s].area_cm;
+  s=s.replace(/^#/, '');
   if(/kcmil/i.test(s)) return parseFloat(s)*1000;
-  const m=s.match(/#?(\d+(?:\/0)?)/);
+  const m=s.match(/(\d+(?:\/0)?)/);
   if(!m) return 0;
   return AWG_AREA[m[1]]||0;
 }
 function dcResistance(size,material,temp=20){
-  const key=size?size.toString().trim():'';
+  const key=normalizeSizeKey(size);
   const mat=material&&material.toLowerCase().includes('al')?'al':'cu';
   let base;
   const props=CONDUCTOR_PROPS[key];


### PR DESCRIPTION
## Summary
- normalize conductor size strings so values like `#500 kcmil` are supported
- update `sizeToArea`, `dcResistance`, and `conductorThermalResistance` to use the normalization
- apply same logic in ampacity library and thermal worker

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6888f99b8be08324ba9df981bd039053