### PR TITLE
Add responsive sidebar for narrow viewports

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,6 +104,8 @@ document.addEventListener('DOMContentLoaded', () => {
         traySearch: document.getElementById('tray-search'),
         cableSearch: document.getElementById('cable-search'),
         conduitType: document.getElementById('conduit-type'),
+        sidebar: document.querySelector('.sidebar'),
+        sidebarToggle: document.getElementById('sidebar-toggle'),
     };
 
     const initHelpIcons = (root = document) => {
@@ -118,6 +120,11 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
     initHelpIcons();
+    if (elements.sidebarToggle && elements.sidebar) {
+        elements.sidebarToggle.addEventListener('click', () => {
+            elements.sidebar.classList.toggle('open');
+        });
+    }
     let cancelRouting = false;
     let currentWorkers = [];
     let workerResolvers = new Map();

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 </head>
 <body>
     <nav class="top-nav">
+        <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Sidebar">☰</button>
         <a href="index.html">Home</a>
         <a href="ductbankroute.html">Ductbank</a>
         <a href="cabletrayfill.html">Tray Fill</a>

--- a/style.css
+++ b/style.css
@@ -75,6 +75,10 @@ body {
     text-decoration: underline;
 }
 
+.sidebar-toggle {
+    display: none;
+}
+
 .container {
     display: flex;
     height: 100vh;
@@ -537,13 +541,37 @@ body.dark-mode .toast { background: #2c3034; color: #f8f9fa; }
         height: auto;
     }
     .sidebar {
-        width: 100%;
-        order: 2;
-        border-right: none;
-        border-bottom: 1px solid var(--border-color);
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 250px;
+        max-width: 80%;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        z-index: 1000;
+        border-right: 1px solid var(--border-color);
+        border-bottom: none;
+    }
+    .sidebar.open {
+        transform: translateX(0);
     }
     .main-content {
         order: 1;
+        padding: 1rem;
+    }
+    .sidebar-toggle {
+        display: inline-block;
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        margin-right: 1rem;
+        cursor: pointer;
+        color: var(--text-color);
+    }
+    .top-nav {
+        display: flex;
+        align-items: center;
     }
 }
 /* --- Ductbank Route Shared Styles --- */


### PR DESCRIPTION
## Summary
- Implement hamburger toggle for sidebar and hide sidebar off-canvas on small screens
- Add button in navigation bar to open/close sidebar
- Enable sidebar control via JavaScript event listener

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iteratively finds ampacity near expected)*
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`
- `npx -y puppeteer@latest node -e "console.log('mobile test placeholder')"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899e544b9ac8324a9ab97f08659ff78