### PR TITLE
chore: configure linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+/*.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+export default [
+  {
+    files: ['**/*.js'],
+    ignores: ['dist/**', 'node_modules/**'],
+    languageOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2021,
+    },
+    rules: {},
+  },
+];

--- a/src/404.js
+++ b/src/404.js
@@ -1,2 +1,2 @@
-import '../workflowStatus.js';
-import '../site.js';
+import "../workflowStatus.js";
+import "../site.js";

--- a/src/cableschedule.js
+++ b/src/cableschedule.js
@@ -1,3 +1,3 @@
-import '../workflowStatus.js';
-import '../site.js';
-import '../tableUtils.js';
+import "../workflowStatus.js";
+import "../site.js";
+import "../tableUtils.js";

--- a/src/cabletrayfill.js
+++ b/src/cabletrayfill.js
@@ -1,3 +1,3 @@
-import '../workflowStatus.js';
-import '../site.js';
-import '../cabletrayfill.js';
+import "../workflowStatus.js";
+import "../site.js";
+import "../cabletrayfill.js";

--- a/src/conduitfill.js
+++ b/src/conduitfill.js
@@ -1,3 +1,3 @@
-import '../workflowStatus.js';
-import '../site.js';
-import '../conduitfill.js';
+import "../workflowStatus.js";
+import "../site.js";
+import "../conduitfill.js";

--- a/src/ductbankroute.js
+++ b/src/ductbankroute.js
@@ -1,5 +1,5 @@
-import '../workflowStatus.js';
-import '../site.js';
-import '../soilResistivityConfig.js';
-import '../conductorProperties.js';
-import '../ductbankroute.js';
+import "../workflowStatus.js";
+import "../site.js";
+import "../soilResistivityConfig.js";
+import "../conductorProperties.js";
+import "../ductbankroute.js";

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-import '../workflowStatus.js';
-import '../site.js';
+import "../workflowStatus.js";
+import "../site.js";

--- a/src/optimalRoute.js
+++ b/src/optimalRoute.js
@@ -1,3 +1,3 @@
-import '../workflowStatus.js';
-import '../site.js';
-import '../optimalRoute.js';
+import "../workflowStatus.js";
+import "../site.js";
+import "../optimalRoute.js";

--- a/src/racewayschedule.js
+++ b/src/racewayschedule.js
@@ -1,5 +1,5 @@
-import '../workflowStatus.js';
-import '../site.js';
-import '../tableUtils.js';
-import '../ductbankTable.js';
-import '../racewayschedule.js';
+import "../workflowStatus.js";
+import "../site.js";
+import "../tableUtils.js";
+import "../ductbankTable.js";
+import "../racewayschedule.js";

