### PR TITLE
Fix docx Media.addImage error

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -2298,11 +2298,12 @@ const children=[];
   const ctx=canvas.getContext('2d');
   ctx.drawImage(img,0,0);
   URL.revokeObjectURL(url);
-  return await new Promise(resolve=>canvas.toBlob(b=>b?b.arrayBuffer().then(resolve):resolve(null)));
+  const buffer=await new Promise(resolve=>canvas.toBlob(b=>b?b.arrayBuffer().then(resolve):resolve(null)));
+  return buffer?{buffer,width:img.width,height:img.height}:null;
  }
- const imgBuf=await captureLayout();
- if(imgBuf){
-  const image=docx.Media.addImage(doc,imgBuf);
+ const imgData=await captureLayout();
+ if(imgData){
+  const image=new docx.ImageRun({data:imgData.buffer,transformation:{width:imgData.width,height:imgData.height}});
   children.push(new docx.Paragraph(image));
   children.push(new docx.Paragraph(''));
  }


### PR DESCRIPTION
## Summary
- Replace deprecated docx.Media.addImage usage with docx.ImageRun and capture image dimensions for report generation

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`
- `node test.js` *(fails: computes conduit temperatures, iteratively finds ampacity)*

------
https://chatgpt.com/codex/tasks/task_e_688bb669489883249c937e048801bafb