### PR TITLE
Handle empty load list

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -206,11 +206,24 @@ function ensureLoadFields(load) {
   };
 }
 
-export const setLoads = loads => write(KEYS.loads, loads.map(ensureLoadFields));
+function isEmptyLoad(load) {
+  const l = ensureLoadFields(load);
+  return Object.values(l).every(v => v === '');
+}
+
+export const setLoads = loads => {
+  const list = (loads.length ? loads : [{}]).map(ensureLoadFields);
+  write(KEYS.loads, list);
+};
 
 export const addLoad = load => {
   const loads = getLoads();
-  loads.push(ensureLoadFields(load));
+  const normalized = ensureLoadFields(load);
+  if (loads.length === 1 && isEmptyLoad(loads[0]) && !isEmptyLoad(normalized)) {
+    loads[0] = normalized;
+  } else {
+    loads.push(normalized);
+  }
   setLoads(loads);
 };
 

--- a/loadlist.js
+++ b/loadlist.js
@@ -187,7 +187,13 @@ if (typeof window !== 'undefined') {
 
   function render() {
     tbody.innerHTML = '';
-    const loads = dataStore.getLoads().map(l => ({ ...l, ...calculateDerived(l) }));
+    let loads = dataStore.getLoads();
+    if (!loads.length) {
+      // Ensure at least one editable row renders even with no stored data
+      loads = [{}];
+    } else {
+      loads = loads.map(l => ({ ...l, ...calculateDerived(l) }));
+    }
     dataStore.setLoads(loads);
     loads.forEach((load, idx) => tbody.appendChild(createRow(load, idx)));
     selectAll.checked = false;


### PR DESCRIPTION
## Summary
- Render a placeholder load row when no loads are stored so headers and totals still appear
- Keep at least one empty load in storage and handle adding the first real load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b73fb82660832498d5adc5278bfdc0