### PR TITLE
Fix syntax error in app.mjs extra parenthesis

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -3204,7 +3204,7 @@ const openDuctbankRoute = (dbId, conduitId) => {
                         sharedRoutes: state.sharedFieldRoutes,
                         metricsHtml: elements.metrics.innerHTML,
                         wallTime: msg.wallTime
-                    }));
+                    });
                 }
             };
             routingWorker.postMessage({ type: 'start', trays: trayDataForRun, options, cables: state.cableList });


### PR DESCRIPTION
## Summary
- Remove extraneous closing parenthesis in app.mjs setItem call to prevent runtime syntax error on optimal route page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a316d117448324ad0670e2ec3ce251