### PR TITLE
feat: centralize project IO with schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "@rollup/plugin-terser": "^0.4.3",
     "rollup": "^3.29.0",
     "@playwright/test": "^1.41.1"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0"
   }
 }

--- a/site.js
+++ b/site.js
@@ -1,4 +1,5 @@
 import "./units.js";
+import { exportProject, importProject } from "./dataStore.js";
 const FOCUSABLE="a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex='-1'])";
 const PROJECT_KEY='CTR_PROJECT_V1';
 
@@ -542,7 +543,7 @@ function initProjectIO(){
   if(exportBtn){
     exportBtn.addEventListener('click',()=>{
       try{
-        const data=globalThis.getProject?globalThis.getProject():defaultProject();
+        const data=exportProject();
         const blob=new Blob([JSON.stringify(data,null,2)],{type:'application/json'});
         const a=document.createElement('a');
         a.href=URL.createObjectURL(blob);
@@ -561,8 +562,7 @@ function initProjectIO(){
       reader.onload=ev=>{
         try{
           const obj=JSON.parse(ev.target.result);
-          if(globalThis.setProject)globalThis.setProject(obj);
-          location.reload();
+          if(importProject(obj)) location.reload();
         }catch(err){console.error('Import failed',err);}
       };
       reader.readAsText(file);


### PR DESCRIPTION
## Summary
- add Ajv-backed project schema and centralized export/import helpers in dataStore
- wire site.js to use centralized project I/O
- include Ajv runtime dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a33792e4a88324af7b2bbd76c6229c