### PR TITLE
refactor: centralize raceway data storage

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
+  <script type="module" src="dataStore.js" defer></script>
   <script src="dist/cableschedule.js" defer></script>
 </head>
 <body>
@@ -99,12 +100,12 @@ const insulationRatings=['60','75','90'];
 
   function getRacewayOptions(){
     const ids=new Set();
-    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.traySchedule))||[]).forEach(t=>{if(t.tray_id) ids.add(t.tray_id);});}catch(e){}
-    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.conduitSchedule))||[]).forEach(c=>{
+    try{dataStore.getTrays().forEach(t=>{if(t.tray_id) ids.add(t.tray_id);});}catch(e){}
+    try{dataStore.getConduits().forEach(c=>{
       const id=c.tray_id||(c.ductbank_id&&c.conduit_id?`${c.ductbank_id}-${c.conduit_id}`:c.conduit_id);
       if(id) ids.add(id);
     });}catch(e){}
-    try{(JSON.parse(localStorage.getItem(TableUtils.STORAGE_KEYS.ductbankSchedule))||[]).forEach(db=>{
+    try{dataStore.getDuctbanks().forEach(db=>{
       const dbId=db.ductbank_id||db.id||db.tag;
       (db.conduits||[]).forEach(c=>{
         const id=c.tray_id||(dbId&&c.conduit_id?`${dbId}-${c.conduit_id}`:c.conduit_id);

--- a/cabletrayfill.js
+++ b/cabletrayfill.js
@@ -1,3 +1,5 @@
+import { getItem, setItem, removeItem, keys as storeKeys } from './dataStore.js';
+
 checkPrereqs([{key:'traySchedule',page:'racewayschedule.html',label:'Raceway Schedule'}]);
 
     document.addEventListener("DOMContentLoaded", function() {
@@ -1610,7 +1612,7 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
       const profileList = document.getElementById("profileList");
       function refreshProfileList() {
         profileList.innerHTML = "";
-        const keys = Object.keys(localStorage).filter(k => k.startsWith("trayProfile_"));
+        const keys = storeKeys().filter(k => k.startsWith("trayProfile_"));
         if (keys.length === 0) {
           const opt = document.createElement("option");
           opt.value = "";
@@ -1670,7 +1672,7 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
           });
         }
         try {
-          localStorage.setItem("trayProfile_" + name, JSON.stringify(arr));
+          setItem("trayProfile_" + name, arr);
           alert(`Profile "${name}" saved.`);
           refreshProfileList();
         } catch (e) {
@@ -1685,19 +1687,13 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
           alert("Select a profile to load.");
           return;
         }
-        const json = localStorage.getItem("trayProfile_" + profileName);
-        if (!json) {
+        const data = getItem("trayProfile_" + profileName);
+        if (!data) {
           alert(`Profile "${profileName}" not found.`);
           refreshProfileList();
           return;
         }
-        let arr;
-        try {
-          arr = JSON.parse(json);
-        } catch (e) {
-          alert("Error parsing profile data: " + e.message);
-          return;
-        }
+        const arr = data;
         cableTbody.innerHTML = "";
         arr.forEach(cable => {
           const newRow = createCableRow();
@@ -1735,7 +1731,7 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
           return;
         }
         if (!confirm(`Delete profile "${profileName}"?`)) return;
-        localStorage.removeItem("trayProfile_" + profileName);
+        removeItem("trayProfile_" + profileName);
         alert(`Profile "${profileName}" deleted.`);
         refreshProfileList();
       });
@@ -1755,10 +1751,10 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
       if(importExcelInput) importExcelInput.addEventListener('change',markUnsaved);
       ['saveProfileBtn','loadProfileBtn','exportExcelBtn'].forEach(id=>{const el=document.getElementById(id);if(el) el.addEventListener('click',markSaved);});
 
-      const stored = localStorage.getItem('trayFillData');
+      const stored = getItem('trayFillData');
       if (stored) {
         try {
-          const { tray, cables } = JSON.parse(stored);
+          const { tray, cables } = stored;
           document.getElementById('trayWidth').value = tray.width;
           document.getElementById('trayDepth').value = tray.height;
           document.getElementById('trayName').value = tray.tray_id || '';
@@ -1793,7 +1789,7 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
         } catch (e) {
           console.error('Failed to load trayFillData', e);
         }
-        localStorage.removeItem('trayFillData');
+        removeItem('trayFillData');
       }
 
       // Attach help popups for table headers

--- a/conduitfill.js
+++ b/conduitfill.js
@@ -1,3 +1,5 @@
+import { getItem, removeItem } from './dataStore.js';
+
 checkPrereqs([{key:'conduitSchedule',page:'racewayschedule.html',label:'Raceway Schedule'}]);
 
     const CONDUIT_SPECS = {
@@ -364,10 +366,10 @@ checkPrereqs([{key:'conduitSchedule',page:'racewayschedule.html',label:'Raceway 
       tableBody.addEventListener('click',e=>{if(e.target.tagName==='BUTTON') markUnsaved();});
       ['copyPngBtn','printBtn','copyBtn'].forEach(id=>{const el=document.getElementById(id);if(el)el.addEventListener('click',markSaved);});
 
-      const stored = localStorage.getItem('conduitFillData');
+      const stored = getItem('conduitFillData');
       if (stored) {
         try {
-          const { type, tradeSize, cables } = JSON.parse(stored);
+          const { type, tradeSize, cables } = stored;
           if (type) {
             typeSel.value = type;
             populateSizes();
@@ -392,7 +394,7 @@ checkPrereqs([{key:'conduitSchedule',page:'racewayschedule.html',label:'Raceway 
         } catch (e) {
           console.error('Failed to load conduitFillData', e);
         }
-        localStorage.removeItem('conduitFillData');
+        removeItem('conduitFillData');
       }
     });
   

--- a/dataStore.js
+++ b/dataStore.js
@@ -1,0 +1,151 @@
+/**
+ * Centralized data store wrapper around localStorage with typed getters and setters
+ * for core schedule data. Emits simple change events.
+ */
+
+/**
+ * @typedef {{[key:string]:any}} GenericRecord
+ * @typedef {GenericRecord} Tray
+ * @typedef {GenericRecord} Cable
+ * @typedef {GenericRecord} Ductbank
+ * @typedef {GenericRecord} Conduit
+ */
+
+const KEYS = {
+  trays: 'traySchedule',
+  cables: 'cableSchedule',
+  ductbanks: 'ductbankSchedule',
+  conduits: 'conduitSchedule'
+};
+
+const listeners = {};
+
+function emit(event, detail) {
+  (listeners[event] || []).forEach(fn => {
+    try { fn(detail); } catch (e) { console.error(e); }
+  });
+}
+
+/**
+ * Subscribe to change events.
+ * @param {string} event
+ * @param {(data:any)=>void} handler
+ */
+export function on(event, handler) {
+  if (!listeners[event]) listeners[event] = [];
+  listeners[event].push(handler);
+}
+
+/**
+ * Remove an event listener.
+ * @param {string} event
+ * @param {(data:any)=>void} handler
+ */
+export function off(event, handler) {
+  const arr = listeners[event];
+  if (!arr) return;
+  const idx = arr.indexOf(handler);
+  if (idx >= 0) arr.splice(idx, 1);
+}
+
+function read(key, fallback) {
+  try {
+    const raw = (typeof localStorage !== 'undefined') ? localStorage.getItem(key) : null;
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function write(key, value) {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(key, JSON.stringify(value));
+    }
+    emit(key, value);
+  } catch (e) {
+    console.error('Failed to store', key, e);
+  }
+}
+
+/**
+ * @returns {Tray[]}
+ */
+export const getTrays = () => read(KEYS.trays, []);
+/**
+ * @param {Tray[]} trays
+ */
+export const setTrays = trays => write(KEYS.trays, trays);
+
+/**
+ * @returns {Cable[]}
+ */
+export const getCables = () => read(KEYS.cables, []);
+/**
+ * @param {Cable[]} cables
+ */
+export const setCables = cables => write(KEYS.cables, cables);
+
+/**
+ * @returns {Ductbank[]}
+ */
+export const getDuctbanks = () => read(KEYS.ductbanks, []);
+/**
+ * @param {Ductbank[]} banks
+ */
+export const setDuctbanks = banks => write(KEYS.ductbanks, banks);
+
+/**
+ * @returns {Conduit[]}
+ */
+export const getConduits = () => read(KEYS.conduits, []);
+/**
+ * @param {Conduit[]} conduits
+ */
+export const setConduits = conduits => write(KEYS.conduits, conduits);
+
+// generic access for other values so pages never touch localStorage directly
+export const getItem = (key, fallback = null) => read(key, fallback);
+export const setItem = (key, value) => write(key, value);
+export const removeItem = key => {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(key);
+    }
+    emit(key, null);
+  } catch (e) {
+    console.error('Failed to remove', key, e);
+  }
+};
+
+export { KEYS as STORAGE_KEYS };
+
+export const keys = () => {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      return Object.keys(localStorage);
+    }
+  } catch {}
+  return [];
+};
+
+// expose on window for non-module scripts
+if (typeof window !== 'undefined') {
+  window.dataStore = {
+    STORAGE_KEYS: KEYS,
+    getTrays,
+    setTrays,
+    getCables,
+    setCables,
+    getDuctbanks,
+    setDuctbanks,
+    getConduits,
+    setConduits,
+    getItem,
+    setItem,
+    removeItem,
+    on,
+    off,
+    keys
+  };
+}

--- a/ductbankTable.js
+++ b/ductbankTable.js
@@ -1,3 +1,5 @@
+import { getDuctbanks, setDuctbanks, setItem, getItem } from './dataStore.js';
+
 (function(){
   let ductbanks=[];
   const DUCTBANK_KEY = TableUtils.STORAGE_KEYS.ductbankSchedule;
@@ -372,7 +374,7 @@
       concreteEncasement:db.concrete_encasement,
       conduits:db.conduits.map(c=>({conduit_id:c.conduit_id,conduit_type:c.type,trade_size:c.trade_size}))
     };
-    try{localStorage.setItem('ductbankSession',JSON.stringify(session));}catch(e){console.error('Failed to store ductbank session',e);}
+    try{setItem('ductbankSession',session);}catch(e){console.error('Failed to store ductbank session',e);}
     window.location.href='ductbankroute.html';
   }
 
@@ -410,12 +412,12 @@
       return;
     }
     ductbanks.forEach(db=>db.conduits.forEach(c=>{c.ductbankTag=db.tag;}));
-    try{localStorage.setItem(DUCTBANK_KEY,JSON.stringify(ductbanks));}catch(e){}
+    try{setDuctbanks(ductbanks);}catch(e){}
     applyFilters();
   }
 
   function loadDuctbanks(){
-    try{ductbanks=JSON.parse(localStorage.getItem(DUCTBANK_KEY))||[];}catch(e){ductbanks=[];}
+    try{ductbanks=getDuctbanks();}catch(e){ductbanks=[];}
     ductbanks.forEach(db=>{
       if(db.expanded===undefined) db.expanded=false;
       if(!db.conduits) db.conduits=[];

--- a/ductbankroute.js
+++ b/ductbankroute.js
@@ -1,3 +1,5 @@
+import { getItem, setItem, removeItem, getCables, getConduits } from './dataStore.js';
+
 checkPrereqs([{key:'ductbankSchedule',page:'racewayschedule.html',label:'Raceway Schedule'}]);
 
 document.addEventListener('DOMContentLoaded',()=>{
@@ -467,14 +469,14 @@ function saveDuctbankSession(){
   conductorRating:document.getElementById('conductorRating').value,
   darkMode:document.body.classList.contains('dark-mode')
 };
- try{localStorage.setItem('ductbankSession',JSON.stringify(session));}catch(e){console.error('save session failed',e);}
+ try{setItem('ductbankSession',session);}catch(e){console.error('save session failed',e);}
 }
 
 function loadDuctbankSession(){
- const stored=localStorage.getItem('ductbankSession');
+ const stored=getItem('ductbankSession');
  if(!stored) return;
  try{
-  const s=JSON.parse(stored);
+  const s=stored;
   if(s.ductbankTag!==undefined)document.getElementById('ductbankTag').value=s.ductbankTag;
   if(s.concreteEncasement!==undefined)document.getElementById('concreteEncasement').checked=s.concreteEncasement;
   if(s.ductbankDepth!==undefined)document.getElementById('ductbankDepth').value=s.ductbankDepth;
@@ -519,11 +521,8 @@ function loadDuctbankSession(){
 function loadCablesFromSchedule(){
   const tbody=document.querySelector('#cableTable tbody');
   if(!tbody||tbody.children.length>0) return;
-  const key=globalThis.TableUtils?.STORAGE_KEYS?.cableSchedule||'cableSchedule';
-  const json=localStorage.getItem(key);
-  if(!json) return;
-  let cables;
-  try{cables=JSON.parse(json);}catch(e){console.error('Failed to parse cable schedule',e);return;}
+  const cables=getCables();
+  if(!cables||cables.length===0) return;
   const conduitSet=new Set(getAllConduits().map(c=>c.conduit_id));
   let added=false;
   cables.forEach(c=>{
@@ -2217,7 +2216,7 @@ function downloadCanvasData(){
 }
 
 function deleteSavedData(){
- localStorage.removeItem('ductbankSession');
+removeItem('ductbankSession');
  document.querySelector('#conduitTable tbody').innerHTML='';
  document.querySelector('#cableTable tbody').innerHTML='';
  ['ductbankTag','ductbankDepth','earthTemp','airTemp','soilResistivity','moistureContent','hSpacing','vSpacing','topPad','bottomPad','leftPad','rightPad','perRow','conductorRating','gridRes','ductThermRes'].forEach(id=>{
@@ -2411,7 +2410,7 @@ loadConductorProperties().then(()=>{
   updateInsulationOptions();
   checkInsulationThickness();
   loadDuctbankSession();
-  const storedRoute = localStorage.getItem('ductbankRouteData');
+  const storedRoute = getItem('ductbankRouteData');
   if (storedRoute) {
     try {
       const { ductbank, cables, conduitId } = JSON.parse(storedRoute);
@@ -2470,7 +2469,7 @@ loadConductorProperties().then(()=>{
     } catch (e) {
       console.error('Failed to load ductbankRouteData', e);
     }
-    localStorage.removeItem('ductbankRouteData');
+    removeItem('ductbankRouteData');
     drawGrid();
     updateAmpacityReport();
   }

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -1,3 +1,5 @@
+import * as dataStore from './dataStore.js';
+
 checkPrereqs([{key:'cableSchedule',page:'cableschedule.html',label:'Cable Schedule'}]);
 
 // Expose conduit specifications globally so other modules bundled into
@@ -33,9 +35,8 @@ document.addEventListener('DOMContentLoaded',()=>{
   initNavToggle();
   function cablesForRaceway(id){
     try{
-      const json=localStorage.getItem(TableUtils.STORAGE_KEYS.cableSchedule);
-      if(!json) return [];
-      const arr=JSON.parse(json);
+      const arr=dataStore.getCables();
+      if(!arr) return [];
       return arr
         .filter(c=>{
           let ids=c.raceway_ids;
@@ -110,7 +111,7 @@ document.addEventListener('DOMContentLoaded',()=>{
         trayTable.save();
         const tray={tray_id:row.tray_id,width:parseFloat(row.inside_width),height:parseFloat(row.tray_depth),allowed_cable_group:row.allowed_cable_group};
         const cables=cablesForRaceway(row.tray_id);
-        localStorage.setItem('trayFillData',JSON.stringify({tray,cables}));
+        dataStore.setItem('trayFillData',{tray,cables});
       }catch(e){console.error('Failed to store tray fill data',e);}
       window.location.href='cabletrayfill.html';
     }
@@ -147,7 +148,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     onView:(row)=>{
       try{
         const cables=cablesForRaceway(row.conduit_id);
-        localStorage.setItem('conduitFillData',JSON.stringify({type:row.type,tradeSize:row.trade_size,cables}));
+        dataStore.setItem('conduitFillData',{type:row.type,tradeSize:row.trade_size,cables});
       }catch(e){console.error('Failed to store conduit fill data',e);}
       window.location.href='conduitfill.html';
     }
@@ -164,9 +165,9 @@ document.addEventListener('DOMContentLoaded',()=>{
       try{
         const res=await fetch('examples/sample_raceways.json');
         const data=await res.json();
-        localStorage.setItem(TableUtils.STORAGE_KEYS.ductbankSchedule,JSON.stringify(data.ductbanks));
-        localStorage.setItem(TableUtils.STORAGE_KEYS.traySchedule,JSON.stringify(data.trays));
-        localStorage.setItem(TableUtils.STORAGE_KEYS.conduitSchedule,JSON.stringify(data.conduits));
+        dataStore.setDuctbanks(data.ductbanks);
+        dataStore.setTrays(data.trays);
+        dataStore.setConduits(data.conduits);
         document.getElementById('load-ductbank-btn').click();
         document.getElementById('load-tray-btn').click();
         document.getElementById('load-conduit-btn').click();

--- a/tableUtils.js
+++ b/tableUtils.js
@@ -1,10 +1,4 @@
-const STORAGE_KEYS = {
-  cableSchedule: 'cableSchedule',
-  ductbankSchedule: 'ductbankSchedule',
-  traySchedule: 'traySchedule',
-  conduitSchedule: 'conduitSchedule',
-  collapsedGroups: 'collapsedGroups'
-};
+import { getItem, setItem, STORAGE_KEYS } from './dataStore.js';
 
 class TableManager {
   constructor(opts) {
@@ -193,14 +187,14 @@ class TableManager {
 
   saveGroupState() {
     let all = {};
-    try { all = JSON.parse(localStorage.getItem(STORAGE_KEYS.collapsedGroups) || '{}'); } catch(e) {}
+    try { all = getItem(STORAGE_KEYS.collapsedGroups, {}); } catch(e) {}
     all[this.storageKey] = Array.from(this.hiddenGroups);
-    try { localStorage.setItem(STORAGE_KEYS.collapsedGroups, JSON.stringify(all)); } catch(e) {}
+    try { setItem(STORAGE_KEYS.collapsedGroups, all); } catch(e) {}
   }
 
   loadGroupState() {
     let all = {};
-    try { all = JSON.parse(localStorage.getItem(STORAGE_KEYS.collapsedGroups) || '{}'); } catch(e) {}
+    try { all = getItem(STORAGE_KEYS.collapsedGroups, {}); } catch(e) {}
     const hidden = all[this.storageKey] || [];
     hidden.forEach(g => this.setGroupVisibility(g, true));
   }
@@ -669,13 +663,13 @@ class TableManager {
   save() {
     this.validateAll();
     try {
-      localStorage.setItem(this.storageKey, JSON.stringify(this.getData()));
+      setItem(this.storageKey, this.getData());
     } catch(e) { console.error('save failed', e); }
   }
 
   load() {
     let data = [];
-    try { data = JSON.parse(localStorage.getItem(this.storageKey) || '[]'); } catch(e) {}
+    try { data = getItem(this.storageKey, []); } catch(e) {}
     data.forEach(row => this.addRow(row));
     this.updateRowCount();
   }
@@ -748,10 +742,10 @@ class TableManager {
 }
 
 function saveToStorage(key, data){
-  try { localStorage.setItem(key, JSON.stringify(data)); } catch(e){}
+  try { setItem(key, data); } catch(e){}
 }
 function loadFromStorage(key){
-  try { return JSON.parse(localStorage.getItem(key) || '[]'); } catch(e){ return []; }
+  try { return getItem(key, []); } catch(e){ return []; }
 }
 
 function createTable(opts){ return new TableManager(opts); }

--- a/workflowStatus.js
+++ b/workflowStatus.js
@@ -1,3 +1,5 @@
+import { getTrays, getCables, getDuctbanks, getConduits, getItem } from './dataStore.js';
+
 window.addEventListener('DOMContentLoaded', () => {
   const cards = document.querySelectorAll('.workflow-grid .workflow-card');
   cards.forEach(card => {
@@ -9,14 +11,12 @@ window.addEventListener('DOMContentLoaded', () => {
     if (key === 'racewaySchedule') {
       // Raceway data is spread across multiple storage keys; mark complete
       // when any of the related tables has saved data.
-      complete = ['ductbankSchedule', 'traySchedule', 'conduitSchedule']
-        .some(k => localStorage.getItem(k));
+      complete = getDuctbanks().length > 0 || getTrays().length > 0 || getConduits().length > 0;
     } else if (key === 'optimalRoute') {
       // Optimal routing relies on both cable and tray schedules.
-      complete = ['cableSchedule', 'traySchedule']
-        .every(k => localStorage.getItem(k));
+      complete = getCables().length > 0 && getTrays().length > 0;
     } else if (key) {
-      complete = !!localStorage.getItem(key);
+      complete = !!getItem(key);
     }
 
     if (complete) {


### PR DESCRIPTION
## Summary
- add dataStore module with typed getters/setters and change events
- refactor pages to use the data store instead of touching localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a276b6cd2c83249dfd9f04caf1c6ad