### PR TITLE
Show selected raceway IDs in table rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -1488,6 +1488,15 @@ body.dark-mode .workflow-card-title {
     text-decoration: underline;
 }
 
+/* Displays selected IDs for multi-checkbox raceway fields */
+.raceway-summary {
+    display: block;
+    font-size: 0.8em;
+    margin-top: 0.25rem;
+    color: var(--text-color);
+    word-break: break-word;
+}
+
 @media (max-width: 600px) {
     .site-footer {
         flex-direction: column;

--- a/tableUtils.js
+++ b/tableUtils.js
@@ -241,8 +241,23 @@ class TableManager {
         el.value = el.options[0].value;
       }
       td.appendChild(el);
+      let summaryEl, updateSummary;
+      if (col.multiple) {
+        summaryEl = document.createElement('span');
+        summaryEl.className = 'raceway-summary';
+        td.appendChild(summaryEl);
+        updateSummary = () => {
+          summaryEl.textContent = (el.getSelectedValues ? el.getSelectedValues() : []).join(', ');
+        };
+        el.addEventListener('change', () => {
+          updateSummary();
+          if (this.onChange) this.onChange();
+        });
+        updateSummary();
+      } else {
+        el.addEventListener('input', () => { if (this.onChange) this.onChange(); });
+      }
       if (col.onChange) el.addEventListener('change', () => { col.onChange(el, tr); });
-      el.addEventListener(col.multiple ? 'change' : 'input', () => { if (this.onChange) this.onChange(); });
       if (col.validate) {
         const rules = Array.isArray(col.validate) ? col.validate : [col.validate];
         el.addEventListener(col.multiple ? 'change' : 'input', () => applyValidation(el, rules));


### PR DESCRIPTION
## Summary
- display selected IDs next to multi-checkbox fields using a new raceway-summary span
- update raceway summary text on checkbox changes and on load
- add styling for raceway summaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bc3dad8108324aacf60ec8bbd0758