### PR TITLE
Preserve project data during self check

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -1,4 +1,4 @@
-import { getItem, setItem, removeItem, getTrays, getCables, getDuctbanks, getConduits } from './dataStore.js';
+import { getItem, setItem, removeItem, getTrays, getCables, getDuctbanks, getConduits, exportProject, importProject } from './dataStore.js';
 import { buildSegmentRows, buildSummaryRows } from './resultsExport.mjs';
 import './site.js';
 
@@ -3832,6 +3832,7 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
 
     async function runSelfCheck(){
         const diag={};
+        const snapshot=exportProject();
         try{
             setProject({name:'',ductbanks:[],conduits:[],trays:[],cables:[],settings:{session:{},collapsedGroups:{},units:'imperial'}});
             diag.cleared=true;
@@ -3884,6 +3885,8 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
             diag.error=e.message||String(e);
             diag.pass=false;
             showSelfCheckModal(diag);
+        }finally{
+            importProject(snapshot);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js",
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js",
     "e2e": "playwright test"
   },
   "devDependencies": {

--- a/tests/selfCheckRestore.test.js
+++ b/tests/selfCheckRestore.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+
+// simple in-memory localStorage stub
+const store = {};
+global.localStorage = {
+  getItem: key => (key in store ? store[key] : null),
+  setItem: (key, value) => { store[key] = value; },
+  removeItem: key => { delete store[key]; }
+};
+
+(async () => {
+  const { exportProject, importProject } = await import('../dataStore.js');
+
+  // initialize project data
+  const initial = {
+    name: 'orig',
+    ductbanks: [{ tag: 'DB1' }],
+    conduits: [{ conduit_id: 'C1', ductbankTag: 'DB1' }],
+    trays: [{ id: 'T1' }],
+    cables: [{ name: 'C1' }],
+    settings: { session: {}, collapsedGroups: {}, units: 'imperial' }
+  };
+  importProject(initial);
+  const before = exportProject();
+
+  // simulate self-check snapshot and restore
+  const snapshot = exportProject();
+  importProject({ name: '', ductbanks: [], conduits: [], trays: [], cables: [], settings: { session: {}, collapsedGroups: {}, units: 'imperial' } });
+  // diagnostics would run here, potentially mutating schedules
+  importProject(snapshot);
+  const after = exportProject();
+
+  assert.deepStrictEqual(after, before);
+  console.log('\u2713 self-check restores project data');
+})().catch(err => { console.error(err); process.exitCode = 1; });


### PR DESCRIPTION
## Summary
- snapshot current project before self-check and restore afterwards so schedules aren't altered
- add test to verify self-check restoration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7bf86da0832490a0338dbf98c4b3