### PR TITLE
chore: use explicit plotly version

### DIFF
--- a/app.js
+++ b/app.js
@@ -2685,7 +2685,7 @@ const openConduitFill = (cables) => {
         const html = `<!DOCTYPE html>
 <html><head><title>3D Route Visualization</title>
 <meta charset="UTF-8">
-<script src="https://cdn.plot.ly/plotly-latest.min.js"><\/script>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"><\/script>
 <style>html,body{margin:0;height:100%;overflow:hidden;}#plot{width:100%;height:100%;}</style>
 </head><body>
 <div id="plot"></div>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -7,7 +7,7 @@
     <title>Optimal 3D Cable Routing System</title>
     <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
-    <script src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
     <script src="dist/optimalRoute.js" defer></script>


### PR DESCRIPTION
## Summary
- pin plotly.js to version 2.27.0 to avoid deprecated `plotly-latest` warning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba365fbf88324bd290ae8d0ab611a