### PR TITLE
Add utilization heatmap visualization

### DIFF
--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -260,6 +260,7 @@
     <canvas id="tempOverlay" width="500" height="500" style="position:absolute;top:0;left:0;pointer-events:none;z-index:3;display:none;"></canvas>
   </div>
 <label style="display:block;margin-top:4px;"><input type="checkbox" id="hideDrawing"> Hide Drawing</label>
+<label style="display:block;margin-top:4px;"><input type="checkbox" id="utilHeatmapToggle"> Utilization Heatmap</label>
 
 <details id="ampacityDetails" open style="margin-top:8px;">
  <summary><strong>Ampacity Estimates</strong></summary>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -242,6 +242,7 @@
                     <button id="view-toggle-btn">2D View</button>
                     <button id="export-png-btn">Export PNG</button>
                     <label><input type="checkbox" id="ductbank-toggle" checked> Show Ductbanks</label>
+                    <label><input type="checkbox" id="heatmap-toggle"> Utilization Heatmap</label>
                 </div>
                 <details id="updated-utilization-details">
                     <summary>Updated Tray Utilization</summary>


### PR DESCRIPTION
## Summary
- add utilization heatmap toggle to route view with colorbar legend
- support ductbank per-conduit heatmap with legend and export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a26e0295888324a48f5db3269e8f05