### PR TITLE
Align group headers and collapse toggles flush left

### DIFF
--- a/style.css
+++ b/style.css
@@ -443,10 +443,18 @@ th, td {
 th {
     background-color: var(--secondary-color);
 }
+th:has(.group-toggle) {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+}
 .group-hidden {
     display: none;
 }
 .group-collapsed {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
     width: 1.5em;
 }
 .group-collapsed span {


### PR DESCRIPTION
## Summary
- Use flexbox to left-align group header cells
- Keep collapse toggle left-aligned when group labels are hidden

## Testing
- `npm test`
- ⚠️ Unable to manually verify group collapse UI in this environment

------
https://chatgpt.com/codex/tasks/task_e_689c91b447988324a736179473956ee9