### PR TITLE
Warn on missing ductbank conduits

### DIFF
--- a/routeWorker.js
+++ b/routeWorker.js
@@ -51,6 +51,8 @@ class CableRoutingSystem {
         this.maxFieldEdge = options.maxFieldEdge || 1000;
         // Limit the number of field connections per node to cap memory usage
         this.maxFieldNeighbors = options.maxFieldNeighbors || 8;
+        // Optionally include ductbank outline segments lacking conduit IDs
+        this.includeDuctbankOutlines = options.includeDuctbankOutlines || false;
         this.sharedFieldSegments = [];
         this.trays = new Map();
     }
@@ -261,11 +263,27 @@ class CableRoutingSystem {
             graph.edges[id2][id1] = { weight, type, trayId };
         };
 
-        const trays = Array.from(this.trays.values())
-            // Remove only ductbank outline segments while keeping conduit records, even if
-            // their IDs are empty or numeric.
-            .filter(t => t.raceway_type !== 'ductbank' ||
+        const allTrays = Array.from(this.trays.values());
+        const missingDuctbank = allTrays.filter(t => t.raceway_type === 'ductbank' &&
+            (t.conduit_id == null || t.conduit_id === ''));
+        if (missingDuctbank.length) {
+            console.warn(`${missingDuctbank.length} ductbank segment(s) without conduit_id; ` +
+                (this.includeDuctbankOutlines ? 'treated as generic raceways.' : 'ignored.'));
+        }
+        let trays;
+        if (this.includeDuctbankOutlines) {
+            let placeholder = 0;
+            trays = allTrays.map(t => {
+                if (t.raceway_type === 'ductbank' && (t.conduit_id == null || t.conduit_id === '')) {
+                    const tray_id = t.tray_id || `ductbank_outline_${placeholder++}`;
+                    return { ...t, tray_id };
+                }
+                return t;
+            });
+        } else {
+            trays = allTrays.filter(t => t.raceway_type !== 'ductbank' ||
                 (t.conduit_id != null && t.conduit_id !== ''));
+        }
 
         trays.forEach(tray => {
             const startId = `${tray.tray_id}_start`;

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -75,4 +75,61 @@ describe("_racewayRoute", () => {
       "ductbank conduit missing from graph",
     );
   });
+
+  it("warns and ignores ductbank outlines without conduit ids", () => {
+    const system = new CableRoutingSystem({});
+    system.addTraySegment({
+      tray_id: "outline-1",
+      raceway_type: "ductbank",
+      start_x: 0,
+      start_y: 0,
+      start_z: 0,
+      end_x: 5,
+      end_y: 0,
+      end_z: 0,
+      width: 1,
+      height: 1,
+      current_fill: 0,
+    });
+    let warned = false;
+    const origWarn = console.warn;
+    console.warn = () => {
+      warned = true;
+    };
+    system.prepareBaseGraph();
+    console.warn = origWarn;
+    assert(warned, "missing ductbank warning not emitted");
+    assert(
+      !system.baseGraph.edges["outline-1_start"]?.["outline-1_end"],
+      "outline segment should be ignored",
+    );
+  });
+
+  it("includes ductbank outlines when configured", () => {
+    const system = new CableRoutingSystem({ includeDuctbankOutlines: true });
+    system.addTraySegment({
+      raceway_type: "ductbank",
+      start_x: 0,
+      start_y: 0,
+      start_z: 0,
+      end_x: 5,
+      end_y: 0,
+      end_z: 0,
+      width: 1,
+      height: 1,
+      current_fill: 0,
+    });
+    let warned = false;
+    const origWarn = console.warn;
+    console.warn = () => {
+      warned = true;
+    };
+    system.prepareBaseGraph();
+    console.warn = origWarn;
+    assert(warned, "missing ductbank warning not emitted");
+    assert(
+      system.baseGraph.edges["ductbank_outline_0_start"]?.["ductbank_outline_0_end"],
+      "ductbank outline not included",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Warn if ductbank segments lack conduit IDs
- Optionally include ductbank outline segments via `includeDuctbankOutlines`
- Add tests for missing conduit warnings and optional inclusion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01cf73f1c8324b208fc7dad669f28