### PR TITLE
feat: support component subtypes in one-line diagram

### DIFF
--- a/icons/Load.svg
+++ b/icons/Load.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <circle cx="40" cy="20" r="18" fill="#fff" stroke="#000"/>
+  <polyline points="40 8 32 20 44 20 36 32" fill="none" stroke="#000" stroke-width="2"/>
+</svg>
+

--- a/icons/MCC.svg
+++ b/icons/MCC.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#000"/>
+  <text x="40" y="25" font-size="12" text-anchor="middle" fill="#000">MCC</text>
+</svg>
+

--- a/icons/MLO.svg
+++ b/icons/MLO.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#000"/>
+  <text x="40" y="25" font-size="12" text-anchor="middle" fill="#000">MLO</text>
+</svg>
+

--- a/icons/Switchgear.svg
+++ b/icons/Switchgear.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#000"/>
+  <rect x="20" y="10" width="40" height="20" fill="#e0e0e0" stroke="#000"/>
+</svg>
+

--- a/icons/Transformer.svg
+++ b/icons/Transformer.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#000"/>
+  <circle cx="30" cy="20" r="8" fill="none" stroke="#000"/>
+  <circle cx="50" cy="20" r="8" fill="none" stroke="#000"/>
+</svg>
+

--- a/oneline.html
+++ b/oneline.html
@@ -51,15 +51,7 @@
       </header>
       <section class="card">
         <div id="palette" class="palette" style="margin-bottom:10px;">
-          <button data-type="equipment">
-            <img src="icons/equipment.svg" alt="" aria-hidden="true"> Equipment
-          </button>
-          <button data-type="panel">
-            <img src="icons/panel.svg" alt="" aria-hidden="true"> Panel
-          </button>
-          <button data-type="load">
-            <img src="icons/load.svg" alt="" aria-hidden="true"> Load
-          </button>
+          <div id="component-buttons"></div>
           <button id="connect-btn">Connect</button>
           <button id="export-btn">Export</button>
           <input type="file" id="import-input" accept=".json" style="display:none;">


### PR DESCRIPTION
## Summary
- build component type map and use it to dynamically create palette buttons
- allow components to include subtype and render appropriate SVG icons
- map component subtypes to schedule categories on export/import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5ac83e988324ad28dfba97191507