### PR TITLE
Use system dark preference on first visit

### DIFF
--- a/site.js
+++ b/site.js
@@ -64,10 +64,13 @@ function initSettings(){
 function initDarkMode(){
   const darkToggle=document.getElementById('dark-toggle');
   const session=JSON.parse(localStorage.getItem('ctrSession')||'{}');
-  if(session.darkMode){
-    document.body.classList.add('dark-mode');
-    if(darkToggle) darkToggle.checked=true;
+  if(session.darkMode===undefined){
+    const prefersDark=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;
+    session.darkMode=prefersDark;
+    localStorage.setItem('ctrSession',JSON.stringify(session));
   }
+  document.body.classList.toggle('dark-mode',session.darkMode);
+  if(darkToggle) darkToggle.checked=!!session.darkMode;
   if(darkToggle){
     darkToggle.addEventListener('change',()=>{
       document.body.classList.toggle('dark-mode',darkToggle.checked);


### PR DESCRIPTION
## Summary
- Default to system `prefers-color-scheme` when no dark mode preference stored
- Persist detected theme to `ctrSession` and update UI accordingly

## Testing
- `node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a8562943c83248d76db681afde97b