--- a/tests/ampacity.test.js
+++ b/tests/ampacity.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require("assert");
 const {
   dcResistance,
   conductorThermalResistance,
@@ -6,8 +6,8 @@ const {
   skinEffect,
   dielectricRise,
   ampacity,
-  calibrateAmpacityModel
-} = require('../ampacity');
+  calibrateAmpacityModel,
+} = require("../ampacity");
 
 function describe(name, fn) {
   console.log(name);
@@ -17,82 +17,109 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.error('  \u2717', name, err.message || err);
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
-describe('core thermal functions', () => {
-  it('dcResistance matches expected value', () => {
-    const r = dcResistance('500 kcmil', 'Copper', 90);
+describe("core thermal functions", () => {
+  it("dcResistance matches expected value", () => {
+    const r = dcResistance("500 kcmil", "Copper", 90);
     assert(Math.abs(r - 0.0000893) < 5e-7);
   });
 
-  it('skinEffect interpolates correctly', () => {
-    const y = skinEffect('500 kcmil');
+  it("skinEffect interpolates correctly", () => {
+    const y = skinEffect("500 kcmil");
     assert(Math.abs(y - 0.1) < 0.001);
   });
 
-  it('dielectricRise gives 0 at 600V', () => {
+  it("dielectricRise gives 0 at 600V", () => {
     const d = dielectricRise(600);
     assert.strictEqual(d, 0);
   });
 
-  it('conductorThermalResistance returns reasonable values', () => {
+  it("conductorThermalResistance returns reasonable values", () => {
     const res = conductorThermalResistance({
-      conductor_size: '500 kcmil',
-      conductor_material: 'Copper'
+      conductor_size: "500 kcmil",
+      conductor_material: "Copper",
     });
     assert(Math.abs(res.Rcond - 0.00274) < 1e-4);
     assert(Math.abs(res.Rins - 0.12626) < 1e-4);
   });
 
-  it('calcRcaComponents includes air resistance', () => {
-    const comps = calcRcaComponents({
-      conductor_size: '500 kcmil',
-      conductor_material: 'Copper'
-    }, { medium: 'air' });
+  it("calcRcaComponents includes air resistance", () => {
+    const comps = calcRcaComponents(
+      {
+        conductor_size: "500 kcmil",
+        conductor_material: "Copper",
+      },
+      { medium: "air" },
+    );
     assert(Math.abs(comps.Rca - 3.529) < 0.01);
   });
 });
 
-describe('ampacity calibration', () => {
-  it('calibrateAmpacityModel brings results within 10%', () => {
+describe("ampacity calibration", () => {
+  it("calibrateAmpacityModel brings results within 10%", () => {
     const res = calibrateAmpacityModel();
-    assert(res.maxError <= 0.10);
+    assert(res.maxError <= 0.1);
 
     const cases = [
-      { ref: 260, cable: { conductor_size: '4/0 AWG', conductor_material: 'Copper', insulation_rating: 90, voltage_rating: 600 } },
-      { ref: 430, cable: { conductor_size: '500 kcmil', conductor_material: 'Copper', insulation_rating: 90, voltage_rating: 600 } },
-      { ref: 215, cable: { conductor_size: '250 kcmil', conductor_material: 'Aluminum', insulation_rating: 75, voltage_rating: 600 } }
+      {
+        ref: 260,
+        cable: {
+          conductor_size: "4/0 AWG",
+          conductor_material: "Copper",
+          insulation_rating: 90,
+          voltage_rating: 600,
+        },
+      },
+      {
+        ref: 430,
+        cable: {
+          conductor_size: "500 kcmil",
+          conductor_material: "Copper",
+          insulation_rating: 90,
+          voltage_rating: 600,
+        },
+      },
+      {
+        ref: 215,
+        cable: {
+          conductor_size: "250 kcmil",
+          conductor_material: "Aluminum",
+          insulation_rating: 75,
+          voltage_rating: 600,
+        },
+      },
     ];
-    cases.forEach(c => {
-      const I = ampacity(c.cable, { medium: 'air' }).ampacity;
+    cases.forEach((c) => {
+      const I = ampacity(c.cable, { medium: "air" }).ampacity;
       const err = Math.abs(I - c.ref) / c.ref;
-      assert(err <= 0.10);
+      assert(err <= 0.1);
     });
   });
-  it('500 kcmil Cu THHN at 90C close to IEEE 835', () => {
+  it("500 kcmil Cu THHN at 90C close to IEEE 835", () => {
     const cable = {
-      conductor_size: '500 kcmil',
-      conductor_material: 'Copper',
+      conductor_size: "500 kcmil",
+      conductor_material: "Copper",
       insulation_rating: 90,
-      voltage_rating: 600
+      voltage_rating: 600,
     };
-    const I = ampacity(cable, { medium: 'air' }).ampacity;
+    const I = ampacity(cable, { medium: "air" }).ampacity;
     assert(Math.abs(I - 430) / 430 < 0.1);
   });
 
-  it('2/0 Al at 75C ~150A', () => {
+  it("2/0 Al at 75C ~150A", () => {
     const cable = {
-      conductor_size: '2/0 AWG',
-      conductor_material: 'Aluminum',
+      conductor_size: "2/0 AWG",
+      conductor_material: "Aluminum",
       insulation_rating: 75,
-      voltage_rating: 600
+      voltage_rating: 600,
     };
-    const I = ampacity(cable, { medium: 'air' }).ampacity;
+    const I = ampacity(cable, { medium: "air" }).ampacity;
     assert(Math.abs(I - 150) / 150 < 0.1);
   });
 });

--- a/tests/ductbankSolver.test.js
+++ b/tests/ductbankSolver.test.js
@@ -1,5 +1,10 @@
-const assert = require('assert');
-const { solveDuctbankTemperatures, SMALL_CONDUITS, SMALL_CABLES, PARAMS } = require('../test');
+const assert = require("assert");
+const {
+  solveDuctbankTemperatures,
+  SMALL_CONDUITS,
+  SMALL_CABLES,
+  PARAMS,
+} = require("../test");
 
 function describe(name, fn) {
   console.log(name);
@@ -9,18 +14,26 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.error('  \u2717', name, err.message || err);
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
-describe('ductbank solver', () => {
-  it('produces temperatures above ambient near conduits', () => {
-    const res = solveDuctbankTemperatures(SMALL_CONDUITS, SMALL_CABLES, { ...PARAMS, earthTemp: 20, airTemp: 20 });
+describe("ductbank solver", () => {
+  it("produces temperatures above ambient near conduits", () => {
+    const res = solveDuctbankTemperatures(SMALL_CONDUITS, SMALL_CABLES, {
+      ...PARAMS,
+      earthTemp: 20,
+      airTemp: 20,
+    });
     let max = -Infinity;
-    res.grid.forEach(row => row.forEach(t => { if (t > max) max = t; }));
+    res.grid.forEach((row) =>
+      row.forEach((t) => {
+        if (t > max) max = t;
+      }),
+    );
     assert(max > 20);
   });
 });

--- a/tests/ieee835.test.js
+++ b/tests/ieee835.test.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const { ampacity } = require('../ampacity');
-const { computeDuctbankTemperatures, calcFiniteAmpacity } = require('../test');
+const assert = require("assert");
+const { ampacity } = require("../ampacity");
+const { computeDuctbankTemperatures, calcFiniteAmpacity } = require("../test");
 
 function describe(name, fn) {
   console.log(name);
@@ -9,44 +9,64 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.error('  \u2717', name, err.message || err);
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
-describe('IEEE 835 underground benchmarks', () => {
-  const conduit = { conduit_id: 'C1', conduit_type: 'PVC Sch 40', trade_size: '4', x: 0, y: 0 };
-  const cable = {
-    conduit_id: 'C1',
-    conductor_size: '500 kcmil',
-    conductor_material: 'Copper',
-    insulation_type: 'THHN',
-    insulation_rating: '90',
-    voltage_rating: '600V',
-    est_load: 392
+describe("IEEE 835 underground benchmarks", () => {
+  const conduit = {
+    conduit_id: "C1",
+    conduit_type: "PVC Sch 40",
+    trade_size: "4",
+    x: 0,
+    y: 0,
   };
-  const params = { soilResistivity: 90, ductbankDepth: 36, earthTemp: 20, hSpacing: 3, vSpacing: 3 };
+  const cable = {
+    conduit_id: "C1",
+    conductor_size: "500 kcmil",
+    conductor_material: "Copper",
+    insulation_type: "THHN",
+    insulation_rating: "90",
+    voltage_rating: "600V",
+    est_load: 392,
+  };
+  const params = {
+    soilResistivity: 90,
+    ductbankDepth: 36,
+    earthTemp: 20,
+    hSpacing: 3,
+    vSpacing: 3,
+  };
 
-  it('Neher-McGrath ampacity within 5% of IEEE 835', () => {
-    const res = ampacity({
-      conductor_size: '500 kcmil',
-      conductor_material: 'Copper',
-      insulation_rating: 90,
-      voltage_rating: 600
-    }, { soilResistivity: 90, ductbankDepth: 36, conduit_diameter: 0.1, ambient: 20 });
+  it("Neher-McGrath ampacity within 5% of IEEE 835", () => {
+    const res = ampacity(
+      {
+        conductor_size: "500 kcmil",
+        conductor_material: "Copper",
+        insulation_rating: 90,
+        voltage_rating: 600,
+      },
+      {
+        soilResistivity: 90,
+        ductbankDepth: 36,
+        conduit_diameter: 0.1,
+        ambient: 20,
+      },
+    );
     const err = Math.abs(res.ampacity - 392) / 392;
     assert(err <= 0.05);
   });
 
-  it('finite-element temperature around 90C at 392A', () => {
+  it("finite-element temperature around 90C at 392A", () => {
     const temps = computeDuctbankTemperatures([conduit], [cable], params);
     const t = temps[cable.conduit_id];
     assert(Math.abs(t - 90) / 90 <= 0.05);
   });
 
-  it('iterative ampacity solver returns ~392A', () => {
+  it("iterative ampacity solver returns ~392A", () => {
     const c = { ...cable, est_load: 100 };
     const I = calcFiniteAmpacity(c, [conduit], [c], params);
     const err = Math.abs(I - 392) / 392;


### PR DESCRIPTION
## Summary
- add flat eslint config for lint tests
- ignore built and root-level JS for prettier
- run prettier on source and test files

## Testing
- `npx prettier --check '**/*.js'`
- `npx eslint . --max-warnings=0`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b89b5bc60832483986c35efc637bc