### PR TITLE
Exclude ductbank tags from raceway options

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -90,7 +90,7 @@ const insulationRatings=['60','75','90'];
     const ids=new Set();
     try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.traySchedule))||[]).forEach(t=>{if(t.tray_id) ids.add(t.tray_id);});}catch(e){}
     try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.conduitSchedule))||[]).forEach(c=>{if(c.conduit_id) ids.add(c.conduit_id);});}catch(e){}
-    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.ductbankSchedule))||[]).forEach(db=>{if(db.tag) ids.add(db.tag);(db.conduits||[]).forEach(c=>{if(c.conduit_id) ids.add(c.conduit_id);});});}catch(e){}
+    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.ductbankSchedule))||[]).forEach(db=>{(db.conduits||[]).forEach(c=>{if(c.conduit_id) ids.add(c.conduit_id);});});}catch(e){}
     return Array.from(ids);
   }
 


### PR DESCRIPTION
## Summary
- Only collect tray IDs, standalone conduit IDs and ductbank conduit IDs when building raceway options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df57dff58832498fd98064e5b7ba2