### PR TITLE
chore: format JS tests to pass lint

### DIFF
--- a/playwright-tests/workflow.spec.js
+++ b/playwright-tests/workflow.spec.js
@@ -1,53 +1,60 @@
-const { test, expect } = require('@playwright/test');
-const path = require('path');
-const root = path.join(__dirname, '..');
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+const root = path.join(__dirname, "..");
 
 function pageUrl(file) {
-  return 'file://' + path.join(root, file);
+  return "file://" + path.join(root, file);
 }
 
-test.describe('CableTrayRoute workflow', () => {
-  test('create DB-01 with three conduits appears in Optimal Route', async ({ page }) => {
-    await page.goto(pageUrl('ductbankroute.html'));
-    await page.fill('#ductbankTag', 'DB-01');
+test.describe("CableTrayRoute workflow", () => {
+  test("create DB-01 with three conduits appears in Optimal Route", async ({
+    page,
+  }) => {
+    await page.goto(pageUrl("ductbankroute.html"));
+    await page.fill("#ductbankTag", "DB-01");
     for (let i = 0; i < 3; i++) {
-      await page.click('#addConduit');
+      await page.click("#addConduit");
     }
-    await expect(page.locator('#conduitTable tbody tr')).toHaveCount(3);
-    await page.goto(pageUrl('optimalRoute.html'));
-    await expect(page.locator('#conduit-count')).toContainText('3');
+    await expect(page.locator("#conduitTable tbody tr")).toHaveCount(3);
+    await page.goto(pageUrl("optimalRoute.html"));
+    await expect(page.locator("#conduit-count")).toContainText("3");
   });
 
-  test('import sample CSV/XLSX and route cables', async ({ page }) => {
-    await page.goto(pageUrl('optimalRoute.html'));
-    const trayFile = path.join(root, 'examples', 'tray_schedule.csv');
-    const cableFile = path.join(root, 'examples', 'cable_schedule.csv');
-    await page.setInputFiles('#import-trays-file', trayFile);
-    await page.click('#import-trays-btn');
-    await page.setInputFiles('#import-cables-file', cableFile);
-    await page.click('#import-cables-btn');
-    await page.click('#calculate-route-btn');
-    await expect(page.locator('#results-section')).toBeVisible();
+  test("import sample CSV/XLSX and route cables", async ({ page }) => {
+    await page.goto(pageUrl("optimalRoute.html"));
+    const trayFile = path.join(root, "examples", "tray_schedule.csv");
+    const cableFile = path.join(root, "examples", "cable_schedule.csv");
+    await page.setInputFiles("#import-trays-file", trayFile);
+    await page.click("#import-trays-btn");
+    await page.setInputFiles("#import-cables-file", cableFile);
+    await page.click("#import-cables-btn");
+    await page.click("#calculate-route-btn");
+    await expect(page.locator("#results-section")).toBeVisible();
   });
 
-  test('lock a cable and reroute', async ({ page }) => {
-    await page.goto(pageUrl('optimalRoute.html'));
-    await page.click('#load-sample-trays-btn');
-    await page.click('#load-sample-cables-btn');
-    await page.click('#calculate-route-btn');
-    const firstRow = page.locator('#cable-list-container tbody tr').first();
-    const lockCheckbox = firstRow.locator('input[type="checkbox"][name="lock"]');
+  test("lock a cable and reroute", async ({ page }) => {
+    await page.goto(pageUrl("optimalRoute.html"));
+    await page.click("#load-sample-trays-btn");
+    await page.click("#load-sample-cables-btn");
+    await page.click("#calculate-route-btn");
+    const firstRow = page.locator("#cable-list-container tbody tr").first();
+    const lockCheckbox = firstRow.locator(
+      'input[type="checkbox"][name="lock"]',
+    );
     await lockCheckbox.check();
-    await page.click('#calculate-route-btn');
-    await expect(page.locator('#results-section')).toBeVisible();
+    await page.click("#calculate-route-btn");
+    await expect(page.locator("#results-section")).toBeVisible();
   });
 
-  test('dirty-state prompts appear when navigating away', async ({ page, context }) => {
-    await page.goto(pageUrl('ductbankroute.html'));
-    await page.fill('#ductbankTag', 'TEMP');
+  test("dirty-state prompts appear when navigating away", async ({
+    page,
+    context,
+  }) => {
+    await page.goto(pageUrl("ductbankroute.html"));
+    await page.fill("#ductbankTag", "TEMP");
     const [dialog] = await Promise.all([
-      context.waitForEvent('dialog'),
-      page.goto(pageUrl('index.html')),
+      context.waitForEvent("dialog"),
+      page.goto(pageUrl("index.html")),
     ]);
     expect(dialog.message()).toMatch(/unsaved|leave/i);
     await dialog.dismiss();

--- a/tests/conduitCount.test.js
+++ b/tests/conduitCount.test.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
 
 // Utility functions for simple test output, mirroring existing tests
 function describe(name, fn) {
@@ -11,62 +11,63 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.error('  \u2717', name, err.message || err);
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
 // Extract the conduit count expression and display function from app.mjs
-const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.mjs'), 'utf8');
+const appCode = fs.readFileSync(path.join(__dirname, "..", "app.mjs"), "utf8");
 
 const conduitMatch = appCode.match(/const conduitCount =([^;]+);/);
-if (!conduitMatch) throw new Error('conduitCount expression not found');
+if (!conduitMatch) throw new Error("conduitCount expression not found");
 const conduitExpr = conduitMatch[1];
-const computeConduitCount = new Function('state', `return ${conduitExpr};`);
+const computeConduitCount = new Function("state", `return ${conduitExpr};`);
 
-const startMarker = 'const displayConduitCount = (count, hasSchedule) => {';
+const startMarker = "const displayConduitCount = (count, hasSchedule) => {";
 const startIdx = appCode.indexOf(startMarker) + startMarker.length;
 let idx = startIdx;
 let depth = 1;
 while (idx < appCode.length && depth > 0) {
   const ch = appCode[idx++];
-  if (ch === '{') depth++;
-  else if (ch === '}') depth--;
+  if (ch === "{") depth++;
+  else if (ch === "}") depth--;
 }
 const dcBody = appCode.slice(startIdx, idx - 1);
 const displayConduitCount = new Function(
-  'count',
-  'hasSchedule',
-  'document',
-  'elements',
-  'console',
+  "count",
+  "hasSchedule",
+  "document",
+  "elements",
+  "console",
   dcBody,
 );
 
-describe('displayConduitCount', () => {
-  it('reflects the actual number of conduits', () => {
+describe("displayConduitCount", () => {
+  it("reflects the actual number of conduits", () => {
     const state = {
       trayData: [
-        { raceway_type: 'conduit' },
-        { raceway_type: 'ductbank' },
-        { raceway_type: 'conduit' },
+        { raceway_type: "conduit" },
+        { raceway_type: "ductbank" },
+        { raceway_type: "conduit" },
       ],
     };
 
     const count = computeConduitCount(state);
     assert.strictEqual(count, 2);
 
-    const el = { textContent: '' };
-    const document = { getElementById: id => (id === 'conduit-count' ? el : null) };
-    let logged = '';
-    const consoleStub = { log: msg => (logged = msg), warn: () => {} };
+    const el = { textContent: "" };
+    const document = {
+      getElementById: (id) => (id === "conduit-count" ? el : null),
+    };
+    let logged = "";
+    const consoleStub = { log: (msg) => (logged = msg), warn: () => {} };
 
     displayConduitCount(count, false, document, {}, consoleStub);
 
-    assert.strictEqual(el.textContent, 'Conduits added: 2');
-    assert.strictEqual(logged, 'Conduits added: 2');
+    assert.strictEqual(el.textContent, "Conduits added: 2");
+    assert.strictEqual(logged, "Conduits added: 2");
   });
 });
-

--- a/tests/dirtyTracker.test.js
+++ b/tests/dirtyTracker.test.js
@@ -1,42 +1,52 @@
-const assert = require('assert');
-const { createDirtyTracker } = require('../dirtyTracker');
+const assert = require("assert");
+const { createDirtyTracker } = require("../dirtyTracker");
 
-function describe(name, fn){
+function describe(name, fn) {
   console.log(name);
   fn();
 }
-function it(name, fn){
-  try{
+function it(name, fn) {
+  try {
     fn();
-    console.log('  \u2713', name);
-  }catch(err){
-    console.error('  \u2717', name, err.message || err);
+    console.log("  \u2713", name);
+  } catch (err) {
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
-function makeWindow(){
+function makeWindow() {
   let handler = null;
   return {
-    addEventListener(type, fn){ if(type==='beforeunload') handler = fn; },
-    removeEventListener(type, fn){ if(type==='beforeunload' && handler===fn) handler=null; },
-    fire(){
-      const e = { defaultPrevented:false, preventDefault(){ this.defaultPrevented=true; }, returnValue:undefined };
-      if(handler) handler(e);
+    addEventListener(type, fn) {
+      if (type === "beforeunload") handler = fn;
+    },
+    removeEventListener(type, fn) {
+      if (type === "beforeunload" && handler === fn) handler = null;
+    },
+    fire() {
+      const e = {
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+        returnValue: undefined,
+      };
+      if (handler) handler(e);
       return e;
-    }
+    },
   };
 }
 
-describe('dirty state tracker', () => {
-  it('no edits -> no prompt', () => {
+describe("dirty state tracker", () => {
+  it("no edits -> no prompt", () => {
     const win = makeWindow();
     createDirtyTracker(win); // no edits
     const e = win.fire();
     assert.strictEqual(e.defaultPrevented, false);
   });
 
-  it('edit a cell -> prompt', () => {
+  it("edit a cell -> prompt", () => {
     const win = makeWindow();
     const tracker = createDirtyTracker(win);
     tracker.markDirty();
@@ -44,7 +54,7 @@ describe('dirty state tracker', () => {
     assert.strictEqual(e.defaultPrevented, true);
   });
 
-  it('Save -> no prompt', () => {
+  it("Save -> no prompt", () => {
     const win = makeWindow();
     const tracker = createDirtyTracker(win);
     tracker.markDirty();

--- a/tests/racewayRoute.test.js
+++ b/tests/racewayRoute.test.js
@@ -16,18 +16,18 @@ vm.runInContext(
 const { CableRoutingSystem } = sandbox;
 
 // Extract rebuildTrayData from app.mjs for geometry warning tests
-const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.mjs'), 'utf8');
-const startMarker = 'const rebuildTrayData = () => {';
+const appCode = fs.readFileSync(path.join(__dirname, "..", "app.mjs"), "utf8");
+const startMarker = "const rebuildTrayData = () => {";
 const startIdx = appCode.indexOf(startMarker) + startMarker.length;
 let idx = startIdx;
 let depth = 1;
 while (idx < appCode.length && depth > 0) {
   const ch = appCode[idx++];
-  if (ch === '{') depth++;
-  else if (ch === '}') depth--;
+  if (ch === "{") depth++;
+  else if (ch === "}") depth--;
 }
 const rtBody = appCode.slice(startIdx, idx - 1);
-const rebuildTrayData = new Function('state', 'CONDUIT_SPECS', rtBody);
+const rebuildTrayData = new Function("state", "CONDUIT_SPECS", rtBody);
 
 function describe(name, fn) {
   console.log(name);
@@ -142,7 +142,9 @@ describe("_racewayRoute", () => {
     console.warn = origWarn;
     assert(warned, "missing ductbank warning not emitted");
     assert(
-      system.baseGraph.edges["ductbank_outline_0_start"]?.["ductbank_outline_0_end"],
+      system.baseGraph.edges["ductbank_outline_0_start"]?.[
+        "ductbank_outline_0_end"
+      ],
       "ductbank outline not included",
     );
   });
@@ -186,48 +188,27 @@ describe("_racewayRoute", () => {
     console.warn = (...args) => {
       warned = args;
     };
-    system.calculateRoute([0, 0, 0], [0, 10, 0], 1, null, '', [], 'cable-1');
+    system.calculateRoute([0, 0, 0], [0, 10, 0], 1, null, "", [], "cable-1");
     console.warn = origWarn;
-    assert(warned, 'mismatch warning not emitted');
-    assert.strictEqual(warned[0], 'Mismatched raceway segments:');
+    assert(warned, "mismatch warning not emitted");
+    assert.strictEqual(warned[0], "Mismatched raceway segments:");
     const records = warned[1];
     assert(Array.isArray(records) && records.length === 1);
-    assert.strictEqual(records[0].tray_id, 'tray-over');
-    assert.strictEqual(records[0].reason, 'over_capacity');
-    assert.strictEqual(records[0].cable_id, 'cable-1');
-      assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','filter','reason','tray_id']);
-    });
+    assert.strictEqual(records[0].tray_id, "tray-over");
+    assert.strictEqual(records[0].reason, "over_capacity");
+    assert.strictEqual(records[0].cable_id, "cable-1");
+    assert.deepStrictEqual(Object.keys(records[0]).sort(), [
+      "cable_id",
+      "filter",
+      "reason",
+      "tray_id",
+    ]);
+  });
 
-    it("details ductbank group mismatch with filter", () => {
-      const system = new CableRoutingSystem({ fillLimit: 0.4 });
-      system.addTraySegment({
-        tray_id: 'DB1-1',
-        start_x: 0,
-        start_y: 0,
-        start_z: 0,
-        end_x: 0,
-        end_y: 10,
-        end_z: 0,
-        width: 10,
-        height: 10,
-        current_fill: 0,
-        allowed_cable_group: 'A',
-        conduit_id: '1',
-        ductbankTag: 'DB1',
-      });
-      const res = system.calculateRoute([0, 0, 0], [0, 10, 0], 1, 'B', '', ['DB1-1'], 'cable-3');
-      assert(!res.success);
-      assert(res.mismatched_records && res.mismatched_records.length === 1);
-      const rec = res.mismatched_records[0];
-      assert.strictEqual(rec.conduit_id, '1');
-      assert.strictEqual(rec.ductbank_tag, 'DB1');
-      assert(rec.filter.includes('DB1'));
-    });
-
-  it("warns for group mismatches with formatted record", () => {
+  it("details ductbank group mismatch with filter", () => {
     const system = new CableRoutingSystem({ fillLimit: 0.4 });
     system.addTraySegment({
-      tray_id: 'tray-group',
+      tray_id: "DB1-1",
       start_x: 0,
       start_y: 0,
       start_z: 0,
@@ -237,24 +218,63 @@ describe("_racewayRoute", () => {
       width: 10,
       height: 10,
       current_fill: 0,
-      allowed_cable_group: 'A',
+      allowed_cable_group: "A",
+      conduit_id: "1",
+      ductbankTag: "DB1",
+    });
+    const res = system.calculateRoute(
+      [0, 0, 0],
+      [0, 10, 0],
+      1,
+      "B",
+      "",
+      ["DB1-1"],
+      "cable-3",
+    );
+    assert(!res.success);
+    assert(res.mismatched_records && res.mismatched_records.length === 1);
+    const rec = res.mismatched_records[0];
+    assert.strictEqual(rec.conduit_id, "1");
+    assert.strictEqual(rec.ductbank_tag, "DB1");
+    assert(rec.filter.includes("DB1"));
+  });
+
+  it("warns for group mismatches with formatted record", () => {
+    const system = new CableRoutingSystem({ fillLimit: 0.4 });
+    system.addTraySegment({
+      tray_id: "tray-group",
+      start_x: 0,
+      start_y: 0,
+      start_z: 0,
+      end_x: 0,
+      end_y: 10,
+      end_z: 0,
+      width: 10,
+      height: 10,
+      current_fill: 0,
+      allowed_cable_group: "A",
     });
     let warned = null;
     const origWarn = console.warn;
     console.warn = (...args) => {
       warned = args;
     };
-    system.calculateRoute([0, 0, 0], [0, 10, 0], 1, 'B', '', [], 'cable-2');
+    system.calculateRoute([0, 0, 0], [0, 10, 0], 1, "B", "", [], "cable-2");
     console.warn = origWarn;
-    assert(warned, 'mismatch warning not emitted');
-    assert.strictEqual(warned[0], 'Mismatched raceway segments:');
+    assert(warned, "mismatch warning not emitted");
+    assert.strictEqual(warned[0], "Mismatched raceway segments:");
     const records = warned[1];
     assert(Array.isArray(records) && records.length === 1);
-    assert.strictEqual(records[0].tray_id, 'tray-group');
-    assert.strictEqual(records[0].reason, 'group_mismatch');
-    assert.strictEqual(records[0].cable_id, 'cable-2');
-      assert.deepStrictEqual(Object.keys(records[0]).sort(), ['cable_id','filter','reason','tray_id']);
-    });
+    assert.strictEqual(records[0].tray_id, "tray-group");
+    assert.strictEqual(records[0].reason, "group_mismatch");
+    assert.strictEqual(records[0].cable_id, "cable-2");
+    assert.deepStrictEqual(Object.keys(records[0]).sort(), [
+      "cable_id",
+      "filter",
+      "reason",
+      "tray_id",
+    ]);
+  });
 
   it("routes when proximity threshold is increased", () => {
     const tray = {
@@ -275,7 +295,7 @@ describe("_racewayRoute", () => {
     let system = new CableRoutingSystem({ proximityThreshold: 72 * 12 });
     system.addTraySegment(tray);
     let result = system.calculateRoute(start, end, 1, null);
-    const reasons = result.exclusions.map(e => e.reason);
+    const reasons = result.exclusions.map((e) => e.reason);
     assert(reasons.includes("start_beyond_proximity"));
     assert(reasons.includes("end_beyond_proximity"));
 
@@ -287,7 +307,10 @@ describe("_racewayRoute", () => {
   });
 
   it("warns when ductbank has no conduits", () => {
-    const appCode = fs.readFileSync(path.join(__dirname, "..", "app.mjs"), "utf8");
+    const appCode = fs.readFileSync(
+      path.join(__dirname, "..", "app.mjs"),
+      "utf8",
+    );
     const startMarker = "const loadSchedulesIntoSession = async () => {";
     const startIdx = appCode.indexOf(startMarker) + startMarker.length;
     let idx = startIdx;
@@ -323,47 +346,72 @@ describe("_racewayRoute", () => {
       state,
       localStorage: storage,
       rebuildTrayData: () => {},
-      globalThis: { TableUtils: { STORAGE_KEYS: { ductbankSchedule: "db", conduitSchedule: "cond" } } },
+      globalThis: {
+        TableUtils: {
+          STORAGE_KEYS: { ductbankSchedule: "db", conduitSchedule: "cond" },
+        },
+      },
       document: undefined,
-      console: { warn: () => { warned = true; } },
+      console: {
+        warn: () => {
+          warned = true;
+        },
+      },
       ensureConductorProps: async () => ({}),
       setRacewayIds: () => {},
     };
     const loadSchedulesIntoSession = vm.runInNewContext(
-      'async function loadSchedulesIntoSession(){' + fnBody + '}; loadSchedulesIntoSession;',
+      "async function loadSchedulesIntoSession(){" +
+        fnBody +
+        "}; loadSchedulesIntoSession;",
       sandbox,
     );
-    storage.setItem("db", JSON.stringify([{ tag: "DB1", start_x: 0, start_y: 0, start_z: 0, end_x: 1, end_y: 0, end_z: 0 }]));
+    storage.setItem(
+      "db",
+      JSON.stringify([
+        {
+          tag: "DB1",
+          start_x: 0,
+          start_y: 0,
+          start_z: 0,
+          end_x: 1,
+          end_y: 0,
+          end_z: 0,
+        },
+      ]),
+    );
     loadSchedulesIntoSession();
     assert(warned, "missing conduit warning not emitted");
     assert.strictEqual(state.ductbanksWithoutConduits.length, 1);
     assert.strictEqual(state.ductbanksWithoutConduits[0], "DB1");
   });
 
-  it('warns and skips ductbanks lacking geometry', () => {
+  it("warns and skips ductbanks lacking geometry", () => {
     const state = {
       manualTrays: [],
       trayData: [],
-      ductbankData: { ductbanks: [{ id: 'DB-missing' }] },
+      ductbankData: { ductbanks: [{ id: "DB-missing" }] },
       conduitData: [],
     };
     let warned = false;
     const origWarn = console.warn;
-    console.warn = () => { warned = true; };
+    console.warn = () => {
+      warned = true;
+    };
     rebuildTrayData(state, {});
     console.warn = origWarn;
-    assert(warned, 'warning not emitted');
+    assert(warned, "warning not emitted");
     assert.strictEqual(state.trayData.length, 0);
   });
 
-  it('warns and skips conduits without paths', () => {
+  it("warns and skips conduits without paths", () => {
     const state = {
       manualTrays: [],
       trayData: [],
       ductbankData: {
         ductbanks: [
           {
-            id: 'DB1',
+            id: "DB1",
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -372,21 +420,21 @@ describe("_racewayRoute", () => {
             end_z: 0,
             width: 12,
             height: 12,
-            conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1' },
-            ],
+            conduits: [{ conduit_id: "C1", type: "RMC", trade_size: "1" }],
           },
         ],
       },
       conduitData: [],
     };
-    const specs = { RMC: { '1': 0.887 } };
+    const specs = { RMC: { 1: 0.887 } };
     let warned = false;
     const origWarn = console.warn;
-    console.warn = () => { warned = true; };
+    console.warn = () => {
+      warned = true;
+    };
     rebuildTrayData(state, specs);
     console.warn = origWarn;
-    assert(warned, 'warning not emitted');
+    assert(warned, "warning not emitted");
     assert.strictEqual(state.trayData.length, 0);
   });
 });

--- a/tests/racewaySampleMapper.test.js
+++ b/tests/racewaySampleMapper.test.js
@@ -1,19 +1,38 @@
-const assert = require('assert');
+const assert = require("assert");
 
-async function run(){
-  const { mapConduitRow } = await import('../racewaySampleData.js');
-  const legacy1 = { 'Conduit ID':'C-001', 'Type':'RMC', 'Trade Size':'3', 'Ductbank':'DB-01' };
-  const legacy2 = { conduitId:'C-002', type:'EMT', tradeSize:'2', ductbankTag:'DB-02', 'Allowed Group':'A' };
-  const legacy3 = { conduit_id:'C-003', Type:'PVC Sch 40', trade_size:'4', ductbank_tag:'DB-03' };
+async function run() {
+  const { mapConduitRow } = await import("../racewaySampleData.js");
+  const legacy1 = {
+    "Conduit ID": "C-001",
+    Type: "RMC",
+    "Trade Size": "3",
+    Ductbank: "DB-01",
+  };
+  const legacy2 = {
+    conduitId: "C-002",
+    type: "EMT",
+    tradeSize: "2",
+    ductbankTag: "DB-02",
+    "Allowed Group": "A",
+  };
+  const legacy3 = {
+    conduit_id: "C-003",
+    Type: "PVC Sch 40",
+    trade_size: "4",
+    ductbank_tag: "DB-03",
+  };
   const r1 = mapConduitRow(legacy1);
   const r2 = mapConduitRow(legacy2);
   const r3 = mapConduitRow(legacy3);
-  assert.equal(r1.conduit_id,'C-001');
-  assert.equal(r1.trade_size,'3');
-  assert.equal(r1.ductbankTag,'DB-01');
-  assert.equal(r2.allowed_cable_group,'A');
-  assert.equal(r3.type,'PVC Sch 40');
-  console.log('racewaySampleMapper.test passed');
+  assert.equal(r1.conduit_id, "C-001");
+  assert.equal(r1.trade_size, "3");
+  assert.equal(r1.ductbankTag, "DB-01");
+  assert.equal(r2.allowed_cable_group, "A");
+  assert.equal(r3.type, "PVC Sch 40");
+  console.log("racewaySampleMapper.test passed");
 }
 
-run().catch(err=>{console.error(err);process.exit(1);});
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/rebuildTrayData.test.js
+++ b/tests/rebuildTrayData.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
 
 function describe(name, fn) {
   console.log(name);
@@ -11,43 +11,49 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.error('  \u2717', name, err.message || err);
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
 // Extract rebuildTrayData function body from app.mjs
-const appCode = fs.readFileSync(path.join(__dirname, '..', 'app.mjs'), 'utf8');
-const startMarker = 'const rebuildTrayData = () => {';
+const appCode = fs.readFileSync(path.join(__dirname, "..", "app.mjs"), "utf8");
+const startMarker = "const rebuildTrayData = () => {";
 const startIdx = appCode.indexOf(startMarker) + startMarker.length;
 let idx = startIdx;
 let depth = 1;
 while (idx < appCode.length && depth > 0) {
   const ch = appCode[idx++];
-  if (ch === '{') depth++;
-  else if (ch === '}') depth--;
+  if (ch === "{") depth++;
+  else if (ch === "}") depth--;
 }
 const fnBody = appCode.slice(startIdx, idx - 1);
-const rebuildTrayData = new Function('state', 'CONDUIT_SPECS', fnBody);
+const rebuildTrayData = new Function("state", "CONDUIT_SPECS", fnBody);
 
 // Load CableRoutingSystem from routeWorker.js
-const workerCode = fs.readFileSync(path.join(__dirname, '..', 'routeWorker.js'), 'utf8');
+const workerCode = fs.readFileSync(
+  path.join(__dirname, "..", "routeWorker.js"),
+  "utf8",
+);
 const sandbox = { console, self: { postMessage: () => {} } };
 vm.createContext(sandbox);
-vm.runInContext(workerCode + '\nthis.CableRoutingSystem = CableRoutingSystem;', sandbox);
+vm.runInContext(
+  workerCode + "\nthis.CableRoutingSystem = CableRoutingSystem;",
+  sandbox,
+);
 const { CableRoutingSystem } = sandbox;
 
-describe('rebuildTrayData', () => {
-  it('skips conduits without paths and warns', () => {
+describe("rebuildTrayData", () => {
+  it("skips conduits without paths and warns", () => {
     const state = {
       manualTrays: [],
       trayData: [],
       ductbankData: {
         ductbanks: [
           {
-            tag: 'DB1',
+            tag: "DB1",
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -56,32 +62,32 @@ describe('rebuildTrayData', () => {
             end_z: 0,
             width: 12,
             height: 12,
-            conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1' },
-            ],
+            conduits: [{ conduit_id: "C1", type: "RMC", trade_size: "1" }],
           },
         ],
       },
       conduitData: [],
     };
-    const CONDUIT_SPECS = { RMC: { '1': 0.887 } };
+    const CONDUIT_SPECS = { RMC: { 1: 0.887 } };
     let warned = false;
     const origWarn = console.warn;
-    console.warn = () => { warned = true; };
+    console.warn = () => {
+      warned = true;
+    };
     rebuildTrayData(state, CONDUIT_SPECS);
     console.warn = origWarn;
     assert.strictEqual(state.trayData.length, 0);
-    assert(warned, 'warning not emitted');
+    assert(warned, "warning not emitted");
   });
 
-  it('routes through conduit segments when path provided', () => {
+  it("routes through conduit segments when path provided", () => {
     const state = {
       manualTrays: [],
       trayData: [],
       ductbankData: {
         ductbanks: [
           {
-            tag: 'DB1',
+            tag: "DB1",
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -91,23 +97,31 @@ describe('rebuildTrayData', () => {
             width: 12,
             height: 12,
             conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1', path: [[0,0,0],[10,0,0]] },
+              {
+                conduit_id: "C1",
+                type: "RMC",
+                trade_size: "1",
+                path: [
+                  [0, 0, 0],
+                  [10, 0, 0],
+                ],
+              },
             ],
           },
         ],
       },
       conduitData: [],
     };
-    const CONDUIT_SPECS = { RMC: { '1': 0.887 } };
+    const CONDUIT_SPECS = { RMC: { 1: 0.887 } };
     rebuildTrayData(state, CONDUIT_SPECS);
     const system = new CableRoutingSystem({});
-    state.trayData.forEach(t => system.addTraySegment(t));
-    const res = system._racewayRoute([0, 0, 0], [10, 0, 0], 0, null, ['C1']);
-    assert(res && res.success, 'routing failed');
-    assert.deepStrictEqual(Array.from(res.tray_segments), ['DB1-C1']);
+    state.trayData.forEach((t) => system.addTraySegment(t));
+    const res = system._racewayRoute([0, 0, 0], [10, 0, 0], 0, null, ["C1"]);
+    assert(res && res.success, "routing failed");
+    assert.deepStrictEqual(Array.from(res.tray_segments), ["DB1-C1"]);
   });
 
-  it('omits ductbank outline segments when disabled', () => {
+  it("omits ductbank outline segments when disabled", () => {
     const state = {
       manualTrays: [],
       trayData: [],
@@ -115,7 +129,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            tag: 'DB1',
+            tag: "DB1",
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -125,20 +139,28 @@ describe('rebuildTrayData', () => {
             width: 12,
             height: 12,
             conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1', path: [[0,0,0],[10,0,0]] },
+              {
+                conduit_id: "C1",
+                type: "RMC",
+                trade_size: "1",
+                path: [
+                  [0, 0, 0],
+                  [10, 0, 0],
+                ],
+              },
             ],
           },
         ],
       },
       conduitData: [],
     };
-    const CONDUIT_SPECS = { RMC: { '1': 0.887 } };
+    const CONDUIT_SPECS = { RMC: { 1: 0.887 } };
     rebuildTrayData(state, CONDUIT_SPECS);
     assert.strictEqual(state.trayData.length, 1);
-    assert.strictEqual(state.trayData[0].raceway_type, 'conduit');
+    assert.strictEqual(state.trayData[0].raceway_type, "conduit");
   });
 
-  it('includes ductbank outline segments when enabled', () => {
+  it("includes ductbank outline segments when enabled", () => {
     const state = {
       manualTrays: [],
       trayData: [],
@@ -146,7 +168,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            tag: 'DB1',
+            tag: "DB1",
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -156,21 +178,29 @@ describe('rebuildTrayData', () => {
             width: 12,
             height: 12,
             conduits: [
-              { conduit_id: 'C1', type: 'RMC', trade_size: '1', path: [[0,0,0],[10,0,0]] },
+              {
+                conduit_id: "C1",
+                type: "RMC",
+                trade_size: "1",
+                path: [
+                  [0, 0, 0],
+                  [10, 0, 0],
+                ],
+              },
             ],
           },
         ],
       },
       conduitData: [],
     };
-    const CONDUIT_SPECS = { RMC: { '1': 0.887 } };
+    const CONDUIT_SPECS = { RMC: { 1: 0.887 } };
     rebuildTrayData(state, CONDUIT_SPECS);
-    const types = state.trayData.map(t => t.raceway_type);
-    assert(types.includes('ductbank'), 'ductbank outline missing');
-    assert(types.includes('conduit'), 'conduit segment missing');
+    const types = state.trayData.map((t) => t.raceway_type);
+    assert(types.includes("ductbank"), "ductbank outline missing");
+    assert(types.includes("conduit"), "conduit segment missing");
   });
 
-  it('reports conduit count after rebuild', () => {
+  it("reports conduit count after rebuild", () => {
     const state = {
       manualTrays: [],
       trayData: [],
@@ -178,7 +208,7 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            tag: 'DB1',
+            tag: "DB1",
             start_x: 0,
             start_y: 0,
             start_z: 0,
@@ -187,26 +217,38 @@ describe('rebuildTrayData', () => {
             end_z: 0,
             width: 12,
             height: 12,
-            conduits: [ { conduit_id: 'C1', path: [[0,0,0],[10,0,0]] } ],
+            conduits: [
+              {
+                conduit_id: "C1",
+                path: [
+                  [0, 0, 0],
+                  [10, 0, 0],
+                ],
+              },
+            ],
           },
           {
-            id: 'DB2',
-            conduits: [ { conduit_id: 'C2' } ],
+            id: "DB2",
+            conduits: [{ conduit_id: "C2" }],
           },
         ],
       },
       conduitData: [],
     };
     let captured = {};
-    global.displayConduitCount = (count, hasSchedule) => { captured = { count, hasSchedule }; };
+    global.displayConduitCount = (count, hasSchedule) => {
+      captured = { count, hasSchedule };
+    };
     rebuildTrayData(state, {});
     delete global.displayConduitCount;
-    const expected = state.trayData.filter(t => t.raceway_type === 'ductbank').length;
+    const expected = state.trayData.filter(
+      (t) => t.raceway_type === "ductbank",
+    ).length;
     assert.strictEqual(captured.count, expected);
     assert.strictEqual(captured.hasSchedule, true);
   });
 
-  it('warns when no conduits are added despite schedule', () => {
+  it("warns when no conduits are added despite schedule", () => {
     const state = {
       manualTrays: [],
       trayData: [],
@@ -214,19 +256,20 @@ describe('rebuildTrayData', () => {
       ductbankData: {
         ductbanks: [
           {
-            tag: 'DB1',
-            conduits: [ { conduit_id: 'C1' } ],
+            tag: "DB1",
+            conduits: [{ conduit_id: "C1" }],
           },
         ],
       },
       conduitData: [],
     };
     let captured = {};
-    global.displayConduitCount = (count, hasSchedule) => { captured = { count, hasSchedule }; };
+    global.displayConduitCount = (count, hasSchedule) => {
+      captured = { count, hasSchedule };
+    };
     rebuildTrayData(state, {});
     delete global.displayConduitCount;
     assert.strictEqual(captured.count, 0);
     assert.strictEqual(captured.hasSchedule, true);
   });
 });
-

--- a/tests/resultsExporter.test.js
+++ b/tests/resultsExporter.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require("assert");
 
 function describe(name, fn) {
   console.log(name);
@@ -8,55 +8,64 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.log('  \u2717', name);
+    console.log("  \u2717", name);
     console.error(err);
   }
 }
 
 (async () => {
-  const { buildSegmentRows, buildSummaryRows } = await import('../resultsExport.mjs');
+  const { buildSegmentRows, buildSummaryRows } = await import(
+    "../resultsExport.mjs"
+  );
 
-  describe('buildSegmentRows', () => {
-    it('creates rows with cumulative length and reasons', () => {
-      const results = [{
-        cable: 'C1',
-        total_length: 10,
-        field_length: 4,
-        segments_count: 2,
-        breakdown: [
-          { length: 3, tray_id: 'T1', type: 'tray' },
-          { length: 7, conduit_id: '1', ductbankTag: 'DB1', type: 'field' }
-        ],
-        exclusions: [{ reason: 'over_capacity' }, { reason: 'group_mismatch' }]
-      }];
+  describe("buildSegmentRows", () => {
+    it("creates rows with cumulative length and reasons", () => {
+      const results = [
+        {
+          cable: "C1",
+          total_length: 10,
+          field_length: 4,
+          segments_count: 2,
+          breakdown: [
+            { length: 3, tray_id: "T1", type: "tray" },
+            { length: 7, conduit_id: "1", ductbankTag: "DB1", type: "field" },
+          ],
+          exclusions: [
+            { reason: "over_capacity" },
+            { reason: "group_mismatch" },
+          ],
+        },
+      ];
       const rows = buildSegmentRows(results);
       assert.strictEqual(rows.length, 2);
       assert.strictEqual(rows[0].cumulative_length, 3);
       assert.strictEqual(rows[1].cumulative_length, 10);
-      assert.strictEqual(rows[0].reason_codes, 'over_capacity; group_mismatch');
-      assert.strictEqual(rows[1].element_type, 'conduit');
-      assert.strictEqual(rows[1].element_id, 'DB1:1');
+      assert.strictEqual(rows[0].reason_codes, "over_capacity; group_mismatch");
+      assert.strictEqual(rows[1].element_type, "conduit");
+      assert.strictEqual(rows[1].element_id, "DB1:1");
     });
   });
 
-  describe('buildSummaryRows', () => {
-    it('summarizes cables', () => {
-      const results = [{
-        cable: 'C1',
-        total_length: 10,
-        field_length: 4,
-        segments_count: 2,
-        exclusions: [{ reason: 'over_capacity' }]
-      }];
+  describe("buildSummaryRows", () => {
+    it("summarizes cables", () => {
+      const results = [
+        {
+          cable: "C1",
+          total_length: 10,
+          field_length: 4,
+          segments_count: 2,
+          exclusions: [{ reason: "over_capacity" }],
+        },
+      ];
       const rows = buildSummaryRows(results);
       assert.deepStrictEqual(rows[0], {
-        cable_tag: 'C1',
+        cable_tag: "C1",
         total_length: 10,
         field_length: 4,
         segments_count: 2,
-        reason_codes: 'over_capacity'
+        reason_codes: "over_capacity",
       });
     });
   });

--- a/tests/sampleLinks.test.js
+++ b/tests/sampleLinks.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
 
 function describe(name, fn) {
   console.log(name);
@@ -11,31 +11,38 @@ function describe(name, fn) {
 function it(name, fn) {
   try {
     fn();
-    console.log('  \u2713', name);
+    console.log("  \u2713", name);
   } catch (err) {
-    console.error('  \u2717', name, err.message || err);
+    console.error("  \u2717", name, err.message || err);
     process.exitCode = 1;
   }
 }
 
-describe('sample links', () => {
-  it('use download and return HTTP 200', () => {
-    const htmlFiles = fs.readdirSync('.').filter(f => f.endsWith('.html'));
-    htmlFiles.forEach(file => {
-      const html = fs.readFileSync(file, 'utf8');
+describe("sample links", () => {
+  it("use download and return HTTP 200", () => {
+    const htmlFiles = fs.readdirSync(".").filter((f) => f.endsWith(".html"));
+    htmlFiles.forEach((file) => {
+      const html = fs.readFileSync(file, "utf8");
       const regex = /<a\s+[^>]*href=["'](examples\/[^"']+)["'][^>]*>/g;
       let match;
       while ((match = regex.exec(html)) !== null) {
         const tag = match[0];
         const url = match[1];
-        assert(/\bdownload\b/i.test(tag), `${file} link ${url} missing download attribute`);
+        assert(
+          /\bdownload\b/i.test(tag),
+          `${file} link ${url} missing download attribute`,
+        );
         if (/^https?:\/\//i.test(url)) {
           try {
-            const statusLine = execSync(`curl -sI ${url} | head -n 1`).toString();
+            const statusLine = execSync(
+              `curl -sI ${url} | head -n 1`,
+            ).toString();
             const m = statusLine.match(/HTTP\/\d\.\d\s+(\d+)/);
             const status = m ? parseInt(m[1], 10) : 0;
             if (status !== 200) {
-              console.error(`\x1b[31mFix-it Hint: ${url} returned ${status}\x1b[0m`);
+              console.error(
+                `\x1b[31mFix-it Hint: ${url} returned ${status}\x1b[0m`,
+              );
               assert.fail(`Sample link ${url} returned HTTP ${status}`);
             }
           } catch (e) {
@@ -45,7 +52,9 @@ describe('sample links', () => {
         } else {
           const targetPath = path.join(path.dirname(file), url);
           if (!fs.existsSync(targetPath)) {
-            console.error(`\x1b[31mFix-it Hint: Broken sample URL ${url}\x1b[0m`);
+            console.error(
+              `\x1b[31mFix-it Hint: Broken sample URL ${url}\x1b[0m`,
+            );
             assert.fail(`Sample link ${url} not found`);
           }
         }

--- a/tests/units.test.js
+++ b/tests/units.test.js
@@ -1,26 +1,33 @@
-const assert = require('assert');
-const units = require('../units.js');
+const assert = require("assert");
+const units = require("../units.js");
 
-function describe(name, fn){
-  console.log(name); fn();
+function describe(name, fn) {
+  console.log(name);
+  fn();
 }
-function it(name, fn){
-  try{ fn(); console.log('  \u2713', name);}catch(err){ console.error('  \u2717', name, err.message||err); process.exitCode=1; }
+function it(name, fn) {
+  try {
+    fn();
+    console.log("  \u2713", name);
+  } catch (err) {
+    console.error("  \u2717", name, err.message || err);
+    process.exitCode = 1;
+  }
 }
 
-describe('unit conversions', () => {
-  it('distance round trip', () => {
-    units.setUnitSystem('metric');
+describe("unit conversions", () => {
+  it("distance round trip", () => {
+    units.setUnitSystem("metric");
     const meters = units.distanceToDisplay(10); // feet to meters
     const back = units.distanceFromInput(meters);
     assert(Math.abs(back - 10) < 1e-9);
-    units.setUnitSystem('imperial');
+    units.setUnitSystem("imperial");
   });
-  it('conduit size round trip', () => {
-    units.setUnitSystem('metric');
+  it("conduit size round trip", () => {
+    units.setUnitSystem("metric");
     const mm = units.conduitToDisplay(2); // inches to mm
     const back = units.conduitFromInput(mm);
     assert(Math.abs(back - 2) < 1e-9);
-    units.setUnitSystem('imperial');
+    units.setUnitSystem("imperial");
   });
 });


### PR DESCRIPTION
## Summary
- format Playwright workflow spec and test files with Prettier

## Testing
- `npx prettier --check '**/*.js'`
- `npx eslint . --max-warnings=0`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac58a242348324ab3a34929858da37