### PR TITLE
feat: support composite tray IDs for conduits

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -89,8 +89,17 @@ const insulationRatings=['60','75','90'];
   function getRacewayOptions(){
     const ids=new Set();
     try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.traySchedule))||[]).forEach(t=>{if(t.tray_id) ids.add(t.tray_id);});}catch(e){}
-    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.conduitSchedule))||[]).forEach(c=>{if(c.conduit_id) ids.add(c.conduit_id);});}catch(e){}
-    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.ductbankSchedule))||[]).forEach(db=>{(db.conduits||[]).forEach(c=>{if(c.conduit_id) ids.add(c.conduit_id);});});}catch(e){}
+    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.conduitSchedule))||[]).forEach(c=>{
+      const id=c.tray_id||(c.ductbank_id&&c.conduit_id?`${c.ductbank_id}-${c.conduit_id}`:c.conduit_id);
+      if(id) ids.add(id);
+    });}catch(e){}
+    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.ductbankSchedule))||[]).forEach(db=>{
+      const dbId=db.ductbank_id||db.id||db.tag;
+      (db.conduits||[]).forEach(c=>{
+        const id=c.tray_id||(dbId&&c.conduit_id?`${dbId}-${c.conduit_id}`:c.conduit_id);
+        if(id) ids.add(id);
+      });
+    });}catch(e){}
     return Array.from(ids);
   }
 
@@ -107,6 +116,7 @@ const columns=[
   {key:'end_z',label:'End Z',type:'number',group:'Routing / Termination',tooltip:'Z-coordinate of cable end'},
   {key:'zone',label:'Cable Zone',type:'number',group:'Routing / Termination',tooltip:'Routing zone or area number'},
   {key:'raceway_ids',label:'Raceway(s)',type:'select',multiple:true,size:5,options:()=>getRacewayOptions(),group:'Routing / Termination',tooltip:'Select raceway IDs from Raceway Schedule'},
+  {key:'manual_path',label:'Manual Path',type:'text',datalist:()=>getRacewayOptions(),group:'Routing / Termination',tooltip:'Tray IDs separated by > to override route'},
   {key:'circuit_group',label:'Circuit Group',type:'number',group:'Routing / Termination',tooltip:'Circuit grouping number'},
   {key:'allowed_cable_group',label:'Allowed Group',type:'text',group:'Routing / Termination',tooltip:'Permitted cable grouping identifier'},
   {key:'cable_type',label:'Cable Type',type:'select',options:cableTypes,group:'Cable Construction & Specs',tooltip:'Category such as Power, Control, or Signal'},

--- a/docs/tray_id_convention.md
+++ b/docs/tray_id_convention.md
@@ -1,0 +1,13 @@
+# Tray ID Convention
+
+Conduits imported from the raceway schedule now use a composite tray identifier. If a conduit belongs to a ductbank, its tray ID is built from the ductbank tag and the conduit identifier joined by a hyphen:
+
+```
+<tray_id> = <ductbank_id>-<conduit_id>
+```
+
+For example, conduit `1` in ductbank `DB-A` becomes tray ID `DB-A-1`.
+
+Use this composite ID when specifying manual paths in the Cable Schedule. Enter multiple tray IDs separated by `>` (e.g., `DB-A-1>TRAY-2`). The same IDs are listed in the Manual Path column's dropdown helper.
+
+Standalone trays keep their existing `tray_id` values.

--- a/tableUtils.js
+++ b/tableUtils.js
@@ -402,6 +402,23 @@ class TableManager {
       } else {
         el = document.createElement('input');
         el.type = col.type || 'text';
+        if (col.datalist) {
+          const listId = `${col.key}-datalist`;
+          el.setAttribute('list', listId);
+          let dl = document.getElementById(listId);
+          if (!dl) {
+            dl = document.createElement('datalist');
+            dl.id = listId;
+            document.body.appendChild(dl);
+          }
+          const opts = typeof col.datalist === 'function' ? col.datalist(tr, data) : col.datalist;
+          dl.innerHTML = '';
+          (opts || []).forEach(opt => {
+            const o = document.createElement('option');
+            o.value = opt;
+            dl.appendChild(o);
+          });
+        }
       }
       el.name = col.key;
       const val = data[col.key] !== undefined ? data[col.key] : col.default;


### PR DESCRIPTION
## Summary
- derive ductbank IDs from conduit tags and generate composite tray IDs
- surface tray IDs for manual paths with dropdown suggestions
- document tray ID convention for referencing ducts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01e0d37bc832484d7eda9ca1137a3