### PR TITLE
feat: expose max field edge parameter

### DIFF
--- a/app.js
+++ b/app.js
@@ -697,7 +697,7 @@ document.addEventListener('DOMContentLoaded', () => {
             this.sharedPenalty = options.sharedPenalty || 0.5;
             // Limit how far apart generic field edges can be created to avoid
             // generating a fully connected graph for large datasets
-            this.maxFieldEdge = options.maxFieldEdge || 150;
+            this.maxFieldEdge = options.maxFieldEdge || 1000;
             // Limit how many field connections each node keeps to further
             // reduce graph density and memory usage
             this.maxFieldNeighbors = options.maxFieldNeighbors || 8;
@@ -2406,7 +2406,7 @@ const openConduitFill = (cables) => {
     };
 
     const mainCalculation = async () => {
-        if (!validateInputs(['proximity-threshold','field-route-penalty','shared-field-penalty'])) return;
+        if (!validateInputs(['proximity-threshold','max-field-edge','field-route-penalty','shared-field-penalty'])) return;
         elements.resultsSection.style.display = 'block';
         elements.messages.innerHTML = '';
         elements.progressContainer.style.display = 'block';
@@ -2423,7 +2423,7 @@ const openConduitFill = (cables) => {
             proximityThreshold: parseFloat(document.getElementById('proximity-threshold').value),
             fieldPenalty: parseFloat(document.getElementById('field-route-penalty').value),
             sharedPenalty: parseFloat(document.getElementById('shared-field-penalty').value),
-            maxFieldEdge: 150,
+            maxFieldEdge: parseFloat(document.getElementById('max-field-edge').value),
             maxFieldNeighbors: 8
         });
         
@@ -2666,7 +2666,7 @@ const openConduitFill = (cables) => {
             proximityThreshold: parseFloat(document.getElementById('proximity-threshold').value),
             fieldPenalty: parseFloat(document.getElementById('field-route-penalty').value),
             sharedPenalty: parseFloat(document.getElementById('shared-field-penalty').value),
-            maxFieldEdge: 150,
+            maxFieldEdge: parseFloat(document.getElementById('max-field-edge').value),
             maxFieldNeighbors: 8
         });
 

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -58,6 +58,13 @@
                  </label>
                  <input type="number" id="proximity-threshold" value="72" min="0" step="1">
 
+                 <label for="max-field-edge">Max Field Connection Distance (in)
+                    <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="max-field-help">?
+                        <span id="max-field-help" class="tooltip">Maximum distance between automatically generated field nodes. Increase for large networks to keep them connectable.</span>
+                    </span>
+                 </label>
+                 <input type="number" id="max-field-edge" value="1000" min="0" max="10000" step="1">
+
                  <label for="field-route-penalty">Field Route Cost Multiplier
                     <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="field-penalty-help">?
                         <span id="field-penalty-help" class="tooltip">This makes field routing (not in a tray) more expensive than routing within a tray. A value of 3 means every inch of field routing costs as much as 3 inches of tray routing, encouraging the algorithm to use trays whenever possible.</span>

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -48,7 +48,7 @@ class CableRoutingSystem {
         this.sharedPenalty = options.sharedPenalty || 0.5;
         // Limit distance between generic field nodes to keep the graph from
         // growing quadratically when many trays are present
-        this.maxFieldEdge = options.maxFieldEdge || 150;
+        this.maxFieldEdge = options.maxFieldEdge || 1000;
         // Limit the number of field connections per node to cap memory usage
         this.maxFieldNeighbors = options.maxFieldNeighbors || 8;
         this.sharedFieldSegments = [];


### PR DESCRIPTION
## Summary
- add Max Field Connection Distance input to routing options
- plumb maxFieldEdge setting into CableRoutingSystem and worker
- raise default maxFieldEdge to 1000 for better connectivity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e43868f7c832495ccf72bbdc855c8