### PR TITLE
Add SVG favicon and reference across site

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Interactive table for organizing cable data and exporting schedules.">
   <title>Cable Schedule</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script src="tableUtils.js" defer></script>

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="description" content="Calculator for packing cables into trays and checking fill levels."/>
   <title>Cable Tray Packing</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 
   <!-- SheetJS / xlsx for Excel import/export -->

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Tool for visualizing conduit fill capacity based on cable sizes." />
   <title>Conduit Fill Visualization</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="conduitfill-page">

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content="Planner for ductbank routes with conduit layout and soil resistivity controls."/>
 <title>Ductbank Route</title>
+<link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="style.css">
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
 <script src="https://unpkg.com/gpu.js@2.10.4/dist/gpu-browser.min.js" defer></script>

--- a/icons/favicon.svg
+++ b/icons/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32">
+  <path d="M8 56 L24 40 L40 48 L56 24" fill="none" stroke="#555" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="48,24 56,24 56,32" fill="none" stroke="#555" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Homepage for Cable Tray Route workflow.">
   <title>Cable Tray Route</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Landing page for configuring the optimal 3D cable routing system.">
     <title>Optimal 3D Cable Routing System</title>
+    <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Interactive tables for organizing raceway data and exporting schedules.">
   <title>Raceway Schedule</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script src="tableUtils.js" defer></script>


### PR DESCRIPTION
## Summary
- add route-based SVG favicon
- reference favicon in all HTML pages for consistent branding

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`
- `node test.js` *(fails: asserts on temperature and ampacity)*

------
https://chatgpt.com/codex/tasks/task_e_689a6c3005e88324a3480e8e7a0ffdd1