### PR TITLE
Ensure TableUtils is loaded on raceway schedule page

### DIFF
--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script src="dirtyTracker.js" defer></script>
+  <script type="module" src="tableUtils.js"></script>
   <script src="dist/racewayschedule.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Load `tableUtils.js` as a module so `TableUtils` is defined for the raceway schedule

## Testing
- `npm test`
- `npm run build` *(warnings: unresolved dependencies for fast-json-patch)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bfad7ebc8324ad8c64f3b21d0314