### PR TITLE
Add step navigation across workflow pages

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -51,6 +51,10 @@
           <button id="add-row-btn" class="primary-btn add-row-btn">Add Cable</button>
         </div>
       </section>
+      <nav class="step-nav">
+        <a href="index.html">Previous</a>
+        <a href="racewayschedule.html">Next</a>
+      </nav>
     </main>
   </div>
   <div id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="help-title">

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -151,6 +151,11 @@
   <div id="results"></div>
   <div id="svgContainer"></div>
 
+  <nav class="step-nav">
+    <a href="ductbankroute.html">Previous</a>
+    <a href="conduitfill.html">Next</a>
+  </nav>
+
   <!-- OVERLAY + POPUP FOR EXPANDED VIEW -->
     <div id="overlay">
       <div id="popup">

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -103,6 +103,11 @@
       <div id="results"></div>
       <div id="svgContainer"></div>
 
+      <nav class="step-nav">
+        <a href="cabletrayfill.html">Previous</a>
+        <a href="optimalRoute.html">Next</a>
+      </nav>
+
       <!-- OVERLAY + POPUP FOR EXPANDED VIEW -->
       <div id="overlay">
         <div id="popup">

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -289,6 +289,11 @@
 </div>
 <div id="solver-info" style="font-size:0.9rem;margin-top:4px;"></div>
 
+ <nav class="step-nav">
+  <a href="racewayschedule.html">Previous</a>
+  <a href="cabletrayfill.html">Next</a>
+ </nav>
+
  </main>
 </div>
 

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -126,7 +126,10 @@
           <button id="add-conduit-btn" class="primary-btn add-row-btn">Add Conduit</button>
         </div>
       </section>
-
+      <nav class="step-nav">
+        <a href="cableschedule.html">Previous</a>
+        <a href="ductbankroute.html">Next</a>
+      </nav>
     </main>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -1344,6 +1344,26 @@ body.dark-mode .workflow-card-title {
     color: var(--text-color);
 }
 
+/* --- Step Navigation --- */
+.step-nav {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.step-nav a {
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.step-nav a:hover {
+    text-decoration: underline;
+}
+
 /* --- Footer --- */
 .site-footer {
     background: var(--secondary-color);


### PR DESCRIPTION
## Summary
- add Previous/Next footer navigation to workflow pages
- style step navigation for consistent responsive layout

## Testing
- `node --test` (fails: test.js 'test failed')
- `node --test tests`


------
https://chatgpt.com/codex/tasks/task_e_689a743848dc832482003f89a9d54cff