### PR TITLE
fix: prevent row copy/paste interfering with cell edits

### DIFF
--- a/loadlist.js
+++ b/loadlist.js
@@ -293,6 +293,8 @@ if (typeof window !== 'undefined') {
   });
 
   document.addEventListener('keydown', e => {
+    const tag = document.activeElement.tagName;
+    if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return; // allow normal copy/paste
     const row = document.activeElement.closest(`.${rowClass}`);
     if (!row) return;
     if (e.ctrlKey && e.key.toLowerCase() === 'c') {


### PR DESCRIPTION
## Summary
- allow standard copy/paste when inputs, textareas, or selects are focused
- keep row copy/paste behavior when focus is elsewhere

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b752713770832494a15c8cc010092c