### PR TITLE
Defer script loading in HTML heads

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Interactive table for organizing cable data and exporting schedules.">
   <title>Cable Schedule</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
 </head>
 <body>
   <nav class="top-nav">

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -7,7 +7,7 @@
   <title>Cable Tray Packing</title>
 
   <!-- SheetJS / xlsx for Excel import/export -->
-  <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
 
   <style>
     body {

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -6,11 +6,11 @@
 <meta name="description" content="Planner for ductbank routes with conduit layout and soil resistivity controls."/>
 <title>Ductbank Route</title>
 <link rel="stylesheet" href="style.css">
-<script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
-<script src="https://unpkg.com/gpu.js@2.10.4/dist/gpu-browser.min.js"></script>
-<script src="soilResistivityConfig.js"></script>
-<script src="conductorProperties.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
+<script src="https://unpkg.com/gpu.js@2.10.4/dist/gpu-browser.min.js" defer></script>
+<script src="soilResistivityConfig.js" defer></script>
+<script src="conductorProperties.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.js" defer></script>
 <style>
 body{font-family:Arial,sans-serif;margin:16px;}
 label{display:inline-block;margin-bottom:4px;font-size:0.9rem;}

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <meta name="description" content="Landing page for configuring the optimal 3D cable routing system.">
     <title>Optimal 3D Cable Routing System</title>
     <link rel="stylesheet" href="style.css">
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
 </head>
 <body>
     <nav class="top-nav">


### PR DESCRIPTION
## Summary
- Add `defer` to script tags in `index.html`, `ductbankroute.html`, `cabletrayfill.html`, and `cableschedule.html` to avoid blocking rendering.

## Testing
- `node test.js` *(fails: computes conduit temperatures and iterative ampacity assertions)*
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899e59249f08324999d728ba74ce25e