### PR TITLE
Format mismatch warnings and surface in UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,6 +139,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         messages: document.getElementById('messages'),
         metrics: document.getElementById('metrics'),
         routeBreakdownContainer: document.getElementById('route-breakdown-container'),
+        mismatchedRacewaysDetails: document.getElementById('mismatched-raceways-details'),
+        mismatchedRacewaysList: document.getElementById('mismatched-raceways-list'),
         plot3d: document.getElementById('plot-3d'),
         popoutPlotBtn: document.getElementById('popout-plot-btn'),
         resetViewBtn: document.getElementById('reset-view-btn'),
@@ -2041,6 +2043,24 @@ const openDuctbankRoute = (dbId, conduitId) => {
         });
         const overall = `<p class="overall-stats"><strong>Overall Total Length:</strong> ${totalLength.toFixed(2)} ft | <strong>Overall Field Length:</strong> ${totalField.toFixed(2)} ft</p>`;
         elements.routeBreakdownContainer.innerHTML = overall + html;
+        const mismatches = [];
+        results.forEach(r => {
+            if (r.mismatched_records && r.mismatched_records.length) {
+                mismatches.push(...r.mismatched_records);
+            }
+        });
+        if (mismatches.length) {
+            elements.mismatchedRacewaysList.innerHTML = mismatches.map(m => {
+                const id = m.tray_id || m.id || 'unknown';
+                const reason = m.reason.replace(/_/g, ' ');
+                const cable = m.cable_id ? ` (cable ${m.cable_id})` : '';
+                return `<li>${id}: ${reason}${cable}</li>`;
+            }).join('');
+            elements.mismatchedRacewaysDetails.style.display = '';
+        } else {
+            elements.mismatchedRacewaysList.innerHTML = '';
+            elements.mismatchedRacewaysDetails.style.display = 'none';
+        }
         if (results.some(r => (r.exclusions && r.exclusions.length > 0) || (r.mismatched_records && r.mismatched_records.length > 0))) {
             document.dispatchEvent(new CustomEvent('exclusions-found'));
         }

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -210,6 +210,10 @@
                 <h2>Routing Results</h2>
                 <div id="messages"></div>
                 <div id="metrics" class="columns"></div>
+                <details id="mismatched-raceways-details" style="display:none;">
+                    <summary>Mismatched Raceway Segments</summary>
+                    <ul id="mismatched-raceways-list" class="exclusions-list"></ul>
+                </details>
                 <details id="route-breakdown-details">
                     <summary>Route Breakdown</summary>
                     <div id="route-breakdown-container"></div>

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -86,6 +86,10 @@ class CableRoutingSystem {
         return utilization;
     }
 
