### PR TITLE
Add persistent column group toggles to TableUtils

### DIFF
--- a/style.css
+++ b/style.css
@@ -443,6 +443,9 @@ th, td {
 th {
     background-color: var(--secondary-color);
 }
+.group-hidden {
+    display: none;
+}
 .sticky-table tbody tr:nth-child(even) {
     background-color: var(--secondary-color);
 }


### PR DESCRIPTION
## Summary
- add collapsible column group headers with toggle buttons
- persist collapsed group state in localStorage
- hide collapsed columns via new `.group-hidden` style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bbfb3898083248340a13e99750593