### PR TITLE
Align navigation order and highlight current page

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -12,11 +12,11 @@
 <body>
   <nav class="top-nav">
     <a href="index.html">Home</a>
+    <a href="cableschedule.html" class="active" aria-current="page">Cable Schedule</a>
+    <a href="racewayschedule.html">Raceway Schedule</a>
     <a href="ductbankroute.html">Ductbank</a>
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
-    <a href="cableschedule.html">Cable Schedule</a>
-    <a href="racewayschedule.html">Raceway Schedule</a>
     <a href="optimalRoute.html">Optimal Route</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -13,11 +13,11 @@
   <body class="cabletrayfill-page">
     <nav class="top-nav">
       <a href="index.html">Home</a>
-      <a href="ductbankroute.html">Ductbank</a>
-      <a href="cabletrayfill.html">Tray Fill</a>
-      <a href="conduitfill.html">Conduit Fill</a>
       <a href="cableschedule.html">Cable Schedule</a>
       <a href="racewayschedule.html">Raceway Schedule</a>
+      <a href="ductbankroute.html">Ductbank</a>
+      <a href="cabletrayfill.html" class="active" aria-current="page">Tray Fill</a>
+      <a href="conduitfill.html">Conduit Fill</a>
       <a href="optimalRoute.html">Optimal Route</a>
       <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
     </nav>

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -10,11 +10,11 @@
 <body class="conduitfill-page">
   <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="ductbankroute.html">Ductbank</a>
-    <a href="cabletrayfill.html">Tray Fill</a>
-    <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
     <a href="racewayschedule.html">Raceway Schedule</a>
+    <a href="ductbankroute.html">Ductbank</a>
+    <a href="cabletrayfill.html">Tray Fill</a>
+    <a href="conduitfill.html" class="active" aria-current="page">Conduit Fill</a>
     <a href="optimalRoute.html">Optimal Route</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -15,11 +15,11 @@
 <body class="ductbank-page">
 <nav class="top-nav">
     <a href="index.html">Home</a>
-    <a href="ductbankroute.html">Ductbank</a>
-    <a href="cabletrayfill.html">Tray Fill</a>
-    <a href="conduitfill.html">Conduit Fill</a>
     <a href="cableschedule.html">Cable Schedule</a>
     <a href="racewayschedule.html">Raceway Schedule</a>
+    <a href="ductbankroute.html" class="active" aria-current="page">Ductbank</a>
+    <a href="cabletrayfill.html">Tray Fill</a>
+    <a href="conduitfill.html">Conduit Fill</a>
     <a href="optimalRoute.html">Optimal Route</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
 </nav>

--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
 </head>
 <body>
   <nav class="top-nav">
-    <a href="index.html">Home</a>
+    <a href="index.html" class="active" aria-current="page">Home</a>
+    <a href="cableschedule.html">Cable Schedule</a>
+    <a href="racewayschedule.html">Raceway Schedule</a>
     <a href="ductbankroute.html">Ductbank</a>
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
-    <a href="cableschedule.html">Cable Schedule</a>
-    <a href="racewayschedule.html">Raceway Schedule</a>
     <a href="optimalRoute.html">Optimal Route</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -14,12 +14,12 @@
     <nav class="top-nav">
         <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Sidebar">☰</button>
         <a href="index.html">Home</a>
+        <a href="cableschedule.html">Cable Schedule</a>
+        <a href="racewayschedule.html">Raceway Schedule</a>
         <a href="ductbankroute.html">Ductbank</a>
         <a href="cabletrayfill.html">Tray Fill</a>
         <a href="conduitfill.html">Conduit Fill</a>
-        <a href="cableschedule.html">Cable Schedule</a>
-        <a href="racewayschedule.html">Raceway Schedule</a>
-        <a href="optimalRoute.html">Optimal Route</a>
+        <a href="optimalRoute.html" class="active" aria-current="page">Optimal Route</a>
         <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
     </nav>
     <div id="settings-menu" class="settings-menu">

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -13,11 +13,11 @@
 <body>
   <nav class="top-nav">
     <a href="index.html">Home</a>
+    <a href="cableschedule.html">Cable Schedule</a>
+    <a href="racewayschedule.html" class="active" aria-current="page">Raceway Schedule</a>
     <a href="ductbankroute.html">Ductbank</a>
     <a href="cabletrayfill.html">Tray Fill</a>
     <a href="conduitfill.html">Conduit Fill</a>
-    <a href="cableschedule.html">Cable Schedule</a>
-    <a href="racewayschedule.html">Raceway Schedule</a>
     <a href="optimalRoute.html">Optimal Route</a>
     <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
   </nav>

--- a/style.css
+++ b/style.css
@@ -78,6 +78,12 @@ body {
     text-decoration: underline;
 }
 
+.top-nav a.active,
+.top-nav a[aria-current="page"] {
+    font-weight: bold;
+    text-decoration: underline;
+}
+
 .sidebar-toggle {
     display: none;
 }


### PR DESCRIPTION
## Summary
- Standardize top navigation order across all HTML pages
- Highlight current page via `active` link styles
- Add CSS rules for active navigation links

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`
- `node test.js` *(fails: computes conduit temperatures close to analytical values)*

------
https://chatgpt.com/codex/tasks/task_e_689a6c2c52d883249fabaf5ec2b6275a