### PR TITLE
Handle ductbank conduits lacking paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js"
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",

--- a/tests/rebuildTrayData.test.js
+++ b/tests/rebuildTrayData.test.js
@@ -1,0 +1,108 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  \u2713', name);
+  } catch (err) {
+    console.error('  \u2717', name, err.message || err);
+    process.exitCode = 1;
+  }
+}
+
+// Extract rebuildTrayData function body from app.js
+const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+const startMarker = 'const rebuildTrayData = () => {';
+const startIdx = appCode.indexOf(startMarker) + startMarker.length;
+let idx = startIdx;
+let depth = 1;
+while (idx < appCode.length && depth > 0) {
+  const ch = appCode[idx++];
+  if (ch === '{') depth++;
+  else if (ch === '}') depth--;
+}
+const fnBody = appCode.slice(startIdx, idx - 1);
+const rebuildTrayData = new Function('state', 'CONDUIT_SPECS', fnBody);
+
+// Load CableRoutingSystem from routeWorker.js
+const workerCode = fs.readFileSync(path.join(__dirname, '..', 'routeWorker.js'), 'utf8');
+const sandbox = { console, self: { postMessage: () => {} } };
+vm.createContext(sandbox);
+vm.runInContext(workerCode + '\nthis.CableRoutingSystem = CableRoutingSystem;', sandbox);
+const { CableRoutingSystem } = sandbox;
+
+describe('rebuildTrayData', () => {
+  it('assigns ductbank coordinates to conduits without paths', () => {
+    const state = {
+      manualTrays: [],
+      trayData: [],
+      ductbankData: {
+        ductbanks: [
+          {
+            id: 'DB1',
+            start_x: 0,
+            start_y: 0,
+            start_z: 0,
+            end_x: 10,
+            end_y: 0,
+            end_z: 0,
+            width: 12,
+            height: 12,
+            conduits: [
+              { conduit_id: 'C1', type: 'RMC', trade_size: '1' },
+            ],
+          },
+        ],
+      },
+      conduitData: [],
+    };
+    const CONDUIT_SPECS = { RMC: { '1': 0.887 } };
+    rebuildTrayData(state, CONDUIT_SPECS);
+    const seg = state.trayData.find(t => t.tray_id === 'DB1-C1');
+    assert(seg, 'conduit segment missing');
+    assert.deepStrictEqual([seg.start_x, seg.start_y, seg.start_z], [0, 0, 0]);
+    assert.deepStrictEqual([seg.end_x, seg.end_y, seg.end_z], [10, 0, 0]);
+  });
+
+  it('routes through generated conduit segments', () => {
+    const state = {
+      manualTrays: [],
+      trayData: [],
+      ductbankData: {
+        ductbanks: [
+          {
+            id: 'DB1',
+            start_x: 0,
+            start_y: 0,
+            start_z: 0,
+            end_x: 10,
+            end_y: 0,
+            end_z: 0,
+            width: 12,
+            height: 12,
+            conduits: [
+              { conduit_id: 'C1', type: 'RMC', trade_size: '1' },
+            ],
+          },
+        ],
+      },
+      conduitData: [],
+    };
+    const CONDUIT_SPECS = { RMC: { '1': 0.887 } };
+    rebuildTrayData(state, CONDUIT_SPECS);
+    const system = new CableRoutingSystem({});
+    state.trayData.forEach(t => system.addTraySegment(t));
+    const res = system._racewayRoute([0, 0, 0], [10, 0, 0], 0, null, ['C1']);
+    assert(res && res.success, 'routing failed');
+    assert.deepStrictEqual(Array.from(res.tray_segments), ['DB1-C1']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Default missing conduit paths to ductbank start/end coordinates during tray rebuild
- Ensure conduit tray IDs always combine ductbank and conduit IDs
- Test that pathless conduits inherit coordinates and route correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1190a07cc83249388ff0ee506cb2b