### PR TITLE
feat: add CAD geometry import/export

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -13,6 +13,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
     <script src="dirtyTracker.js" defer></script>
     <script src="dist/optimalRoute.js" defer></script>
+    <script type="module" src="dataStore.js"></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -122,6 +123,9 @@
             <header class="page-header">
                 <h1>Optimal 3D Cable Routing System</h1>
                 <p>Find the most efficient path for routing cables through tray networks with capacity constraints.</p>
+                <button id="import-cad-btn" onclick="document.getElementById('import-cad-input').click()">Import CAD</button>
+                <input type="file" id="import-cad-input" accept=".json,.ifc" style="display:none;" onchange="dataStore.importFromCad(this.files[0])">
+                <button id="export-cad-btn" onclick="dataStore.exportToCad('json')">Export CAD</button>
             </header>
             <details class="method-panel">
                 <summary>Method &amp; Assumptions</summary>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -11,6 +11,7 @@
   <script src="dirtyTracker.js" defer></script>
   <script type="module" src="tableUtils.js"></script>
   <script src="dist/racewayschedule.js" defer></script>
+  <script type="module" src="dataStore.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -49,6 +50,9 @@
         <p>Centralized tables for managing raceway data.</p>
         <button id="raceway-load-samples">Load Sample Data</button>
         <button id="validate-raceway-btn">Validate</button>
+        <button id="import-cad-btn" onclick="document.getElementById('import-cad-input').click()">Import CAD</button>
+        <input type="file" id="import-cad-input" accept=".json,.ifc" style="display:none;" onchange="dataStore.importFromCad(this.files[0])">
+        <button id="export-cad-btn" onclick="dataStore.exportToCad('json')">Export CAD</button>
       </header>
       <details class="method-panel">
         <summary>Method &amp; Assumptions</summary>

--- a/src/importers/revit.js
+++ b/src/importers/revit.js
@@ -1,0 +1,120 @@
+/**
+ * Simple parser for Revit/IFC exports that extracts tray and conduit
+ * geometry. The goal is not to support the full schemas but to pull out
+ * basic start/end coordinates used by the app. The function accepts
+ * either a JSON object/string or raw IFC STEP text.
+ *
+ * Returned geometry objects use the field names already consumed by the
+ * data store (start_x, start_y, ...).
+ *
+ * @param {string|object} input - IFC STEP text or Revit JSON.
+ * @returns {{trays:Array, conduits:Array}}
+ */
+export function parseRevit(input) {
+  if (typeof input === 'string') {
+    // Try JSON first – many exporters can emit JSON directly.
+    try {
+      const obj = JSON.parse(input);
+      return parseRevitJSON(obj);
+    } catch {
+      // Treat as IFC STEP text
+      return parseIFC(input);
+    }
+  }
+  // Already an object – assume JSON structure
+  return parseRevitJSON(input);
+}
+
+/**
+ * Parse a Revit style JSON export. The exporter format is not
+ * standardized so we try a few common field names.
+ * @param {any} obj
+ */
+function parseRevitJSON(obj) {
+  if (!obj || typeof obj !== 'object') return { trays: [], conduits: [] };
+  const trays = [];
+  const conduits = [];
+
+  const traySrc = obj.trays || obj.Trays || obj.cableTrays || obj.CableTrays || [];
+  for (const t of traySrc) {
+    trays.push(normalizeTray(t));
+  }
+
+  const conduitSrc = obj.conduits || obj.Conduits || obj.cableConduits || obj.ConduitSegments || [];
+  for (const c of conduitSrc) {
+    conduits.push(normalizeConduit(c));
+  }
+
+  return { trays, conduits };
+}
+
+function num(val) {
+  const n = parseFloat(val);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function normalizeTray(t = {}) {
+  return {
+    id: t.id || t.tag || t.tray_id || t.TrayID || t.name || t.Tag || '',
+    start_x: num(t.start_x ?? t.sx ?? t.x1 ?? t.StartX ?? t.start?.x),
+    start_y: num(t.start_y ?? t.sy ?? t.y1 ?? t.StartY ?? t.start?.y),
+    start_z: num(t.start_z ?? t.sz ?? t.z1 ?? t.StartZ ?? t.start?.z),
+    end_x: num(t.end_x ?? t.ex ?? t.x2 ?? t.EndX ?? t.end?.x),
+    end_y: num(t.end_y ?? t.ey ?? t.y2 ?? t.EndY ?? t.end?.y),
+    end_z: num(t.end_z ?? t.ez ?? t.z2 ?? t.EndZ ?? t.end?.z),
+    width: num(t.width ?? t.w ?? t.Width ?? t.size_x),
+    height: num(t.height ?? t.h ?? t.Height ?? t.size_y)
+  };
+}
+
+function normalizeConduit(c = {}) {
+  return {
+    conduit_id: c.conduit_id || c.id || c.tag || c.ConduitID || '',
+    type: c.type || c.conduit_type || c.Type || '',
+    trade_size: c.trade_size || c.tradeSize || c.size || c.TradeSize || '',
+    start_x: num(c.start_x ?? c.sx ?? c.x1 ?? c.start?.x),
+    start_y: num(c.start_y ?? c.sy ?? c.y1 ?? c.start?.y),
+    start_z: num(c.start_z ?? c.sz ?? c.z1 ?? c.start?.z),
+    end_x: num(c.end_x ?? c.ex ?? c.x2 ?? c.end?.x),
+    end_y: num(c.end_y ?? c.ey ?? c.y2 ?? c.end?.y),
+    end_z: num(c.end_z ?? c.ez ?? c.z2 ?? c.end?.z),
+    capacity: num(c.capacity ?? c.fill)
+  };
+}
+
+/**
+ * Extremely small IFC STEP parser. It looks for entities that contain an
+ * `IFCPOLYLINE` with two points – the start and end of a segment. If the
+ * entity name includes `CABLECARRIER` it is treated as a tray; otherwise
+ * it is treated as a conduit segment.
+ *
+ * This is a best‑effort helper and is not meant to cover the entire IFC
+ * specification, but it is sufficient for small test files and demos.
+ *
+ * @param {string} text
+ */
+function parseIFC(text) {
+  const trays = [];
+  const conduits = [];
+  const segRegex = /#\d+=IFC([^;]*?)SEGMENT[^;]*?IFCPOLYLINE\(\(([^)]+)\),\(([^)]+)\)\)/gi;
+  let match;
+  let i = 0;
+  while ((match = segRegex.exec(text))) {
+    const kind = match[1] || '';
+    const start = match[2].split(',').map(v => parseFloat(v));
+    const end = match[3].split(',').map(v => parseFloat(v));
+    const seg = {
+      id: `SEG-${i++}`,
+      start_x: start[0],
+      start_y: start[1],
+      start_z: start[2],
+      end_x: end[0],
+      end_y: end[1],
+      end_z: end[2]
+    };
+    if (/CABLECARRIER/i.test(kind)) trays.push(seg); else conduits.push(seg);
+  }
+  return { trays, conduits };
+}
+
+export default { parseRevit };


### PR DESCRIPTION
## Summary
- parse tray and conduit geometry from Revit JSON or IFC exports
- expose importFromCad and exportToCad helpers in data store
- wire CAD import/export buttons into raceway and optimal route pages

## Testing
- `npm test`
- `npm run build` *(fails: RollupError: "default" is not exported by "ampacity.js", imported by "src/voltageDrop.js".)*

------
https://chatgpt.com/codex/tasks/task_e_68b70d8ffb488324b7f68b14dd9827d8