### PR TITLE
Add unified CSV/XLSX import with validation and templates

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
     <script src="dirtyTracker.js" defer></script>
     <script src="dist/optimalRoute.js" defer></script>
@@ -127,8 +128,9 @@
                     <button id="load-sample-trays-btn">Load Sample Tray Network</button>
                     <div class="table-import-export">
                         <button id="export-trays-btn">Export Trays CSV</button>
-                        <input type="file" id="import-trays-file" accept=".csv" style="display:none;">
-                        <button id="import-trays-btn">Import Trays CSV</button>
+                        <button id="download-trays-template-btn">Download Sample</button>
+                        <input type="file" id="import-trays-file" accept=".csv,.xlsx" style="display:none;">
+                        <button id="import-trays-btn">Import Trays</button>
                         <button id="clear-trays-btn">Clear All Trays</button>
                     </div>
                 </div>
@@ -194,8 +196,9 @@
                         <button id="load-sample-cables-btn">Load Sample Cable List</button>
                         <div class="table-import-export">
                             <button id="export-cables-btn">Export Cables CSV</button>
-                            <input type="file" id="import-cables-file" accept=".csv" style="display:none;">
-                            <button id="import-cables-btn">Import Cables CSV</button>
+                            <button id="download-cables-template-btn">Download Sample</button>
+                            <input type="file" id="import-cables-file" accept=".csv,.xlsx" style="display:none;">
+                            <button id="import-cables-btn">Import Cables</button>
                         </div>
                         <button id="clear-cables-btn">Clear Cable List</button>
                     </div>
@@ -265,6 +268,7 @@
             </div>
         </div>
     </div>
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
     <script src="app.js" defer></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -590,6 +590,10 @@ body.dark-mode .sticky-table tbody tr:hover {
 }
 .toast.show { opacity: 1; }
 body.dark-mode .toast { background: #2c3034; color: #f8f9fa; }
+.toast-success { background: #28a745; color: #fff; }
+.toast-error { background: #dc3545; color: #fff; }
+body.dark-mode .toast-success { background: #28a745; }
+body.dark-mode .toast-error { background: #dc3545; }
 
 #warning-area { margin-top: 8px; }
 #soilWarning { margin-top:4px; font-size:0.8rem; color: var(--warning-text); }


### PR DESCRIPTION
## Summary
- Validate tray and cable imports through a shared parser using SheetJS and Papa Parse
- Surface import errors and successes via colored toast messages
- Provide downloadable tray and cable templates matching required columns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a250f0c1108324aec66f47916646fe