### PR TITLE
Propagate conduit cable grouping into tray data

### DIFF
--- a/app.js
+++ b/app.js
@@ -392,7 +392,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             path: [
                                 [parseFloat(c.start_x), parseFloat(c.start_y), parseFloat(c.start_z)],
                                 [parseFloat(c.end_x), parseFloat(c.end_y), parseFloat(c.end_z)]
-                            ]
+                            ],
+                            allowed_cable_group: c.allowed_cable_group
                         }))
                     };
                 })
@@ -446,7 +447,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             height: dia,
                             current_fill: 0,
                             shape: 'STR',
-                            allowed_cable_group: '',
+                            allowed_cable_group: cond.allowed_cable_group || '',
                             raceway_type: 'conduit',
                         });
                     }
@@ -473,7 +474,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     height: dia,
                     current_fill: 0,
                     shape: 'STR',
-                    allowed_cable_group: '',
+                    allowed_cable_group: cond.allowed_cable_group || '',
                     raceway_type: 'conduit',
                 });
             });


### PR DESCRIPTION
## Summary
- Include `allowed_cable_group` when mapping ductbank conduits into `state.ductbankData`
- Preserve conduit `allowed_cable_group` in `rebuildTrayData`

## Testing
- `node -e "const fs=require('fs'); const vm=require('vm'); const code=fs.readFileSync('routeWorker.js','utf8'); const sandbox={self:{}, console}; vm.createContext(sandbox); vm.runInContext(code, sandbox); const System=vm.runInContext('CableRoutingSystem', sandbox); const sys=new System({min_edge_length:0}); sys.addTraySegment({tray_id:'db1', start_x:0,start_y:0,start_z:0,end_x:10,end_y:0,end_z:0,width:1,height:1,current_fill:0,shape:'STR',allowed_cable_group:'',raceway_type:'ductbank'}); sys.addTraySegment({tray_id:'cond1', start_x:0,start_y:0,start_z:0,end_x:10,end_y:0,end_z:0,width:1,height:1,current_fill:0,shape:'STR',allowed_cable_group:'HV',raceway_type:'conduit'}); const res=sys.calculateRoute([0,0,0],[10,0,0],0.1,'HV'); console.log(JSON.stringify(res,null,2));"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f30313bc08324b90c5db537375c54