### PR TITLE
Add tray and cable CSV import templates

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,3 +48,11 @@ Columns (in order): `tray_id`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`
 ## Stand-alone Conduits (`conduit_schedule.csv`)
 
 Columns (in order): `conduit_id`, `type`, `trade_size`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`, `capacity`
+
+## Tray Import Template (`trays_template.csv`)
+
+Columns (in order): `tray_id`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`, `width`, `height`, `current_fill`, `allowed_cable_group`
+
+## Cable Import Template (`cables_template.csv`)
+
+Columns (in order): `tag`, `start_tag`, `end_tag`, `cable_type`, `conductors`, `conductor_size`, `diameter`, `weight`, `allowed_cable_group`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`

--- a/examples/cables_template.csv
+++ b/examples/cables_template.csv
@@ -1,0 +1,3 @@
+tag,start_tag,end_tag,cable_type,conductors,conductor_size,diameter,weight,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
+CABLE-1,START1,END1,Power,3,500 kcmil,1.5,2.0,HV,0,0,0,40,0,0
+CABLE-2,START2,END2,Control,2,#12 AWG,0.5,0.1,LV,0,0,10,40,0,10

--- a/examples/trays_template.csv
+++ b/examples/trays_template.csv
@@ -1,0 +1,3 @@
+tray_id,start_x,start_y,start_z,end_x,end_y,end_z,width,height,current_fill,allowed_cable_group
+T1,0,0,10,40,0,10,16,4,0,HV
+T2,40,0,10,80,0,10,16,4,0,LV


### PR DESCRIPTION
## Summary
- Restore `examples/trays_template.csv` and `examples/cables_template.csv` with headers matching the import formats
- Document the new templates in `examples/README.md`

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a7f173f6883248bcca0be12168ac2