### PR TITLE
Handle unknown manual raceways gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ the tag can be edited for each cable in the table.
 
 Cable trays and cables now include an **Allowed Cable Group** property. During routing, a cable will only use trays whose allowed group matches the cable's group. This helps ensure voltage-rated cables are routed appropriately.
 
+## Manual Raceway vs Automatic Routing
+
+Supplying specific **Raceway IDs** on a cable forces the router to follow those tray segments in order. Any IDs that do not match trays in the schedule are ignored. If none of the provided IDs exist, the router automatically reverts to its standard pathfinding. Leaving the field empty always triggers automatic routing.
+
 ## New Feature: Manual Batch Cable Entry
 
 When batch mode is selected, you can now use the **Add Cable to List** button to


### PR DESCRIPTION
## Summary
- Ignore raceway IDs not present in the tray schedule and warn when found
- Fall back to automatic routing if no valid manual raceways remain
- Document manual raceway assignment versus automatic routing in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e426afba48324b085f4793f5bb053