### PR TITLE
Include ductbank tags in conduit export

### DIFF
--- a/ductbankTable.js
+++ b/ductbankTable.js
@@ -414,8 +414,8 @@
   function exportDuctbankXlsx(){
     const dbData=[['ductbank_id','tag','from','to','concrete_encasement','start_x','start_y','start_z','end_x','end_y','end_z']];
     ductbanks.forEach(db=>dbData.push([db.id,db.tag,db.from,db.to,db.concrete_encasement?1:0,db.start_x,db.start_y,db.start_z,db.end_x,db.end_y,db.end_z]));
-    const cData=[['ductbank_id','conduit_id','type','trade_size','start_x','start_y','start_z','end_x','end_y','end_z','allowed_cable_group']];
-    ductbanks.forEach(db=>db.conduits.forEach(c=>cData.push([db.id,c.conduit_id,c.type,c.trade_size,c.start_x,c.start_y,c.start_z,c.end_x,c.end_y,c.end_z,c.allowed_cable_group])));
+    const cData=[['ductbank_id','ductbankTag','conduit_id','type','trade_size','start_x','start_y','start_z','end_x','end_y','end_z','allowed_cable_group']];
+    ductbanks.forEach(db=>db.conduits.forEach(c=>cData.push([db.id,db.tag||db.id,c.conduit_id,c.type,c.trade_size,c.start_x,c.start_y,c.start_z,c.end_x,c.end_y,c.end_z,c.allowed_cable_group])));
     const wb=XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb,XLSX.utils.aoa_to_sheet(dbData),'Ductbanks');
     XLSX.utils.book_append_sheet(wb,XLSX.utils.aoa_to_sheet(cData),'Conduits');

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,8 @@ The `raceway_ids` column contains one or more conduit or tray tags separated by 
 
 Two files represent the different sheets:
 
+- `ductbank_schedule_ductbanks.csv` — `ductbank_id`, `tag`, `from`, `to`, `concrete_encasement`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`
+- `ductbank_schedule_conduits.csv` — `ductbank_id`, `ductbankTag`, `conduit_id`, `type`, `trade_size`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`
 - `ductbank_conduits.csv` — `conduit_id`, `conduit_type`, `trade_size`, `x`, `y`, `z`, `angle`
 - `ductbank_cables.csv` — `tag`, `cable_type`, `diameter`, `conductors`, `conductor_size`, `weight`, `start_conduit_id`, `end_conduit_id`
 

--- a/examples/ductbank_schedule_conduits.csv
+++ b/examples/ductbank_schedule_conduits.csv
@@ -1,2 +1,2 @@
-ductbank_id,conduit_id,type,trade_size,start_x,start_y,start_z,end_x,end_y,end_z
-DB1,C1,PVC,4,0,0,0,100,0,0
+ductbank_id,ductbankTag,conduit_id,type,trade_size,start_x,start_y,start_z,end_x,end_y,end_z
+DB1,DB-1,C1,PVC,4,0,0,0,100,0,0


### PR DESCRIPTION
## Summary
- add `ductbankTag` column when exporting ductbank conduits and populate with ductbank tag
- update ductbank conduit template and docs to show new column

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22671abdc83249e29f78bb91846c5