### PR TITLE
preserve conduit id in route segments for ductbank prefiltering

### DIFF
--- a/app.js
+++ b/app.js
@@ -1852,7 +1852,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
                         link = `<button class="conduit-fill-btn" data-cable="${res.cable}">Open</button>`;
                     } else if (b.type === 'duct bank') {
                         const [dbId] = b.tray_id.split(' - ');
-                        link = `<button class="ductbank-fill-btn" data-ductbank="${dbId}" data-conduit="${b.conduit_id}">Fill</button>`;
+                        const conduitAttr = b.conduit_id ? ` data-conduit="${b.conduit_id}"` : '';
+                        link = `<button class="ductbank-fill-btn" data-ductbank="${dbId}"${conduitAttr}>Fill</button>`;
                     } else if (b.tray_id && b.tray_id !== 'Field Route' && b.tray_id !== 'N/A') {
                         link = `<button class="tray-fill-btn" data-tray="${b.tray_id}">Fill</button>`;
                     }

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -625,25 +625,27 @@ class CableRoutingSystem {
             }
             if (type === 'tray') traySegments.add(tray_id);
 
+            const conduit_id = this.trays.get(tray_id)?.conduit_id;
+
             if (edge.type === 'field') {
                 let curr = p1.slice();
                 if (p2[0] !== curr[0]) {
                     const next = [p2[0], curr[1], curr[2]];
-                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[0]-curr[0]), tray_id });
+                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[0]-curr[0]), tray_id, conduit_id });
                     curr = next;
                 }
                 if (p2[1] !== curr[1]) {
                     const next = [curr[0], p2[1], curr[2]];
-                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[1]-curr[1]), tray_id });
+                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[1]-curr[1]), tray_id, conduit_id });
                     curr = next;
                 }
                 if (p2[2] !== curr[2]) {
                     const next = [curr[0], curr[1], p2[2]];
-                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[2]-curr[2]), tray_id });
+                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[2]-curr[2]), tray_id, conduit_id });
                     curr = next;
                 }
             } else {
-                routeSegments.push({ type, start: p1, end: p2, length, tray_id });
+                routeSegments.push({ type, start: p1, end: p2, length, tray_id, conduit_id });
             }
         }
 


### PR DESCRIPTION
## Summary
- propagate conduit_id from tray definitions into routeSegments so breakdown retains conduit references
- include data-conduit attribute on duct bank buttons when rendering batch results

## Testing
- `node tests/ampacity.test.js`
- `node tests/ductbankSolver.test.js`
- `node tests/ieee835.test.js`
- `node tests/tableUtilsNavigation.test.js`
- `node - <<'NODE' ...` (route segment sample)
- `node - <<'NODE' ...` (openDuctbankRoute localStorage)


------
https://chatgpt.com/codex/tasks/task_e_689f785b586883248765d37445a30bf8