### PR TITLE
feat: support manual cable routing

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -181,6 +181,11 @@
                         </div>
                         <button id="clear-cables-btn">Clear Cable List</button>
                     </div>
+                    <details id="manual-route-details">
+                        <summary>Manual Route Entry</summary>
+                        <p>Use the "Manual Path" column to enter tray IDs (e.g. TR1&gt;TR2) or coordinate waypoints
+                        (e.g. 0,0,0;10,0,0) for a cable. Leave blank to auto-route.</p>
+                    </details>
                     <details id="cable-list-details">
                         <summary id="cable-list-summary">Cables to Route Table</summary>
                         <input type="text" id="cable-search" class="table-search" placeholder="Filter cables">


### PR DESCRIPTION
## Summary
- allow specifying manual cable paths with tray IDs or coordinates
- store manual path definitions alongside cable data and display manual vs auto results
- route worker validates manual paths and bypasses automatic Dijkstra when provided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb1583d148324909972db50d2fb6d