### PR TITLE
Fix proximity threshold unit handling

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -1073,7 +1073,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     class CableRoutingSystem {
         constructor(options) {
             this.fillLimit = options.fillLimit || 0.4;
-            this.proximityThreshold = options.proximityThreshold || 72.0;
+            // Proximity threshold is specified in inches; convert to feet for calculations
+            this.proximityThreshold = (options.proximityThreshold ?? 72.0) / 12.0;
             this.fieldPenalty = options.fieldPenalty || 3.0;
             this.sharedPenalty = options.sharedPenalty || 0.5;
             // Limit how far apart generic field edges can be created to avoid

--- a/routeWorker.js
+++ b/routeWorker.js
@@ -44,7 +44,8 @@ class MinHeap {
 class CableRoutingSystem {
     constructor(options) {
         this.fillLimit = options.fillLimit || 0.4;
-        this.proximityThreshold = options.proximityThreshold || 72.0;
+        // Proximity threshold is specified in inches; convert to feet for calculations
+        this.proximityThreshold = (options.proximityThreshold ?? 72.0) / 12.0;
         this.fieldPenalty = options.fieldPenalty || 3.0;
         this.sharedPenalty = options.sharedPenalty || 0.5;
         // Limit distance between generic field nodes to keep the graph from

--- a/test.js
+++ b/test.js
@@ -57,7 +57,8 @@ class MinHeap {
 class CableRoutingSystem {
   constructor(options) {
     this.fillLimit = options.fillLimit || 0.4;
-    this.proximityThreshold = options.proximityThreshold || 72.0;
+    // Proximity threshold is specified in inches; convert to feet for calculations
+    this.proximityThreshold = (options.proximityThreshold ?? 72.0) / 12.0;
     this.fieldPenalty = options.fieldPenalty || 3.0;
     this.sharedPenalty = options.sharedPenalty || 0.5;
     this.sharedFieldSegments = [];

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -272,14 +272,14 @@ describe("_racewayRoute", () => {
     const start = [0, -73, 0];
     const end = [0, 83, 0];
 
-    let system = new CableRoutingSystem({ proximityThreshold: 72 });
+    let system = new CableRoutingSystem({ proximityThreshold: 72 * 12 });
     system.addTraySegment(tray);
     let result = system.calculateRoute(start, end, 1, null);
     const reasons = result.exclusions.map(e => e.reason);
     assert(reasons.includes("start_beyond_proximity"));
     assert(reasons.includes("end_beyond_proximity"));
 
-    system = new CableRoutingSystem({ proximityThreshold: 80 });
+    system = new CableRoutingSystem({ proximityThreshold: 80 * 12 });
     system.addTraySegment(tray);
     result = system.calculateRoute(start, end, 1, null);
     assert(result.success, "route should succeed with higher threshold");


### PR DESCRIPTION
## Summary
- Convert proximity threshold input from inches to feet inside `CableRoutingSystem`
- Adjust raceway routing tests for inch-based threshold

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a325fdf7cc8324afefaa890a34d008