### PR TITLE
Fix context menu target in loadlist

### DIFF
--- a/loadlist.js
+++ b/loadlist.js
@@ -33,7 +33,11 @@ class ContextMenu {
         color: '#000'
       });
       li.tabIndex = 0;
-      li.addEventListener('click', () => { this.hide(); action(this.target); });
+      li.addEventListener('click', () => {
+        const target = this.target;
+        this.hide();
+        action(target);
+      });
       li.addEventListener('mouseenter', () => { li.style.background = '#eee'; });
       li.addEventListener('mouseleave', () => { li.style.background = ''; });
       this.menu.appendChild(li);


### PR DESCRIPTION
## Summary
- Preserve context menu target before hiding so row actions act on correct element

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74b7c43b48324bca943ecb3ad680f