### PR TITLE
Allow trays with unspecified cable group to accept any group

### DIFF
--- a/app.js
+++ b/app.js
@@ -1016,7 +1016,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
             // Remove trays without remaining capacity
             this.trays.forEach(tray => {
-                if (tray.current_fill + cableArea > tray.maxFill || tray.allowed_cable_group !== allowedGroup) {
+                if (tray.current_fill + cableArea > tray.maxFill ||
+                    (tray.allowed_cable_group &&
+                     tray.allowed_cable_group !== allowedGroup)) {
                     const remove = Object.keys(graph.nodes).filter(n => n.includes(tray.tray_id));
                     remove.forEach(n => {
                         delete graph.nodes[n];

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -485,7 +485,9 @@ class CableRoutingSystem {
 
         // Remove trays without remaining capacity
         this.trays.forEach(tray => {
-            if (tray.current_fill + cableArea > tray.maxFill || tray.allowed_cable_group !== allowedGroup) {
+            if (tray.current_fill + cableArea > tray.maxFill ||
+                (tray.allowed_cable_group &&
+                 tray.allowed_cable_group !== allowedGroup)) {
                 const remove = Object.keys(graph.nodes).filter(n => n.includes(tray.tray_id));
                 remove.forEach(n => {
                     delete graph.nodes[n];


### PR DESCRIPTION
## Summary
- Skip allowed cable group filtering when trays don't specify a group
- Mirror updated filter logic in main thread route calculation

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3a1e78fc832492b5f07787279c5d