### PR TITLE
Fix thermal analysis residual property

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -1662,8 +1662,9 @@ async function runFiniteThermalAnalysis(){
   pl.textContent=`Solving (${it}/${max})`;
  });
  pc.style.display='none';
- document.getElementById('solver-info').textContent=
-  `Iterations: ${result.iter}  Residual: ${result.residual.toFixed(3)}`;
+ const residual = result.residual !== undefined ? result.residual : result.diff;
+ document.getElementById('solver-info').textContent =
+  `Iterations: ${result.iter}  Residual: ${Number(residual).toFixed(3)}`;
 const grid=result.grid;
 const conduitTemps=result.conduitTemps;
 const ambientRes=result.ambient;


### PR DESCRIPTION
## Summary
- prevent crash when thermal solver runs without web worker by checking `result.diff`

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688a0d1476248324a1b2ced4a59f0f22