### PR TITLE
Move settings control into top navigation

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -15,17 +15,17 @@
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
+    <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>
+  <div id="settings-menu" class="settings-menu">
+    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+    <button id="help-btn" aria-expanded="false">Site Help</button>
+  </div>
   <div class="container">
     <main class="main-content">
       <header class="page-header">
         <h1>Cable Schedule</h1>
-        <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
         <p>Centralized table for managing cable data.</p>
-        <div id="settings-menu" class="settings-menu">
-          <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-          <button id="help-btn" aria-expanded="false">Site Help</button>
-        </div>
       </header>
 
       <section class="card">

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -17,16 +17,16 @@
       <a href="cabletrayfill.html">Tray Fill</a>
       <a href="conduitfill.html">Conduit Fill</a>
       <a href="cableschedule.html">Cable Schedule</a>
+      <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
     </nav>
+    <div id="settings-menu" class="settings-menu">
+      <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+      <button id="help-btn" aria-expanded="false">Help</button>
+    </div>
     <div class="container">
       <main class="main-content">
         <header class="page-header">
           <h1>Cable Tray Packing</h1>
-          <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
-          <div id="settings-menu" class="settings-menu">
-            <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-            <button id="help-btn" aria-expanded="false">Help</button>
-          </div>
         </header>
 
         <!-- TRAY PARAMETERS -->

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -14,16 +14,16 @@
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
+    <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>
+  <div id="settings-menu" class="settings-menu">
+    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+    <button id="help-btn" aria-expanded="false">Help</button>
+  </div>
   <div class="container">
     <main class="main-content">
       <header class="page-header">
         <h1>Conduit Fill Visualization</h1>
-        <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
-        <div id="settings-menu" class="settings-menu">
-          <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-          <button id="help-btn" aria-expanded="false">Help</button>
-        </div>
       </header>
 
       <fieldset>

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -19,15 +19,15 @@
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
+    <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
 </nav>
+<div id="settings-menu" class="settings-menu">
+ <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+ <button id="helpBtn" aria-expanded="false">Help</button>
+ <button id="deleteDataBtn">Delete Saved Data</button>
+</div>
 <header class="page-header">
  <h1>Ductbank Route</h1>
- <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
- <div id="settings-menu" class="settings-menu">
-  <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-  <button id="helpBtn" aria-expanded="false">Help</button>
-  <button id="deleteDataBtn">Delete Saved Data</button>
- </div>
 </header>
 <details id="infoSection" open>
  <summary><strong>Ductbank Info</strong></summary>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,13 @@
         <a href="cabletrayfill.html">Tray Fill</a>
         <a href="conduitfill.html">Conduit Fill</a>
         <a href="cableschedule.html">Cable Schedule</a>
+        <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
     </nav>
+    <div id="settings-menu" class="settings-menu">
+        <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+        <button id="help-btn" aria-expanded="false">Site Help</button>
+        <button id="delete-data-btn">Delete Saved Data</button>
+    </div>
     <div class="container">
         <aside class="sidebar">
             <header>
@@ -86,13 +92,7 @@
         <main class="main-content">
             <header class="page-header">
                 <h1>Optimal 3D Cable Routing System</h1>
-                <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
                 <p>Find the most efficient path for routing cables through tray networks with capacity constraints.</p>
-                <div id="settings-menu" class="settings-menu">
-                    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
-                    <button id="help-btn" aria-expanded="false">Site Help</button>
-                    <button id="delete-data-btn">Delete Saved Data</button>
-                </div>
             </header>
 
             <section class="card">

--- a/style.css
+++ b/style.css
@@ -24,10 +24,8 @@ body.dark-mode {
     position: relative;
 }
 
+
 .settings-btn {
-    position: absolute;
-    top: 0;
-    right: 0;
     background: none;
     border: none;
     font-size: 1.4rem;
@@ -37,8 +35,8 @@ body.dark-mode {
 
 .settings-menu {
     position: absolute;
-    top: 2.2rem;
-    right: 0;
+    top: 3rem;
+    right: 1rem;
     background: var(--secondary-color);
     border: 1px solid var(--border-color);
     border-radius: 4px;
@@ -65,6 +63,11 @@ body {
     background: var(--secondary-color);
     border-bottom: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+}
+.top-nav .settings-btn {
+    margin-left: auto;
 }
 .top-nav a {
     margin-right: 1rem;


### PR DESCRIPTION
## Summary
- Move settings gear from page headers to top navigation and keep its menu accessible across all pages
- Flex layout for navigation and right-aligned settings button
- Simplify settings button styling and adjust menu positioning

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899f9e898e083249dc48a917b94d5ea