### PR TITLE
Show conduit IDs for duct bank segments

### DIFF
--- a/app.js
+++ b/app.js
@@ -1872,24 +1872,22 @@ const openDuctbankRoute = (dbId, conduitId) => {
             if (!isNaN(fl)) totalField += fl;
             html += `<details><summary>${res.cable} | ${res.status} | ${res.mode} | Total ${res.total_length} | Field ${res.field_length} | Segments ${res.segments_count}</summary>`;
             if (res.breakdown && res.breakdown.length > 0) {
-                html += '<div class="table-scroll"><table class="sticky-table"><thead><tr><th>Segment</th><th>Raceway ID</th><th>Type</th><th>From</th><th>To</th><th>Length</th><th>Recommended Raceway</th><th>Fill</th></tr></thead><tbody>';
+                html += '<div class="table-scroll"><table class="sticky-table"><thead><tr><th>Segment</th><th>Raceway ID</th><th>Conduit</th><th>Type</th><th>From</th><th>To</th><th>Length</th><th>Recommended Raceway</th><th>Fill</th></tr></thead><tbody>';
                 res.breakdown.forEach(b => {
                     let link = '';
+                    let racewayId = b.tray_id || '';
+                    let conduit = '';
                     if (b.type === 'field') {
                         link = `<button class="conduit-fill-btn" data-seg="${b.segment_key}">Open</button>`;
                     } else if (b.type === 'duct bank') {
                         const [dbId] = b.tray_id.split(' - ');
-                        const conduitAttr = b.conduit_id ? ` data-conduit="${b.conduit_id}"` : '';
-                        link = `<button class="ductbank-fill-btn" data-ductbank="${dbId}"${conduitAttr}>Fill</button>`;
+                        racewayId = dbId;
+                        conduit = b.conduit_id || '';
+                        link = `<button class="ductbank-fill-btn" data-ductbank="${dbId}" data-conduit="${b.conduit_id}">Fill</button>`;
                     } else if (b.tray_id && b.tray_id !== 'Field Route' && b.tray_id !== 'N/A') {
                         link = `<button class="tray-fill-btn" data-tray="${b.tray_id}">Fill</button>`;
                     }
-                    // Include conduit identifier for duct bank segments so the
-                    // "Raceway ID" column displays both the duct bank and the
-                    // specific conduit used. This helps distinguish individual
-                    // conduit paths within a duct bank.
-                    const racewayId = b.conduit_id ? `${b.tray_id} - ${b.conduit_id}` : b.tray_id;
-                    html += `<tr><td>${b.segment}</td><td>${racewayId}</td><td>${b.type}</td><td>${b.from}</td><td>${b.to}</td><td>${b.length}</td><td>${b.raceway || ''}</td><td>${link}</td></tr>`;
+                    html += `<tr><td>${b.segment}</td><td>${racewayId}</td><td>${conduit}</td><td>${b.type}</td><td>${b.from}</td><td>${b.to}</td><td>${b.length}</td><td>${b.raceway || ''}</td><td>${link}</td></tr>`;
                 });
                 html += '</tbody></table></div>';
             }


### PR DESCRIPTION
## Summary
- Split route breakdown table into separate Raceway ID and Conduit columns
- Pass duct bank and conduit IDs to Fill button so ductbank routes open with conduit preselected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f8a2f9e1483248570eafcf59e7fdc