### PR TITLE
Parameterize schedule storage keys and add global clear option

### DIFF
--- a/app.js
+++ b/app.js
@@ -1745,7 +1745,8 @@ const openConduitFill = (cables) => {
     };
 
     const deleteSavedData = () => {
-        localStorage.removeItem('ctrSession');
+        ['ctrSession','cableSchedule','ductbankSchedule','traySchedule','conduitSchedule']
+            .forEach(k => localStorage.removeItem(k));
         state.manualTrays = [];
         state.cableList = [];
         if (elements.manualTrayTableContainer) {
@@ -1754,7 +1755,7 @@ const openConduitFill = (cables) => {
         updateCableListDisplay();
         updateTrayDisplay();
         updateTableCounts();
-        alert('Saved session data cleared.');
+        alert('All saved data cleared.');
     };
 
     const showMessage = (type, text) => {

--- a/cableschedule.html
+++ b/cableschedule.html
@@ -150,7 +150,7 @@ const columns=[
 
 TableUtils.createTable({
   tableId:'cableScheduleTable',
-  storageKey:'cableSchedule',
+  storageKey:TableUtils.STORAGE_KEYS.cableSchedule,
   addRowBtnId:'add-row-btn',
   saveBtnId:'save-schedule-btn',
   loadBtnId:'load-schedule-btn',

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div id="settings-menu" class="settings-menu">
         <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
         <button id="help-btn" aria-expanded="false">Site Help</button>
-        <button id="delete-data-btn">Delete Saved Data</button>
+        <button id="delete-data-btn">Delete All Saved Data</button>
     </div>
     <div class="container">
         <aside class="sidebar">

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -173,6 +173,7 @@ if(helpBtn&&helpModal&&closeHelpBtn){
 
 const ductbankTbody=document.querySelector('#ductbankTable tbody');
 let ductbanks=[];
+const DUCTBANK_KEY = TableUtils.STORAGE_KEYS.ductbankSchedule;
 
 function renderDuctbanks(){
   ductbankTbody.innerHTML='';
@@ -280,11 +281,11 @@ function deleteConduit(i,j){
 }
 
 function saveDuctbanks(){
-  try{localStorage.setItem('ductbankHierarchy',JSON.stringify(ductbanks));}catch(e){}
+  try{localStorage.setItem(DUCTBANK_KEY,JSON.stringify(ductbanks));}catch(e){}
 }
 
 function loadDuctbanks(){
-  try{ductbanks=JSON.parse(localStorage.getItem('ductbankHierarchy'))||[];}catch(e){ductbanks=[];}
+  try{ductbanks=JSON.parse(localStorage.getItem(DUCTBANK_KEY))||[];}catch(e){ductbanks=[];}
   ductbanks.forEach(db=>{if(db.expanded===undefined) db.expanded=false; if(!db.conduits) db.conduits=[];});
   renderDuctbanks();
 }
@@ -342,7 +343,7 @@ const trayColumns=[
 ];
 TableUtils.createTable({
   tableId:'trayTable',
-  storageKey:'traySchedule',
+  storageKey:TableUtils.STORAGE_KEYS.traySchedule,
   addRowBtnId:'add-tray-btn',
   saveBtnId:'save-tray-btn',
   loadBtnId:'load-tray-btn',
@@ -368,7 +369,7 @@ const conduitColumns=[
 ];
 TableUtils.createTable({
   tableId:'conduitTable',
-  storageKey:'conduitSchedule',
+  storageKey:TableUtils.STORAGE_KEYS.conduitSchedule,
   addRowBtnId:'add-conduit-btn',
   saveBtnId:'save-conduit-btn',
   loadBtnId:'load-conduit-btn',

--- a/tableUtils.js
+++ b/tableUtils.js
@@ -1,3 +1,10 @@
+const STORAGE_KEYS = {
+  cableSchedule: 'cableSchedule',
+  ductbankSchedule: 'ductbankSchedule',
+  traySchedule: 'traySchedule',
+  conduitSchedule: 'conduitSchedule'
+};
+
 class TableManager {
   constructor(opts) {
     this.table = document.getElementById(opts.tableId);
@@ -242,4 +249,4 @@ function applyValidation(el, rules = []) {
   }
 }
 
-window.TableUtils = { createTable, saveToStorage, loadFromStorage, applyValidation };
+window.TableUtils = { createTable, saveToStorage, loadFromStorage, applyValidation, STORAGE_KEYS };


### PR DESCRIPTION
## Summary
- Centralize localStorage keys for schedules in `tableUtils.js` and export them for reuse
- Use unique storage keys for cable, tray, conduit and ductbank schedules
- Add global "Delete All Saved Data" button on home page to clear all stored schedule data

## Testing
- `node test.js` (fails: solveDuctbankTemperatures, calcFiniteAmpacity)
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a2eadb5c48324b9e40a843dfba271