### PR TITLE
fix: ensure ductbank lookup matches id or tag

### DIFF
--- a/app.js
+++ b/app.js
@@ -1452,7 +1452,7 @@ const openConduitFill = (cables) => {
 };
 
 const openDuctbankRoute = (dbId, conduitId) => {
-    const ductbank = state.ductbankData?.ductbanks?.find(db => (db.id || db.tag) === dbId);
+    const ductbank = state.ductbankData?.ductbanks?.find(db => db.id === dbId || db.tag === dbId);
     const key = conduitId ? `${dbId} - ${conduitId}` : dbId;
     const cables = (state.trayCableMap && state.trayCableMap[key]) ? state.trayCableMap[key] : [];
     if (!ductbank) return;


### PR DESCRIPTION
## Summary
- handle ductbank route lookup when ductbank has both `id` and `tag`
- keep selected conduit id when opening ductbank route page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f719db3e08324998e988952a2ef93