### PR TITLE
test: add loadlist persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js && node tests/equipmentColumns.test.js && node tests/equipmentPersistence.test.js",
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js && node tests/equipmentColumns.test.js && node tests/equipmentPersistence.test.js && node tests/loadlistPersistence.test.js",
     "e2e": "playwright test"
   },
   "devDependencies": {

--- a/tests/loadlistPersistence.test.js
+++ b/tests/loadlistPersistence.test.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+
+class Element {
+  constructor(tag = '') {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.style = {};
+    this.dataset = {};
+    this.innerHTML = '';
+    this.textContent = '';
+    this.value = '';
+    this.checked = false;
+    this.classList = { add() {}, remove() {} };
+  }
+  appendChild(child) {
+    this.children.push(child);
+    child.parentElement = this;
+    return child;
+  }
+  querySelector() { return new Element(); }
+  querySelectorAll() { return []; }
+  addEventListener() {}
+  removeEventListener() {}
+  setAttribute(name, value) { this[name] = value; }
+  closest() { return null; }
+}
+
+function makeDOM() {
+  const elements = {};
+  const document = {
+    createElement: tag => new Element(tag),
+    getElementById: id => elements[id],
+    addEventListener() {},
+    body: new Element('body')
+  };
+  const window = {
+    addEventListener(type, fn) {
+      this._listeners = this._listeners || {};
+      (this._listeners[type] || (this._listeners[type] = [])).push(fn);
+    },
+    dispatchEvent(evt) {
+      const list = (this._listeners && this._listeners[evt.type]) || [];
+      list.forEach(fn => fn(evt));
+    },
+    Event: class { constructor(type) { this.type = type; } }
+  };
+  document.defaultView = window;
+
+  elements['load-table'] = new Element('table');
+  elements['load-table-tbody'] = new Element('tbody');
+  elements['load-table-tbody'].dataset = { rowClass: 'load-row' };
+  elements['load-table-tfoot'] = new Element('tfoot');
+  elements['load-table'].querySelector = sel => {
+    if (sel === 'tbody') return elements['load-table-tbody'];
+    if (sel === 'tfoot') return elements['load-table-tfoot'];
+    return new Element();
+  };
+  elements['load-table'].querySelectorAll = () => [];
+  elements['delete-selected-btn'] = new Element('button');
+  elements['select-all'] = new Element('input');
+  elements['source-summary'] = new Element('div');
+  elements['export-btn'] = new Element('button');
+  elements['export-csv-btn'] = new Element('button');
+  elements['copy-btn'] = new Element('button');
+  elements['import-input'] = new Element('input');
+  elements['import-btn'] = new Element('button');
+  elements['import-csv-btn'] = new Element('button');
+  elements['import-csv-input'] = new Element('input');
+
+  return { window, document };
+}
+
+const store = {};
+global.localStorage = {
+  getItem: key => (key in store ? store[key] : null),
+  setItem: (key, value) => { store[key] = value; },
+  removeItem: key => { delete store[key]; }
+};
+
+global.initSettings = global.initDarkMode = global.initCompactMode = global.initNavToggle = () => {};
+global.alert = () => {};
+global.confirm = () => true;
+global.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+
+(async () => {
+  let dom = makeDOM();
+  global.window = dom.window;
+  global.document = dom.document;
+
+  const dataStore = await import('../dataStore.mjs');
+  dataStore.addLoad({ source: 'S1', description: 'L1', kw: '10', voltage: '120' });
+  dataStore.addLoad({ source: 'S2', description: 'L2', kw: '20', voltage: '240' });
+  const before = dataStore.getLoads();
+
+  await import('../loadlist.js');
+  window.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+  dom = makeDOM();
+  global.window = dom.window;
+  global.document = dom.document;
+
+  await import('../loadlist.js?cache=' + Date.now());
+  window.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+  const reloaded = await import('../dataStore.mjs?cache=' + Date.now());
+  const after = reloaded.getLoads();
+
+  assert.deepStrictEqual(after, before);
+  console.log('\u2713 loadlist persistence');
+})().catch(err => { console.error(err); process.exitCode = 1; });


### PR DESCRIPTION
## Summary
- add regression test ensuring loadlist render preserves stored loads across reloads
- include loadlist persistence test in npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b1a0047c8324b375c9c1d850ae9d