### PR TITLE
Log mismatched raceway segments

### DIFF
--- a/app.js
+++ b/app.js
@@ -1953,6 +1953,16 @@ const openDuctbankRoute = (dbId, conduitId) => {
                 });
                 html += '</ul>';
             }
+            if (res.mismatched_records && res.mismatched_records.length > 0) {
+                html += '<p class="exclusions-title"><strong>Mismatched Raceways:</strong></p><ul class="exclusions-list">';
+                res.mismatched_records.forEach(m => {
+                    const id = m.tray_id || m.id || 'unknown';
+                    const reason = m.reason.replace(/_/g, ' ');
+                    const cable = m.cable_id ? ` (cable ${m.cable_id})` : '';
+                    html += `<li>${id}: ${reason}${cable}</li>`;
+                });
+                html += '</ul>';
+            }
             if (res.breakdown && res.breakdown.length > 0) {
                 html += '<div class="table-scroll"><table class="sticky-table"><thead><tr><th>Segment</th><th>Raceway ID</th><th>Conduit</th><th>Type</th><th>From</th><th>To</th><th>Length</th><th>Recommended Raceway</th><th>Fill</th></tr></thead><tbody>';
                 res.breakdown.forEach(b => {
@@ -1976,7 +1986,7 @@ const openDuctbankRoute = (dbId, conduitId) => {
         });
         const overall = `<p class="overall-stats"><strong>Overall Total Length:</strong> ${totalLength.toFixed(2)} ft | <strong>Overall Field Length:</strong> ${totalField.toFixed(2)} ft</p>`;
         elements.routeBreakdownContainer.innerHTML = overall + html;
-        if (results.some(r => r.exclusions && r.exclusions.length > 0)) {
+        if (results.some(r => (r.exclusions && r.exclusions.length > 0) || (r.mismatched_records && r.mismatched_records.length > 0))) {
             document.dispatchEvent(new CustomEvent('exclusions-found'));
         }
         elements.routeBreakdownContainer.querySelectorAll('.conduit-fill-btn').forEach(btn => {

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -153,6 +153,35 @@ describe("_racewayRoute", () => {
     assert.strictEqual(res.exclusions[0].reason, "over_capacity");
   });
 
+  it("warns with mismatched record details", () => {
+    const system = new CableRoutingSystem({ fillLimit: 0.4 });
+    system.addTraySegment({
+      tray_id: "tray-over",
+      start_x: 0,
+      start_y: 0,
+      start_z: 0,
+      end_x: 0,
+      end_y: 10,
+      end_z: 0,
+      width: 10,
+      height: 10,
+      current_fill: 40,
+    });
+    let warned = null;
+    const origWarn = console.warn;
+    console.warn = (...args) => {
+      warned = args;
+    };
+    system.calculateRoute([0, 0, 0], [0, 10, 0], 1, null, '', [], 'cable-1');
+    console.warn = origWarn;
+    assert(warned, 'mismatch warning not emitted');
+    const records = warned[1];
+    assert(Array.isArray(records) && records.length === 1);
+    assert.strictEqual(records[0].tray_id, 'tray-over');
+    assert.strictEqual(records[0].reason, 'over_capacity');
+    assert.strictEqual(records[0].cable_id, 'cable-1');
+  });
+
   it("routes when proximity threshold is increased", () => {
     const tray = {
       tray_id: "tray-prox",


### PR DESCRIPTION
## Summary
- track raceway segments dropped for capacity or group mismatches and warn after graph prep
- expose mismatched raceways in route breakdown UI
- test that mismatched segments are logged

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e25e4704832491f8aceccdf2b713