### PR TITLE
docs: add persistent sidebar navigation

### DIFF
--- a/docs/AMPACITY_METHOD.html
+++ b/docs/AMPACITY_METHOD.html
@@ -25,6 +25,7 @@
     <h1>Ampacity Method</h1>
     <p>Neher‑McGrath equation and related guidance.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>The application estimates conductor ampacity using the Neher‑McGrath method. This approach was introduced in the 1957 paper <em>The Calculation of the Temperature Rise and Load Carrying Capability of Cable Systems</em> by J. H. Neher and M. H. McGrath. It forms the basis of ampacity guidance in <strong>NEC 310‑15(C)</strong> and the calculation procedures detailed in <strong>IEEE Std 835</strong>.</p>
@@ -85,6 +86,7 @@
       <li>J. H. Neher and M. H. McGrath, “The Calculation of the Temperature Rise and Load Carrying Capability of Cable Systems,” <em>AIEE Transactions</em>, 1957.</li>
     </ul>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -97,6 +99,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/geometry-fields.html
+++ b/docs/geometry-fields.html
@@ -25,12 +25,14 @@
     <h1>Required Geometry Fields</h1>
     <p>Structure geometry data correctly to avoid skipped entries.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>Ductbank records must provide either an <code>outline</code> array of 3D points or both start and end coordinates using the fields <code>start_x</code>, <code>start_y</code>, <code>start_z</code>, <code>end_x</code>, <code>end_y</code>, and <code>end_z</code>.</p>
     <p>Conduit records must include a <code>path</code> array with at least two <code>[x, y, z]</code> points describing the run of the conduit.</p>
     <p>Entries missing these fields cannot be placed in the model and will be skipped.</p>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -43,6 +45,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,7 @@
     <h1>Documentation</h1>
     <p>Guides and references for CableTrayRoute.</p>
   </header>
+  <div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation">
@@ -67,6 +68,7 @@
     </div>
     <footer class="doc-footer">Docs last updated: <span id="last-updated"></span></footer>
   </main>
+  </div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">

--- a/docs/math.html
+++ b/docs/math.html
@@ -25,6 +25,7 @@
     <h1>Math References</h1>
     <p>NEC and Neher-McGrath background used in calculations.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>Ampacity calculations follow the Neher-McGrath method and guidance from the National Electrical Code (NEC). The app uses parameters for conductor resistance, thermal resistivity, and geometry to estimate allowable current.</p>
@@ -35,6 +36,7 @@
       <li><a href="standards.html">Standards</a></li>
     </ul>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -47,6 +49,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -25,6 +25,7 @@
     <h1>Quick Start</h1>
     <p>Follow the six-step workflow to plan and route cables efficiently. Each tool can operate on its own, but completing the steps in sequence yields the best results.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ol class="workflow-list">
@@ -56,6 +57,7 @@
     </ol>
     <p class="note">You can open any tool directly for ad‑hoc checks, but stepping through them in order ensures data flows smoothly from one phase to the next.</p>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -68,6 +70,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/soil_resistivity.html
+++ b/docs/soil_resistivity.html
@@ -25,6 +25,7 @@
     <h1>Soil Resistivity Reference</h1>
     <p>Typical thermal resistivity values for earth surrounding a ductbank.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>The thermal resistance of the earth surrounding a ductbank depends heavily on soil resistivity (ρ). IEEE Std 835 provides typical values that are often used when detailed geotechnical data is unavailable.</p>
@@ -37,6 +38,7 @@
     </ul>
     <p>Values outside this range may be encountered in unusual conditions. The ductbank route calculator accepts custom inputs but will warn when they fall outside the typical IEEE range.</p>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -49,6 +51,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/standards.html
+++ b/docs/standards.html
@@ -25,6 +25,7 @@
     <h1>Engineering References</h1>
     <p>Standards and publications underpinning the calculations.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <p>This project relies on several established standards and publications for its electrical calculations.</p>
@@ -35,6 +36,7 @@
     </ul>
     <p>See this file as the citation source for comments in the code referencing each of these standards.</p>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -47,6 +49,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/templates.html
+++ b/docs/templates.html
@@ -25,6 +25,7 @@
     <h1>CSV/XLSX Templates</h1>
     <p>Starter spreadsheets for the workflow.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ul class="doc-list">
@@ -36,6 +37,7 @@
     </ul>
     <p>Download a CSV and open it in your spreadsheet editor. Save as XLSX if you prefer Excel formats.</p>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -48,6 +50,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/tray_id_convention.html
+++ b/docs/tray_id_convention.html
@@ -25,6 +25,7 @@
     <h1>Tray ID Convention</h1>
     <p>How composite tray identifiers are built for ductbank conduits.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <h2>Composite Tray IDs</h2>
@@ -34,6 +35,7 @@
     <p>Use this composite ID when specifying manual paths in the Cable Schedule. Enter multiple tray IDs separated by <code>&gt;</code> (e.g., <code>DB-A-1&gt;TRAY-2</code>). The same IDs are listed in the Manual Path column's dropdown helper.</p>
     <p>Standalone trays keep their existing <code>tray_id</code> values.</p>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -25,6 +25,7 @@
     <h1>Troubleshooting</h1>
     <p>Solutions to common issues.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ul class="doc-list">
@@ -34,6 +35,7 @@
       <li><strong>Browser performance:</strong> Large projects run faster in a modern desktop browser.</li>
     </ul>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -46,6 +48,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -25,6 +25,7 @@
     <h1>From Empty to Routed</h1>
     <p>End-to-end walkthrough of the routing workflow.</p>
   </header>
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
     <ol>
@@ -36,6 +37,7 @@
     </ol>
     <p>This sequence builds a project from scratch and produces routed cables ready for export.</p>
   </main>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
@@ -48,6 +50,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script src="docs.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.querySelector('.nav-toggle');

--- a/style.css
+++ b/style.css
@@ -1770,14 +1770,24 @@ body.dark-mode .workflow-card-title {
 }
 
 /* --- Documentation Pages --- */
-.doc-main {
-    max-width: 800px;
-    margin: 2rem auto;
-    padding: 0 1rem;
+.doc-content {
+    display: flex;
+    align-items: flex-start;
+    max-width: 1200px;
+    margin: 0 auto;
 }
 
 .doc-nav {
-    margin: 1rem 0;
+    width: 200px;
+    margin: 2rem 2rem 0 0;
+    flex-shrink: 0;
+}
+
+.doc-main {
+    flex: 1;
+    max-width: 800px;
+    margin: 2rem 0;
+    padding: 0 1rem;
 }
 
 .doc-nav .nav-section {


### PR DESCRIPTION
## Summary
- lay out docs navigation as a left sidebar
- include docs.js on all documentation pages for shared navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf12541a483249f01ee4d01278b4e