### PR TITLE
Fix workflow completion status for raceway and optimal route

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             <span>5. Conduit Fill</span>
             <span class="status">Incomplete</span>
           </a>
-          <a href="optimalRoute.html" class="workflow-card">
+          <a href="optimalRoute.html" class="workflow-card" data-storage-key="optimalRoute">
             <img src="icons/route.svg" alt="Route icon" class="workflow-icon">
             <span>6. Optimal Cable Route</span>
             <span class="status">Incomplete</span>

--- a/workflowStatus.js
+++ b/workflowStatus.js
@@ -4,7 +4,22 @@ window.addEventListener('DOMContentLoaded', () => {
     const key = card.dataset.storageKey;
     const statusEl = card.querySelector('.status');
     if (!statusEl) return;
-    if (key && localStorage.getItem(key)) {
+
+    let complete = false;
+    if (key === 'racewaySchedule') {
+      // Raceway data is spread across multiple storage keys; mark complete
+      // when any of the related tables has saved data.
+      complete = ['ductbankSchedule', 'traySchedule', 'conduitSchedule']
+        .some(k => localStorage.getItem(k));
+    } else if (key === 'optimalRoute') {
+      // Optimal routing relies on both cable and tray schedules.
+      complete = ['cableSchedule', 'traySchedule']
+        .every(k => localStorage.getItem(k));
+    } else if (key) {
+      complete = !!localStorage.getItem(key);
+    }
+
+    if (complete) {
       card.classList.add('complete');
       statusEl.textContent = '✓';
       statusEl.setAttribute('aria-label', 'Completed');


### PR DESCRIPTION
## Summary
- mark raceway step complete when any related schedule is saved
- show optimal cable route completion once cable and tray schedules exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df020ea9c8324a14e4d0dbf812523