### PR TITLE
Add per-page dirty state tracking and tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,10 +89,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     initHelpModal('help-btn','help-modal','close-help-btn');
     initNavToggle();
     // --- UNSAVED CHANGES TRACKING ---
-    let saved = true;
-    const markSaved = () => { saved = true; };
-    const markUnsaved = () => { saved = false; };
-    window.addEventListener('beforeunload', e => { if(!saved){ e.preventDefault(); e.returnValue=''; }});
+    const dirty = createDirtyTracker();
+    const markSaved = () => { dirty.markClean(); };
+    const markUnsaved = () => { dirty.markDirty(); };
 
     // --- STATE MANAGEMENT ---
     let state = {

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -10,6 +10,7 @@
 
   <!-- SheetJS / xlsx for Excel import/export -->
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
+  <script src="dirtyTracker.js" defer></script>
   <script src="dist/cabletrayfill.js" defer></script>
 </head>
   <body class="cabletrayfill-page">

--- a/cabletrayfill.js
+++ b/cabletrayfill.js
@@ -5,10 +5,9 @@ checkPrereqs([{key:'traySchedule',page:'racewayschedule.html',label:'Raceway Sch
       initDarkMode();
       initHelpModal('help-btn','helpOverlay','helpClose');
       initNavToggle();
-      let saved = true;
-      const markSaved = () => { saved = true; };
-      const markUnsaved = () => { saved = false; };
-      window.addEventListener('beforeunload', e => { if (!saved) { e.preventDefault(); e.returnValue=''; } });
+      const dirty = createDirtyTracker();
+      const markSaved = () => { dirty.markClean(); };
+      const markUnsaved = () => { dirty.markDirty(); };
       // ─────────────────────────────────────────────────────────────
       // (A) Default Configurations (3 conductors + ground) :contentReference[oaicite:0]{index=0}
       // ─────────────────────────────────────────────────────────────

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -7,6 +7,7 @@
   <title>Conduit Fill Visualization</title>
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
+  <script src="dirtyTracker.js" defer></script>
   <script src="dist/conduitfill.js" defer></script>
 </head>
 <body class="conduitfill-page">

--- a/conduitfill.js
+++ b/conduitfill.js
@@ -20,10 +20,9 @@ checkPrereqs([{key:'conduitSchedule',page:'racewayschedule.html',label:'Raceway 
       initDarkMode();
       initHelpModal('help-btn','help-modal','close-help-btn');
       initNavToggle();
-      let saved = true;
-      const markSaved = () => { saved = true; };
-      const markUnsaved = () => { saved = false; };
-      window.addEventListener('beforeunload', e => { if(!saved){ e.preventDefault(); e.returnValue=''; }});
+      const dirty = createDirtyTracker();
+      const markSaved = () => { dirty.markClean(); };
+      const markUnsaved = () => { dirty.markDirty(); };
 
       const typeSel = document.getElementById('conduitType');
       const sizeSel = document.getElementById('tradeSize');

--- a/dirtyTracker.js
+++ b/dirtyTracker.js
@@ -1,0 +1,22 @@
+function createDirtyTracker(win = (typeof window !== 'undefined' ? window : undefined)) {
+  if (!win) throw new Error('Window object required');
+  let dirty = false;
+  const handler = e => {
+    e.preventDefault();
+    e.returnValue = '';
+  };
+  const update = () => {
+    if (dirty) {
+      win.addEventListener('beforeunload', handler);
+    } else {
+      win.removeEventListener('beforeunload', handler);
+    }
+  };
+  return {
+    markDirty() { if (!dirty) { dirty = true; update(); } },
+    markClean() { if (dirty) { dirty = false; update(); } },
+    isDirty() { return dirty; }
+  };
+}
+if (typeof module !== 'undefined') module.exports = { createDirtyTracker };
+if (typeof window !== 'undefined') window.createDirtyTracker = createDirtyTracker;

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -10,6 +10,7 @@
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
 <script src="https://unpkg.com/gpu.js@2.10.4/dist/gpu-browser.min.js" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.js" defer></script>
+<script src="dirtyTracker.js" defer></script>
 <script src="dist/ductbankroute.js" defer></script>
 </head>
 <body class="ductbank-page">

--- a/ductbankroute.js
+++ b/ductbankroute.js
@@ -2306,10 +2306,9 @@ document.querySelector('#conduitTable').addEventListener('input',saveDuctbankSes
 document.querySelector('#cableTable').addEventListener('input',saveDuctbankSession);
 document.querySelector('#heatSourceTable').addEventListener('input',saveDuctbankSession);
 window.addEventListener('beforeunload',saveDuctbankSession);
-let saved=true;
-const markSaved=()=>{saved=true;};
-const markUnsaved=()=>{saved=false;};
-window.addEventListener('beforeunload',e=>{if(!saved){e.preventDefault();e.returnValue='';}});
+const dirty = createDirtyTracker();
+const markSaved = () => dirty.markClean();
+const markUnsaved = () => dirty.markDirty();
 ['ductbankTag','concreteEncasement','ductbankDepth','earthTemp','airTemp','soilResistivity','moistureContent','heatSources','hSpacing','vSpacing','topPad','bottomPad','leftPad','rightPad','perRow','conductorRating','gridRes','ductThermRes'].forEach(id=>{const el=document.getElementById(id);if(el){el.addEventListener('input',markUnsaved);el.addEventListener('change',markUnsaved);}});
 document.getElementById('conduitTable').addEventListener('input',markUnsaved);
 document.getElementById('cableTable').addEventListener('input',markUnsaved);

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -10,6 +10,7 @@
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+    <script src="dirtyTracker.js" defer></script>
     <script src="dist/optimalRoute.js" defer></script>
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js"
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
+  <script src="dirtyTracker.js" defer></script>
   <script src="dist/racewayschedule.js" defer></script>
 </head>
 <body>

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -59,10 +59,9 @@ document.addEventListener('DOMContentLoaded',()=>{
         });
     }catch(e){console.error('Failed to load cables for',id,e);return[];}
   }
-  let saved=true;
-  const markSaved=()=>{saved=true;};
-  const markUnsaved=()=>{saved=false;};
-  window.addEventListener('beforeunload',e=>{if(!saved){e.preventDefault();e.returnValue='';}});
+  const dirty = createDirtyTracker();
+  const markSaved = () => dirty.markClean();
+  const markUnsaved = () => dirty.markDirty();
 
   document.addEventListener('keydown',e=>{
     if((e.key==='ArrowUp'||e.key==='ArrowDown')&&['INPUT','SELECT'].includes(e.target.tagName)){

--- a/tests/dirtyTracker.test.js
+++ b/tests/dirtyTracker.test.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+const { createDirtyTracker } = require('../dirtyTracker');
+
+function describe(name, fn){
+  console.log(name);
+  fn();
+}
+function it(name, fn){
+  try{
+    fn();
+    console.log('  \u2713', name);
+  }catch(err){
+    console.error('  \u2717', name, err.message || err);
+    process.exitCode = 1;
+  }
+}
+
+function makeWindow(){
+  let handler = null;
+  return {
+    addEventListener(type, fn){ if(type==='beforeunload') handler = fn; },
+    removeEventListener(type, fn){ if(type==='beforeunload' && handler===fn) handler=null; },
+    fire(){
+      const e = { defaultPrevented:false, preventDefault(){ this.defaultPrevented=true; }, returnValue:undefined };
+      if(handler) handler(e);
+      return e;
+    }
+  };
+}
+
+describe('dirty state tracker', () => {
+  it('no edits -> no prompt', () => {
+    const win = makeWindow();
+    createDirtyTracker(win); // no edits
+    const e = win.fire();
+    assert.strictEqual(e.defaultPrevented, false);
+  });
+
+  it('edit a cell -> prompt', () => {
+    const win = makeWindow();
+    const tracker = createDirtyTracker(win);
+    tracker.markDirty();
+    const e = win.fire();
+    assert.strictEqual(e.defaultPrevented, true);
+  });
+
+  it('Save -> no prompt', () => {
+    const win = makeWindow();
+    const tracker = createDirtyTracker(win);
+    tracker.markDirty();
+    tracker.markClean();
+    const e = win.fire();
+    assert.strictEqual(e.defaultPrevented, false);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable dirty-state tracker that only prompts on navigation when edits are unsaved
- integrate tracker across Raceway Schedule, Ductbank, Tray Fill, Conduit Fill, and Optimal Route pages
- add tests ensuring beforeunload prompt appears only when expected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a246af5fec8324a41679469adf19db