### PR TITLE
Add Load List link to site navigation

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -17,6 +17,7 @@
     <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
+      <a href="loadlist.html">Load List</a>
       <a href="cableschedule.html" class="active" aria-current="page">Cable Schedule</a>
       <a href="panelschedule.html">Panel Schedule</a>
       <a href="racewayschedule.html">Raceway Schedule</a>

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -19,6 +19,7 @@
       <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
       <div id="nav-links" class="nav-links">
         <a href="index.html">Home</a>
+      <a href="loadlist.html">Load List</a>
         <a href="cableschedule.html">Cable Schedule</a>
         <a href="panelschedule.html">Panel Schedule</a>
         <a href="racewayschedule.html">Raceway Schedule</a>

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -16,6 +16,7 @@
     <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
+      <a href="loadlist.html">Load List</a>
       <a href="cableschedule.html">Cable Schedule</a>
       <a href="panelschedule.html">Panel Schedule</a>
       <a href="racewayschedule.html">Raceway Schedule</a>

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -19,6 +19,7 @@
     <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
     <div id="nav-links" class="nav-links">
         <a href="index.html">Home</a>
+      <a href="loadlist.html">Load List</a>
         <a href="cableschedule.html">Cable Schedule</a>
         <a href="panelschedule.html">Panel Schedule</a>
         <a href="racewayschedule.html">Raceway Schedule</a>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html" class="active" aria-current="page">Home</a>
+      <a href="loadlist.html">Load List</a>
       <a href="cableschedule.html">Cable Schedule</a>
       <a href="panelschedule.html">Panel Schedule</a>
       <a href="racewayschedule.html">Raceway Schedule</a>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -22,6 +22,7 @@
         <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
         <div id="nav-links" class="nav-links">
             <a href="index.html">Home</a>
+      <a href="loadlist.html">Load List</a>
             <a href="cableschedule.html">Cable Schedule</a>
             <a href="panelschedule.html">Panel Schedule</a>
             <a href="racewayschedule.html">Raceway Schedule</a>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -19,6 +19,7 @@
     <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
+      <a href="loadlist.html">Load List</a>
       <a href="cableschedule.html">Cable Schedule</a>
       <a href="panelschedule.html">Panel Schedule</a>
       <a href="racewayschedule.html" class="active" aria-current="page">Raceway Schedule</a>


### PR DESCRIPTION
## Summary
- add Load List link after Home in top navigation across schedule and routing pages

## Testing
- `node - <<'NODE' ... NODE`
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68b727af9a5883248dbe690c23c2c408