### PR TITLE
feat: add duty field to load list

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -197,6 +197,7 @@ function ensureLoadFields(load) {
     quantity: '',
     voltage: '',
     loadType: '',
+    duty: '',
     kw: '',
     powerFactor: '',
     demandFactor: '',

--- a/loadlist.html
+++ b/loadlist.html
@@ -71,6 +71,7 @@
                 <th>Qty</th>
                 <th>Voltage (V)</th>
                 <th>Load Type</th>
+                <th>Duty</th>
                 <th>kW</th>
                 <th>Power Factor</th>
                 <th>Demand Factor (%)</th>


### PR DESCRIPTION
## Summary
- add Duty column with selectable options for loads
- capture and persist duty in data store and import/export routines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b742d39fa48324a93816779daceaab