### PR TITLE
feat: add multi-select widget support

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -107,7 +107,7 @@ const columns=[
   {key:'end_z',label:'End Z',type:'number',group:'Routing / Termination',tooltip:'Z-coordinate of cable end'},
   {key:'zone',label:'Cable Zone',type:'number',group:'Routing / Termination',tooltip:'Routing zone or area number'},
   {key:'conduit_id',label:'Conduit',type:'text',group:'Routing / Termination',tooltip:'Conduit identifier if routed through conduit'},
-  {key:'raceway_ids',label:'Raceway(s)',type:'select',multiple:true,options:()=>getRacewayOptions(),group:'Routing / Termination',tooltip:'Select raceway IDs from Raceway Schedule'},
+  {key:'raceway_ids',label:'Raceway(s)',type:'select',multiple:true,size:5,options:()=>getRacewayOptions(),group:'Routing / Termination',tooltip:'Select raceway IDs from Raceway Schedule'},
   {key:'circuit_group',label:'Circuit Group',type:'number',group:'Routing / Termination',tooltip:'Circuit grouping number'},
   {key:'allowed_cable_group',label:'Allowed Group',type:'text',group:'Routing / Termination',tooltip:'Permitted cable grouping identifier'},
   {key:'cable_type',label:'Cable Type',type:'select',options:cableTypes,group:'Cable Construction & Specs',tooltip:'Category such as Power, Control, or Signal'},


### PR DESCRIPTION
## Summary
- add checkbox-based widget for multi-select columns
- persist selections when reading/writing table rows
- show raceway choices in Cable Schedule with 5-row list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bbe8c6f7483249215362fdacbed53