### PR TITLE
Parse numeric values in table data

### DIFF
--- a/tableUtils.js
+++ b/tableUtils.js
@@ -125,7 +125,21 @@ class TableManager {
       const row = {};
       this.columns.forEach((col,i) => {
         const el = tr.cells[i].firstChild;
-        row[col.key] = el ? el.value : '';
+        if (el) {
+          const val = el.value;
+          if (col.type === 'number') {
+            const num = parseFloat(val);
+            if (val === '') {
+              row[col.key] = '';
+            } else {
+              row[col.key] = isNaN(num) ? null : num;
+            }
+          } else {
+            row[col.key] = val;
+          }
+        } else {
+          row[col.key] = '';
+        }
       });
       rows.push(row);
     });


### PR DESCRIPTION
## Summary
- parse numeric cells with `parseFloat` when gathering table data
- prevent `NaN` in saved data by returning `null` or empty string for invalid numbers

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a3f0e310c8324a69489030e26f8e8