### PR TITLE
feat: include ductbank id in route segments

### DIFF
--- a/app.js
+++ b/app.js
@@ -780,7 +780,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         addTraySegment(tray) {
             const maxFill = tray.width * tray.height * this.fillLimit;
-            this.trays.set(tray.tray_id, { ...tray, maxFill });
+            // Preserve ductbank association for later use
+            this.trays.set(tray.tray_id, { ...tray, ductbank_id: tray.ductbank_id, maxFill });
         }
 
         updateTrayFill(trayIds, cableArea) {
@@ -1228,26 +1229,28 @@ document.addEventListener('DOMContentLoaded', async () => {
                     tray_id = node_id.split('_')[0]
                 }
                 if (type === 'tray') traySegments.add(tray_id);
+                const conduit_id = this.trays.get(tray_id)?.conduit_id;
+                const ductbank_id = this.trays.get(tray_id)?.ductbank_id;
 
                 if (edge.type === 'field') {
                     let curr = p1.slice();
                     if (p2[0] !== curr[0]) {
                         const next = [p2[0], curr[1], curr[2]];
-                        routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[0]-curr[0]), tray_id });
+                        routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[0]-curr[0]), tray_id, conduit_id, ductbank_id });
                         curr = next;
                     }
                     if (p2[1] !== curr[1]) {
                         const next = [curr[0], p2[1], curr[2]];
-                        routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[1]-curr[1]), tray_id });
+                        routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[1]-curr[1]), tray_id, conduit_id, ductbank_id });
                         curr = next;
                     }
                     if (p2[2] !== curr[2]) {
                         const next = [curr[0], curr[1], p2[2]];
-                        routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[2]-curr[2]), tray_id });
+                        routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[2]-curr[2]), tray_id, conduit_id, ductbank_id });
                         curr = next;
                     }
                 } else {
-                    routeSegments.push({ type, start: p1, end: p2, length, tray_id });
+                    routeSegments.push({ type, start: p1, end: p2, length, tray_id, conduit_id, ductbank_id });
                 }
             }
 
@@ -2639,7 +2642,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
                                     to: formatPoint(seg.end),
                                     length: seg.length.toFixed(2),
                                     raceway,
-                                    conduit_id
+                                    conduit_id,
+                                    ductbank_id: seg.ductbank_id
                                 };
                             }) : []
                         };
@@ -2857,7 +2861,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
                             to: formatPoint(seg.end),
                             length: seg.length.toFixed(2),
                             raceway,
-                            conduit_id
+                            conduit_id,
+                            ductbank_id: seg.ductbank_id
                         };
                     })
                 };

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -57,7 +57,8 @@ class CableRoutingSystem {
 
     addTraySegment(tray) {
         const maxFill = tray.width * tray.height * this.fillLimit;
-        this.trays.set(tray.tray_id, { ...tray, maxFill });
+        // Ensure ductbank_id persists for later lookups
+        this.trays.set(tray.tray_id, { ...tray, ductbank_id: tray.ductbank_id, maxFill });
     }
 
     updateTrayFill(trayIds, cableArea) {
@@ -629,26 +630,27 @@ class CableRoutingSystem {
             if (type === 'tray') traySegments.add(tray_id);
 
             const conduit_id = this.trays.get(tray_id)?.conduit_id;
+            const ductbank_id = this.trays.get(tray_id)?.ductbank_id;
 
             if (edge.type === 'field') {
                 let curr = p1.slice();
                 if (p2[0] !== curr[0]) {
                     const next = [p2[0], curr[1], curr[2]];
-                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[0]-curr[0]), tray_id, conduit_id });
+                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[0]-curr[0]), tray_id, conduit_id, ductbank_id });
                     curr = next;
                 }
                 if (p2[1] !== curr[1]) {
                     const next = [curr[0], p2[1], curr[2]];
-                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[1]-curr[1]), tray_id, conduit_id });
+                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[1]-curr[1]), tray_id, conduit_id, ductbank_id });
                     curr = next;
                 }
                 if (p2[2] !== curr[2]) {
                     const next = [curr[0], curr[1], p2[2]];
-                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[2]-curr[2]), tray_id, conduit_id });
+                    routeSegments.push({ type, start: curr, end: next, length: Math.abs(p2[2]-curr[2]), tray_id, conduit_id, ductbank_id });
                     curr = next;
                 }
             } else {
-                routeSegments.push({ type, start: p1, end: p2, length, tray_id, conduit_id });
+                routeSegments.push({ type, start: p1, end: p2, length, tray_id, conduit_id, ductbank_id });
             }
         }
 


### PR DESCRIPTION
## Summary
- preserve ductbank id when storing trays
- attach conduit and ductbank ids to calculated route segments
- surface ductbank ids in UI breakdown rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f96fac4e08324bc672a38b7e5b581