### PR TITLE
Respect ductbank conduit allowed groups

### DIFF
--- a/app.js
+++ b/app.js
@@ -2144,7 +2144,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
                 res.exclusions.forEach(ex => {
                     const id = ex.tray_id || ex.id || 'unknown';
                     const reason = ex.reason.replace(/_/g, ' ');
-                    html += `<li>${id}: ${reason}</li>`;
+                    const link = ex.filter ? ` <a href="${ex.filter}">Filter</a>` : '';
+                    html += `<li>${id}: ${reason}${link}</li>`;
                 });
                 html += '</ul>';
             }
@@ -2154,7 +2155,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
                     const id = m.tray_id || m.id || 'unknown';
                     const reason = m.reason.replace(/_/g, ' ');
                     const cable = m.cable_id ? ` (cable ${m.cable_id})` : '';
-                    html += `<li>${id}: ${reason}${cable}</li>`;
+                    const link = m.filter ? ` <a href="${m.filter}">Filter</a>` : '';
+                    html += `<li>${id}: ${reason}${cable}${link}</li>`;
                 });
                 html += '</ul>';
             }
@@ -2192,7 +2194,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
                 const id = m.tray_id || m.id || 'unknown';
                 const reason = m.reason.replace(/_/g, ' ');
                 const cable = m.cable_id ? ` (cable ${m.cable_id})` : '';
-                return `<li>${id}: ${reason}${cable}</li>`;
+                const link = m.filter ? ` <a href="${m.filter}">Filter</a>` : '';
+                return `<li>${id}: ${reason}${cable}${link}</li>`;
             }).join('');
             elements.mismatchedRacewaysDetails.style.display = '';
         } else {

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -195,8 +195,34 @@ describe("_racewayRoute", () => {
     assert.strictEqual(records[0].tray_id, 'tray-over');
     assert.strictEqual(records[0].reason, 'over_capacity');
     assert.strictEqual(records[0].cable_id, 'cable-1');
-    assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','reason','tray_id']);
-  });
+      assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','filter','reason','tray_id']);
+    });
+
+    it("details ductbank group mismatch with filter", () => {
+      const system = new CableRoutingSystem({ fillLimit: 0.4 });
+      system.addTraySegment({
+        tray_id: 'DB1-1',
+        start_x: 0,
+        start_y: 0,
+        start_z: 0,
+        end_x: 0,
+        end_y: 10,
+        end_z: 0,
+        width: 10,
+        height: 10,
+        current_fill: 0,
+        allowed_cable_group: 'A',
+        conduit_id: '1',
+        ductbankTag: 'DB1',
+      });
+      const res = system.calculateRoute([0, 0, 0], [0, 10, 0], 1, 'B', '', ['DB1-1'], 'cable-3');
+      assert(!res.success);
+      assert(res.mismatched_records && res.mismatched_records.length === 1);
+      const rec = res.mismatched_records[0];
+      assert.strictEqual(rec.conduit_id, '1');
+      assert.strictEqual(rec.ductbank_tag, 'DB1');
+      assert(rec.filter.includes('DB1'));
+    });
 
   it("warns for group mismatches with formatted record", () => {
     const system = new CableRoutingSystem({ fillLimit: 0.4 });
@@ -227,8 +253,8 @@ describe("_racewayRoute", () => {
     assert.strictEqual(records[0].tray_id, 'tray-group');
     assert.strictEqual(records[0].reason, 'group_mismatch');
     assert.strictEqual(records[0].cable_id, 'cable-2');
-    assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','reason','tray_id']);
-  });
+      assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','filter','reason','tray_id']);
+    });
 
   it("routes when proximity threshold is increased", () => {
     const tray = {


### PR DESCRIPTION
## Summary
- Check cable allowed group against ductbank conduit allowed group and report the exact segment on mismatch
- Include filter URLs for offending raceways so schedule views can be narrowed to the problem rows
- Link mismatch details in the UI and add test coverage for ductbank group restrictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25f2d0cec8324ba608bbb139c109f