+    _formatMismatchedRecords() {
+        return this.mismatchedRecords.map(({ tray_id, reason, cable_id }) => ({ tray_id, reason, cable_id }));
+    }
+
     // Geometric helper: 3D distance
     distance(p1, p2) {
         return Math.sqrt(Math.pow(p1[0] - p2[0], 2) + Math.pow(p1[1] - p2[1], 2) + Math.pow(p1[2] - p2[2], 2));
@@ -360,7 +364,8 @@ class CableRoutingSystem {
 
         this.baseGraph = graph;
         if (this.mismatchedRecords.length) {
-            console.warn('Mismatched raceway segments:', this.mismatchedRecords);
+            const formatted = this._formatMismatchedRecords();
+            console.warn('Mismatched raceway segments:', formatted);
         }
     }
 
@@ -488,13 +493,13 @@ class CableRoutingSystem {
                 const record = { tray_id: id, reason: 'group_mismatch', cable_id: cableId };
                 exclusions.push(record);
                 this.mismatchedRecords.push(record);
-                return { success: false, manual: true, manual_raceway: true, message: `Tray ${id} not allowed`, exclusions, mismatched_records: this.mismatchedRecords.slice() };
+                return { success: false, manual: true, manual_raceway: true, message: `Tray ${id} not allowed`, exclusions, mismatched_records: this._formatMismatchedRecords() };
             }
             if (tray.current_fill + cableArea > tray.maxFill) {
                 const record = { tray_id: id, reason: 'over_capacity', cable_id: cableId };
                 exclusions.push(record);
                 this.mismatchedRecords.push(record);
-                return { success: false, manual: true, manual_raceway: true, message: `Tray ${id} over capacity`, exclusions, mismatched_records: this.mismatchedRecords.slice() };
+                return { success: false, manual: true, manual_raceway: true, message: `Tray ${id} over capacity`, exclusions, mismatched_records: this._formatMismatchedRecords() };
             }
             const a = [tray.start_x, tray.start_y, tray.start_z];
             const b = [tray.end_x, tray.end_y, tray.end_z];
@@ -520,7 +525,7 @@ class CableRoutingSystem {
             total_length: total,
             field_routed_length: fieldLen,
             exclusions,
-            mismatched_records: this.mismatchedRecords.slice(),
+            mismatched_records: this._formatMismatchedRecords(),
         };
     }
     calculateRoute(startPoint, endPoint, cableArea, allowedGroup, manualPath = '', racewayIds = [], cableId = null) {
@@ -573,7 +578,8 @@ class CableRoutingSystem {
         });
 
         if (this.mismatchedRecords.length) {
-            console.warn('Mismatched raceway segments:', this.mismatchedRecords);
+            const formatted = this._formatMismatchedRecords();
+            console.warn('Mismatched raceway segments:', formatted);
         }
 
         const addNode = (id, point, type = 'generic') => {
@@ -745,7 +751,7 @@ class CableRoutingSystem {
             manual: false,
             manual_raceway: false,
             exclusions,
-            mismatched_records: this.mismatchedRecords.slice(),
+            mismatched_records: this._formatMismatchedRecords(),
         };
     }
 }

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -175,11 +175,45 @@ describe("_racewayRoute", () => {
     system.calculateRoute([0, 0, 0], [0, 10, 0], 1, null, '', [], 'cable-1');
     console.warn = origWarn;
     assert(warned, 'mismatch warning not emitted');
+    assert.strictEqual(warned[0], 'Mismatched raceway segments:');
     const records = warned[1];
     assert(Array.isArray(records) && records.length === 1);
     assert.strictEqual(records[0].tray_id, 'tray-over');
     assert.strictEqual(records[0].reason, 'over_capacity');
     assert.strictEqual(records[0].cable_id, 'cable-1');
+    assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','reason','tray_id']);
+  });
+
+  it("warns for group mismatches with formatted record", () => {
+    const system = new CableRoutingSystem({ fillLimit: 0.4 });
+    system.addTraySegment({
+      tray_id: 'tray-group',
+      start_x: 0,
+      start_y: 0,
+      start_z: 0,
+      end_x: 0,
+      end_y: 10,
+      end_z: 0,
+      width: 10,
+      height: 10,
+      current_fill: 0,
+      allowed_cable_group: 'A',
+    });
+    let warned = null;
+    const origWarn = console.warn;
+    console.warn = (...args) => {
+      warned = args;
+    };
+    system.calculateRoute([0, 0, 0], [0, 10, 0], 1, 'B', '', [], 'cable-2');
+    console.warn = origWarn;
+    assert(warned, 'mismatch warning not emitted');
+    assert.strictEqual(warned[0], 'Mismatched raceway segments:');
+    const records = warned[1];
+    assert(Array.isArray(records) && records.length === 1);
+    assert.strictEqual(records[0].tray_id, 'tray-group');
+    assert.strictEqual(records[0].reason, 'group_mismatch');
+    assert.strictEqual(records[0].cable_id, 'cable-2');
+    assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','reason','tray_id']);
   });
 
   it("routes when proximity threshold is increased", () => {


### PR DESCRIPTION
## Summary
- Format mismatched raceway warnings as `{ tray_id, reason, cable_id }` and log them in a structured console message
- Expose mismatched raceways in a collapsible section on the results page
- Add tests covering over-capacity and group-mismatch warning formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1253229c883248c91834a8126d7a0