### PR TITLE
Polish documentation pages with shared navigation and styling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,23 +7,55 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <div class="nav-links">
+      <a href="../index.html">Home</a>
+      <a href="../cableschedule.html">Cable Schedule</a>
+      <a href="../racewayschedule.html">Raceway Schedule</a>
+      <a href="../ductbankroute.html">Ductbank</a>
+      <a href="../cabletrayfill.html">Tray Fill</a>
+      <a href="../conduitfill.html">Conduit Fill</a>
+      <a href="../optimalRoute.html">Optimal Route</a>
+      <a href="index.html" class="active" aria-current="page">Docs</a>
+    </div>
+  </nav>
   <header class="hero">
     <h1>Documentation</h1>
     <p>Guides and references for CableTrayRoute.</p>
   </header>
-  <main class="container">
-    <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation" style="margin-bottom:1rem;">
-    <ul id="doc-list">
+  <main id="main-content" class="doc-main">
+    <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation">
+    <ul id="doc-list" class="doc-list">
       <li><a href="quickstart.html">Quick Start</a></li>
       <li><a href="templates.html">CSV/XLSX Templates</a></li>
       <li><a href="tutorial.html">From empty to routed</a></li>
       <li><a href="math.html">Math References</a></li>
       <li><a href="troubleshooting.html">Troubleshooting</a></li>
     </ul>
+    <footer class="doc-footer">Docs last updated: <span id="last-updated"></span></footer>
   </main>
-  <footer class="doc-footer">
-    Docs last updated: <span id="last-updated"></span>
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links">
+      <a href="../README.md">README</a>
+      <a href="quickstart.html">Quick Start</a>
+      <a href="index.html">Docs</a>
+      <a href="mailto:contact@example.com">Contact</a>
+    </nav>
   </footer>
   <script src="docs.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      toggle.addEventListener('click', () => {
+        document.querySelector('.top-nav').classList.toggle('open');
+      });
+    });
+  </script>
 </body>
 </html>

--- a/docs/math.html
+++ b/docs/math.html
@@ -7,22 +7,53 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <div class="nav-links">
+      <a href="../index.html">Home</a>
+      <a href="../cableschedule.html">Cable Schedule</a>
+      <a href="../racewayschedule.html">Raceway Schedule</a>
+      <a href="../ductbankroute.html">Ductbank</a>
+      <a href="../cabletrayfill.html">Tray Fill</a>
+      <a href="../conduitfill.html">Conduit Fill</a>
+      <a href="../optimalRoute.html">Optimal Route</a>
+      <a href="index.html" class="active" aria-current="page">Docs</a>
+    </div>
+  </nav>
   <header class="hero">
     <h1>Math References</h1>
     <p>NEC and Neher-McGrath background used in calculations.</p>
   </header>
-  <main class="container">
+  <main id="main-content" class="doc-main">
     <p>Ampacity calculations follow the Neher-McGrath method and guidance from the National Electrical Code (NEC). The app uses parameters for conductor resistance, thermal resistivity, and geometry to estimate allowable current.</p>
     <p>See the following documents for detailed formulas and tables:</p>
-    <ul>
+    <ul class="doc-list">
       <li><a href="AMPACITY_METHOD.md">Ampacity Method</a></li>
       <li><a href="soil_resistivity.md">Soil Resistivity</a></li>
       <li><a href="standards.md">Standards</a></li>
     </ul>
   </main>
-  <footer class="doc-footer">
-    Docs last updated: <span id="last-updated"></span>
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links">
+      <a href="../README.md">README</a>
+      <a href="quickstart.html">Quick Start</a>
+      <a href="index.html">Docs</a>
+      <a href="mailto:contact@example.com">Contact</a>
+    </nav>
   </footer>
-  <script src="docs.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      toggle.addEventListener('click', () => {
+        document.querySelector('.top-nav').classList.toggle('open');
+      });
+    });
+  </script>
 </body>
 </html>
