### PR TITLE
fix: ensure TableUtils loaded before use on Cable Schedule page

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -59,6 +59,7 @@
     </div>
   </div>
 <script>
+window.addEventListener('DOMContentLoaded',()=>{
 const darkToggle=document.getElementById('dark-toggle');
 const settingsBtn=document.getElementById('settings-btn');
 const settingsMenu=document.getElementById('settings-menu');
@@ -167,6 +168,7 @@ function getCableSchedule(){
   return cableTable.getData();
 }
 window.getCableSchedule=getCableSchedule;
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wait for DOM content to load before initializing Cable Schedule table

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a54f6ca688324abcdad75a2f5bc45