### PR TITLE
Fix ductbank table init on raceway schedule

### DIFF
--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -204,8 +204,11 @@ setupHelpModal('help-btn','help-modal');
 setupHelpModal('ductbank-help-btn','ductbank-help-modal');
 setupHelpModal('tray-help-btn','tray-help-modal');
 setupHelpModal('conduit-help-btn','conduit-help-modal');
-
-initDuctbankTable();
+document.addEventListener('DOMContentLoaded',()=>{
+  if(typeof initDuctbankTable==='function'){
+    initDuctbankTable();
+  }
+});
 
 const trayColumns=[
   {key:'tray_id',label:'Tray ID',type:'text',validate:['required']},


### PR DESCRIPTION
## Summary
- Ensure ductbank table init runs after deferred scripts load to avoid ReferenceError on racewayschedule.html

## Testing
- `node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a4a0787588324b196c992eb490d74