### PR TITLE
Handle standalone conduits in self-check

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -3847,8 +3847,10 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
             setProject(proj);
             diag.counts={ductbanks:proj.ductbanks.length,conduits:proj.conduits.length,trays:proj.trays.length,cables:proj.cables.length};
             const dbTags=new Set(proj.ductbanks.map(db=>db.tag));
-            const invalid=proj.conduits.filter(c=>!c.ductbankTag||!dbTags.has(c.ductbankTag));
+            const standalone=proj.conduits.filter(c=>!c.ductbankTag);
+            const invalid=proj.conduits.filter(c=>c.ductbankTag&&!dbTags.has(c.ductbankTag));
             diag.invalidConduits=invalid.map(c=>c.conduit_id||c.id);
+            diag.standaloneConduits=standalone.map(c=>c.conduit_id||c.id);
             if(Object.values(diag.counts).some(c=>c===0)||invalid.length) throw new Error('Data validation failed');
             await mainCalculation();
             const banner=document.getElementById('ductbank-no-conduits-warning');


### PR DESCRIPTION
## Summary
- treat conduits without a ductbankTag as standalone in self-check
- record standalone conduits in diagnostic output

## Testing
- `npm test`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68af76639a3c8324a48ff5be0202b725