### PR TITLE
Add Playwright test scaffolding for workflow cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js"
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js",
+    "e2e": "playwright test"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",
-    "rollup": "^3.29.0"
+    "rollup": "^3.29.0",
+    "@playwright/test": "^1.41.1"
   }
 }

--- a/playwright-tests/workflow.spec.js
+++ b/playwright-tests/workflow.spec.js
@@ -1,0 +1,55 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const root = path.join(__dirname, '..');
+
+function pageUrl(file) {
+  return 'file://' + path.join(root, file);
+}
+
+test.describe('CableTrayRoute workflow', () => {
+  test('create DB-01 with three conduits appears in Optimal Route', async ({ page }) => {
+    await page.goto(pageUrl('ductbankroute.html'));
+    await page.fill('#ductbankTag', 'DB-01');
+    for (let i = 0; i < 3; i++) {
+      await page.click('#addConduit');
+    }
+    await expect(page.locator('#conduitTable tbody tr')).toHaveCount(3);
+    await page.goto(pageUrl('optimalRoute.html'));
+    await expect(page.locator('#conduit-count')).toContainText('3');
+  });
+
+  test('import sample CSV/XLSX and route cables', async ({ page }) => {
+    await page.goto(pageUrl('optimalRoute.html'));
+    const trayFile = path.join(root, 'examples', 'tray_schedule.csv');
+    const cableFile = path.join(root, 'examples', 'cable_schedule.csv');
+    await page.setInputFiles('#import-trays-file', trayFile);
+    await page.click('#import-trays-btn');
+    await page.setInputFiles('#import-cables-file', cableFile);
+    await page.click('#import-cables-btn');
+    await page.click('#calculate-route-btn');
+    await expect(page.locator('#results-section')).toBeVisible();
+  });
+
+  test('lock a cable and reroute', async ({ page }) => {
+    await page.goto(pageUrl('optimalRoute.html'));
+    await page.click('#load-sample-trays-btn');
+    await page.click('#load-sample-cables-btn');
+    await page.click('#calculate-route-btn');
+    const firstRow = page.locator('#cable-list-container tbody tr').first();
+    const lockCheckbox = firstRow.locator('input[type="checkbox"][name="lock"]');
+    await lockCheckbox.check();
+    await page.click('#calculate-route-btn');
+    await expect(page.locator('#results-section')).toBeVisible();
+  });
+
+  test('dirty-state prompts appear when navigating away', async ({ page, context }) => {
+    await page.goto(pageUrl('ductbankroute.html'));
+    await page.fill('#ductbankTag', 'TEMP');
+    const [dialog] = await Promise.all([
+      context.waitForEvent('dialog'),
+      page.goto(pageUrl('index.html')),
+    ]);
+    expect(dialog.message()).toMatch(/unsaved|leave/i);
+    await dialog.dismiss();
+  });
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,10 @@
+const { defineConfig } = require('@playwright/test');
+const path = require('path');
+module.exports = defineConfig({
+  testDir: path.join(__dirname, 'playwright-tests'),
+  use: {
+    baseURL: 'file://' + __dirname + '/',
+    headless: true,
+  },
+  timeout: 30000,
+});


### PR DESCRIPTION
## Summary
- add Playwright config and sample e2e tests covering ductbank creation, imports, rerouting and dirty state prompts
- wire e2e script into package.json

## Testing
- `npm test`
- `npm run e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a27555b2b88324af0c0aeddfe60979