### PR TITLE
Fix raceway schedule conduit display and persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -687,7 +687,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             };
 
             state.ductbanksWithoutConduits = state.ductbankData.ductbanks
-                .filter(db => !db.conduits || db.conduits.length === 0)
+                .filter(db => (state.conduitsByDb[normalize(db.tag || db.id)] || []).length === 0)
                 .map(db => db.tag || db.id);
             if (state.ductbanksWithoutConduits.length > 0) {
                 const fixUrl = `racewayschedule.html?db=${encodeURIComponent(state.ductbanksWithoutConduits[0])}`;

--- a/ductbankTable.js
+++ b/ductbankTable.js
@@ -271,6 +271,7 @@ import { getDuctbanks, setDuctbanks, setItem, getItem } from './dataStore.js';
         h.appendChild(th);
       });
       const cBody=cTable.createTBody();
+      db.conduits.forEach(c=>{if(c.ductbankTag===undefined)c.ductbankTag=db.tag;});
       db.conduits.forEach((c,j)=>{
         const r=cBody.insertRow();
         if (c.error) r.classList.add('missing-tag-row');

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -167,7 +167,21 @@ document.addEventListener('DOMContentLoaded',()=>{
         const data=await res.json();
         dataStore.setDuctbanks(data.ductbanks);
         dataStore.setTrays(data.trays);
-        dataStore.setConduits(data.conduits);
+        const flat=[];
+        (data.ductbanks||[]).forEach(db=>{
+          (db.conduits||[]).forEach(c=>{
+            flat.push({
+              ductbankTag:db.tag,
+              conduit_id:c.conduit_id,
+              type:c.type,
+              trade_size:c.trade_size,
+              start_x:c.start_x,start_y:c.start_y,start_z:c.start_z,
+              end_x:c.end_x,end_y:c.end_y,end_z:c.end_z,
+              allowed_cable_group:c.allowed_cable_group
+            });
+          });
+        });
+        dataStore.setConduits([...(data.conduits||[]),...flat]);
         document.getElementById('load-ductbank-btn').click();
         document.getElementById('load-tray-btn').click();
         document.getElementById('load-conduit-btn').click();
@@ -183,6 +197,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     const conduits=[];
     nested.forEach(db=>{
       (db.conduits||[]).forEach(c=>{
+        c.ductbankTag=db.tag;
         conduits.push({
           ductbankTag:db.tag,
           conduit_id:c.conduit_id,
@@ -205,7 +220,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   function persistAllConduits(){
     const {ductbanks,conduits:dbConduits}=serializeDuctbankSchedule();
     const standalone=conduitTable.getData();
-    persistConduits({ductbanks,conduits:[...dbConduits,...standalone]});
+    const all=[...dbConduits,...standalone];
+    persistConduits({ductbanks,conduits:all});
+    try{dataStore.setConduits(all);}catch(e){console.error('Failed to store conduits',e);}
   }
 
   function getRacewaySchedule(){

--- a/site.js
+++ b/site.js
@@ -582,7 +582,11 @@ function initTableNav(){
 const CTR_CONDUITS = 'CTR_CONDUITS';
 
 function persistConduits(data){
-  try{localStorage.setItem(CTR_CONDUITS,JSON.stringify(data));}catch(e){console.error('Failed to persist conduits',e);}
+  try{
+    localStorage.setItem(CTR_CONDUITS,JSON.stringify(data));
+    const condKey=globalThis.TableUtils?.STORAGE_KEYS?.conduitSchedule||'conduitSchedule';
+    localStorage.setItem(condKey,JSON.stringify(data.conduits||[]));
+  }catch(e){console.error('Failed to persist conduits',e);}
 }
 
 function loadConduits(){


### PR DESCRIPTION
## Summary
- Flatten ductbank conduits with tags when loading samples
- Serialize ductbank conduits with ductbankTag and persist unified list
- Ensure project conduit data saved and "No conduits" only shown when appropriate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a280b81c9483248876c66958cb9794