### PR TITLE
Use global font stack for specialized pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -750,7 +750,6 @@ body.dark-mode .legalDisclaimer {
 /* --- Ductbank Route Page --- */
 body.ductbank-page {
     margin: 0;
-    font-family: Arial, sans-serif;
 }
 body.ductbank-page label {
     display: inline-block;
@@ -777,7 +776,6 @@ body.ductbank-page button {
 /* --- Conduit Fill Page --- */
 body.conduitfill-page {
     margin: 0;
-    font-family: Arial, sans-serif;
 }
 body.conduitfill-page h1 {
     margin-bottom: 8px;


### PR DESCRIPTION
## Summary
- Remove font-family overrides from ductbank and conduit fill pages to inherit the global stack

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iteratively finds ampacity near expected)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f931d28083248a7d98a6d817e543