### PR TITLE
Expose cable and raceway schedule getters

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -148,7 +148,7 @@ const columns=[
   {key:'notes',label:'Notes',type:'text',group:'Notes',tooltip:'Additional comments or notes'}
 ];
 
-TableUtils.createTable({
+const cableTable=TableUtils.createTable({
   tableId:'cableScheduleTable',
   storageKey:TableUtils.STORAGE_KEYS.cableSchedule,
   addRowBtnId:'add-row-btn',
@@ -161,6 +161,12 @@ TableUtils.createTable({
   deleteAllBtnId:'delete-all-btn',
   columns
 });
+
+function getCableSchedule(){
+  cableTable.save();
+  return cableTable.getData();
+}
+window.getCableSchedule=getCableSchedule;
 </script>
 </body>
 </html>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -341,7 +341,7 @@ const trayColumns=[
   {key:'height',label:'Height (in)',type:'number',validate:['required','numeric']},
   {key:'capacity',label:'Capacity',type:'number',validate:['numeric']}
 ];
-TableUtils.createTable({
+const trayTable=TableUtils.createTable({
   tableId:'trayTable',
   storageKey:TableUtils.STORAGE_KEYS.traySchedule,
   addRowBtnId:'add-tray-btn',
@@ -367,7 +367,7 @@ const conduitColumns=[
   {key:'end_z',label:'End Z',type:'number',validate:['required','numeric']},
   {key:'capacity',label:'Capacity',type:'number',validate:['numeric']}
 ];
-TableUtils.createTable({
+const conduitTable=TableUtils.createTable({
   tableId:'conduitTable',
   storageKey:TableUtils.STORAGE_KEYS.conduitSchedule,
   addRowBtnId:'add-conduit-btn',
@@ -380,6 +380,14 @@ TableUtils.createTable({
   deleteAllBtnId:'delete-conduit-btn',
   columns:conduitColumns
 });
+
+function getRacewaySchedule(){
+  saveDuctbanks();
+  trayTable.save();
+  conduitTable.save();
+  return {ductbanks:ductbanks,trays:trayTable.getData(),conduits:conduitTable.getData()};
+}
+window.getRacewaySchedule=getRacewaySchedule;
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add global `getRacewaySchedule` aggregating ductbanks, trays and conduits
- add global `getCableSchedule` for current cable entries

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a34b65d90832490a10ccc55d0da36