### PR TITLE
Use plural storage keys for raceway data

### DIFF
--- a/dataStore.js
+++ b/dataStore.js
@@ -15,10 +15,16 @@
  */
 
 const KEYS = {
+  // Preferred property names
   trays: 'traySchedule',
   cables: 'cableSchedule',
   ductbanks: 'ductbankSchedule',
-  conduits: 'conduitSchedule'
+  conduits: 'conduitSchedule',
+  // Legacy aliases for backward compatibility
+  traySchedule: 'traySchedule',
+  cableSchedule: 'cableSchedule',
+  ductbankSchedule: 'ductbankSchedule',
+  conduitSchedule: 'conduitSchedule'
 };
 
 const listeners = {};

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   ];
   const trayTable=TableUtils.createTable({
     tableId:'trayTable',
-    storageKey:TableUtils.STORAGE_KEYS.traySchedule,
+    storageKey:TableUtils.STORAGE_KEYS.trays,
     addRowBtnId:'add-tray-btn',
     saveBtnId:'save-tray-btn',
     loadBtnId:'load-tray-btn',
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   ];
   const conduitTable=TableUtils.createTable({
     tableId:'conduitTable',
-    storageKey:TableUtils.STORAGE_KEYS.conduitSchedule,
+    storageKey:TableUtils.STORAGE_KEYS.conduits,
     addRowBtnId:'add-conduit-btn',
     saveBtnId:'save-conduit-btn',
     loadBtnId:'load-conduit-btn',


### PR DESCRIPTION
## Summary
- Switch raceway schedule table to `TableUtils.STORAGE_KEYS.trays` and conduits to `STORAGE_KEYS.conduits`
- Export legacy alias names in `dataStore` so older code still works with new keys

## Testing
- `node - <<'NODE'
…
NODE`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7984ac08832489e0f8041de126e4