### PR TITLE
Add workflow progress indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,29 +36,35 @@
       <section class="card">
         <h2>Workflow</h2>
         <div class="workflow-grid">
-          <a href="cableschedule.html" class="workflow-card">
+          <a href="cableschedule.html" class="workflow-card" data-storage-key="cableSchedule">
             <img src="icons/cable.svg" alt="Cable icon" class="workflow-icon">
             <span>1. Cable Schedule</span>
+            <span class="status">Incomplete</span>
           </a>
-          <a href="racewayschedule.html" class="workflow-card">
+          <a href="racewayschedule.html" class="workflow-card" data-storage-key="racewaySchedule">
             <img src="icons/raceway.svg" alt="Raceway icon" class="workflow-icon">
             <span>2. Raceway Schedule</span>
+            <span class="status">Incomplete</span>
           </a>
-          <a href="ductbankroute.html" class="workflow-card">
+          <a href="ductbankroute.html" class="workflow-card" data-storage-key="ductbankSchedule">
             <img src="icons/ductbank.svg" alt="Ductbank icon" class="workflow-icon">
             <span>3. Ductbank</span>
+            <span class="status">Incomplete</span>
           </a>
-          <a href="cabletrayfill.html" class="workflow-card">
+          <a href="cabletrayfill.html" class="workflow-card" data-storage-key="traySchedule">
             <img src="icons/tray.svg" alt="Tray icon" class="workflow-icon">
             <span>4. Tray Fill</span>
+            <span class="status">Incomplete</span>
           </a>
-          <a href="conduitfill.html" class="workflow-card">
+          <a href="conduitfill.html" class="workflow-card" data-storage-key="conduitSchedule">
             <img src="icons/conduit.svg" alt="Conduit icon" class="workflow-icon">
             <span>5. Conduit Fill</span>
+            <span class="status">Incomplete</span>
           </a>
           <a href="optimalRoute.html" class="workflow-card">
             <img src="icons/route.svg" alt="Route icon" class="workflow-icon">
             <span>6. Optimal Cable Route</span>
+            <span class="status">Incomplete</span>
           </a>
         </div>
       </section>
@@ -82,6 +88,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="workflowStatus.js"></script>
   <script>
   window.addEventListener('DOMContentLoaded', () => {
     const darkToggle = document.getElementById('dark-toggle');

--- a/style.css
+++ b/style.css
@@ -17,6 +17,8 @@ body.dark-mode {
     --secondary-color: #343a40;
     --border-color: #495057;
     --text-color: #f8f9fa;
+    --success-text: #28a745;
+    --warning-text: #ffc107;
     background-color: #212529;
 }
 
@@ -1293,6 +1295,7 @@ body.dark-mode .hero-tagline {
     align-items: center;
     justify-content: center;
     gap: 0.75rem;
+    flex-direction: column;
     transition: background 0.3s, box-shadow 0.3s, transform 0.3s;
 }
 
@@ -1311,6 +1314,15 @@ body.dark-mode .hero-tagline {
 .workflow-card-title {
     font-size: 1rem;
     margin: 0;
+}
+
+.workflow-card .status {
+    font-size: 0.85rem;
+    color: var(--warning-text);
+}
+
+.workflow-card.complete .status {
+    color: var(--success-text);
 }
 
 body.dark-mode .workflow-card {

--- a/workflowStatus.js
+++ b/workflowStatus.js
@@ -1,0 +1,15 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const cards = document.querySelectorAll('.workflow-grid .workflow-card');
+  cards.forEach(card => {
+    const key = card.dataset.storageKey;
+    const statusEl = card.querySelector('.status');
+    if (!statusEl) return;
+    if (key && localStorage.getItem(key)) {
+      card.classList.add('complete');
+      statusEl.textContent = '✓';
+      statusEl.setAttribute('aria-label', 'Completed');
+    } else {
+      statusEl.textContent = 'Incomplete';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- show completion status for each workflow step on home page
- read localStorage keys to mark finished steps
- style status indicators for light and dark mode

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a6eb63a1c8324a4dc4d03ca592a95