### PR TITLE
refactor: centralize site initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,9 @@ const SHAPE_COLORS = {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+    initSettings();
+    initDarkMode();
+    initHelpModal('help-btn','help-modal','close-help-btn');
     // --- UNSAVED CHANGES TRACKING ---
     let saved = true;
     const markSaved = () => { saved = true; };
@@ -2728,76 +2731,6 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
         elements.resetViewBtn.addEventListener('click', reset3DView);
     }
     elements.cancelRoutingBtn.addEventListener('click', cancelCurrentRouting);
-    if (elements.darkToggle) {
-        elements.darkToggle.addEventListener('change', () => {
-            if (elements.darkToggle.checked) {
-                document.body.classList.add('dark-mode');
-            } else {
-                document.body.classList.remove('dark-mode');
-            }
-            saveSession();
-        });
-        if (document.body.classList.contains('dark-mode')) {
-            elements.darkToggle.checked = true;
-        }
-    }
-    if (elements.settingsBtn && elements.settingsMenu) {
-        elements.settingsBtn.addEventListener('click', () => {
-            const expanded = elements.settingsMenu.style.display === 'flex';
-            elements.settingsMenu.style.display = expanded ? 'none' : 'flex';
-            elements.settingsBtn.setAttribute('aria-expanded', String(!expanded));
-        });
-        document.addEventListener('click', (e) => {
-            if (!elements.settingsMenu.contains(e.target) && e.target !== elements.settingsBtn) {
-                elements.settingsMenu.style.display = 'none';
-                elements.settingsBtn.setAttribute('aria-expanded', 'false');
-            }
-        });
-    }
-    if (elements.helpBtn && elements.helpModal && elements.closeHelpBtn) {
-        const focusableSelector = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
-        let firstFocusable, lastFocusable, previousFocus;
-        const trapFocus = (e) => {
-            if (e.key === 'Tab') {
-                if (e.shiftKey) {
-                    if (document.activeElement === firstFocusable) {
-                        e.preventDefault();
-                        lastFocusable.focus();
-                    }
-                } else if (document.activeElement === lastFocusable) {
-                    e.preventDefault();
-                    firstFocusable.focus();
-                }
-            } else if (e.key === 'Escape') {
-                closeModal();
-            }
-        };
-        const openModal = () => {
-            previousFocus = document.activeElement;
-            elements.helpModal.style.display = 'flex';
-            elements.helpModal.setAttribute('aria-hidden', 'false');
-            elements.helpBtn.setAttribute('aria-expanded', 'true');
-            const focusables = elements.helpModal.querySelectorAll(focusableSelector);
-            firstFocusable = focusables[0];
-            lastFocusable = focusables[focusables.length - 1];
-            firstFocusable && firstFocusable.focus();
-            elements.helpModal.addEventListener('keydown', trapFocus);
-        };
-        const closeModal = () => {
-            elements.helpModal.style.display = 'none';
-            elements.helpModal.setAttribute('aria-hidden', 'true');
-            elements.helpBtn.setAttribute('aria-expanded', 'false');
-            elements.helpModal.removeEventListener('keydown', trapFocus);
-            previousFocus && previousFocus.focus();
-        };
-        elements.helpBtn.addEventListener('click', openModal);
-        elements.closeHelpBtn.addEventListener('click', closeModal);
-        elements.helpModal.addEventListener('click', (e) => {
-            if (e.target === elements.helpModal) {
-                closeModal();
-            }
-        });
-    }
     if (elements.deleteDataBtn) {
         elements.deleteDataBtn.addEventListener('click', deleteSavedData);
     }

--- a/cableschedule.html
+++ b/cableschedule.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script src="tableUtils.js" defer></script>
+  <script src="site.js" defer></script>
 </head>
 <body>
   <nav class="top-nav">
