### PR TITLE
Add meta descriptions to HTML pages

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Interactive table for organizing cable data and exporting schedules.">
   <title>Cable Schedule</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="Calculator for packing cables into trays and checking fill levels."/>
   <title>Cable Tray Packing</title>
 
   <!-- SheetJS / xlsx for Excel import/export -->

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Tool for visualizing conduit fill capacity based on cable sizes." />
   <title>Conduit Fill Visualization</title>
   <style>
     body {

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="description" content="Planner for ductbank routes with conduit layout and soil resistivity controls."/>
 <title>Ductbank Route</title>
 <link rel="stylesheet" href="style.css">
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Landing page for configuring the optimal 3D cable routing system.">
     <title>Optimal 3D Cable Routing System</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>


### PR DESCRIPTION
## Summary
- add meta description tags to main application pages for clearer summaries and SEO

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iteratively finds ampacity near expected)*
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899e30ae578832492f16043f26aaa7b