### PR TITLE
Warn on missing geometry in imported ductbanks

### DIFF
--- a/docs/geometry-fields.html
+++ b/docs/geometry-fields.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Required Geometry Fields</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Required Geometry Fields</h1>
+    <p>Ductbank records must provide either an <code>outline</code> array of 3D points or both start and end coordinates using the fields <code>start_x</code>, <code>start_y</code>, <code>start_z</code>, <code>end_x</code>, <code>end_y</code>, and <code>end_z</code>.</p>
+    <p>Conduit records must include a <code>path</code> array with at least two <code>[x, y, z]</code> points describing the run of the conduit.</p>
+    <p>Entries missing these fields cannot be placed in the model and will be skipped.</p>
+  </main>
+</body>
+</html>

--- a/tests/rebuildTrayData.test.js
+++ b/tests/rebuildTrayData.test.js
@@ -40,7 +40,7 @@ vm.runInContext(workerCode + '\nthis.CableRoutingSystem = CableRoutingSystem;', 
 const { CableRoutingSystem } = sandbox;
 
 describe('rebuildTrayData', () => {
-  it('assigns ductbank coordinates to conduits without paths', () => {
+  it('skips conduits without paths and warns', () => {
     const state = {
       manualTrays: [],
       trayData: [],
@@ -65,14 +65,16 @@ describe('rebuildTrayData', () => {
       conduitData: [],
     };
     const CONDUIT_SPECS = { RMC: { '1': 0.887 } };
+    let warned = false;
+    const origWarn = console.warn;
+    console.warn = () => { warned = true; };
     rebuildTrayData(state, CONDUIT_SPECS);
-    const seg = state.trayData.find(t => t.tray_id === 'DB1-C1');
-    assert(seg, 'conduit segment missing');
-    assert.deepStrictEqual([seg.start_x, seg.start_y, seg.start_z], [0, 0, 0]);
-    assert.deepStrictEqual([seg.end_x, seg.end_y, seg.end_z], [10, 0, 0]);
+    console.warn = origWarn;
+    assert.strictEqual(state.trayData.length, 0);
+    assert(warned, 'warning not emitted');
   });
 
-  it('routes through generated conduit segments', () => {
+  it('routes through conduit segments when path provided', () => {
     const state = {
       manualTrays: [],
       trayData: [],
@@ -89,7 +91,7 @@ describe('rebuildTrayData', () => {
             width: 12,
             height: 12,
             conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1' },
+              { conduit_id: 'C1', type: 'RMC', trade_size: '1', path: [[0,0,0],[10,0,0]] },
             ],
           },
         ],
@@ -123,7 +125,7 @@ describe('rebuildTrayData', () => {
             width: 12,
             height: 12,
             conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1' },
+              { conduit_id: 'C1', type: 'RMC', trade_size: '1', path: [[0,0,0],[10,0,0]] },
             ],
           },
         ],
@@ -154,7 +156,7 @@ describe('rebuildTrayData', () => {
             width: 12,
             height: 12,
             conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1' },
+              { conduit_id: 'C1', type: 'RMC', trade_size: '1', path: [[0,0,0],[10,0,0]] },
             ],
           },
         ],


### PR DESCRIPTION
## Summary
- warn and skip ductbanks lacking outline/coordinates and conduits missing paths
- show consolidated banner linking to geometry field docs
- add unit tests for absent geometry warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1fab98da88324be910fa8796302ca