### PR TITLE
Consolidate route load prompts in Optimal Route

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -234,6 +234,15 @@
             </ul>
         </div>
     </div>
+    <div id="resume-modal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="resume-title">
+        <div class="modal-content">
+            <p id="resume-title">A saved project was detected. Would you like to load the previous tray network and cable list?</p>
+            <div class="modal-actions">
+                <button id="resume-yes-btn" class="primary-btn">Yes</button>
+                <button id="resume-no-btn">No</button>
+            </div>
+        </div>
+    </div>
     <script src="app.js" defer></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -418,6 +418,13 @@ details > summary {
     position: relative;
 }
 
+.modal-actions {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+
 .close-btn {
     position: absolute;
     top: 0.5rem;


### PR DESCRIPTION
## Summary
- Replace multiple load confirmations with single resume modal when saved data detected
- Simplify schedule loading from localStorage and add modal styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dd23968ac83248edfd4463788bc12