### PR TITLE
Add custom 404 page for missing routes

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="404 page for missing routes.">
+  <title>Page Not Found</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="cableschedule.html">Cable Schedule</a>
+      <a href="racewayschedule.html">Raceway Schedule</a>
+      <a href="ductbankroute.html">Ductbank</a>
+      <a href="cabletrayfill.html">Tray Fill</a>
+      <a href="conduitfill.html">Conduit Fill</a>
+      <a href="optimalRoute.html">Optimal Route</a>
+      <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+    </div>
+  </nav>
+  <div id="settings-menu" class="settings-menu">
+    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+    <button id="help-btn" aria-expanded="false">Site Help</button>
+  </div>
+  <div class="container">
+    <main class="main-content">
+      <section class="card">
+        <h1>Page Not Found</h1>
+        <p>The page you requested could not be found.</p>
+        <p><a href="index.html">Return to the homepage</a></p>
+      </section>
+    </main>
+  </div>
+  <div id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="help-title">
+    <div class="modal-content">
+      <button id="close-help-btn" class="close-btn" aria-label="Close Help">&times;</button>
+      <h2 id="help-title">Need Help?</h2>
+      <p>Use the navigation links above to find your way.</p>
+    </div>
+  </div>
+  <script src="site.js" defer></script>
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      initSettings();
+      initDarkMode();
+      initHelpModal('help-btn','help-modal','close-help-btn');
+      initNavToggle();
+    });
+  </script>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -121,3 +121,7 @@ Use the buttons above each table to **Save** to browser storage, **Load** saved 
 
 ## Clearing Saved Sessions
 The application stores your trays, cables and theme preference in browser storage. Open the settings menu (⚙) and click **Delete Saved Data** to clear this information.
+
+## Missing Pages
+
+A custom [`404.html`](404.html) page displays a short message and navigation when a route isn't found. GitHub Pages will automatically serve this file for unknown paths so visitors can return to the [home page](index.html).


### PR DESCRIPTION
## Summary
- add `404.html` with site navigation, a helpful message, and a link back to `index.html`
- document GitHub Pages behavior so missing routes serve the new 404 page

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a85666d988324a95443ec711c751c