### PR TITLE
Report conduit import count

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Supplying specific **Raceway IDs** on a cable forces the router to follow those 
 
 When routing, any raceway that cannot be used—because it is over capacity, belongs to a different cable group, or sits beyond the start/end proximity threshold—is recorded with a reason. The Route Breakdown now lists these exclusions so you can see why particular conduits were skipped.
 
+## New Feature: Conduit Import Count
+
+After raceway data is loaded, the app logs and displays how many ductbank conduits were successfully added. If a conduit schedule is supplied but no conduits load, a warning suggests possible geometry problems or mismatched identifiers.
+
 ## New Feature: Manual Batch Cable Entry
 
 When batch mode is selected, you can now use the **Add Cable to List** button to

--- a/app.js
+++ b/app.js
@@ -205,6 +205,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     };
 
+    const displayConduitCount = (count, hasSchedule) => {
+        console.log(`Conduits added: ${count}`);
+        const el = typeof document !== 'undefined' && document.getElementById('conduit-count');
+        if (el) {
+            el.textContent = `Conduits added: ${count}`;
+            if (count === 0 && hasSchedule) {
+                el.textContent += ' (No valid conduits found; check geometry or IDs)';
+            }
+        }
+        if (count === 0 && hasSchedule) {
+            console.warn('No valid conduits were loaded. Check geometry fields or conduit IDs.');
+            if (typeof elements !== 'undefined' && elements.messages) {
+                elements.messages.innerHTML += '<div class="message warning">No valid conduits were loaded. Verify geometry fields or conduit identifiers.</div>';
+            }
+        }
+    };
+
     const loadDuctbankData = async () => {
         if (state.ductbankData && state.ductbankData.ductbanks && state.ductbankData.ductbanks.length) {
             update3DPlot();
@@ -656,6 +673,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         if ((state.geometryWarnings.ductbanks.length || state.geometryWarnings.conduits.length) && typeof displayGeometryWarnings === 'function') {
             displayGeometryWarnings();
+        }
+        const conduitCount = state.trayData.filter(t => t.raceway_type === 'ductbank').length;
+        const hasSchedule = !!(
+            (state.ductbankData && state.ductbankData.ductbanks && state.ductbankData.ductbanks.some(db => (db.conduits || []).length)) ||
+            (state.conduitData && state.conduitData.length)
+        );
+        if (typeof displayConduitCount === 'function') {
+            displayConduitCount(conduitCount, hasSchedule);
         }
     };
 

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -110,6 +110,8 @@
                 <p>Find the most efficient path for routing cables through tray networks with capacity constraints.</p>
             </header>
 
+            <div id="conduit-count" class="message info"></div>
+
             <div id="ductbank-no-conduits-warning" class="message warning" style="display:none;">
                 Ductbank(s) <span class="db-list"></span> have no conduits and will be ignored until a conduit schedule is imported.
                 <a href="racewayschedule.html">Import ductbank_schedule_conduits.csv</a>

--- a/tests/rebuildTrayData.test.js
+++ b/tests/rebuildTrayData.test.js
@@ -169,5 +169,64 @@ describe('rebuildTrayData', () => {
     assert(types.includes('ductbank'), 'ductbank outline missing');
     assert(types.includes('conduit'), 'conduit segment missing');
   });
+
+  it('reports conduit count after rebuild', () => {
+    const state = {
+      manualTrays: [],
+      trayData: [],
+      includeDuctbankOutlines: true,
+      ductbankData: {
+        ductbanks: [
+          {
+            id: 'DB1',
+            start_x: 0,
+            start_y: 0,
+            start_z: 0,
+            end_x: 10,
+            end_y: 0,
+            end_z: 0,
+            width: 12,
+            height: 12,
+            conduits: [ { conduit_id: 'C1', path: [[0,0,0],[10,0,0]] } ],
+          },
+          {
+            id: 'DB2',
+            conduits: [ { conduit_id: 'C2' } ],
+          },
+        ],
+      },
+      conduitData: [],
+    };
+    let captured = {};
+    global.displayConduitCount = (count, hasSchedule) => { captured = { count, hasSchedule }; };
+    rebuildTrayData(state, {});
+    delete global.displayConduitCount;
+    const expected = state.trayData.filter(t => t.raceway_type === 'ductbank').length;
+    assert.strictEqual(captured.count, expected);
+    assert.strictEqual(captured.hasSchedule, true);
+  });
+
+  it('warns when no conduits are added despite schedule', () => {
+    const state = {
+      manualTrays: [],
+      trayData: [],
+      includeDuctbankOutlines: true,
+      ductbankData: {
+        ductbanks: [
+          {
+            id: 'DB1',
+            conduits: [ { conduit_id: 'C1' } ],
+          },
+        ],
+      },
+      conduitData: [],
+    };
+    let captured = {};
+    global.displayConduitCount = (count, hasSchedule) => { captured = { count, hasSchedule }; };
+    rebuildTrayData(state, {});
+    delete global.displayConduitCount;
+    assert.strictEqual(captured.count, 0);
+    assert.strictEqual(captured.hasSchedule, true);
+  });
 });
 


### PR DESCRIPTION
## Summary
- Log and display how many ductbank conduits load after rebuilding tray data
- Warn when a conduit schedule is present but yields no valid conduits
- Document conduit import count and add tests verifying reported totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20ca91b888324b8ba0c35a977b443