### PR TITLE
style: ensure context menu visible in dark mode

### DIFF
--- a/loadlist.js
+++ b/loadlist.js
@@ -13,7 +13,8 @@ class ContextMenu {
       padding: '4px 0',
       background: '#fff',
       border: '1px solid #ccc',
-      zIndex: 1000
+      zIndex: 1000,
+      color: '#000'
     });
     document.body.appendChild(this.menu);
     document.addEventListener('click', () => this.hide());
@@ -26,9 +27,15 @@ class ContextMenu {
     items.forEach(({ label, action }) => {
       const li = document.createElement('li');
       li.textContent = label;
-      Object.assign(li.style, { padding: '4px 12px', cursor: 'pointer' });
+      Object.assign(li.style, {
+        padding: '4px 12px',
+        cursor: 'pointer',
+        color: '#000'
+      });
       li.tabIndex = 0;
       li.addEventListener('click', () => { this.hide(); action(this.target); });
+      li.addEventListener('mouseenter', () => { li.style.background = '#eee'; });
+      li.addEventListener('mouseleave', () => { li.style.background = ''; });
       this.menu.appendChild(li);
     });
   }


### PR DESCRIPTION
## Summary
- assign explicit text color for context menu and items
- add light hover background to keep menu visible in dark mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74ad70ea48324a6c346c417adff5f