### PR TITLE
Group conduits by ductbank in tray utilization

### DIFF
--- a/routeWorker.js
+++ b/routeWorker.js
@@ -265,7 +265,7 @@ class CableRoutingSystem {
         };
 
         const allTrays = Array.from(this.trays.values());
-        const missingDuctbank = allTrays.filter(t => t.raceway_type === 'ductbank' &&
+        const missingDuctbank = allTrays.filter(t => (t.raceway_type === 'ductbank' || t.ductbank_id) &&
             (t.conduit_id == null || t.conduit_id === ''));
         if (missingDuctbank.length) {
             console.warn(`${missingDuctbank.length} ductbank segment(s) without conduit_id; ` +


### PR DESCRIPTION
## Summary
- Store ductbank conduits as `raceway_type: 'conduit'` and keep their `ductbank_id`
- Let `prepareBaseGraph` handle conduit raceways and warn when ductbank segments lack conduit ids
- Filter ductbank outlines from tray utilization and group conduits beneath their ductbank headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a105d8f3a883249dc3a8850b8fc2eb