### PR TITLE
Align nav bar to page top

### DIFF
--- a/style.css
+++ b/style.css
@@ -749,7 +749,7 @@ body.dark-mode .legalDisclaimer {
 
 /* --- Ductbank Route Page --- */
 body.ductbank-page {
-    margin: 16px;
+    margin: 0;
     font-family: Arial, sans-serif;
 }
 body.ductbank-page label {
@@ -776,7 +776,7 @@ body.ductbank-page button {
 
 /* --- Conduit Fill Page --- */
 body.conduitfill-page {
-    margin: 16px;
+    margin: 0;
     font-family: Arial, sans-serif;
 }
 body.conduitfill-page h1 {


### PR DESCRIPTION
## Summary
- Remove default margins from ductbank and conduit fill pages so the nav bar sits flush at the top

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iteratively finds ampacity near expected)*
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899f8689aec832493ff898f5e79bffa