### PR TITLE
feat: add ductbank/conduit hierarchy

### DIFF
--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -29,26 +29,33 @@
         <p>Centralized tables for managing raceway data.</p>
       </header>
 
-      <!-- Ductbank Table -->
+      <!-- Ductbank / Conduit Hierarchy -->
       <section class="card">
         <h2>Ductbank Schedule</h2>
         <div style="margin-bottom:10px;">
           <button id="save-ductbank-btn">Save</button>
           <button id="load-ductbank-btn">Load</button>
-          <button id="clear-ductbank-filters-btn">Clear Filters</button>
           <button id="export-ductbank-xlsx-btn">Export XLSX</button>
           <input type="file" id="import-ductbank-xlsx-input" accept=".xlsx" style="display:none;">
           <button id="import-ductbank-xlsx-btn">Import XLSX</button>
-          <button id="delete-ductbank-btn">Delete All Rows</button>
+          <button id="delete-ductbank-btn">Delete All</button>
         </div>
         <div class="table-scroll">
           <table id="ductbankTable" class="sticky-table">
-            <thead></thead>
+            <thead>
+              <tr>
+                <th></th>
+                <th>Tag</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
             <tbody></tbody>
           </table>
         </div>
         <div style="margin-top:10px;">
-          <button id="add-ductbank-row-btn" class="primary-btn add-row-btn">Add Row</button>
+          <button id="add-ductbank-btn" class="primary-btn">Add Ductbank</button>
         </div>
       </section>
 
@@ -75,28 +82,6 @@
         </div>
       </section>
 
-      <!-- Conduit Table -->
-      <section class="card">
-        <h2>Conduit Schedule</h2>
-        <div style="margin-bottom:10px;">
-          <button id="save-conduit-btn">Save</button>
-          <button id="load-conduit-btn">Load</button>
-          <button id="clear-conduit-filters-btn">Clear Filters</button>
-          <button id="export-conduit-xlsx-btn">Export XLSX</button>
-          <input type="file" id="import-conduit-xlsx-input" accept=".xlsx" style="display:none;">
-          <button id="import-conduit-xlsx-btn">Import XLSX</button>
-          <button id="delete-conduit-btn">Delete All Rows</button>
-        </div>
-        <div class="table-scroll">
-          <table id="conduitTable" class="sticky-table">
-            <thead></thead>
-            <tbody></tbody>
-          </table>
-        </div>
-        <div style="margin-top:10px;">
-          <button id="add-conduit-row-btn" class="primary-btn add-row-btn">Add Row</button>
-        </div>
-      </section>
     </main>
   </div>
 
@@ -162,24 +147,153 @@ if(helpBtn&&helpModal&&closeHelpBtn){
   helpModal.addEventListener('click',e=>{ if(e.target===helpModal) closeModal(); });
 }
 
