### PR TITLE
Include ductbank image in ampacity report

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -2308,9 +2308,9 @@ const children=[];
  }
  const imgData=await captureLayout();
  if(imgData){
-  const image=new docx.ImageRun({data:imgData.buffer,transformation:{width:imgData.width,height:imgData.height}});
-  children.push(new docx.Paragraph(image));
-  children.push(new docx.Paragraph(''));
+ const image=new docx.ImageRun({data:imgData.buffer,transformation:{width:imgData.width,height:imgData.height}});
+ children.push(new docx.Paragraph({children:[image]}));
+ children.push(new docx.Paragraph(''));
  }
  children.push(new docx.Paragraph('Ampacity Results'));
  children.push(new docx.Paragraph('----------------'));


### PR DESCRIPTION
## Summary
- Ensure the ductbank cross-section image is embedded in the Ampacity Calculation Report by wrapping the captured layout in a docx paragraph

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688bbed294088324bc5fb177c9ec9ec7