### PR TITLE
Log ignored ductbank segments lacking conduit IDs

### DIFF
--- a/app.js
+++ b/app.js
@@ -1033,8 +1033,28 @@ document.addEventListener('DOMContentLoaded', async () => {
             const missingDuctbank = allTrays.filter(t => t.raceway_type === 'ductbank' &&
                 (t.conduit_id == null || t.conduit_id === ''));
             if (missingDuctbank.length) {
-                console.warn(`${missingDuctbank.length} ductbank segment(s) without conduit_id; ` +
-                    (this.includeDuctbankOutlines ? 'treated as generic raceways.' : 'ignored.'));
+                const ids = missingDuctbank.map(t =>
+                    t.tag || t.ductbank_id || t.tray_id ||
+                    `[${t.start_x},${t.start_y},${t.start_z}]→[${t.end_x},${t.end_y},${t.end_z}]`);
+                const list = ids.map(id => ` - ${id}`).join('\n');
+                console.warn(
+                    `${missingDuctbank.length} ductbank segment(s) without conduit_id; ` +
+                    (this.includeDuctbankOutlines ? 'treated as generic raceways.' : 'ignored.') +
+                    `\nMissing segments:\n${list}`
+                );
+                this.missingDuctbankSegments = ids;
+                const warnEl = typeof document !== 'undefined' && document.getElementById('missing-ductbank-details');
+                if (warnEl) {
+                    document.getElementById('missing-ductbank-count').textContent = missingDuctbank.length;
+                    const listEl = document.getElementById('missing-ductbank-list');
+                    listEl.innerHTML = '';
+                    ids.forEach(id => {
+                        const li = document.createElement('li');
+                        li.textContent = id;
+                        listEl.appendChild(li);
+                    });
+                    warnEl.style.display = '';
+                }
             }
             let trays;
             if (this.includeDuctbankOutlines) {

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -170,6 +170,11 @@
                     <summary>Tray Utilization</summary>
                     <div id="tray-utilization-container"></div>
                 </details>
+
+                <details id="missing-ductbank-details" style="display:none">
+                    <summary>Ignored Ductbank Segments (<span id="missing-ductbank-count"></span>)</summary>
+                    <ul id="missing-ductbank-list"></ul>
+                </details>
             </section>
 
             <section class="card">

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -268,8 +268,15 @@ class CableRoutingSystem {
         const missingDuctbank = allTrays.filter(t => t.raceway_type === 'ductbank' &&
             (t.conduit_id == null || t.conduit_id === ''));
         if (missingDuctbank.length) {
-            console.warn(`${missingDuctbank.length} ductbank segment(s) without conduit_id; ` +
-                (this.includeDuctbankOutlines ? 'treated as generic raceways.' : 'ignored.'));
+            const ids = missingDuctbank.map((t) =>
+                t.tag || t.ductbank_id || t.tray_id ||
+                `[${t.start_x},${t.start_y},${t.start_z}]→[${t.end_x},${t.end_y},${t.end_z}]`);
+            const list = ids.map(id => ` - ${id}`).join('\n');
+            console.warn(
+                `${missingDuctbank.length} ductbank segment(s) without conduit_id; ` +
+                (this.includeDuctbankOutlines ? 'treated as generic raceways.' : 'ignored.') +
+                `\nMissing segments:\n${list}`
+            );
         }
         let trays;
         if (this.includeDuctbankOutlines) {

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -105,6 +105,46 @@ describe("_racewayRoute", () => {
     );
   });
 
+  it("includes full list of ignored ductbank segments in warning", () => {
+    const system = new CableRoutingSystem({});
+    system.addTraySegment({
+      tray_id: "outline-1",
+      raceway_type: "ductbank",
+      start_x: 0,
+      start_y: 0,
+      start_z: 0,
+      end_x: 5,
+      end_y: 0,
+      end_z: 0,
+      width: 1,
+      height: 1,
+      current_fill: 0,
+    });
+    system.addTraySegment({
+      tray_id: "outline-2",
+      raceway_type: "ductbank",
+      start_x: 5,
+      start_y: 0,
+      start_z: 0,
+      end_x: 10,
+      end_y: 0,
+      end_z: 0,
+      width: 1,
+      height: 1,
+      current_fill: 0,
+    });
+    let warnMsg = "";
+    const origWarn = console.warn;
+    console.warn = (msg) => {
+      warnMsg = msg;
+    };
+    system.prepareBaseGraph();
+    console.warn = origWarn;
+    assert(warnMsg.includes("2 ductbank segment"));
+    assert(warnMsg.includes("outline-1"));
+    assert(warnMsg.includes("outline-2"));
+  });
+
   it("includes ductbank outlines when configured", () => {
     const system = new CableRoutingSystem({ includeDuctbankOutlines: true });
     system.addTraySegment({


### PR DESCRIPTION
## Summary
- warn with detailed list of ductbank segments missing conduit_id
- surface ignored ductbank segments in optional UI panel
- test warning output includes complete list of skipped ductbank segments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e8de9e808324b95ba26e9f7b8fbb