### PR TITLE
Add group header class and update styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -443,12 +443,12 @@ th, td {
 th {
     background-color: var(--secondary-color);
 }
-th:has(.group-toggle) {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    padding-left: 0;
-    gap: 0.25rem;
+.group-header {
+    display:flex;
+    align-items:center;
+    justify-content:flex-start;
+    padding-left:0;
+    gap:0.25rem;
 }
 .group-hidden {
     display: none;

--- a/tableUtils.js
+++ b/tableUtils.js
@@ -80,6 +80,7 @@ class TableManager {
       groups.forEach(g => {
         const th = document.createElement('th');
         th.colSpan = g.span;
+        th.classList.add('group-header');
         if (g.name){
           const label = document.createElement('span');
           label.textContent = g.name;


### PR DESCRIPTION
## Summary
- Use a `.group-header` class for group header `<th>` elements.
- Replace `:has()` selector with `.group-header` styling and remove unsupported selector usage.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc7b6900c83249cd0033e2332bb54