### PR TITLE
Align group headers with their columns on cable schedule

### DIFF
--- a/style.css
+++ b/style.css
@@ -444,23 +444,26 @@ th {
     background-color: var(--secondary-color);
 }
 .group-header {
-    display:flex;
-    align-items:center;
-    justify-content:flex-start;
-    padding-left:0;
-    gap:0.25rem;
+    padding-left: 0;
 }
+
+.group-header .group-toggle {
+    margin-left: 0.25rem;
+}
+
 .group-hidden {
     display: none;
 }
+
 .group-collapsed {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
     width: 1.5em;
     padding-left: 0;
-    gap: 0.25rem;
 }
+
+.group-collapsed .group-toggle {
+    margin-left: 0;
+}
+
 .group-collapsed span {
     display: none;
 }


### PR DESCRIPTION
## Summary
- ensure cable schedule's collapsible group headers remain table cells so they sit directly above their columns
- tweak toggle spacing to keep compact layout when groups are collapsed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf13283108324b4430d3ff0c8db9c