### PR TITLE
feat(oneline): add dynamic component property dialog

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -67,11 +67,7 @@
             </defs>
             <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
           </svg>
-          <form id="prop-form" class="prop-form" style="position:absolute;top:10px;right:10px;background:#fff;padding:5px;border:1px solid #ccc;display:none;">
-            <label>Label <input id="prop-label" type="text"></label>
-            <label>Ref ID <input id="prop-ref" type="text"></label>
-            <button type="submit">Save</button>
-          </form>
+          <div id="prop-modal" class="prop-modal" style="position:absolute;top:10px;right:10px;background:#fff;padding:5px;border:1px solid #ccc;display:none;"></div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- open component properties with double-click and modal editor
- generate component fields from per-subtype schemas and persist edits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb5be2cbbc8324ac8892ea8de1f738