+

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -7,11 +7,25 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <div class="nav-links">
+      <a href="../index.html">Home</a>
+      <a href="../cableschedule.html">Cable Schedule</a>
+      <a href="../racewayschedule.html">Raceway Schedule</a>
+      <a href="../ductbankroute.html">Ductbank</a>
+      <a href="../cabletrayfill.html">Tray Fill</a>
+      <a href="../conduitfill.html">Conduit Fill</a>
+      <a href="../optimalRoute.html">Optimal Route</a>
+      <a href="index.html" class="active" aria-current="page">Docs</a>
+    </div>
+  </nav>
   <header class="hero">
     <h1>Quick Start</h1>
     <p>Follow the six-step workflow to plan and route cables efficiently. Each tool can operate on its own, but completing the steps in sequence yields the best results.</p>
   </header>
-  <main class="container">
+  <main id="main-content" class="doc-main">
     <ol class="workflow-list">
       <li>
         <img src="../icons/cable.svg" alt="Cable icon" class="workflow-icon">
@@ -41,9 +55,26 @@
     </ol>
     <p class="note">You can open any tool directly for ad‑hoc checks, but stepping through them in order ensures data flows smoothly from one phase to the next.</p>
   </main>
-  <footer class="doc-footer">
-    Docs last updated: <span id="last-updated"></span>
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links">
+      <a href="../README.md">README</a>
+      <a href="quickstart.html">Quick Start</a>
+      <a href="index.html">Docs</a>
+      <a href="mailto:contact@example.com">Contact</a>
+    </nav>
   </footer>
-  <script src="docs.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      toggle.addEventListener('click', () => {
+        document.querySelector('.top-nav').classList.toggle('open');
+      });
+    });
+  </script>
 </body>
 </html>
+

--- a/docs/templates.html
+++ b/docs/templates.html
@@ -7,12 +7,26 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <div class="nav-links">
+      <a href="../index.html">Home</a>
+      <a href="../cableschedule.html">Cable Schedule</a>
+      <a href="../racewayschedule.html">Raceway Schedule</a>
+      <a href="../ductbankroute.html">Ductbank</a>
+      <a href="../cabletrayfill.html">Tray Fill</a>
+      <a href="../conduitfill.html">Conduit Fill</a>
+      <a href="../optimalRoute.html">Optimal Route</a>
+      <a href="index.html" class="active" aria-current="page">Docs</a>
+    </div>
+  </nav>
   <header class="hero">
     <h1>CSV/XLSX Templates</h1>
     <p>Starter spreadsheets for the workflow.</p>
   </header>
-  <main class="container">
-    <ul>
+  <main id="main-content" class="doc-main">
+    <ul class="doc-list">
       <li><a href="../examples/cables_template.csv">Cable schedule template</a></li>
       <li><a href="../examples/trays_template.csv">Tray schedule template</a></li>
       <li><a href="../examples/ductbank_conduits.csv">Ductbank conduits template</a></li>
@@ -21,9 +35,26 @@
     </ul>
     <p>Download a CSV and open it in your spreadsheet editor. Save as XLSX if you prefer Excel formats.</p>
   </main>
-  <footer class="doc-footer">
-    Docs last updated: <span id="last-updated"></span>
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links">
+      <a href="../README.md">README</a>
+      <a href="quickstart.html">Quick Start</a>
+      <a href="index.html">Docs</a>
+      <a href="mailto:contact@example.com">Contact</a>
+    </nav>
   </footer>
-  <script src="docs.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      toggle.addEventListener('click', () => {
+        document.querySelector('.top-nav').classList.toggle('open');
+      });
+    });
+  </script>
 </body>
 </html>
+

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -7,21 +7,52 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <div class="nav-links">
+      <a href="../index.html">Home</a>
+      <a href="../cableschedule.html">Cable Schedule</a>
+      <a href="../racewayschedule.html">Raceway Schedule</a>
+      <a href="../ductbankroute.html">Ductbank</a>
+      <a href="../cabletrayfill.html">Tray Fill</a>
+      <a href="../conduitfill.html">Conduit Fill</a>
+      <a href="../optimalRoute.html">Optimal Route</a>
+      <a href="index.html" class="active" aria-current="page">Docs</a>
+    </div>
+  </nav>
   <header class="hero">
     <h1>Troubleshooting</h1>
     <p>Solutions to common issues.</p>
   </header>
