### PR TITLE
build: bundle scripts with rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/404.html
+++ b/404.html
@@ -42,7 +42,7 @@
       <p>Use the navigation links above to find your way.</p>
     </div>
   </div>
-  <script src="site.js" defer></script>
+  <script src="dist/404.js" defer></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       initSettings();

--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,8 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
-  <script src="tableUtils.js" defer></script>
-  <script src="site.js" defer></script>
+  <script src="dist/cableschedule.js" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -10,8 +10,7 @@
 
   <!-- SheetJS / xlsx for Excel import/export -->
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
-  <script src="site.js" defer></script>
-  <script src="cabletrayfill.js" defer></script>
+  <script src="dist/cabletrayfill.js" defer></script>
 </head>
   <body class="cabletrayfill-page">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -7,8 +7,7 @@
   <title>Conduit Fill Visualization</title>
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
-  <script src="site.js" defer></script>
-  <script src="conduitfill.js" defer></script>
+  <script src="dist/conduitfill.js" defer></script>
 </head>
 <body class="conduitfill-page">
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -9,11 +9,8 @@
 <link rel="stylesheet" href="style.css">
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
 <script src="https://unpkg.com/gpu.js@2.10.4/dist/gpu-browser.min.js" defer></script>
-<script src="soilResistivityConfig.js" defer></script>
-<script src="conductorProperties.js" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.js" defer></script>
-<script src="site.js" defer></script>
-<script src="ductbankroute.js" defer></script>
+<script src="dist/ductbankroute.js" defer></script>
 </head>
 <body class="ductbank-page">
 <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/index.html
+++ b/index.html
@@ -93,8 +93,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
-  <script src="workflowStatus.js"></script>
-  <script src="site.js" defer></script>
+  <script src="dist/index.js" defer></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       initSettings();

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -10,8 +10,7 @@
     <script src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
-    <script src="site.js" defer></script>
-    <script src="optimalRoute.js" defer></script>
+    <script src="dist/optimalRoute.js" defer></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cabletrayroute",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "rollup -c",
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js"
+  },
+  "devDependencies": {
+    "@rollup/plugin-terser": "^0.4.3",
+    "rollup": "^3.29.0"
+  }
+}

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -8,10 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
-  <script src="tableUtils.js" defer></script>
-  <script src="ductbankTable.js" defer></script>
-  <script src="site.js" defer></script>
-  <script src="racewayschedule.js" defer></script>
+  <script src="dist/racewayschedule.js" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,20 @@
+const { terser } = require('@rollup/plugin-terser');
+
+module.exports = {
+  input: {
+    index: 'src/index.js',
+    cableschedule: 'src/cableschedule.js',
+    racewayschedule: 'src/racewayschedule.js',
+    ductbankroute: 'src/ductbankroute.js',
+    cabletrayfill: 'src/cabletrayfill.js',
+    conduitfill: 'src/conduitfill.js',
+    optimalRoute: 'src/optimalRoute.js',
+    '404': 'src/404.js'
+  },
+  output: {
+    dir: 'dist',
+    format: 'iife',
+    sourcemap: false
+  },
+  plugins: [terser()]
+};

--- a/src/404.js
+++ b/src/404.js
@@ -1,0 +1,2 @@
+import '../workflowStatus.js';
+import '../site.js';

--- a/src/cableschedule.js
+++ b/src/cableschedule.js
@@ -1,0 +1,3 @@
+import '../workflowStatus.js';
+import '../site.js';
+import '../tableUtils.js';

--- a/src/cabletrayfill.js
+++ b/src/cabletrayfill.js
@@ -1,0 +1,3 @@
+import '../workflowStatus.js';
+import '../site.js';
+import '../cabletrayfill.js';

--- a/src/conduitfill.js
+++ b/src/conduitfill.js
@@ -1,0 +1,3 @@
+import '../workflowStatus.js';
+import '../site.js';
+import '../conduitfill.js';

--- a/src/ductbankroute.js
+++ b/src/ductbankroute.js
@@ -1,0 +1,5 @@
+import '../workflowStatus.js';
+import '../site.js';
+import '../soilResistivityConfig.js';
+import '../conductorProperties.js';
+import '../ductbankroute.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+import '../workflowStatus.js';
+import '../site.js';

--- a/src/optimalRoute.js
+++ b/src/optimalRoute.js
@@ -1,0 +1,3 @@
+import '../workflowStatus.js';
+import '../site.js';
+import '../optimalRoute.js';

--- a/src/racewayschedule.js
+++ b/src/racewayschedule.js
@@ -1,0 +1,5 @@
+import '../workflowStatus.js';
+import '../site.js';
+import '../tableUtils.js';
+import '../ductbankTable.js';
+import '../racewayschedule.js';


### PR DESCRIPTION
## Summary
- add Rollup config bundling common and page-specific scripts
- update HTML pages to load minified bundles from dist/
- ignore generated dist directory

## Testing
- `npm test`
- `npm install` (failed: 403 Forbidden - GET https://registry.npmjs.org/@rollup%2fplugin-terser)
- `npm run build` (failed: rollup: not found)

------
https://chatgpt.com/codex/tasks/task_e_689a86d651d48324ae9e88200a974128