@@ -66,62 +67,13 @@
   </div>
 <script>
 window.addEventListener('DOMContentLoaded',()=>{
+initSettings();
+initDarkMode();
+initHelpModal('help-btn','help-modal','close-help-btn');
 let saved=true;
 const markSaved=()=>{saved=true;};
 const markUnsaved=()=>{saved=false;};
 window.addEventListener('beforeunload',e=>{if(!saved){e.preventDefault();e.returnValue='';}});
-const darkToggle=document.getElementById('dark-toggle');
-const settingsBtn=document.getElementById('settings-btn');
-const settingsMenu=document.getElementById('settings-menu');
-if(settingsBtn&&settingsMenu){
-  settingsBtn.addEventListener('click',()=>{
-    const expanded=settingsMenu.style.display==='flex';
-    settingsMenu.style.display=expanded?'none':'flex';
-    settingsBtn.setAttribute('aria-expanded',String(!expanded));
-  });
-  document.addEventListener('click',e=>{
-    if(!settingsMenu.contains(e.target)&&e.target!==settingsBtn){
-      settingsMenu.style.display='none';
-      settingsBtn.setAttribute('aria-expanded','false');
-    }
-  });
-}
-if(darkToggle){
-  const sess=JSON.parse(localStorage.getItem('ctrSession')||'{}');
-  if(sess.darkMode){
-    document.body.classList.add('dark-mode');
-    darkToggle.checked=true;
-  }
-  darkToggle.addEventListener('change',()=>{
-    if(darkToggle.checked){
-      document.body.classList.add('dark-mode');
-    }else{
-      document.body.classList.remove('dark-mode');
-    }
-    sess.darkMode=darkToggle.checked;
-    localStorage.setItem('ctrSession',JSON.stringify(sess));
-  });
-}
-const helpBtn=document.getElementById('help-btn');
-const helpModal=document.getElementById('help-modal');
-const closeHelpBtn=document.getElementById('close-help-btn');
-if(helpBtn&&helpModal&&closeHelpBtn){
-  const openModal=()=>{
-    helpModal.style.display='flex';
-    helpModal.setAttribute('aria-hidden','false');
-    helpBtn.setAttribute('aria-expanded','true');
-    closeHelpBtn.focus();
-  };
-  const closeModal=()=>{
-    helpModal.style.display='none';
-    helpModal.setAttribute('aria-hidden','true');
-    helpBtn.setAttribute('aria-expanded','false');
-  };
-  helpBtn.addEventListener('click',openModal);
-  closeHelpBtn.addEventListener('click',closeModal);
-  helpModal.addEventListener('click',e=>{ if(e.target===helpModal) closeModal(); });
-}
-
 const INSULATION_TEMP_LIMIT={THHN:90,XLPE:90,PVC:75,XHHW:90,'XHHW-2':90,'THWN-2':90,THW:75,THWN:75,TW:60,UF:60};
 const conductorSizes=['#22 AWG','#20 AWG','#18 AWG','#16 AWG','#14 AWG','#12 AWG','#10 AWG','#8 AWG','#6 AWG','#4 AWG','#2 AWG','#1 AWG','1/0 AWG','2/0 AWG','3/0 AWG','4/0 AWG','250 kcmil','350 kcmil','500 kcmil','750 kcmil','1000 kcmil'];
 const cableTypes=['Power','Control','Signal'];

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -10,6 +10,7 @@
 
   <!-- SheetJS / xlsx for Excel import/export -->
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
+  <script src="site.js" defer></script>
 </head>
   <body class="cabletrayfill-page">
     <script>
@@ -201,56 +202,13 @@
 
   <script>
     document.addEventListener("DOMContentLoaded", function() {
+      initSettings();
+      initDarkMode();
+      initHelpModal('help-btn','helpOverlay','helpClose');
       let saved = true;
       const markSaved = () => { saved = true; };
       const markUnsaved = () => { saved = false; };
       window.addEventListener('beforeunload', e => { if (!saved) { e.preventDefault(); e.returnValue=''; } });
-      const session = JSON.parse(localStorage.getItem('ctrSession') || '{}');
-      if (session.darkMode) {
-        document.body.classList.add('dark-mode');
-      }
-      window.addEventListener('storage', (e) => {
-        if (e.key === 'ctrSession') {
-          try {
-            const data = JSON.parse(e.newValue);
-            if (data && data.darkMode) {
-              document.body.classList.add('dark-mode');
-            } else {
-              document.body.classList.remove('dark-mode');
-            }
-          } catch {}
-        }
-      });
-      const darkToggle = document.getElementById('dark-toggle');
-      const settingsBtn = document.getElementById('settings-btn');
-      const settingsMenu = document.getElementById('settings-menu');
-      if (settingsBtn && settingsMenu) {
-        settingsBtn.addEventListener('click', () => {
-          const expanded = settingsMenu.style.display === 'flex';
-          settingsMenu.style.display = expanded ? 'none' : 'flex';
-          settingsBtn.setAttribute('aria-expanded', String(!expanded));
-        });
-        document.addEventListener('click', e => {
-          if (!settingsMenu.contains(e.target) && e.target !== settingsBtn) {
-            settingsMenu.style.display = 'none';
-            settingsBtn.setAttribute('aria-expanded', 'false');
-          }
-        });
-      }
-      if (darkToggle) {
-        if (session.darkMode) {
-          darkToggle.checked = true;
-        }
-        darkToggle.addEventListener('change', () => {
-          if (darkToggle.checked) {
-            document.body.classList.add('dark-mode');
-          } else {
-            document.body.classList.remove('dark-mode');
-          }
-          session.darkMode = darkToggle.checked;
-          localStorage.setItem('ctrSession', JSON.stringify(session));
-        });
-      }
       // ─────────────────────────────────────────────────────────────
       // (A) Default Configurations (3 conductors + ground) :contentReference[oaicite:0]{index=0}
       // ─────────────────────────────────────────────────────────────
@@ -1955,14 +1913,6 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
         }
         localStorage.removeItem('trayFillData');
       }
-
-      // Global help overlay
-      document.getElementById("help-btn").addEventListener("click", () => {
-        document.getElementById("helpOverlay").style.display = "flex";
-      });
-      document.getElementById("helpClose").addEventListener("click", () => {
-        document.getElementById("helpOverlay").style.display = "none";
-      });
 
       // Attach help popups for table headers
       document.querySelectorAll('.helpBtn').forEach(btn => {

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -7,6 +7,7 @@
   <title>Conduit Fill Visualization</title>
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
+  <script src="site.js" defer></script>
 </head>
 <body class="conduitfill-page">
   <script>
@@ -147,26 +148,13 @@
     };
 
     document.addEventListener('DOMContentLoaded', () => {
+      initSettings();
+      initDarkMode();
+      initHelpModal('help-btn','help-modal','close-help-btn');
       let saved = true;
       const markSaved = () => { saved = true; };
       const markUnsaved = () => { saved = false; };
       window.addEventListener('beforeunload', e => { if(!saved){ e.preventDefault(); e.returnValue=''; }});
-      const session = JSON.parse(localStorage.getItem('ctrSession') || '{}');
-      if (session.darkMode) {
-        document.body.classList.add('dark-mode');
-      }
-      window.addEventListener('storage', (e) => {
-        if (e.key === 'ctrSession') {
-          try {
-            const data = JSON.parse(e.newValue);
-            if (data && data.darkMode) {
-              document.body.classList.add('dark-mode');
-            } else {
-              document.body.classList.remove('dark-mode');
-            }
-          } catch {}
-        }
-      });
 
       const typeSel = document.getElementById('conduitType');
       const sizeSel = document.getElementById('tradeSize');
@@ -506,79 +494,6 @@
       tableBody.addEventListener('input',markUnsaved);
       tableBody.addEventListener('click',e=>{if(e.target.tagName==='BUTTON') markUnsaved();});
       ['copyPngBtn','printBtn','copyBtn'].forEach(id=>{const el=document.getElementById(id);if(el)el.addEventListener('click',markSaved);});
-      const darkToggle = document.getElementById('dark-toggle');
-      const settingsBtn = document.getElementById('settings-btn');
-      const settingsMenu = document.getElementById('settings-menu');
-      if (settingsBtn && settingsMenu) {
-        settingsBtn.addEventListener('click', () => {
-          const expanded = settingsMenu.style.display === 'flex';
-          settingsMenu.style.display = expanded ? 'none' : 'flex';
-          settingsBtn.setAttribute('aria-expanded', String(!expanded));
-        });
-        document.addEventListener('click', e => {
-          if (!settingsMenu.contains(e.target) && e.target !== settingsBtn) {
-            settingsMenu.style.display = 'none';
-            settingsBtn.setAttribute('aria-expanded', 'false');
-          }
-        });
-      }
-      if (darkToggle) {
-        if (session.darkMode) {
-          darkToggle.checked = true;
-        }
-        darkToggle.addEventListener('change', () => {
-          if (darkToggle.checked) {
-            document.body.classList.add('dark-mode');
-          } else {
-            document.body.classList.remove('dark-mode');
-          }
-          session.darkMode = darkToggle.checked;
-          localStorage.setItem('ctrSession', JSON.stringify(session));
-        });
-      }
-      const helpBtn = document.getElementById('help-btn');
-      const helpModal = document.getElementById('help-modal');
-      const closeHelpBtn = document.getElementById('close-help-btn');
-      if (helpBtn && helpModal && closeHelpBtn) {
-        const focusableSelector = 'a[href],button:not([disabled]),textarea,input,select,[tabindex]:not([tabindex="-1"])';
-        let firstFocusable, lastFocusable, previousFocus;
-        const trapFocus = e => {
-          if (e.key === 'Tab') {
-            if (e.shiftKey) {
-              if (document.activeElement === firstFocusable) {
-                e.preventDefault();
-                lastFocusable.focus();
-              }
-            } else if (document.activeElement === lastFocusable) {
-              e.preventDefault();
-              firstFocusable.focus();
-            }
-          } else if (e.key === 'Escape') {
-            closeModal();
-          }
-        };
-        const openModal = () => {
-          previousFocus = document.activeElement;
-          helpModal.style.display = 'flex';
-          helpModal.setAttribute('aria-hidden', 'false');
-          helpBtn.setAttribute('aria-expanded', 'true');
-          const focusables = helpModal.querySelectorAll(focusableSelector);
-          firstFocusable = focusables[0];
-          lastFocusable = focusables[focusables.length - 1];
-          firstFocusable && firstFocusable.focus();
-          helpModal.addEventListener('keydown', trapFocus);
-        };
-        const closeModal = () => {
-          helpModal.style.display = 'none';
-          helpModal.setAttribute('aria-hidden', 'true');
-          helpBtn.setAttribute('aria-expanded', 'false');
-          helpModal.removeEventListener('keydown', trapFocus);
-          previousFocus && previousFocus.focus();
-        };
-        helpBtn.addEventListener('click', openModal);
-        closeHelpBtn.addEventListener('click', closeModal);
-        helpModal.addEventListener('click', e => { if (e.target === helpModal) closeModal(); });
-      }
 
       const stored = localStorage.getItem('conduitFillData');
       if (stored) {

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -12,6 +12,7 @@
 <script src="soilResistivityConfig.js" defer></script>
 <script src="conductorProperties.js" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.js" defer></script>
+<script src="site.js" defer></script>
 </head>
 <body class="ductbank-page">
 <script>
@@ -326,6 +327,11 @@
 </div>
 
 <script>
+document.addEventListener('DOMContentLoaded',()=>{
+  initSettings();
+  initDarkMode();
+  initHelpModal('helpBtn','helpOverlay','helpClose');
+});
 let heatVisible=false;
 window.lastHeatGrid=null;
 window.lastConduitTemps=null;
@@ -2528,28 +2534,6 @@ document.getElementById('scrollTopBtn').addEventListener('click',()=>{
 });
 document.getElementById('heatToggleBtn').addEventListener('click',toggleHeatMap);
 
-const darkToggle = document.getElementById('dark-toggle');
-const stored=JSON.parse(localStorage.getItem('ctrSession')||'{}');
-if(stored.darkMode){
-  document.body.classList.add('dark-mode');
-}
-if(darkToggle){
-  if(document.body.classList.contains('dark-mode')){
-    darkToggle.checked=true;
-  }
-  darkToggle.addEventListener('change',()=>{
-    if(darkToggle.checked){
-      document.body.classList.add('dark-mode');
-    }else{
-      document.body.classList.remove('dark-mode');
-    }
-    const session=JSON.parse(localStorage.getItem('ctrSession')||'{}');
-    session.darkMode=document.body.classList.contains('dark-mode');
-    localStorage.setItem('ctrSession',JSON.stringify(session));
-    saveDuctbankSession();
-  });
-}
-
 const hideDrawing=document.getElementById('hideDrawing');
 if(hideDrawing){
   hideDrawing.addEventListener('change',()=>{
@@ -2561,70 +2545,8 @@ if(hideDrawing){
   });
 }
 
-window.addEventListener('storage',e=>{if(e.key==='ctrSession'){const d=JSON.parse(e.newValue);if(d.darkMode)document.body.classList.add('dark-mode');else document.body.classList.remove('dark-mode');}});
-
-const helpBtn=document.getElementById('helpBtn');
-const helpOverlay=document.getElementById('helpOverlay');
-const helpClose=document.getElementById('helpClose');
-if(helpBtn&&helpOverlay&&helpClose){
- const focusableSelector='a[href],button:not([disabled]),textarea,input,select,[tabindex]:not([tabindex="-1"])';
- let firstFocusable,lastFocusable,previousFocus;
- const trapFocus=e=>{
-  if(e.key==='Tab'){
-   if(e.shiftKey){
-    if(document.activeElement===firstFocusable){
-     e.preventDefault();
-     lastFocusable.focus();
-    }
-   }else if(document.activeElement===lastFocusable){
-    e.preventDefault();
-    firstFocusable.focus();
-   }
-  }else if(e.key==='Escape'){
-   closeHelp();
-  }
- };
- const openHelp=()=>{
-  document.getElementById('settings-menu').style.display='none';
-  previousFocus=document.activeElement;
-  helpOverlay.style.display='flex';
-  helpOverlay.setAttribute('aria-hidden','false');
-  helpBtn.setAttribute('aria-expanded','true');
-  const focusables=helpOverlay.querySelectorAll(focusableSelector);
-  firstFocusable=focusables[0];
-  lastFocusable=focusables[focusables.length-1];
-  firstFocusable&&firstFocusable.focus();
-  helpOverlay.addEventListener('keydown',trapFocus);
- };
- const closeHelp=()=>{
-  helpOverlay.style.display='none';
-  helpOverlay.setAttribute('aria-hidden','true');
-  helpBtn.setAttribute('aria-expanded','false');
-  helpOverlay.removeEventListener('keydown',trapFocus);
-  previousFocus&&previousFocus.focus();
- };
- helpBtn.addEventListener('click',openHelp);
- helpClose.addEventListener('click',closeHelp);
- helpOverlay.addEventListener('click',e=>{if(e.target===helpOverlay)closeHelp();});
-}
 document.getElementById('deleteDataBtn').addEventListener('click',deleteSavedData);
 document.getElementById('resetBtn').addEventListener('click',deleteSavedData);
-
-const settingsBtn=document.getElementById('settings-btn');
-const settingsMenu=document.getElementById('settings-menu');
-if(settingsBtn&&settingsMenu){
- settingsBtn.addEventListener('click',()=>{
-  const expanded=settingsMenu.style.display==='flex';
-  settingsMenu.style.display=expanded?'none':'flex';
-  settingsBtn.setAttribute('aria-expanded',String(!expanded));
- });
- document.addEventListener('click',e=>{
-  if(!settingsMenu.contains(e.target)&&e.target!==settingsBtn){
-   settingsMenu.style.display='none';
-   settingsBtn.setAttribute('aria-expanded','false');
-  }
- });
-}
 
 const initHelpIcons=(root=document)=>{
  root.querySelectorAll('.help-icon').forEach(icon=>{

--- a/index.html
+++ b/index.html
@@ -90,54 +90,13 @@
     </nav>
   </footer>
   <script src="workflowStatus.js"></script>
+  <script src="site.js" defer></script>
   <script>
-  window.addEventListener('DOMContentLoaded', () => {
-    const darkToggle = document.getElementById('dark-toggle');
-    const settingsBtn = document.getElementById('settings-btn');
-    const settingsMenu = document.getElementById('settings-menu');
-    const helpBtn = document.getElementById('help-btn');
-    const helpModal = document.getElementById('help-modal');
-    const closeHelpBtn = document.getElementById('close-help-btn');
-
-    if(settingsBtn && settingsMenu){
-      settingsBtn.addEventListener('click', () => {
-        const expanded = settingsMenu.style.display === 'flex';
-        settingsMenu.style.display = expanded ? 'none' : 'flex';
-        settingsBtn.setAttribute('aria-expanded', String(!expanded));
-      });
-      document.addEventListener('click', e => {
-        if(!settingsMenu.contains(e.target) && e.target !== settingsBtn){
-          settingsMenu.style.display = 'none';
-          settingsBtn.setAttribute('aria-expanded', 'false');
-        }
-      });
-    }
-
-    if(darkToggle){
-      const sess = JSON.parse(localStorage.getItem('ctrSession') || '{}');
-      if(sess.darkMode){
-        document.body.classList.add('dark-mode');
-        darkToggle.checked = true;
-      }
-      darkToggle.addEventListener('change', () => {
-        document.body.classList.toggle('dark-mode', darkToggle.checked);
-        const sess = JSON.parse(localStorage.getItem('ctrSession') || '{}');
-        sess.darkMode = darkToggle.checked;
-        localStorage.setItem('ctrSession', JSON.stringify(sess));
-      });
-    }
-
-    if(helpBtn && helpModal && closeHelpBtn){
-      helpBtn.addEventListener('click', () => {
-        helpModal.style.display = 'flex';
-        helpModal.setAttribute('aria-hidden','false');
-      });
-      closeHelpBtn.addEventListener('click', () => {
-        helpModal.style.display = 'none';
-        helpModal.setAttribute('aria-hidden','true');
-      });
-    }
-  });
+    window.addEventListener('DOMContentLoaded', () => {
+      initSettings();
+      initDarkMode();
+      initHelpModal('help-btn','help-modal','close-help-btn');
+    });
   </script>
 </body>
 </html>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -10,6 +10,7 @@
     <script src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+    <script src="site.js" defer></script>
 </head>
 <body>
     <script>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -10,6 +10,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script src="tableUtils.js" defer></script>
   <script src="ductbankTable.js" defer></script>
+  <script src="site.js" defer></script>
 </head>
 <body>
   <script>
@@ -166,65 +167,6 @@
   </div>
 
 <script>
-const darkToggle=document.getElementById('dark-toggle');
-const settingsBtn=document.getElementById('settings-btn');
-const settingsMenu=document.getElementById('settings-menu');
-if(settingsBtn&&settingsMenu){
-  settingsBtn.addEventListener('click',()=>{
-    const expanded=settingsMenu.style.display==='flex';
-    settingsMenu.style.display=expanded?'none':'flex';
-    settingsBtn.setAttribute('aria-expanded',String(!expanded));
-  });
-  document.addEventListener('click',e=>{
-    if(!settingsMenu.contains(e.target)&&e.target!==settingsBtn){
-      settingsMenu.style.display='none';
-      settingsBtn.setAttribute('aria-expanded','false');
-    }
-  });
-}
-if(darkToggle){
-  const sess=JSON.parse(localStorage.getItem('ctrSession')||'{}');
-  if(sess.darkMode){
-    document.body.classList.add('dark-mode');
-    darkToggle.checked=true;
-  }
-  darkToggle.addEventListener('change',()=>{
-    if(darkToggle.checked){
-      document.body.classList.add('dark-mode');
-    }else{
-      document.body.classList.remove('dark-mode');
-    }
-    sess.darkMode=darkToggle.checked;
-    localStorage.setItem('ctrSession',JSON.stringify(sess));
-  });
-}
-
-function setupHelpModal(btnId,modalId){
-  const btn=document.getElementById(btnId);
-  const modal=document.getElementById(modalId);
-  if(!btn||!modal) return;
-  const closeBtn=modal.querySelector('.close-btn');
-  const open=()=>{
-    modal.style.display='flex';
-    modal.setAttribute('aria-hidden','false');
-    btn.setAttribute('aria-expanded','true');
-    if(closeBtn) closeBtn.focus();
-  };
-  const close=()=>{
-    modal.style.display='none';
-    modal.setAttribute('aria-hidden','true');
-    btn.setAttribute('aria-expanded','false');
-  };
-  btn.addEventListener('click',open);
-  if(closeBtn) closeBtn.addEventListener('click',close);
-  modal.addEventListener('click',e=>{ if(e.target===modal) close(); });
-}
-
-setupHelpModal('help-btn','help-modal');
-setupHelpModal('ductbank-help-btn','ductbank-help-modal');
-  setupHelpModal('tray-help-btn','tray-help-modal');
-  setupHelpModal('conduit-help-btn','conduit-help-modal');
-
 const CONDUIT_SPECS={"EMT":{"1/2":0.304,"3/4":0.533,"1":0.864,"1-1/4":1.496,"1-1/2":2.036,"2":3.356,"2-1/2":5.858,"3":8.846,"3-1/2":11.545,"4":14.753},"ENT":{"1/2":0.285,"3/4":0.508,"1":0.832,"1-1/4":1.453,"1-1/2":1.986,"2":3.291},"FMC":{"3/8":0.116,"1/2":0.317,"3/4":0.533,"1":0.817,"1-1/4":1.277,"1-1/2":1.858,"2":3.269,"2-1/2":4.909,"3":7.069,"3-1/2":9.621,"4":12.566},"IMC":{"1/2":0.342,"3/4":0.586,"1":0.959,"1-1/4":1.647,"1-1/2":2.225,"2":3.63,"2-1/2":5.135,"3":7.922,"3-1/2":10.584,"4":13.631},"LFNC-A":{"3/8":0.192,"1/2":0.312,"3/4":0.535,"1":0.854,"1-1/4":1.502,"1-1/2":2.018,"2":3.343},"LFNC-B":{"3/8":0.192,"1/2":0.314,"3/4":0.541,"1":0.873,"1-1/4":1.528,"1-1/2":1.981,"2":3.246},"LFMC":{"3/8":0.192,"1/2":0.314,"3/4":0.541,"1":0.873,"1-1/4":1.277,"1-1/2":1.858,"2":3.269,"2-1/2":4.881,"3":7.475,"3-1/2":9.731,"4":12.692},"RMC":{"1/2":0.314,"3/4":0.549,"1":0.887,"1-1/4":1.526,"1-1/2":2.071,"2":3.408,"2-1/2":4.866,"3":7.499,"3-1/2":10.01,"4":12.882,"5":20.212,"6":29.158},"PVC Sch 80":{"1/2":0.217,"3/4":0.409,"1":0.688,"1-1/4":1.237,"1-1/2":1.711,"2":2.874,"2-1/2":4.119,"3":6.442,"3-1/2":8.688,"4":11.258,"5":17.855,"6":25.598},"PVC Sch 40":{"1/2":0.285,"3/4":0.508,"1":0.832,"1-1/4":1.453,"1-1/2":1.986,"2":3.291,"2-1/2":4.695,"3":7.268,"3-1/2":9.737,"4":12.554,"5":19.761,"6":28.567},"PVC Type A":{"1/2":0.385,"3/4":0.65,"1":1.084,"1-1/4":1.767,"1-1/2":2.324,"2":3.647,"2-1/2":5.453,"3":8.194,"3-1/2":10.694,"4":13.723},"PVC Type EB":{"2":3.874,"3":8.709,"3-1/2":11.365,"4":14.448,"5":22.195,"6":31.53}};
 
 function parseSize(sz){
@@ -242,6 +184,12 @@ const TRAY_WIDTH_OPTIONS=['2','3','4','6','8','9','12','16','18','20','24','30',
 const TRAY_DEPTH_OPTIONS=['2','3','4','5','6','7','8','9','10','11','12'];
 
   document.addEventListener('DOMContentLoaded',()=>{
+  initSettings();
+  initDarkMode();
+  initHelpModal('help-btn','help-modal','close-help-btn');
+  initHelpModal('ductbank-help-btn','ductbank-help-modal');
+  initHelpModal('tray-help-btn','tray-help-modal');
+  initHelpModal('conduit-help-btn','conduit-help-modal');
   let saved=true;
   const markSaved=()=>{saved=true;};
   const markUnsaved=()=>{saved=false;};

--- a/site.js
+++ b/site.js
@@ -1,0 +1,70 @@
+function initSettings(){
+  const settingsBtn=document.getElementById('settings-btn');
+  const settingsMenu=document.getElementById('settings-menu');
+  if(settingsBtn&&settingsMenu){
+    settingsBtn.addEventListener('click',()=>{
+      const expanded=settingsMenu.style.display==='flex';
+      settingsMenu.style.display=expanded?'none':'flex';
+      settingsBtn.setAttribute('aria-expanded',String(!expanded));
+    });
+    document.addEventListener('click',e=>{
+      if(!settingsMenu.contains(e.target)&&e.target!==settingsBtn){
+        settingsMenu.style.display='none';
+        settingsBtn.setAttribute('aria-expanded','false');
+      }
+    });
+  }
+}
+
+function initDarkMode(){
+  const darkToggle=document.getElementById('dark-toggle');
+  const session=JSON.parse(localStorage.getItem('ctrSession')||'{}');
+  if(session.darkMode){
+    document.body.classList.add('dark-mode');
+    if(darkToggle) darkToggle.checked=true;
+  }
+  if(darkToggle){
+    darkToggle.addEventListener('change',()=>{
+      document.body.classList.toggle('dark-mode',darkToggle.checked);
+      session.darkMode=darkToggle.checked;
+      localStorage.setItem('ctrSession',JSON.stringify(session));
+      if(typeof window.saveSession==='function') window.saveSession();
+      if(typeof window.saveDuctbankSession==='function') window.saveDuctbankSession();
+    });
+  }
+  window.addEventListener('storage',e=>{
+    if(e.key==='ctrSession'){
+      try{
+        const data=JSON.parse(e.newValue);
+        document.body.classList.toggle('dark-mode',data&&data.darkMode);
+        if(darkToggle) darkToggle.checked=!!(data&&data.darkMode);
+      }catch{}
+    }
+  });
+}
+
+function initHelpModal(btnId='help-btn',modalId='help-modal',closeId){
+  const btn=document.getElementById(btnId);
+  const modal=document.getElementById(modalId);
+  const closeBtn=closeId?document.getElementById(closeId):(modal?modal.querySelector('.close-btn'):null);
+  if(btn&&modal&&closeBtn){
+    const open=()=>{
+      modal.style.display='flex';
+      modal.setAttribute('aria-hidden','false');
+      btn.setAttribute('aria-expanded','true');
+      closeBtn.focus();
+    };
+    const close=()=>{
+      modal.style.display='none';
+      modal.setAttribute('aria-hidden','true');
+      btn.setAttribute('aria-expanded','false');
+    };
+    btn.addEventListener('click',open);
+    closeBtn.addEventListener('click',close);
+    modal.addEventListener('click',e=>{if(e.target===modal)close();});
+  }
+}
+
+window.initSettings=initSettings;
+window.initDarkMode=initDarkMode;
+window.initHelpModal=initHelpModal;


### PR DESCRIPTION
## Summary
- add site.js with shared init functions for settings menu, dark mode, and help modal
- remove per-page scripts and load site.js across the app
- initialize common features on DOMContentLoaded for each page

## Testing
- `node test.js` *(fails: computes conduit temperatures close to analytical values, iteratively finds ampacity near expected)*
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a784888d48324922f605a7cf0f7f1