-const ductbankColumns=[
-  {key:'tag',label:'Tag',type:'text'},
-  {key:'from',label:'From',type:'text'},
-  {key:'to',label:'To',type:'text'}
-];
-TableUtils.createTable({
-  tableId:'ductbankTable',
-  storageKey:'ductbankSchedule',
-  addRowBtnId:'add-ductbank-row-btn',
-  saveBtnId:'save-ductbank-btn',
-  loadBtnId:'load-ductbank-btn',
-  clearFiltersBtnId:'clear-ductbank-filters-btn',
-  exportBtnId:'export-ductbank-xlsx-btn',
-  importInputId:'import-ductbank-xlsx-input',
-  importBtnId:'import-ductbank-xlsx-btn',
-  deleteAllBtnId:'delete-ductbank-btn',
-  columns:ductbankColumns
-});
+const ductbankTbody=document.querySelector('#ductbankTable tbody');
+let ductbanks=[];
+
+function renderDuctbanks(){
+  ductbankTbody.innerHTML='';
+  ductbanks.forEach((db,i)=>{
+    const row=ductbankTbody.insertRow();
+    row.className='ductbank-row';
+    const tgl=row.insertCell();
+    const tglBtn=document.createElement('button');
+    tglBtn.textContent=db.expanded?'\u25BC':'\u25B6';
+    tglBtn.addEventListener('click',()=>{db.expanded=!db.expanded;renderDuctbanks();});
+    tgl.appendChild(tglBtn);
+
+    const tag=row.insertCell();
+    const tagInput=document.createElement('input');
+    tagInput.value=db.tag||'';
+    tagInput.addEventListener('input',e=>{db.tag=e.target.value;saveDuctbanks();});
+    tag.appendChild(tagInput);
+
+    const from=row.insertCell();
+    const fromInput=document.createElement('input');
+    fromInput.value=db.from||'';
+    fromInput.addEventListener('input',e=>{db.from=e.target.value;saveDuctbanks();});
+    from.appendChild(fromInput);
+
+    const to=row.insertCell();
+    const toInput=document.createElement('input');
+    toInput.value=db.to||'';
+    toInput.addEventListener('input',e=>{db.to=e.target.value;saveDuctbanks();});
+    to.appendChild(toInput);
+
+    const act=row.insertCell();
+    const addC=document.createElement('button');
+    addC.textContent='Add Conduit';
+    addC.addEventListener('click',()=>{addConduit(i);});
+    const del=document.createElement('button');
+    del.textContent='Delete';
+    del.addEventListener('click',()=>{deleteDuctbank(i);});
+    act.appendChild(addC);
+    act.appendChild(del);
+
+    const cRow=ductbankTbody.insertRow();
+    cRow.className='conduit-container';
+    cRow.style.display=db.expanded?'':'none';
+    const cCell=cRow.insertCell();
+    cCell.colSpan=5;
+    const cTable=document.createElement('table');
+    const cHead=cTable.createTHead();
+    const h=cHead.insertRow();
+    ['Conduit ID','Type','Trade Size','From','To','Actions'].forEach(txt=>{
+      const th=document.createElement('th');
+      th.textContent=txt;
+      h.appendChild(th);
+    });
+    const cBody=cTable.createTBody();
+    db.conduits.forEach((c,j)=>{
+      const r=cBody.insertRow();
+      ['conduit_id','type','trade_size','from','to'].forEach(key=>{
+        const cell=r.insertCell();
+        const inp=document.createElement('input');
+        inp.value=c[key]||'';
+        inp.addEventListener('input',e=>{c[key]=e.target.value;saveDuctbanks();});
+        cell.appendChild(inp);
+      });
+      const actc=r.insertCell();
+      const delc=document.createElement('button');
+      delc.textContent='Delete';
+      delc.addEventListener('click',()=>{deleteConduit(i,j);});
+      actc.appendChild(delc);
+    });
+    cCell.appendChild(cTable);
+  });
+}
+
+function addDuctbank(){
+  ductbanks.push({id:Date.now(),tag:'',from:'',to:'',conduits:[],expanded:true});
+  renderDuctbanks();
+  saveDuctbanks();
+}
+
+function addConduit(i){
+  ductbanks[i].conduits.push({conduit_id:'',type:'',trade_size:'',from:'',to:''});
+  renderDuctbanks();
+  saveDuctbanks();
+}
+
+function deleteDuctbank(i){
+  ductbanks.splice(i,1);
+  renderDuctbanks();
+  saveDuctbanks();
+}
+
+function deleteConduit(i,j){
+  ductbanks[i].conduits.splice(j,1);
+  renderDuctbanks();
+  saveDuctbanks();
+}
+
+function saveDuctbanks(){
+  try{localStorage.setItem('ductbankHierarchy',JSON.stringify(ductbanks));}catch(e){}
+}
+
+function loadDuctbanks(){
+  try{ductbanks=JSON.parse(localStorage.getItem('ductbankHierarchy'))||[];}catch(e){ductbanks=[];}
+  ductbanks.forEach(db=>{if(db.expanded===undefined) db.expanded=false; if(!db.conduits) db.conduits=[];});
+  renderDuctbanks();
+}
+
+function exportDuctbankXlsx(){
+  const dbData=[['ductbank_id','tag','from','to']];
+  ductbanks.forEach(db=>dbData.push([db.id,db.tag,db.from,db.to]));
+  const cData=[['ductbank_id','conduit_id','type','trade_size','from','to']];
+  ductbanks.forEach(db=>db.conduits.forEach(c=>cData.push([db.id,c.conduit_id,c.type,c.trade_size,c.from,c.to])));
+  const wb=XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb,XLSX.utils.aoa_to_sheet(dbData),'Ductbanks');
+  XLSX.utils.book_append_sheet(wb,XLSX.utils.aoa_to_sheet(cData),'Conduits');
+  XLSX.writeFile(wb,'ductbank_schedule.xlsx');
+}
+
+function importDuctbankXlsx(file){
+  if(!file) return;
+  const reader=new FileReader();
+  reader.onload=e=>{
+    const wb=XLSX.read(e.target.result,{type:'binary'});
+    const dbSheet=wb.Sheets['Ductbanks']||wb.Sheets[wb.SheetNames[0]];
+    const cSheet=wb.Sheets['Conduits']||wb.Sheets[wb.SheetNames[1]];
+    const dbJson=XLSX.utils.sheet_to_json(dbSheet,{defval:''});
+    const cJson=cSheet?XLSX.utils.sheet_to_json(cSheet,{defval:''}):[];
+    const map={};
+    ductbanks=dbJson.map(r=>{const db={id:r['ductbank_id']||r['id']||Date.now()+Math.random(),tag:r['tag']||'',from:r['from']||'',to:r['to']||'',conduits:[],expanded:false};map[db.id]=db;return db;});
+    cJson.forEach(r=>{const p=map[r['ductbank_id']];if(p){p.conduits.push({conduit_id:r['conduit_id']||'',type:r['type']||'',trade_size:r['trade_size']||'',from:r['from']||'',to:r['to']||''});}});
+    renderDuctbanks();
+    saveDuctbanks();
+  };
+  reader.readAsBinaryString(file);
+}
+
+document.getElementById('add-ductbank-btn').addEventListener('click',addDuctbank);
+document.getElementById('save-ductbank-btn').addEventListener('click',saveDuctbanks);
+document.getElementById('load-ductbank-btn').addEventListener('click',loadDuctbanks);
+document.getElementById('delete-ductbank-btn').addEventListener('click',()=>{ductbanks=[];renderDuctbanks();saveDuctbanks();});
+document.getElementById('export-ductbank-xlsx-btn').addEventListener('click',exportDuctbankXlsx);
+document.getElementById('import-ductbank-xlsx-btn').addEventListener('click',()=>document.getElementById('import-ductbank-xlsx-input').click());
+document.getElementById('import-ductbank-xlsx-input').addEventListener('change',e=>{importDuctbankXlsx(e.target.files[0]);e.target.value='';});
+
+loadDuctbanks();
 
 const trayColumns=[
   {key:'tray_id',label:'Tray ID',type:'text'},
@@ -199,27 +313,6 @@ TableUtils.createTable({
   importBtnId:'import-tray-xlsx-btn',
   deleteAllBtnId:'delete-tray-btn',
   columns:trayColumns
-});
-
-const conduitColumns=[
-  {key:'conduit_id',label:'Conduit ID',type:'text'},
-  {key:'type',label:'Type',type:'text'},
-  {key:'trade_size',label:'Trade Size',type:'text'},
-  {key:'from',label:'From',type:'text'},
-  {key:'to',label:'To',type:'text'}
-];
-TableUtils.createTable({
-  tableId:'conduitTable',
-  storageKey:'conduitSchedule',
-  addRowBtnId:'add-conduit-row-btn',
-  saveBtnId:'save-conduit-btn',
-  loadBtnId:'load-conduit-btn',
-  clearFiltersBtnId:'clear-conduit-filters-btn',
-  exportBtnId:'export-conduit-xlsx-btn',
-  importInputId:'import-conduit-xlsx-input',
-  importBtnId:'import-conduit-xlsx-btn',
-  deleteAllBtnId:'delete-conduit-btn',
-  columns:conduitColumns
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- support ductbanks with nested conduit rows and expand/collapse controls
- enable adding/removing ductbanks and conduits and import/export via XLSX sheets keyed by `ductbank_id`
- keep tray schedule using existing table utilities

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iterative ampacity solver)*
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a29638da483248420c735b5a4ef11