### PR TITLE
feat: add accessible raceway listbox trigger

### DIFF
--- a/style.css
+++ b/style.css
@@ -1516,11 +1516,14 @@ body.dark-mode .workflow-card-title {
 
 /* Displays selected IDs for multi-checkbox raceway fields */
 .raceway-summary {
-    display: block;
+    display: inline-block;
     font-size: 0.8em;
     margin-top: 0.25rem;
-    color: var(--text-color);
+    color: var(--primary-color);
+    text-decoration: underline;
     word-break: break-word;
+    background: none;
+    border: none;
     cursor: pointer;
 }
 

--- a/tableUtils.js
+++ b/tableUtils.js
@@ -267,9 +267,9 @@ class TableManager {
       td.appendChild(el);
       let summaryEl, updateSummary;
       if (col.multiple) {
-        summaryEl = document.createElement('span');
+        summaryEl = document.createElement('button');
+        summaryEl.type = 'button';
         summaryEl.className = 'raceway-summary';
-        summaryEl.tabIndex = 0;
         summaryEl.addEventListener('click', e => {
           e.stopPropagation();
           this.showListboxPopup(el, td);


### PR DESCRIPTION
## Summary
- add button trigger in TableUtils for multi-select raceway listbox with keyboard support
- style raceway summary trigger for clearer interactivity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c90412b048324b535485ce9c344f1