### PR TITLE
Align group header toggles with columns

### DIFF
--- a/style.css
+++ b/style.css
@@ -447,6 +447,8 @@ th:has(.group-toggle) {
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    padding-left: 0;
+    gap: 0.25rem;
 }
 .group-hidden {
     display: none;
@@ -456,12 +458,11 @@ th:has(.group-toggle) {
     align-items: center;
     justify-content: flex-start;
     width: 1.5em;
+    padding-left: 0;
+    gap: 0.25rem;
 }
 .group-collapsed span {
     display: none;
-}
-.group-collapsed .group-toggle {
-    margin-left: 0;
 }
 .sticky-table tbody tr:nth-child(even) {
     background-color: var(--secondary-color);
@@ -768,7 +769,6 @@ body.dark-mode .db-table td {
 }
 
 .group-toggle {
-    margin-left: 4px;
     background: none;
     border: 1px solid var(--border-color);
     cursor: pointer;


### PR DESCRIPTION
## Summary
- remove left padding on group header cells and collapsed headers, adding a small flex gap for label/toggle alignment
- drop manual margin on group toggle button to rely on flex gap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb59f08dc8324ace7b77f7ac8dc3f