### PR TITLE
feat: add configurable proximity threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ NEC 40% fill guideline used for tray capacity calculations.
 
 ## Updates
 
-- Default *Tray Proximity Threshold* is now **72 in**.
+ - Default *Tray Proximity Threshold* is now **72 in**. Increase this value to let the router connect endpoints to trays or ductbank conduits that are slightly farther away.
 - Each cable row in batch mode includes **Duplicate** and **Delete** controls.
 - Tray utilization tables show **Available Space** to two decimal places.
 - CSV export flattens the breakdown so each segment is a separate row.

--- a/app.js
+++ b/app.js
@@ -271,7 +271,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 manualTrays: state.manualTrays,
                 cableList: state.cableList,
                 darkMode: document.body.classList.contains('dark-mode'),
-                conduitType: elements.conduitType ? elements.conduitType.value : 'EMT'
+                conduitType: elements.conduitType ? elements.conduitType.value : 'EMT',
+                proximityThreshold: parseFloat(document.getElementById('proximity-threshold')?.value) || 72
             };
             localStorage.setItem('ctrSession', JSON.stringify(data));
         } catch (e) {
@@ -289,6 +290,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (data.darkMode) document.body.classList.add('dark-mode');
                 if (data.conduitType && elements.conduitType) {
                     elements.conduitType.value = data.conduitType;
+                }
+                const prox = document.getElementById('proximity-threshold');
+                if (prox && data.proximityThreshold !== undefined) {
+                    prox.value = data.proximityThreshold;
                 }
             }
         } catch (e) {
@@ -3305,6 +3310,8 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
     
     // --- INITIALIZATION & EVENT LISTENERS ---
     elements.fillLimitIn.addEventListener('input', updateFillLimitDisplay);
+    const proximityInput = document.getElementById('proximity-threshold');
+    if (proximityInput) proximityInput.addEventListener('change', saveSession);
     elements.calculateBtn.addEventListener('click', mainCalculation);
     if (elements.loadSampleTraysBtn) {
         elements.loadSampleTraysBtn.addEventListener('click', loadSampleTrays);

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -53,10 +53,10 @@
 
                  <label for="proximity-threshold">Tray Proximity Threshold (in)
                     <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="proximity-help">?
-                        <span id="proximity-help" class="tooltip">The maximum distance a cable can jump from its start or end point to connect to a nearby tray segment.</span>
+                        <span id="proximity-help" class="tooltip">The maximum distance a cable can jump from its start or end point to connect to a nearby tray or ductbank segment.</span>
                     </span>
-                 </label>
-                 <input type="number" id="proximity-threshold" value="72" min="0" step="1">
+                </label>
+                <input type="number" id="proximity-threshold" value="72" min="0" step="1">
 
                  <label for="max-field-edge">Max Field Connection Distance (in)
                     <span class="help-icon" tabindex="0" role="button" aria-label="Help" aria-expanded="false" aria-describedby="max-field-help">?

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -152,4 +152,34 @@ describe("_racewayRoute", () => {
     assert.strictEqual(res.exclusions[0].tray_id, "tray-over");
     assert.strictEqual(res.exclusions[0].reason, "over_capacity");
   });
+
+  it("routes when proximity threshold is increased", () => {
+    const tray = {
+      tray_id: "tray-prox",
+      start_x: 0,
+      start_y: 0,
+      start_z: 0,
+      end_x: 0,
+      end_y: 10,
+      end_z: 0,
+      width: 10,
+      height: 10,
+      current_fill: 0,
+    };
+    const start = [0, -73, 0];
+    const end = [0, 83, 0];
+
+    let system = new CableRoutingSystem({ proximityThreshold: 72 });
+    system.addTraySegment(tray);
+    let result = system.calculateRoute(start, end, 1, null);
+    const reasons = result.exclusions.map(e => e.reason);
+    assert(reasons.includes("start_beyond_proximity"));
+    assert(reasons.includes("end_beyond_proximity"));
+
+    system = new CableRoutingSystem({ proximityThreshold: 80 });
+    system.addTraySegment(tray);
+    result = system.calculateRoute(start, end, 1, null);
+    assert(result.success, "route should succeed with higher threshold");
+    assert.strictEqual(result.exclusions.length, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- allow users to configure the tray/ductbank proximity threshold
- persist proximity threshold in session settings
- document how proximity affects ductbank selection
- test routing beyond default threshold

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a021cde4308324949f5bab5ce9f9dc