### PR TITLE
Normalize ductbank tags when loading conduit schedules

### DIFF
--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -307,7 +307,7 @@ describe("_racewayRoute", () => {
       'async function loadSchedulesIntoSession(){' + fnBody + '}; loadSchedulesIntoSession;',
       sandbox,
     );
-    storage.setItem("db", JSON.stringify([{ ductbank_id: "DB1", start_x: 0, start_y: 0, start_z: 0, end_x: 1, end_y: 0, end_z: 0 }]));
+    storage.setItem("db", JSON.stringify([{ tag: "DB1", start_x: 0, start_y: 0, start_z: 0, end_x: 1, end_y: 0, end_z: 0 }]));
     loadSchedulesIntoSession();
     assert(warned, "missing conduit warning not emitted");
     assert.strictEqual(state.ductbanksWithoutConduits.length, 1);

--- a/tests/rebuildTrayData.test.js
+++ b/tests/rebuildTrayData.test.js
@@ -47,7 +47,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            id: 'DB1',
+            tag: 'DB1',
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -81,7 +81,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            id: 'DB1',
+            tag: 'DB1',
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -115,7 +115,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            id: 'DB1',
+            tag: 'DB1',
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -146,7 +146,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            id: 'DB1',
+            tag: 'DB1',
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -178,7 +178,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            id: 'DB1',
+            tag: 'DB1',
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -214,7 +214,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            id: 'DB1',
+            tag: 'DB1',
             conduits: [ { conduit_id: 'C1' } ],
           },
         ],


### PR DESCRIPTION
## Summary
- Map conduits by ductbank tag in `loadSchedulesIntoSession` and attach via normalized keys
- Carry ductbank tags through tray rebuilding and routing segments, treating tag-less conduits as standalone
- Adjust tests to use ductbank tags for ductbank identification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22914c86483249ef52076c4f37a91