### PR TITLE
Add Raceway Schedule to navigation across site

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -16,6 +16,7 @@
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
+    <a href="racewayschedule.html">Raceway Schedule</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>
   <div id="settings-menu" class="settings-menu">

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -17,6 +17,7 @@
       <a href="cabletrayfill.html">Tray Fill</a>
       <a href="conduitfill.html">Conduit Fill</a>
       <a href="cableschedule.html">Cable Schedule</a>
+      <a href="racewayschedule.html">Raceway Schedule</a>
       <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
     </nav>
     <div id="settings-menu" class="settings-menu">

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -14,6 +14,7 @@
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
+    <a href="racewayschedule.html">Raceway Schedule</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>
   <div id="settings-menu" class="settings-menu">

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -19,6 +19,7 @@
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
+    <a href="racewayschedule.html">Raceway Schedule</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
 </nav>
 <div id="settings-menu" class="settings-menu">

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <a href="cabletrayfill.html">Tray Fill</a>
         <a href="conduitfill.html">Conduit Fill</a>
         <a href="cableschedule.html">Cable Schedule</a>
+        <a href="racewayschedule.html">Raceway Schedule</a>
         <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
     </nav>
     <div id="settings-menu" class="settings-menu">

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -15,6 +15,7 @@
     <a href="ductbankroute.html">Ductbank</a>
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
+    <a href="cableschedule.html">Cable Schedule</a>
     <a href="racewayschedule.html">Raceway Schedule</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>


### PR DESCRIPTION
## Summary
- Add 'Raceway Schedule' link to top navigation of main site pages
- Link back to 'Cable Schedule' from the new Raceway Schedule page

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iteratively finds ampacity near expected)*

------
https://chatgpt.com/codex/tasks/task_e_689a2c116e688324abc2861808d49cc2