### PR TITLE
Fix module import error on Optimal Route page

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Underground ductbanks can be displayed alongside tray routes in the 3D viewer. E
 }
 ```
 
-`app.js` loads this data when rendering the 3D route and adds Plotly traces for the ductbank outline and each conduit. In `optimalRoute.html` a **Show Ductbanks** checkbox below the 3D plot toggles their visibility.
+`app.mjs` loads this data when rendering the 3D route and adds Plotly traces for the ductbank outline and each conduit. In `optimalRoute.html` a **Show Ductbanks** checkbox below the 3D plot toggles their visibility.
 
 ## Clearing Saved Sessions
 The application stores your trays, cables and theme preference in browser storage. Open the settings menu (⚙) and click **Delete Saved Data** to clear this information.

--- a/app.mjs
+++ b/app.mjs
@@ -1,7 +1,7 @@
 import { getItem, setItem, removeItem, getTrays, getCables, getDuctbanks, getConduits } from './dataStore.js';
 import { buildSegmentRows, buildSummaryRows } from './resultsExport.mjs';
 
-// Filename: app.js
+// Filename: app.mjs
 // (This is an improved version that adds route segment consolidation)
 
 // Ensure Canvas 2D contexts are optimized for repeated pixel reads.

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -285,6 +285,6 @@
         <summary>Debug Console</summary>
         <pre id="debug-log"></pre>
     </details>
-    <script type="module" src="app.js"></script>
+    <script type="module" src="app.mjs"></script>
 </body>
 </html>

--- a/tests/conduitCount.test.js
+++ b/tests/conduitCount.test.js
@@ -18,8 +18,8 @@ function it(name, fn) {
   }
 }
 
-// Extract the conduit count expression and display function from app.js
-const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+// Extract the conduit count expression and display function from app.mjs
+const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.mjs'), 'utf8');
 
 const conduitMatch = appCode.match(/const conduitCount =([^;]+);/);
 if (!conduitMatch) throw new Error('conduitCount expression not found');

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -15,8 +15,8 @@ vm.runInContext(
 );
 const { CableRoutingSystem } = sandbox;
 
-// Extract rebuildTrayData from app.js for geometry warning tests
-const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+// Extract rebuildTrayData from app.mjs for geometry warning tests
+const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.mjs'), 'utf8');
 const startMarker = 'const rebuildTrayData = () => {';
 const startIdx = appCode.indexOf(startMarker) + startMarker.length;
 let idx = startIdx;
@@ -287,7 +287,7 @@ describe("_racewayRoute", () => {
   });
 
   it("warns when ductbank has no conduits", () => {
-    const appCode = fs.readFileSync(path.join(__dirname, "..", "app.js"), "utf8");
+    const appCode = fs.readFileSync(path.join(__dirname, "..", "app.mjs"), "utf8");
     const startMarker = "const loadSchedulesIntoSession = async () => {";
     const startIdx = appCode.indexOf(startMarker) + startMarker.length;
     let idx = startIdx;

--- a/tests/rebuildTrayData.test.js
+++ b/tests/rebuildTrayData.test.js
@@ -18,8 +18,8 @@ function it(name, fn) {
   }
 }
 
-// Extract rebuildTrayData function body from app.js
-const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+// Extract rebuildTrayData function body from app.mjs
+const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.mjs'), 'utf8');
 const startMarker = 'const rebuildTrayData = () => {';
 const startIdx = appCode.indexOf(startMarker) + startMarker.length;
 let idx = startIdx;


### PR DESCRIPTION
## Summary
- rename app.js to app.mjs and update references
- ensure Optimal Route page loads script as module
- adjust tests and documentation for new module path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2874a6d848324883f3af5724d96bf