### PR TITLE
Add icons to one-line palette buttons

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -51,9 +51,15 @@
       </header>
       <section class="card">
         <div id="palette" class="palette" style="margin-bottom:10px;">
-          <button data-type="equipment">Equipment</button>
-          <button data-type="panel">Panel</button>
-          <button data-type="load">Load</button>
+          <button data-type="equipment">
+            <img src="icons/equipment.svg" alt="" aria-hidden="true"> Equipment
+          </button>
+          <button data-type="panel">
+            <img src="icons/panel.svg" alt="" aria-hidden="true"> Panel
+          </button>
+          <button data-type="load">
+            <img src="icons/load.svg" alt="" aria-hidden="true"> Load
+          </button>
           <button id="connect-btn">Connect</button>
           <button id="export-btn">Export</button>
           <input type="file" id="import-input" accept=".json" style="display:none;">

--- a/style.css
+++ b/style.css
@@ -282,6 +282,21 @@ button:focus-visible, .primary-btn:focus-visible {
     outline-offset: 2px;
 }
 
+/* Palette buttons with icons */
+#palette button {
+    display: inline-flex;
+    align-items: center;
+}
+#palette button img {
+    width: 1.2em;
+    height: 1.2em;
+    margin-right: 0.25rem;
+}
+body.compact-mode #palette button img {
+    width: 1em;
+    height: 1em;
+}
+
 /* Icon style buttons */
 .icon-button {
     background: none;


### PR DESCRIPTION
## Summary
- show icons for Equipment/Panel/Load palette buttons in oneline editor
- style palette icons for alignment and sizing including compact mode
- verified event listeners still read button dataset.type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb57c29ef88324b5752886da6728f4