### PR TITLE
fix: remove leftover cancelRouting assignment

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -2939,7 +2939,6 @@ const openDuctbankRoute = (dbId, conduitId) => {
         elements.progressLabel.textContent = 'Starting...';
         elements.cancelRoutingBtn.style.display = 'block';
         elements.cancelRoutingBtn.disabled = false;
-        cancelRouting = false;
         rebuildTrayData();
 
         // clear previous manual path validation errors


### PR DESCRIPTION
## Summary
- drop unused `cancelRouting` flag in `mainCalculation` to prevent ReferenceError during routing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a31ea80b2083249b1f244bc911b226