### PR TITLE
Add skip links for main content

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -12,6 +12,7 @@
   <script src="site.js" defer></script>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
     <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
     <div class="nav-links">
@@ -30,7 +31,7 @@
     <button id="help-btn" aria-expanded="false">Site Help</button>
   </div>
   <div class="container">
-    <main class="main-content">
+    <main id="main-content" class="main-content">
       <header class="page-header">
         <h1>Cable Schedule</h1>
         <p>Centralized table for managing cable data.</p>

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -14,6 +14,7 @@
   <script src="cabletrayfill.js" defer></script>
 </head>
   <body class="cabletrayfill-page">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <nav class="top-nav">
       <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <div class="nav-links">
@@ -32,7 +33,7 @@
       <button id="help-btn" aria-expanded="false">Help</button>
     </div>
     <div class="container">
-      <main class="main-content">
+      <main id="main-content" class="main-content">
         <header class="page-header">
           <h1>Cable Tray Packing</h1>
         </header>

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -11,6 +11,7 @@
   <script src="conduitfill.js" defer></script>
 </head>
 <body class="conduitfill-page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
     <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
     <div class="nav-links">
@@ -29,7 +30,7 @@
     <button id="help-btn" aria-expanded="false">Help</button>
   </div>
   <div class="container">
-    <main class="main-content">
+    <main id="main-content" class="main-content">
       <header class="page-header">
         <h1>Conduit Fill Visualization</h1>
       </header>

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -16,6 +16,7 @@
 <script src="ductbankroute.js" defer></script>
 </head>
 <body class="ductbank-page">
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <nav class="top-nav">
     <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
     <div class="nav-links">
@@ -35,7 +36,7 @@
  <button id="deleteDataBtn">Delete Saved Data</button>
 </div>
 <div class="container">
- <main class="main-content">
+ <main id="main-content" class="main-content">
 <header class="page-header">
  <h1>Ductbank Route</h1>
 </header>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
     <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
     <div class="nav-links">
@@ -31,7 +32,7 @@
     <p class="hero-tagline">Browser-based toolkit unifying cable scheduling, analysis, and routing for streamlined design.</p>
   </header>
   <div class="container">
-    <main class="main-content">
+    <main id="main-content" class="main-content">
       <section class="about" id="about">
         <h2>Why CableTrayRoute?</h2>
         <p>CableTrayRoute streamlines electrical design by linking scheduling, analysis, and routing tools in one browser-based workflow. Engineers can define cables, assess tray and conduit capacity, and generate optimal paths without juggling spreadsheets. Automated checks against fill limits and thermal constraints reduce errors and rework. The unified interface accelerates planning and helps deliver consistent, code-compliant results on complex projects.</p>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -14,6 +14,7 @@
     <script src="optimalRoute.js" defer></script>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <nav class="top-nav">
         <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Sidebar">☰</button>
         <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
@@ -97,7 +98,7 @@
             </section>
         </aside>
 
-        <main class="main-content">
+        <main id="main-content" class="main-content">
             <header class="page-header">
                 <h1>Optimal 3D Cable Routing System</h1>
                 <p>Find the most efficient path for routing cables through tray networks with capacity constraints.</p>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -14,6 +14,7 @@
   <script src="racewayschedule.js" defer></script>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
     <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
     <div class="nav-links">
@@ -32,7 +33,7 @@
     <button id="help-btn" aria-expanded="false">Site Help</button>
   </div>
   <div class="container">
-    <main class="main-content">
+    <main id="main-content" class="main-content">
       <header class="page-header">
         <h1>Raceway Schedule</h1>
         <p>Centralized tables for managing raceway data.</p>

--- a/style.css
+++ b/style.css
@@ -60,6 +60,20 @@ body {
     color: var(--text-color);
 }
 
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: var(--secondary-color);
+    color: var(--text-color);
+    padding: 8px;
+    z-index: 100;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
 /* --- Top Navigation --- */
 .top-nav {
     background: var(--secondary-color);


### PR DESCRIPTION
## Summary
- Add hidden skip link on every HTML page for quick access to main content
- Assign `id="main-content"` to each page's primary `<main>` element
- Style skip link so it's hidden until focused for accessibility

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a855e2d948324891cca637e5f0118