### PR TITLE
Add cable pull tension and sidewall pressure calculations

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -151,6 +151,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         messages: document.getElementById('messages'),
         metrics: document.getElementById('metrics'),
         routeBreakdownContainer: document.getElementById('route-breakdown-container'),
+        pullChecksContainer: document.getElementById('pull-checks-container'),
+        pullChecksDetails: document.getElementById('pull-checks-details'),
         mismatchedRacewaysDetails: document.getElementById('mismatched-raceways-details'),
         mismatchedRacewaysList: document.getElementById('mismatched-raceways-list'),
         plot3d: document.getElementById('plot-3d'),
@@ -2199,9 +2201,30 @@ const openDuctbankRoute = (dbId, conduitId) => {
     };
 
     const downloadTraySample=()=>downloadSampleTemplate(trayTemplateHeaders,'tray_list_template.xlsx');
-    const downloadCableSample=()=>downloadSampleTemplate(cableTemplateHeaders,'cable_options_template.xlsx');
+const downloadCableSample=()=>downloadSampleTemplate(cableTemplateHeaders,'cable_options_template.xlsx');
 
-    const renderBatchResults = (results) => {
+const renderPullChecks = (results) => {
+    if (!elements.pullChecksContainer || !elements.pullChecksDetails) return;
+    if (!results || results.length === 0) {
+        elements.pullChecksContainer.innerHTML = '';
+        elements.pullChecksDetails.style.display = 'none';
+        return;
+    }
+    let html = '<div class="table-scroll"><table class="sticky-table"><thead><tr><th>Cable</th><th>Tension</th><th>Allowable</th><th>Pressure</th><th>Allowable</th></tr></thead><tbody>';
+    results.forEach(r => {
+        const pc = r.pull_check || {};
+        const t = pc.maxTension;
+        const tAllow = pc.allowableTension;
+        const p = pc.maxSidewallPressure;
+        const pAllow = pc.allowableSidewallPressure;
+        html += `<tr><td>${r.cable}</td><td>${t !== undefined ? Number(t).toFixed(2) : 'N/A'}</td><td>${tAllow !== undefined && isFinite(tAllow) ? Number(tAllow).toFixed(2) : 'N/A'}</td><td>${p !== undefined ? Number(p).toFixed(2) : 'N/A'}</td><td>${pAllow !== undefined && isFinite(pAllow) ? Number(pAllow).toFixed(2) : 'N/A'}</td></tr>`;
+    });
+    html += '</tbody></table></div>';
+    elements.pullChecksContainer.innerHTML = html;
+    elements.pullChecksDetails.style.display = '';
+};
+
+const renderBatchResults = (results) => {
         let totalLength = 0;
         let totalField = 0;
         let html = '';
@@ -2331,6 +2354,7 @@ const openDuctbankRoute = (dbId, conduitId) => {
                 renderBatchResults(state.latestRouteData);
             });
         });
+        renderPullChecks(results);
     };
     
     const updateCableListDisplay = () => {

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -247,6 +247,10 @@
                     <summary>Route Breakdown</summary>
                     <div id="route-breakdown-container"></div>
                 </details>
+                <details id="pull-checks-details" style="display:none;">
+                    <summary>Cable Pull Checks</summary>
+                    <div id="pull-checks-container"></div>
+                </details>
                 <h3>3D Route Visualization</h3>
                 <div id="plot-3d"></div>
                 <div class="plot-controls">

--- a/src/pullCalc.js
+++ b/src/pullCalc.js
@@ -1,0 +1,36 @@
+export function calcSidewallPressure(bendRadius, tension) {
+    if (!bendRadius) return 0;
+    return tension / bendRadius;
+}
+
+export function calcPullTension(routeSegments = [], cableProps = {}) {
+    const mu = cableProps.coeffFriction ?? cableProps.mu ?? 0.35;
+    const weight = cableProps.weight ?? 0;
+    let tension = 0;
+    let maxTension = 0;
+    let maxSidewall = 0;
+    for (const seg of routeSegments) {
+        if (!seg) continue;
+        if (seg.type === 'bend') {
+            tension += weight * mu * (seg.length || 0);
+            tension *= Math.exp(mu * (seg.angle || 0));
+            const swp = calcSidewallPressure(seg.radius || 1, tension);
+            if (swp > maxSidewall) maxSidewall = swp;
+        } else {
+            tension += weight * mu * (seg.length || 0);
+        }
+        if (tension > maxTension) maxTension = tension;
+    }
+    return {
+        totalTension: tension,
+        maxTension,
+        maxSidewallPressure: maxSidewall,
+        allowableTension: cableProps.maxTension ?? cableProps.allowableTension ?? cableProps.max_tension ?? Infinity,
+        allowableSidewallPressure: cableProps.maxSidewallPressure ?? cableProps.allowableSidewallPressure ?? cableProps.max_sidewall_pressure ?? Infinity
+    };
+}
+
+if (typeof self !== 'undefined') {
+    self.calcPullTension = calcPullTension;
+    self.calcSidewallPressure = calcSidewallPressure;
+}


### PR DESCRIPTION
## Summary
- add pull calculation utilities for tension and sidewall pressure
- compute pull metrics in routing worker and expose to UI
- display Cable Pull Checks panel in routing results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7061a2da08324af154d69543d1afc