### PR TITLE
chore: format table utils navigation test

### DIFF
--- a/tests/tableUtilsNavigation.test.js
+++ b/tests/tableUtilsNavigation.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require("assert");
 
 function describe(name, fn) {
   console.log(name);
@@ -8,26 +8,31 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.error('  \u2717', name, err.message || err);
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
 let activeEl = null;
-function makeInput(value = '') {
+function makeInput(value = "") {
   return {
     value,
     selectionStart: 0,
     selectionEnd: value.length,
-    focus() { activeEl = this; },
-    select() { this.selectionStart = 0; this.selectionEnd = this.value.length; },
+    focus() {
+      activeEl = this;
+    },
+    select() {
+      this.selectionStart = 0;
+      this.selectionEnd = this.value.length;
+    },
     dispatchEvent(ev) {
       ev.target = this;
       if (this.onkeydown) this.onkeydown(ev);
       return !ev.defaultPrevented;
-    }
+    },
   };
 }
 
@@ -35,7 +40,9 @@ function makeCell(input) {
   return {
     previousElementSibling: null,
     nextElementSibling: null,
-    querySelector() { return input; }
+    querySelector() {
+      return input;
+    },
   };
 }
 
@@ -43,25 +50,30 @@ function keyEvent(key) {
   return {
     key,
     defaultPrevented: false,
-    preventDefault() { this.defaultPrevented = true; },
-    type: 'keydown'
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    type: "keydown",
   };
 }
 
 function attach(el, td) {
-  el.onkeydown = e => {
-    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+  el.onkeydown = (e) => {
+    if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
       const start = e.target.selectionStart ?? 0;
       const end = e.target.selectionEnd ?? 0;
-      const len = (e.target.value || '').length;
+      const len = (e.target.value || "").length;
       if (start === 0 && end === len) {
         e.preventDefault();
-        const sib = e.key === 'ArrowLeft' ? td.previousElementSibling : td.nextElementSibling;
+        const sib =
+          e.key === "ArrowLeft"
+            ? td.previousElementSibling
+            : td.nextElementSibling;
         if (sib) {
-          const next = sib.querySelector('input,select');
+          const next = sib.querySelector("input,select");
           if (next) {
             next.focus();
-            if (typeof next.select === 'function') next.select();
+            if (typeof next.select === "function") next.select();
           }
         }
       }
@@ -69,10 +81,10 @@ function attach(el, td) {
   };
 }
 
-describe('tableUtils arrow navigation', () => {
-  it('ArrowRight moves to next cell when text selected', () => {
-    const input1 = makeInput('one');
-    const input2 = makeInput('two');
+describe("tableUtils arrow navigation", () => {
+  it("ArrowRight moves to next cell when text selected", () => {
+    const input1 = makeInput("one");
+    const input2 = makeInput("two");
     const td1 = makeCell(input1);
     const td2 = makeCell(input2);
     td1.nextElementSibling = td2;
@@ -81,7 +93,7 @@ describe('tableUtils arrow navigation', () => {
     attach(input2, td2);
     input1.focus();
     input1.select();
-    const ev = keyEvent('ArrowRight');
+    const ev = keyEvent("ArrowRight");
     const result = input1.dispatchEvent(ev);
     assert(!result);
     assert.strictEqual(activeEl, input2);
@@ -89,9 +101,9 @@ describe('tableUtils arrow navigation', () => {
     assert.strictEqual(input2.selectionEnd, input2.value.length);
   });
 
-  it('ArrowLeft moves to previous cell when text selected', () => {
-    const input1 = makeInput('one');
-    const input2 = makeInput('two');
+  it("ArrowLeft moves to previous cell when text selected", () => {
+    const input1 = makeInput("one");
+    const input2 = makeInput("two");
     const td1 = makeCell(input1);
     const td2 = makeCell(input2);
     td1.nextElementSibling = td2;
@@ -100,7 +112,7 @@ describe('tableUtils arrow navigation', () => {
     attach(input2, td2);
     input2.focus();
     input2.select();
-    const ev = keyEvent('ArrowLeft');
+    const ev = keyEvent("ArrowLeft");
     const result = input2.dispatchEvent(ev);
     assert(!result);
     assert.strictEqual(activeEl, input1);
@@ -108,9 +120,9 @@ describe('tableUtils arrow navigation', () => {
     assert.strictEqual(input1.selectionEnd, input1.value.length);
   });
 
-  it('ArrowRight moves from empty cell', () => {
-    const input1 = makeInput('');
-    const input2 = makeInput('two');
+  it("ArrowRight moves from empty cell", () => {
+    const input1 = makeInput("");
+    const input2 = makeInput("two");
     const td1 = makeCell(input1);
     const td2 = makeCell(input2);
     td1.nextElementSibling = td2;
@@ -118,7 +130,7 @@ describe('tableUtils arrow navigation', () => {
     attach(input1, td1);
     attach(input2, td2);
     input1.focus();
-    const ev = keyEvent('ArrowRight');
+    const ev = keyEvent("ArrowRight");
     const result = input1.dispatchEvent(ev);
     assert(!result);
     assert.strictEqual(activeEl, input2);


### PR DESCRIPTION
## Summary
- run prettier on tests/tableUtilsNavigation.test.js so lint passes

## Testing
- `npx eslint . --max-warnings=0`
- `npx prettier --check '**/*.js'`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd455c87c832497e91f14ff01a405