### PR TITLE
Add quick start guide and footer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # CableTrayRoute
 Designed to find the optimal cable route for your cable.
 
+## Quick Start
+
+For a step-by-step overview of the workflow, see the [Quick Start](docs/quickstart.html) guide. Each tool can run on its own, but following the six steps in sequence provides a smoother experience.
+
 ## Landing Page and Workflow
 
 The new landing page (`index.html`) links to every tool in the suite and outlines

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quick Start</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1>Quick Start</h1>
+    <p>Follow the six-step workflow to plan and route cables efficiently. Each tool can operate on its own, but completing the steps in sequence yields the best results.</p>
+  </header>
+  <main class="container">
+    <ol class="workflow-list">
+      <li>
+        <img src="../icons/cable.svg" alt="Cable icon" class="workflow-icon">
+        <strong>Cable Schedule</strong> – define the cables you need to route.
+      </li>
+      <li>
+        <img src="../icons/raceway.svg" alt="Raceway icon" class="workflow-icon">
+        <strong>Raceway Schedule</strong> – catalog trays, conduits, and ductbanks.
+      </li>
+      <li>
+        <img src="../icons/ductbank.svg" alt="Ductbank icon" class="workflow-icon">
+        <strong>Ductbank</strong> – analyze underground ductbanks and thermal limits.
+      </li>
+      <li>
+        <img src="../icons/tray.svg" alt="Tray icon" class="workflow-icon">
+        <strong>Tray Fill</strong> – visualize how cables occupy trays.
+      </li>
+      <li>
+        <img src="../icons/conduit.svg" alt="Conduit icon" class="workflow-icon">
+        <strong>Conduit Fill</strong> – evaluate stand‑alone conduit loading.
+      </li>
+      <li>
+        <img src="../icons/route.svg" alt="Route icon" class="workflow-icon">
+        <strong>Optimal Cable Route</strong> – generate the best path for each cable.
+      </li>
+    </ol>
+    <p class="note">You can open any tool directly for ad‑hoc checks, but stepping through them in order ensures data flows smoothly from one phase to the next.</p>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
     </div>
     <nav class="footer-links">
       <a href="README.md">README</a>
+      <a href="docs/quickstart.html">Quick Start</a>
       <a href="docs/">Docs</a>
       <a href="mailto:contact@example.com">Contact</a>
     </nav>


### PR DESCRIPTION
## Summary
- create `docs/quickstart.html` outlining six-step workflow
- add Quick Start section and link in `README.md`
- link quick start guide from homepage footer

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a759fc2d08324af32450d9676bcec