### PR TITLE
Add panel schedule Excel export

### DIFF
--- a/exportPanelSchedule.js
+++ b/exportPanelSchedule.js
@@ -1,0 +1,40 @@
+import * as dataStore from './dataStore.js';
+
+/**
+ * Export a panel schedule to an XLSX file.
+ * Uses global SheetJS (XLSX) library loaded on the page.
+ * @param {string} panelId
+ */
+export function exportPanelSchedule(panelId) {
+  if (typeof XLSX === 'undefined') {
+    console.error('XLSX library not loaded');
+    return;
+  }
+  const panels = dataStore.getPanels();
+  const panel = panels.find(p => p.id === panelId || p.panel_id === panelId) || {};
+  const loads = dataStore.getLoads().filter(l => l.panelId === panelId);
+
+  const data = [];
+  data.push(['Panel', panelId]);
+  data.push(['Voltage', panel.voltage || panel.voltage_rating || '']);
+  data.push(['Main Rating (A)', panel.mainRating || panel.main_rating || '']);
+  data.push([]);
+  data.push(['Circuit', 'Poles', 'Description', 'Demand (kVA)']);
+
+  for (let circuit = 1; circuit <= 42; circuit++) {
+    const load = loads.find(l => Number(l.breaker) === circuit);
+    const poles = load ? (load.poles || load.phases || '') : '';
+    const desc = load ? (load.description || '') : '';
+    const demandVal = load ? (parseFloat(load.demand) || parseFloat(load.power) || 0) : 0;
+    data.push([circuit, poles, desc, demandVal]);
+  }
+
+  const ws = XLSX.utils.aoa_to_sheet(data);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, panelId);
+  XLSX.writeFile(wb, `${panelId}_panel_schedule.xlsx`);
+}
+
+if (typeof window !== 'undefined') {
+  window.exportPanelSchedule = exportPanelSchedule;
+}

--- a/panelschedule.html
+++ b/panelschedule.html
@@ -7,6 +7,7 @@
   <title>Panel Schedule</title>
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script type="module" src="dataStore.js" defer></script>
   <script type="module" src="panelschedule.js" defer></script>
 </head>
@@ -50,6 +51,7 @@
       <section class="card">
         <div id="panel-container"></div>
         <div id="panel-totals" style="margin-top:10px;"></div>
+        <button id="export-panel-btn">Export to Excel</button>
       </section>
       <nav class="step-nav">
         <a href="loadlist.html">Load List</a>

--- a/panelschedule.js
+++ b/panelschedule.js
@@ -1,4 +1,5 @@
 import * as dataStore from './dataStore.js';
+import { exportPanelSchedule } from './exportPanelSchedule.js';
 
 /**
  * Assign a load to a breaker within a panel.
@@ -93,6 +94,7 @@ function updateTotals(panelId) {
 window.addEventListener('DOMContentLoaded', () => {
   const panelId = 'P1';
   render(panelId);
+  document.getElementById('export-panel-btn').addEventListener('click', () => exportPanelSchedule(panelId));
   document.getElementById('panel-container').addEventListener('change', e => {
     if (e.target.matches('select[data-breaker]')) {
       const breaker = parseInt(e.target.dataset.breaker, 10);


### PR DESCRIPTION
## Summary
- add exportPanelSchedule module using SheetJS to build XLSX files with panel headers and breaker rows
- hook up new "Export to Excel" button on panel schedule page
- wire panel schedule page to call exportPanelSchedule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b71a9b3d108324b35b026d4e06a48a