### PR TITLE
fix: remove ajv dependency from dataStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@playwright/test": "^1.41.1"
   },
   "dependencies": {
-    "ajv": "^8.12.0",
     "fast-json-patch": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace ajv schema validation with lightweight manual check in `dataStore`
- drop unused ajv dependency from package.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a340d40b108324bc1867c699726b9d