### PR TITLE
Reduce footer logo size

### DIFF
--- a/style.css
+++ b/style.css
@@ -1346,8 +1346,9 @@ body.dark-mode .workflow-card-title {
 }
 
 .footer-logo {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
+    max-width: 100%;
 }
 
 .footer-links {


### PR DESCRIPTION
## Summary
- Shrink footer logo to 20px square and prevent upscaling with max-width

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a6c1495cc8324afb649ae602524bb