### PR TITLE
Add equipment persistence test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js && node tests/equipmentColumns.test.js",
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js && node tests/equipmentColumns.test.js && node tests/equipmentPersistence.test.js",
     "e2e": "playwright test"
   },
   "devDependencies": {

--- a/tests/equipmentPersistence.test.js
+++ b/tests/equipmentPersistence.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+
+const store = {};
+global.localStorage = {
+  getItem: key => (key in store ? store[key] : null),
+  setItem: (key, value) => { store[key] = value; },
+  removeItem: key => { delete store[key]; }
+};
+
+(async () => {
+  global.window = {};
+  const dataStore = await import('../dataStore.mjs');
+  await import('../tableUtils.js');
+  const TableUtils = global.window.TableUtils;
+  const { STORAGE_KEYS } = TableUtils;
+
+  const rows = [
+    { id: 'eq1', description: 'Breaker', voltage: '480', category: 'A', subCategory: 'B', x: 1, y: 2, z: 3 }
+  ];
+
+  TableUtils.saveToStorage(STORAGE_KEYS.equipment, rows);
+  const loaded = TableUtils.loadFromStorage(STORAGE_KEYS.equipment);
+  assert.deepStrictEqual(loaded, rows);
+
+  const stored = dataStore.getItem(STORAGE_KEYS.equipment);
+  assert.deepStrictEqual(stored, rows);
+
+  console.log('\u2713 equipment persistence');
+})().catch(err => { console.error(err); process.exitCode = 1; });


### PR DESCRIPTION
## Summary
- add test to ensure equipment rows persist via TableUtils and dataStore
- include new test in npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8989099fc8324bfb809acf91d10ce