-  <main class="container">
-    <ul>
+  <main id="main-content" class="doc-main">
+    <ul class="doc-list">
       <li><strong>Import errors:</strong> Ensure CSV headers match the templates exactly.</li>
       <li><strong>No routes found:</strong> Check that raceways connect between cable endpoints.</li>
       <li><strong>Incorrect ampacity:</strong> Verify soil resistivity and conductor properties.</li>
       <li><strong>Browser performance:</strong> Large projects run faster in a modern desktop browser.</li>
     </ul>
   </main>
-  <footer class="doc-footer">
-    Docs last updated: <span id="last-updated"></span>
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links">
+      <a href="../README.md">README</a>
+      <a href="quickstart.html">Quick Start</a>
+      <a href="index.html">Docs</a>
+      <a href="mailto:contact@example.com">Contact</a>
+    </nav>
   </footer>
-  <script src="docs.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      toggle.addEventListener('click', () => {
+        document.querySelector('.top-nav').classList.toggle('open');
+      });
+    });
+  </script>
 </body>
 </html>
+

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -7,11 +7,25 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <div class="nav-links">
+      <a href="../index.html">Home</a>
+      <a href="../cableschedule.html">Cable Schedule</a>
+      <a href="../racewayschedule.html">Raceway Schedule</a>
+      <a href="../ductbankroute.html">Ductbank</a>
+      <a href="../cabletrayfill.html">Tray Fill</a>
+      <a href="../conduitfill.html">Conduit Fill</a>
+      <a href="../optimalRoute.html">Optimal Route</a>
+      <a href="index.html" class="active" aria-current="page">Docs</a>
+    </div>
+  </nav>
   <header class="hero">
     <h1>From Empty to Routed</h1>
     <p>End-to-end walkthrough of the routing workflow.</p>
   </header>
-  <main class="container">
+  <main id="main-content" class="doc-main">
     <ol>
       <li>Start with the <a href="templates.html">CSV/XLSX templates</a> and populate them with your project data.</li>
       <li>Import the cable and raceway schedules into the app's <strong>Cable Schedule</strong> and <strong>Raceway Schedule</strong> pages.</li>
@@ -21,9 +35,26 @@
     </ol>
     <p>This sequence builds a project from scratch and produces routed cables ready for export.</p>
   </main>
-  <footer class="doc-footer">
-    Docs last updated: <span id="last-updated"></span>
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links">
+      <a href="../README.md">README</a>
+      <a href="quickstart.html">Quick Start</a>
+      <a href="index.html">Docs</a>
+      <a href="mailto:contact@example.com">Contact</a>
+    </nav>
   </footer>
-  <script src="docs.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      toggle.addEventListener('click', () => {
+        document.querySelector('.top-nav').classList.toggle('open');
+      });
+    });
+  </script>
 </body>
 </html>
+

--- a/style.css
+++ b/style.css
@@ -1754,3 +1754,48 @@ body.dark-mode .workflow-card-title {
     cursor: pointer;
     margin-bottom: 0.5rem;
 }
+
+/* --- Documentation Pages --- */
+.doc-main {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+#doc-search {
+    width: 100%;
+    max-width: 400px;
+    padding: 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    margin: 0 auto 1.5rem;
+    display: block;
+}
+
+.doc-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.doc-list a {
+    display: block;
+    padding: 0.75rem 1rem;
+    background: var(--secondary-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    text-decoration: none;
+    color: var(--text-color);
+}
+
+.doc-list a:hover {
+    background: var(--primary-color);
+    color: #fff;
+}
+
+.doc-footer {
+    text-align: center;
+    margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- add documentation-specific CSS for cleaner layout
- embed site navigation and footer across docs pages
- introduce styled search and link list on docs home

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5ec9188c8324be2d265208399e95