### PR TITLE
Add basic documentation site with search and updated nav

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const last = document.getElementById('last-updated');
+  if (last) {
+    const date = new Date(document.lastModified);
+    last.textContent = date.toLocaleDateString();
+  }
+  const search = document.getElementById('doc-search');
+  if (search) {
+    search.addEventListener('input', () => {
+      const term = search.value.toLowerCase();
+      document.querySelectorAll('#doc-list li').forEach(li => {
+        const text = li.textContent.toLowerCase();
+        li.style.display = text.includes(term) ? '' : 'none';
+      });
+    });
+  }
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Documentation</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1>Documentation</h1>
+    <p>Guides and references for CableTrayRoute.</p>
+  </header>
+  <main class="container">
+    <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation" style="margin-bottom:1rem;">
+    <ul id="doc-list">
+      <li><a href="quickstart.html">Quick Start</a></li>
+      <li><a href="templates.html">CSV/XLSX Templates</a></li>
+      <li><a href="tutorial.html">From empty to routed</a></li>
+      <li><a href="math.html">Math References</a></li>
+      <li><a href="troubleshooting.html">Troubleshooting</a></li>
+    </ul>
+  </main>
+  <footer class="doc-footer">
+    Docs last updated: <span id="last-updated"></span>
+  </footer>
+  <script src="docs.js"></script>
+</body>
+</html>

--- a/docs/math.html
+++ b/docs/math.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Math References</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1>Math References</h1>
+    <p>NEC and Neher-McGrath background used in calculations.</p>
+  </header>
+  <main class="container">
+    <p>Ampacity calculations follow the Neher-McGrath method and guidance from the National Electrical Code (NEC). The app uses parameters for conductor resistance, thermal resistivity, and geometry to estimate allowable current.</p>
+    <p>See the following documents for detailed formulas and tables:</p>
+    <ul>
+      <li><a href="AMPACITY_METHOD.md">Ampacity Method</a></li>
+      <li><a href="soil_resistivity.md">Soil Resistivity</a></li>
+      <li><a href="standards.md">Standards</a></li>
+    </ul>
+  </main>
+  <footer class="doc-footer">
+    Docs last updated: <span id="last-updated"></span>
+  </footer>
+  <script src="docs.js"></script>
+</body>
+</html>

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -41,5 +41,9 @@
     </ol>
     <p class="note">You can open any tool directly for ad‑hoc checks, but stepping through them in order ensures data flows smoothly from one phase to the next.</p>
   </main>
+  <footer class="doc-footer">
+    Docs last updated: <span id="last-updated"></span>
+  </footer>
+  <script src="docs.js"></script>
 </body>
 </html>

--- a/docs/templates.html
+++ b/docs/templates.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSV/XLSX Templates</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1>CSV/XLSX Templates</h1>
+    <p>Starter spreadsheets for the workflow.</p>
+  </header>
+  <main class="container">
+    <ul>
+      <li><a href="../examples/cables_template.csv">Cable schedule template</a></li>
+      <li><a href="../examples/trays_template.csv">Tray schedule template</a></li>
+      <li><a href="../examples/ductbank_conduits.csv">Ductbank conduits template</a></li>
+      <li><a href="../examples/ductbank_cables.csv">Ductbank cables template</a></li>
+      <li><a href="../examples/ductbank_schedule_conduits.csv">Ductbank schedule template</a></li>
+    </ul>
+    <p>Download a CSV and open it in your spreadsheet editor. Save as XLSX if you prefer Excel formats.</p>
+  </main>
+  <footer class="doc-footer">
+    Docs last updated: <span id="last-updated"></span>
+  </footer>
+  <script src="docs.js"></script>
+</body>
+</html>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Troubleshooting</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1>Troubleshooting</h1>
+    <p>Solutions to common issues.</p>
+  </header>
+  <main class="container">
+    <ul>
+      <li><strong>Import errors:</strong> Ensure CSV headers match the templates exactly.</li>
+      <li><strong>No routes found:</strong> Check that raceways connect between cable endpoints.</li>
+      <li><strong>Incorrect ampacity:</strong> Verify soil resistivity and conductor properties.</li>
+      <li><strong>Browser performance:</strong> Large projects run faster in a modern desktop browser.</li>
+    </ul>
+  </main>
+  <footer class="doc-footer">
+    Docs last updated: <span id="last-updated"></span>
+  </footer>
+  <script src="docs.js"></script>
+</body>
+</html>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>From Empty to Routed</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="hero">
+    <h1>From Empty to Routed</h1>
+    <p>End-to-end walkthrough of the routing workflow.</p>
+  </header>
+  <main class="container">
+    <ol>
+      <li>Start with the <a href="templates.html">CSV/XLSX templates</a> and populate them with your project data.</li>
+      <li>Import the cable and raceway schedules into the app's <strong>Cable Schedule</strong> and <strong>Raceway Schedule</strong> pages.</li>
+      <li>Analyze underground configurations in <strong>Ductbank</strong>, then verify tray capacity with <strong>Tray Fill</strong>.</li>
+      <li>Check individual conduits using <strong>Conduit Fill</strong>.</li>
+      <li>Generate paths on the <strong>Optimal Cable Route</strong> page to complete the process.</li>
+    </ol>
+    <p>This sequence builds a project from scratch and produces routed cables ready for export.</p>
+  </main>
+  <footer class="doc-footer">
+    Docs last updated: <span id="last-updated"></span>
+  </footer>
+  <script src="docs.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     <nav class="footer-links">
       <a href="README.md">README</a>
       <a href="docs/quickstart.html">Quick Start</a>
-      <a href="docs/">Docs</a>
+      <a href="docs/index.html">Docs</a>
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>


### PR DESCRIPTION
## Summary
- Set up simple documentation site in `/docs` with home, templates, tutorial, math references, and troubleshooting pages
- Added `docs.js` for client-side search and "Docs last updated" timestamp across pages
- Updated homepage nav to point "Docs" to `/docs/index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5747af908324a94e0a852b5f142a