### PR TITLE
Add prerequisite data checks for workflow pages

### DIFF
--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -12,6 +12,21 @@
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
 </head>
   <body class="cabletrayfill-page">
+    <script>
+    (function(){
+      const prereqs=[{key:'traySchedule',page:'racewayschedule.html',label:'Raceway Schedule'}];
+      const missing=prereqs.filter(p=>!localStorage.getItem(p.key));
+      if(missing.length){
+        document.addEventListener('DOMContentLoaded',()=>{
+          const notice=document.createElement('div');
+          notice.style.cssText='background:#fee;border:1px solid #f99;padding:10px;margin:10px;';
+          notice.innerHTML='Missing required data: '+missing.map(m=>`<a href="${m.page}">${m.label}</a>`).join(', ')+'.';
+          document.body.prepend(notice);
+          document.querySelectorAll('main button, aside button').forEach(btn=>btn.disabled=true);
+        });
+      }
+    })();
+    </script>
     <nav class="top-nav">
       <a href="index.html">Home</a>
       <a href="cableschedule.html">Cable Schedule</a>

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -9,6 +9,21 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="conduitfill-page">
+  <script>
+  (function(){
+    const prereqs=[{key:'conduitSchedule',page:'racewayschedule.html',label:'Raceway Schedule'}];
+    const missing=prereqs.filter(p=>!localStorage.getItem(p.key));
+    if(missing.length){
+      document.addEventListener('DOMContentLoaded',()=>{
+        const notice=document.createElement('div');
+        notice.style.cssText='background:#fee;border:1px solid #f99;padding:10px;margin:10px;';
+        notice.innerHTML='Missing required data: '+missing.map(m=>`<a href="${m.page}">${m.label}</a>`).join(', ')+'.';
+        document.body.prepend(notice);
+        document.querySelectorAll('main button, aside button').forEach(btn=>btn.disabled=true);
+      });
+    }
+  })();
+  </script>
   <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="cableschedule.html">Cable Schedule</a>

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -14,6 +14,21 @@
 <script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.js" defer></script>
 </head>
 <body class="ductbank-page">
+<script>
+(function(){
+  const prereqs=[{key:'ductbankSchedule',page:'racewayschedule.html',label:'Raceway Schedule'}];
+  const missing=prereqs.filter(p=>!localStorage.getItem(p.key));
+  if(missing.length){
+    document.addEventListener('DOMContentLoaded',()=>{
+      const notice=document.createElement('div');
+      notice.style.cssText='background:#fee;border:1px solid #f99;padding:10px;margin:10px;';
+      notice.innerHTML='Missing required data: '+missing.map(m=>`<a href="${m.page}">${m.label}</a>`).join(', ')+'.';
+      document.body.prepend(notice);
+      document.querySelectorAll('main button, aside button').forEach(btn=>btn.disabled=true);
+    });
+  }
+})();
+</script>
 <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="cableschedule.html">Cable Schedule</a>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -12,6 +12,24 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
 </head>
 <body>
+    <script>
+    (function(){
+        const prereqs=[
+            {key:'cableSchedule',page:'cableschedule.html',label:'Cable Schedule'},
+            {key:'traySchedule',page:'racewayschedule.html',label:'Raceway Schedule'}
+        ];
+        const missing=prereqs.filter(p=>!localStorage.getItem(p.key));
+        if(missing.length){
+            document.addEventListener('DOMContentLoaded',()=>{
+                const notice=document.createElement('div');
+                notice.style.cssText='background:#fee;border:1px solid #f99;padding:10px;margin:10px;';
+                notice.innerHTML='Missing required data: '+missing.map(m=>`<a href="${m.page}">${m.label}</a>`).join(', ')+'.';
+                document.body.prepend(notice);
+                document.querySelectorAll('main button, aside button').forEach(btn=>btn.disabled=true);
+            });
+        }
+    })();
+    </script>
     <nav class="top-nav">
         <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Sidebar">☰</button>
         <a href="index.html">Home</a>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -12,6 +12,21 @@
   <script src="ductbankTable.js" defer></script>
 </head>
 <body>
+  <script>
+  (function(){
+    const prereqs=[{key:'cableSchedule',page:'cableschedule.html',label:'Cable Schedule'}];
+    const missing=prereqs.filter(p=>!localStorage.getItem(p.key));
+    if(missing.length){
+      document.addEventListener('DOMContentLoaded',()=>{
+        const notice=document.createElement('div');
+        notice.style.cssText='background:#fee;border:1px solid #f99;padding:10px;margin:10px;';
+        notice.innerHTML='Missing required data: '+missing.map(m=>`<a href="${m.page}">${m.label}</a>`).join(', ')+'.';
+        document.body.prepend(notice);
+        document.querySelectorAll('main button, aside button').forEach(btn=>btn.disabled=true);
+      });
+    }
+  })();
+  </script>
   <nav class="top-nav">
     <a href="index.html">Home</a>
     <a href="cableschedule.html">Cable Schedule</a>


### PR DESCRIPTION
## Summary
- Ensure raceway schedule cannot be used until a cable schedule exists
- Block ductbank, tray fill, conduit fill and optimal route pages when their required schedule data is missing
- Each page shows a notice linking back to the page that supplies missing data and disables main controls

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a71cddc188324b7532eb65144db9c