### PR TITLE
feat: add route map view and export controls

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -233,6 +233,8 @@
                 <div class="plot-controls">
                     <button id="popout-plot-btn">Open Full Screen</button>
                     <button id="reset-view-btn">Reset View</button>
+                    <button id="view-toggle-btn">2D View</button>
+                    <button id="export-png-btn">Export PNG</button>
                     <label><input type="checkbox" id="ductbank-toggle" checked> Show Ductbanks</label>
                 </div>
                 <details id="updated-utilization-details">


### PR DESCRIPTION
## Summary
- add View on Map buttons to routing results to highlight cable paths
- support toggling between 2D/3D views and export current plot as PNG
- color trays vs ductbanks and annotate conduit IDs when a cable is highlighted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25d0e2d588324aae95b7aa4fd15cd