### PR TITLE
fix module import error on optimal route page

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -285,6 +285,6 @@
         <summary>Debug Console</summary>
         <pre id="debug-log"></pre>
     </details>
-    <script src="app.js" defer></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `app.js` as an ES module on Optimal Route page to avoid import syntax errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28589cd3883248d1da6a344f56608