### PR TITLE
Expose loadConductorProperties globally

### DIFF
--- a/conductorProperties.js
+++ b/conductorProperties.js
@@ -4,3 +4,8 @@ function loadConductorProperties(){
     .then(data=>{window.CONDUCTOR_PROPS=data;return data;})
     .catch(err=>{console.error('Failed to load conductor properties',err);window.CONDUCTOR_PROPS={};return {};});
 }
+
+// Ensure the loader is available globally when modules are bundled.
+if (typeof window !== 'undefined') {
+  window.loadConductorProperties = loadConductorProperties;
+}


### PR DESCRIPTION
## Summary
- Make `loadConductorProperties` attach to `window` so ductbank sample cable loading works when bundled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8793ed64832499b2a92545885336