### PR TITLE
Add Load List link to workflow navigation

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -84,6 +84,7 @@
       </section>
       <nav class="step-nav">
         <a href="index.html">Previous</a>
+        <a href="loadlist.html">Load List</a>
         <a href="panelschedule.html">Next</a>
       </nav>
     </main>

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -173,6 +173,7 @@
 
   <nav class="step-nav">
     <a href="ductbankroute.html">Previous</a>
+    <a href="loadlist.html">Load List</a>
     <a href="conduitfill.html">Next</a>
   </nav>
 

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -119,6 +119,7 @@
 
       <nav class="step-nav">
         <a href="cabletrayfill.html">Previous</a>
+        <a href="loadlist.html">Load List</a>
         <a href="optimalRoute.html">Next</a>
       </nav>
 

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -305,6 +305,7 @@
 
  <nav class="step-nav">
   <a href="racewayschedule.html">Previous</a>
+  <a href="loadlist.html">Load List</a>
   <a href="cabletrayfill.html">Next</a>
  </nav>
 

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -158,6 +158,7 @@
       </section>
       <nav class="step-nav">
         <a href="panelschedule.html">Previous</a>
+        <a href="loadlist.html">Load List</a>
         <a href="ductbankroute.html">Next</a>
       </nav>
     </main>


### PR DESCRIPTION
## Summary
- Insert Load List step into cable, raceway, ductbank, tray fill, and conduit fill navigation
- Align navigation order so users can reach Load List before Panel Schedule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b72b1276fc8324b86531c24f2b5106