### PR TITLE
Refactor table controls and add raceway nesting styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,9 +98,9 @@
 
             <section class="card">
                 <h2>Cable Tray Network</h2>
-                <div class="tray-controls">
+                <div class="table-controls">
                     <button id="load-sample-trays-btn">Load Sample Tray Network</button>
-                    <div class="tray-import-export">
+                    <div class="table-import-export">
                         <button id="export-trays-btn">Export Trays CSV</button>
                         <input type="file" id="import-trays-file" accept=".csv" style="display:none;">
                         <button id="import-trays-btn">Import Trays CSV</button>
@@ -165,9 +165,9 @@
                     <button id="add-cable-btn">Add Cable to List</button>
                     <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="add-cable-help">?</span>
                     <span id="add-cable-help" class="tooltip">Add a new cable row using the current settings.</span>
-                    <div class="cable-controls">
+                    <div class="table-controls">
                         <button id="load-sample-cables-btn">Load Sample Cable List</button>
-                        <div class="cable-import-export">
+                        <div class="table-import-export">
                             <button id="export-cables-btn">Export Cables CSV</button>
                             <input type="file" id="import-cables-file" accept=".csv" style="display:none;">
                             <button id="import-cables-btn">Import Cables CSV</button>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -225,6 +225,7 @@ function renderDuctbanks(){
     const cCell=cRow.insertCell();
     cCell.colSpan=5;
     const cTable=document.createElement('table');
+    cTable.className='nested-table';
     const cHead=cTable.createTHead();
     const h=cHead.insertRow();
     ['Conduit ID','Type','Trade Size','From','To','Actions'].forEach(txt=>{

--- a/style.css
+++ b/style.css
@@ -248,7 +248,7 @@ details > summary {
     padding: 1rem 0;
 }
 
-.tray-import-export {
+.table-import-export {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
@@ -256,15 +256,7 @@ details > summary {
     margin-top: 10px;
 }
 
-.cable-import-export {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    align-items: center;
-    margin-top: 10px;
-}
-
-.tray-controls, .cable-controls {
+.table-controls {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -272,8 +264,7 @@ details > summary {
     margin-bottom: 10px;
 }
 
-.tray-controls .tray-import-export,
-.cable-controls .cable-import-export {
+.table-controls .table-import-export {
     margin-top: 0;
 }
 
@@ -749,6 +740,27 @@ body.dark-mode .legalDisclaimer {
 
 /* Highlight missing values */
 .missing-value{background-color:var(--warning-bg);}
+
+/* --- Raceway Schedule Page --- */
+.ductbank-row > td {
+    background-color: var(--secondary-color);
+    font-weight: bold;
+}
+
+.conduit-container {
+    background-color: var(--secondary-color);
+}
+
+.conduit-container table {
+    margin-left: 1.5rem;
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.nested-table th, .nested-table td {
+    padding: 4px;
+    border-bottom: 1px solid var(--border-color);
+}
 
 /* --- Ductbank Route Page --- */
 body.ductbank-page {


### PR DESCRIPTION
## Summary
- Rename cable-specific table control classes to generic `.table-controls` and `.table-import-export`
- Add raceway schedule styles for ductbank rows and nested conduit tables
- Hook up nested conduit table with new CSS class

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`
- Attempted to install puppeteer for rendering tests but received `403 Forbidden`

------
https://chatgpt.com/codex/tasks/task_e_689a2d2689a883249fcf9020a4fbca4c