### PR TITLE
Add docs navigation and index coverage

### DIFF
--- a/docs/AMPACITY_METHOD.html
+++ b/docs/AMPACITY_METHOD.html
@@ -25,6 +25,7 @@
     <h1>Ampacity Method</h1>
     <p>Neher‑McGrath equation and related guidance.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>The application estimates conductor ampacity using the Neher‑McGrath method. This approach was introduced in the 1957 paper <em>The Calculation of the Temperature Rise and Load Carrying Capability of Cable Systems</em> by J. H. Neher and M. H. McGrath. It forms the basis of ampacity guidance in <strong>NEC 310‑15(C)</strong> and the calculation procedures detailed in <strong>IEEE Std 835</strong>.</p>
 

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,16 +1,52 @@
+const DOC_PAGES = [
+  { href: "index.html", title: "Docs Home" },
+  { href: "quickstart.html", title: "Quick Start" },
+  { href: "templates.html", title: "CSV/XLSX Templates" },
+  { href: "tutorial.html", title: "From empty to routed" },
+  { href: "AMPACITY_METHOD.html", title: "Ampacity Method" },
+  { href: "geometry-fields.html", title: "Geometry Fields" },
+  { href: "soil_resistivity.html", title: "Soil Resistivity" },
+  { href: "math.html", title: "Math References" },
+  { href: "standards.html", title: "Engineering References" },
+  { href: "troubleshooting.html", title: "Troubleshooting" },
+  { href: "tray_id_convention.html", title: "Tray ID Convention" }
+];
+
 document.addEventListener("DOMContentLoaded", () => {
   const last = document.getElementById("last-updated");
   if (last) {
     const date = new Date(document.lastModified);
     last.textContent = date.toLocaleDateString();
   }
+
+  const nav = document.getElementById("doc-nav");
+  if (nav) {
+    DOC_PAGES.forEach((page) => {
+      const link = document.createElement("a");
+      link.href = page.href;
+      link.textContent = page.title;
+      if (location.pathname.endsWith(page.href)) {
+        link.classList.add("active");
+        link.setAttribute("aria-current", "page");
+      }
+      nav.appendChild(link);
+    });
+  }
+
   const search = document.getElementById("doc-search");
   if (search) {
+    const sections = Array.from(document.querySelectorAll("#doc-list section"));
     search.addEventListener("input", () => {
       const term = search.value.toLowerCase();
-      document.querySelectorAll("#doc-list li").forEach((li) => {
-        const text = li.textContent.toLowerCase();
-        li.style.display = text.includes(term) ? "" : "none";
+      sections.forEach((section) => {
+        let visible = false;
+        section.querySelectorAll("li").forEach((li) => {
+          const text = li.textContent.toLowerCase();
+          const show = text.includes(term);
+          li.style.display = show ? "" : "none";
+          if (show) visible = true;
+        });
+        section.style.display = visible ? "" : "none";
       });
     });
   }

--- a/docs/geometry-fields.html
+++ b/docs/geometry-fields.html
@@ -25,6 +25,7 @@
     <h1>Required Geometry Fields</h1>
     <p>Structure geometry data correctly to avoid skipped entries.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>Ductbank records must provide either an <code>outline</code> array of 3D points or both start and end coordinates using the fields <code>start_x</code>, <code>start_y</code>, <code>start_z</code>, <code>end_x</code>, <code>end_y</code>, and <code>end_z</code>.</p>
     <p>Conduit records must include a <code>path</code> array with at least two <code>[x, y, z]</code> points describing the run of the conduit.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,15 +25,46 @@
     <h1>Documentation</h1>
     <p>Guides and references for CableTrayRoute.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation">
-    <ul id="doc-list" class="doc-list">
-      <li><a href="quickstart.html">Quick Start</a></li>
-      <li><a href="templates.html">CSV/XLSX Templates</a></li>
-      <li><a href="tutorial.html">From empty to routed</a></li>
-      <li><a href="math.html">Math References</a></li>
-      <li><a href="troubleshooting.html">Troubleshooting</a></li>
-    </ul>
+    <div id="doc-list">
+      <section>
+        <h2>Getting Started</h2>
+        <ul class="doc-list">
+          <li><a href="quickstart.html">Quick Start</a></li>
+          <li><a href="tutorial.html">From empty to routed</a></li>
+        </ul>
+      </section>
+      <section>
+        <h2>Data &amp; Templates</h2>
+        <ul class="doc-list">
+          <li><a href="templates.html">CSV/XLSX Templates</a></li>
+          <li><a href="geometry-fields.html">Geometry Fields</a></li>
+          <li><a href="tray_id_convention.html">Tray ID Convention</a></li>
+        </ul>
+      </section>
+      <section>
+        <h2>Advanced Topics</h2>
+        <ul class="doc-list">
+          <li><a href="AMPACITY_METHOD.html">Ampacity Method</a></li>
+          <li><a href="soil_resistivity.html">Soil Resistivity</a></li>
+          <li><a href="math.html">Math References</a></li>
+        </ul>
+      </section>
+      <section>
+        <h2>Standards</h2>
+        <ul class="doc-list">
+          <li><a href="standards.html">Engineering References</a></li>
+        </ul>
+      </section>
+      <section>
+        <h2>Support</h2>
+        <ul class="doc-list">
+          <li><a href="troubleshooting.html">Troubleshooting</a></li>
+        </ul>
+      </section>
+    </div>
     <footer class="doc-footer">Docs last updated: <span id="last-updated"></span></footer>
   </main>
   <footer class="site-footer">

--- a/docs/math.html
+++ b/docs/math.html
@@ -25,6 +25,7 @@
     <h1>Math References</h1>
     <p>NEC and Neher-McGrath background used in calculations.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>Ampacity calculations follow the Neher-McGrath method and guidance from the National Electrical Code (NEC). The app uses parameters for conductor resistance, thermal resistivity, and geometry to estimate allowable current.</p>
     <p>See the following documents for detailed formulas and tables:</p>

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -25,6 +25,7 @@
     <h1>Quick Start</h1>
     <p>Follow the six-step workflow to plan and route cables efficiently. Each tool can operate on its own, but completing the steps in sequence yields the best results.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ol class="workflow-list">
       <li>

--- a/docs/standards.html
+++ b/docs/standards.html
@@ -25,6 +25,7 @@
     <h1>Engineering References</h1>
     <p>Standards and publications underpinning the calculations.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>This project relies on several established standards and publications for its electrical calculations.</p>
     <ul>

--- a/docs/templates.html
+++ b/docs/templates.html
@@ -25,6 +25,7 @@
     <h1>CSV/XLSX Templates</h1>
     <p>Starter spreadsheets for the workflow.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ul class="doc-list">
       <li><a href="../examples/cables_template.csv">Cable schedule template</a></li>

--- a/docs/tray_id_convention.html
+++ b/docs/tray_id_convention.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Soil Resistivity Reference</title>
+  <title>Tray ID Convention</title>
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
@@ -22,20 +22,17 @@
     </div>
   </nav>
   <header class="hero">
-    <h1>Soil Resistivity Reference</h1>
-    <p>Typical thermal resistivity values for earth surrounding a ductbank.</p>
+    <h1>Tray ID Convention</h1>
+    <p>How composite tray identifiers are built for ductbank conduits.</p>
   </header>
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
-    <p>The thermal resistance of the earth surrounding a ductbank depends heavily on soil resistivity (ρ). IEEE Std 835 provides typical values that are often used when detailed geotechnical data is unavailable.</p>
-    <p>Typical resistivity values:</p>
-    <ul>
-      <li><strong>60 °C·cm/W</strong> – damp soil or clay</li>
-      <li><strong>90 °C·cm/W</strong> – average native soil</li>
-      <li><strong>120 °C·cm/W</strong> – dry sand</li>
-      <li><strong>150 °C·cm/W</strong> – dry sand and gravel</li>
-    </ul>
-    <p>Values outside this range may be encountered in unusual conditions. The ductbank route calculator accepts custom inputs but will warn when they fall outside the typical IEEE range.</p>
+    <h2>Composite Tray IDs</h2>
+    <p>Conduits imported from the raceway schedule now use a composite tray identifier. If a conduit belongs to a ductbank, its tray ID is built from the ductbank tag and the conduit identifier joined by a hyphen:</p>
+    <pre><code>&lt;tray_id&gt; = &lt;ductbank_id&gt;-&lt;conduit_id&gt;</code></pre>
+    <p>For example, conduit <code>1</code> in ductbank <code>DB-A</code> becomes tray ID <code>DB-A-1</code>.</p>
+    <p>Use this composite ID when specifying manual paths in the Cable Schedule. Enter multiple tray IDs separated by <code>&gt;</code> (e.g., <code>DB-A-1&gt;TRAY-2</code>). The same IDs are listed in the Manual Path column's dropdown helper.</p>
+    <p>Standalone trays keep their existing <code>tray_id</code> values.</p>
   </main>
   <footer class="site-footer">
     <div class="footer-left">
@@ -49,6 +46,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -25,6 +25,7 @@
     <h1>Troubleshooting</h1>
     <p>Solutions to common issues.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ul class="doc-list">
       <li><strong>Import errors:</strong> Ensure CSV headers match the templates exactly.</li>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -25,6 +25,7 @@
     <h1>From Empty to Routed</h1>
     <p>End-to-end walkthrough of the routing workflow.</p>
   </header>
+  <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ol>
       <li>Start with the <a href="templates.html">CSV/XLSX templates</a> and populate them with your project data.</li>

--- a/style.css
+++ b/style.css
@@ -1776,6 +1776,27 @@ body.dark-mode .workflow-card-title {
     padding: 0 1rem;
 }
 
+.doc-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+}
+
+.doc-nav a {
+    text-decoration: none;
+    padding: 0.25rem 0.5rem;
+    background: var(--secondary-color);
+    border-radius: 4px;
+    color: var(--text-color);
+}
+
+.doc-nav a.active {
+    font-weight: bold;
+    background: var(--primary-color);
+    color: #fff;
+}
+
 #doc-search {
     width: 100%;
     max-width: 400px;


### PR DESCRIPTION
## Summary
- add navigation bar linking all documentation pages
- reorganize docs index into categorized sections covering every page
- document tray ID naming for ductbank conduits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcc7f8ae48324bde14580360fa9f7