### PR TITLE
Improve accessibility with aria attributes and focus management

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,6 +105,19 @@ document.addEventListener('DOMContentLoaded', () => {
         cableSearch: document.getElementById('cable-search'),
         conduitType: document.getElementById('conduit-type'),
     };
+
+    const initHelpIcons = (root = document) => {
+        root.querySelectorAll('.help-icon').forEach(icon => {
+            icon.setAttribute('role', 'button');
+            if (!icon.hasAttribute('aria-label')) icon.setAttribute('aria-label', 'Help');
+            if (!icon.hasAttribute('aria-expanded')) icon.setAttribute('aria-expanded', 'false');
+            icon.addEventListener('mouseenter', () => icon.setAttribute('aria-expanded', 'true'));
+            icon.addEventListener('mouseleave', () => icon.setAttribute('aria-expanded', 'false'));
+            icon.addEventListener('focus', () => icon.setAttribute('aria-expanded', 'true'));
+            icon.addEventListener('blur', () => icon.setAttribute('aria-expanded', 'false'));
+        });
+    };
+    initHelpIcons();
     let cancelRouting = false;
     let currentWorkers = [];
     let workerResolvers = new Map();
@@ -1173,7 +1186,7 @@ const openConduitFill = (cables) => {
             '<th data-key="height">Height</th>' +
             '<th data-key="current_fill">Current Fill</th>' +
             '<th data-key="allowed_cable_group">Allowed Group</th>' +
-            '<th data-key="shape">Shape <span class="help-icon" tabindex="0" aria-describedby="shape-help">?<span id="shape-help" class="tooltip">STR: Straight<br>90B: 90\u00B0 Bend<br>45B: 45\u00B0 Bend<br>30B/60B: 30\u00B0/60\u00B0 Bend<br>TEE: Tee<br>X: Cross<br>VI: Vertical Inside<br>VO: Vertical Outside<br>45VI: 45\u00B0 Vertical Inside<br>45VO: 45\u00B0 Vertical Outside<br>RED-C: Center Reducer<br>RED-S: Side Reducer<br>Z: Z-Bend<br>OFFSET: Offset<br>SPIRAL: Spiral</span></span></th>' +
+            '<th data-key="shape">Shape <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="shape-help">?<span id="shape-help" class="tooltip">STR: Straight<br>90B: 90\u00B0 Bend<br>45B: 45\u00B0 Bend<br>30B/60B: 30\u00B0/60\u00B0 Bend<br>TEE: Tee<br>X: Cross<br>VI: Vertical Inside<br>VO: Vertical Outside<br>45VI: 45\u00B0 Vertical Inside<br>45VO: 45\u00B0 Vertical Outside<br>RED-C: Center Reducer<br>RED-S: Side Reducer<br>Z: Z-Bend<br>OFFSET: Offset<br>SPIRAL: Spiral</span></span></th>' +
             '<th></th><th></th></tr></thead><tbody>';
         state.manualTrays.forEach((t, idx) => {
             table += `<tr data-idx="${idx}">
@@ -1203,6 +1216,7 @@ const openConduitFill = (cables) => {
         });
         table += '</tbody></table>';
         elements.manualTrayTableContainer.innerHTML = table;
+        initHelpIcons(elements.manualTrayTableContainer);
         elements.manualTrayTableContainer.classList.add('table-scroll');
         
         const updateTrayData = () => { state.trayData = state.manualTrays; updateTrayDisplay(); };
@@ -2683,27 +2697,58 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
     }
     if (elements.settingsBtn && elements.settingsMenu) {
         elements.settingsBtn.addEventListener('click', () => {
-            elements.settingsMenu.style.display = elements.settingsMenu.style.display === 'flex' ? 'none' : 'flex';
+            const expanded = elements.settingsMenu.style.display === 'flex';
+            elements.settingsMenu.style.display = expanded ? 'none' : 'flex';
+            elements.settingsBtn.setAttribute('aria-expanded', String(!expanded));
         });
         document.addEventListener('click', (e) => {
             if (!elements.settingsMenu.contains(e.target) && e.target !== elements.settingsBtn) {
                 elements.settingsMenu.style.display = 'none';
+                elements.settingsBtn.setAttribute('aria-expanded', 'false');
             }
         });
     }
     if (elements.helpBtn && elements.helpModal && elements.closeHelpBtn) {
-        elements.helpBtn.addEventListener('click', () => {
+        const focusableSelector = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+        let firstFocusable, lastFocusable, previousFocus;
+        const trapFocus = (e) => {
+            if (e.key === 'Tab') {
+                if (e.shiftKey) {
+                    if (document.activeElement === firstFocusable) {
+                        e.preventDefault();
+                        lastFocusable.focus();
+                    }
+                } else if (document.activeElement === lastFocusable) {
+                    e.preventDefault();
+                    firstFocusable.focus();
+                }
+            } else if (e.key === 'Escape') {
+                closeModal();
+            }
+        };
+        const openModal = () => {
+            previousFocus = document.activeElement;
             elements.helpModal.style.display = 'flex';
             elements.helpModal.setAttribute('aria-hidden', 'false');
-        });
-        elements.closeHelpBtn.addEventListener('click', () => {
+            elements.helpBtn.setAttribute('aria-expanded', 'true');
+            const focusables = elements.helpModal.querySelectorAll(focusableSelector);
+            firstFocusable = focusables[0];
+            lastFocusable = focusables[focusables.length - 1];
+            firstFocusable && firstFocusable.focus();
+            elements.helpModal.addEventListener('keydown', trapFocus);
+        };
+        const closeModal = () => {
             elements.helpModal.style.display = 'none';
             elements.helpModal.setAttribute('aria-hidden', 'true');
-        });
+            elements.helpBtn.setAttribute('aria-expanded', 'false');
+            elements.helpModal.removeEventListener('keydown', trapFocus);
+            previousFocus && previousFocus.focus();
+        };
+        elements.helpBtn.addEventListener('click', openModal);
+        elements.closeHelpBtn.addEventListener('click', closeModal);
         elements.helpModal.addEventListener('click', (e) => {
             if (e.target === elements.helpModal) {
-                elements.helpModal.style.display = 'none';
-                elements.helpModal.setAttribute('aria-hidden', 'true');
+                closeModal();
             }
         });
     }

--- a/cableschedule.html
+++ b/cableschedule.html
@@ -19,11 +19,11 @@
     <main class="main-content">
       <header class="page-header">
         <h1>Cable Schedule</h1>
-        <button id="settings-btn" class="settings-btn" aria-label="Settings">⚙</button>
+        <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
         <p>Centralized table for managing cable data.</p>
         <div id="settings-menu" class="settings-menu">
           <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-          <button id="help-btn">Site Help</button>
+          <button id="help-btn" aria-expanded="false">Site Help</button>
         </div>
       </header>
 
@@ -490,11 +490,14 @@ const settingsBtn=document.getElementById('settings-btn');
 const settingsMenu=document.getElementById('settings-menu');
 if(settingsBtn&&settingsMenu){
   settingsBtn.addEventListener('click',()=>{
-    settingsMenu.style.display=settingsMenu.style.display==='flex'?'none':'flex';
+    const expanded=settingsMenu.style.display==='flex';
+    settingsMenu.style.display=expanded?'none':'flex';
+    settingsBtn.setAttribute('aria-expanded',String(!expanded));
   });
   document.addEventListener('click',e=>{
     if(!settingsMenu.contains(e.target)&&e.target!==settingsBtn){
       settingsMenu.style.display='none';
+      settingsBtn.setAttribute('aria-expanded','false');
     }
   });
 }
@@ -518,19 +521,45 @@ const helpBtn=document.getElementById('help-btn');
 const helpModal=document.getElementById('help-modal');
 const closeHelpBtn=document.getElementById('close-help-btn');
 if(helpBtn&&helpModal&&closeHelpBtn){
-  helpBtn.addEventListener('click',()=>{
+  const focusableSelector='a[href],button:not([disabled]),textarea,input,select,[tabindex]:not([tabindex="-1"])';
+  let firstFocusable,lastFocusable,previousFocus;
+  const trapFocus=e=>{
+    if(e.key==='Tab'){
+      if(e.shiftKey){
+        if(document.activeElement===firstFocusable){
+          e.preventDefault();
+          lastFocusable.focus();
+        }
+      }else if(document.activeElement===lastFocusable){
+        e.preventDefault();
+        firstFocusable.focus();
+      }
+    }else if(e.key==='Escape'){
+      closeModal();
+    }
+  };
+  const openModal=()=>{
+    previousFocus=document.activeElement;
     helpModal.style.display='flex';
     helpModal.setAttribute('aria-hidden','false');
-  });
-  closeHelpBtn.addEventListener('click',()=>{
+    helpBtn.setAttribute('aria-expanded','true');
+    const focusables=helpModal.querySelectorAll(focusableSelector);
+    firstFocusable=focusables[0];
+    lastFocusable=focusables[focusables.length-1];
+    firstFocusable&&firstFocusable.focus();
+    helpModal.addEventListener('keydown',trapFocus);
+  };
+  const closeModal=()=>{
     helpModal.style.display='none';
     helpModal.setAttribute('aria-hidden','true');
-  });
+    helpBtn.setAttribute('aria-expanded','false');
+    helpModal.removeEventListener('keydown',trapFocus);
+    previousFocus&&previousFocus.focus();
+  };
+  helpBtn.addEventListener('click',openModal);
+  closeHelpBtn.addEventListener('click',closeModal);
   helpModal.addEventListener('click',e=>{
-    if(e.target===helpModal){
-      helpModal.style.display='none';
-      helpModal.setAttribute('aria-hidden','true');
-    }
+    if(e.target===helpModal)closeModal();
   });
 }
 

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -28,10 +28,10 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
 </nav>
 <header class="page-header">
  <h1>Ductbank Route</h1>
- <button id="settings-btn" class="settings-btn" aria-label="Settings">⚙</button>
+ <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
  <div id="settings-menu" class="settings-menu">
   <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-  <button id="helpBtn">Help</button>
+  <button id="helpBtn" aria-expanded="false">Help</button>
   <button id="deleteDataBtn">Delete Saved Data</button>
  </div>
 </header>
@@ -128,19 +128,19 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
  <summary><strong>Parameters</strong></summary>
  <div>
  <label>Ambient Earth Temperature (&#176;F)
-  <span class="help-icon" tabindex="0" aria-describedby="earthTempHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="earthTempHelp">?
    <span id="earthTempHelp" class="tooltip">Degrees Fahrenheit of the surrounding soil. Typical 50–80°F.</span>
   </span>
   <input type="number" id="earthTemp" style="width:60px;">
  </label>
 <label style="margin-left:8px;">Ambient Air Temperature (&#176;F)
-  <span class="help-icon" tabindex="0" aria-describedby="airTempHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="airTempHelp">?
    <span id="airTempHelp" class="tooltip">Air temperature around the installation in °F. Usually 50–110°F.</span>
   </span>
   <input type="number" id="airTemp" style="width:60px;">
  </label>
 <label style="margin-left:8px;">Thermal Resistivity of Soil (&#176;C&#183;cm/W)
-  <span class="help-icon" tabindex="0" aria-describedby="soilResHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="soilResHelp">?
    <span id="soilResHelp" class="tooltip">Typical soil ranges from 40–150 &#176;C&#183;cm/W.</span>
   </span>
   <input type="number" id="soilResistivity" list="soilResList" style="width:120px;">
@@ -148,14 +148,14 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
  <div id="soilWarning" style="display:none;font-size:0.8rem;color:var(--warning-text);"></div>
  <datalist id="soilResList"></datalist>
  <label style="margin-left:8px;">Moisture Content (%)
-  <span class="help-icon" tabindex="0" aria-describedby="moistureHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="moistureHelp">?
    <span id="moistureHelp" class="tooltip">Percent water by weight in soil.</span>
   </span>
   <input type="number" id="moistureContent" min="0" max="40" style="width:60px;">
  </label>
  <div id="moistureWarning" style="display:none;font-size:0.8rem;color:var(--warning-text);"></div>
 <label style="margin-left:8px;">Allowable Conductor Temperature Tc
-  <span class="help-icon" tabindex="0" aria-describedby="ratingHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="ratingHelp">?
    <span id="ratingHelp" class="tooltip">Select the design insulation rating (°C).</span>
   </span>
   <select id="conductorRating" style="margin-left:4px;">
@@ -165,14 +165,14 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
   </select>
  </label>
 <label style="margin-left:8px;">Presence of Adjacent Heat Sources
-  <span class="help-icon" tabindex="0" aria-describedby="heatHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="heatHelp">?
    <span id="heatHelp" class="tooltip">Toggle additional heat sources near the ductbank.</span>
   </span>
   <input type="checkbox" id="heatSources" style="margin-left:4px;">
  </label>
  <button type="button" id="addHeatSource" style="display:none;margin-left:4px;">Add Heat Source</button>
  <label style="margin-left:8px;">Grid Resolution
-  <span class="help-icon" tabindex="0" aria-describedby="gridHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="gridHelp">?
    <span id="gridHelp" class="tooltip">Number of nodes used for the thermal solver.</span>
   </span>
   <select id="gridRes" style="margin-left:4px;">
@@ -182,7 +182,7 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
   </select>
  </label>
 <label style="margin-left:8px;">Duct Thermal Resistance (&#176;C·m/W)
-  <span class="help-icon" tabindex="0" aria-describedby="ductResHelp">?
+  <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="ductResHelp">?
    <span id="ductResHelp" class="tooltip">Thermal resistance of the conduit itself. Leave 0 when using the preset table. Typical range 0–0.2 &#176;C·m/W.</span>
   </span>
   <input type="number" id="ductThermRes" value="0.0" placeholder="0.05" style="width:60px;">
@@ -275,7 +275,7 @@ button{padding:4px 8px;margin:4px 2px;cursor:pointer;}
 </div>
 <div id="solver-info" style="font-size:0.9rem;margin-top:4px;"></div>
 
-<div id="helpOverlay">
+<div id="helpOverlay" aria-hidden="true" role="dialog">
  <div id="helpPopup">
   <button id="helpClose">Close</button>
   <h2>Ductbank Route Help</h2>
@@ -2541,26 +2541,81 @@ if(hideDrawing){
 
 window.addEventListener('storage',e=>{if(e.key==='ctrSession'){const d=JSON.parse(e.newValue);if(d.darkMode)document.body.classList.add('dark-mode');else document.body.classList.remove('dark-mode');}});
 
-document.getElementById('helpBtn').addEventListener('click',()=>{
- document.getElementById('settings-menu').style.display='none';
- document.getElementById('helpOverlay').style.display='flex';
-});
-document.getElementById('helpClose').addEventListener('click',()=>{
- document.getElementById('helpOverlay').style.display='none';
-});
+const helpBtn=document.getElementById('helpBtn');
+const helpOverlay=document.getElementById('helpOverlay');
+const helpClose=document.getElementById('helpClose');
+if(helpBtn&&helpOverlay&&helpClose){
+ const focusableSelector='a[href],button:not([disabled]),textarea,input,select,[tabindex]:not([tabindex="-1"])';
+ let firstFocusable,lastFocusable,previousFocus;
+ const trapFocus=e=>{
+  if(e.key==='Tab'){
+   if(e.shiftKey){
+    if(document.activeElement===firstFocusable){
+     e.preventDefault();
+     lastFocusable.focus();
+    }
+   }else if(document.activeElement===lastFocusable){
+    e.preventDefault();
+    firstFocusable.focus();
+   }
+  }else if(e.key==='Escape'){
+   closeHelp();
+  }
+ };
+ const openHelp=()=>{
+  document.getElementById('settings-menu').style.display='none';
+  previousFocus=document.activeElement;
+  helpOverlay.style.display='flex';
+  helpOverlay.setAttribute('aria-hidden','false');
+  helpBtn.setAttribute('aria-expanded','true');
+  const focusables=helpOverlay.querySelectorAll(focusableSelector);
+  firstFocusable=focusables[0];
+  lastFocusable=focusables[focusables.length-1];
+  firstFocusable&&firstFocusable.focus();
+  helpOverlay.addEventListener('keydown',trapFocus);
+ };
+ const closeHelp=()=>{
+  helpOverlay.style.display='none';
+  helpOverlay.setAttribute('aria-hidden','true');
+  helpBtn.setAttribute('aria-expanded','false');
+  helpOverlay.removeEventListener('keydown',trapFocus);
+  previousFocus&&previousFocus.focus();
+ };
+ helpBtn.addEventListener('click',openHelp);
+ helpClose.addEventListener('click',closeHelp);
+ helpOverlay.addEventListener('click',e=>{if(e.target===helpOverlay)closeHelp();});
+}
 document.getElementById('deleteDataBtn').addEventListener('click',deleteSavedData);
 document.getElementById('resetBtn').addEventListener('click',deleteSavedData);
 
-document.getElementById('settings-btn').addEventListener('click',()=>{
- const menu=document.getElementById('settings-menu');
- menu.style.display=menu.style.display==='flex'?'none':'flex';
-});
-document.addEventListener('click',e=>{
- const menu=document.getElementById('settings-menu');
- if(!menu.contains(e.target)&&e.target!==document.getElementById('settings-btn')){
-  menu.style.display='none';
- }
-});
+const settingsBtn=document.getElementById('settings-btn');
+const settingsMenu=document.getElementById('settings-menu');
+if(settingsBtn&&settingsMenu){
+ settingsBtn.addEventListener('click',()=>{
+  const expanded=settingsMenu.style.display==='flex';
+  settingsMenu.style.display=expanded?'none':'flex';
+  settingsBtn.setAttribute('aria-expanded',String(!expanded));
+ });
+ document.addEventListener('click',e=>{
+  if(!settingsMenu.contains(e.target)&&e.target!==settingsBtn){
+   settingsMenu.style.display='none';
+   settingsBtn.setAttribute('aria-expanded','false');
+  }
+ });
+}
+
+const initHelpIcons=(root=document)=>{
+ root.querySelectorAll('.help-icon').forEach(icon=>{
+  icon.setAttribute('role','button');
+  if(!icon.hasAttribute('aria-label'))icon.setAttribute('aria-label','Help');
+  if(!icon.hasAttribute('aria-expanded'))icon.setAttribute('aria-expanded','false');
+  icon.addEventListener('mouseenter',()=>icon.setAttribute('aria-expanded','true'));
+  icon.addEventListener('mouseleave',()=>icon.setAttribute('aria-expanded','false'));
+  icon.addEventListener('focus',()=>icon.setAttribute('aria-expanded','true'));
+  icon.addEventListener('blur',()=>icon.setAttribute('aria-expanded','false'));
+ });
+};
+initHelpIcons();
 
 // keyboard navigation within conduit and cable tables
 document.addEventListener('keydown',e=>{

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <section>
                 <h3>Routing Parameters</h3>
                  <label for="fill-limit">Max Tray Fill (%)
-                    <span class="help-icon" tabindex="0" role="button" aria-describedby="fill-limit-help">?
+                    <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="fill-limit-help">?
                         <span id="fill-limit-help" class="tooltip">The maximum allowed fill capacity for a cable tray, based on standards like the NEC 40% rule.</span>
                     </span>
                  </label>
@@ -36,21 +36,21 @@
                  <span id="fill-limit-value">40%</span>
 
                  <label for="proximity-threshold">Tray Proximity Threshold (in)
-                    <span class="help-icon" tabindex="0" role="button" aria-describedby="proximity-help">?
+                    <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="proximity-help">?
                         <span id="proximity-help" class="tooltip">The maximum distance a cable can jump from its start or end point to connect to a nearby tray segment.</span>
                     </span>
                  </label>
                  <input type="number" id="proximity-threshold" value="72" step="1">
 
                  <label for="field-route-penalty">Field Route Cost Multiplier
-                    <span class="help-icon" tabindex="0" role="button" aria-describedby="field-penalty-help">?
+                    <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="field-penalty-help">?
                         <span id="field-penalty-help" class="tooltip">This makes field routing (not in a tray) more expensive than routing within a tray. A value of 3 means every inch of field routing costs as much as 3 inches of tray routing, encouraging the algorithm to use trays whenever possible.</span>
                     </span>
                  </label>
                  <input type="number" id="field-route-penalty" value="3.0" step="0.1">
 
                  <label for="shared-field-penalty">Shared Field Route Cost Multiplier
-                    <span class="help-icon" tabindex="0" role="button" aria-describedby="shared-field-help">?
+                    <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="shared-field-help">?
                         <span id="shared-field-help" class="tooltip">Multiplier applied when a cable uses an existing field-routed path from a previous cable. Use a value less than 1 to make shared field routes cheaper than new field routes.</span>
                     </span>
                  </label>
@@ -84,11 +84,11 @@
         <main class="main-content">
             <header class="page-header">
                 <h1>Optimal 3D Cable Routing System</h1>
-                <button id="settings-btn" class="settings-btn" aria-label="Settings">⚙</button>
+                <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
                 <p>Find the most efficient path for routing cables through tray networks with capacity constraints.</p>
                 <div id="settings-menu" class="settings-menu">
                     <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-                    <button id="help-btn">Site Help</button>
+                    <button id="help-btn" aria-expanded="false">Site Help</button>
                     <button id="delete-data-btn">Delete Saved Data</button>
                 </div>
             </header>
@@ -138,7 +138,7 @@
                              </select>
                              <input type="text" id="t-group" placeholder="Allowed Cable Group">
                              <button id="add-tray-btn">Add Tray</button>
-                             <span class="help-icon" tabindex="0" aria-describedby="add-tray-help">?</span>
+                             <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="add-tray-help">?</span>
                              <span id="add-tray-help" class="tooltip">Add the tray segment above to the list.</span>
                         </div>
                     </details>
@@ -160,7 +160,7 @@
 
                 <div id="batch-section">
                     <button id="add-cable-btn">Add Cable to List</button>
-                    <span class="help-icon" tabindex="0" aria-describedby="add-cable-help">?</span>
+                    <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="add-cable-help">?</span>
                     <span id="add-cable-help" class="tooltip">Add a new cable row using the current settings.</span>
                     <div class="cable-controls">
                         <button id="load-sample-cables-btn">Load Sample Cable List</button>


### PR DESCRIPTION
## Summary
- add `aria-expanded` and labels to interactive spans and buttons across UI
- focus first element and trap focus within help modals
- sync `aria-expanded` states in scripts for settings and help toggles

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iteratively finds ampacity near expected)*
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899e3589e3083248f86b90ce9f3d12a