### PR TITLE
Add cable templates to one-line connections

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -192,7 +192,7 @@ export const removeEquipment = index => {
  * @property {number} y Y coordinate
  * @property {string} [label] Display label
  * @property {string} [ref] Linked schedule id
- * @property {string[]} [connections] Target component ids
+ * @property {{target:string, cable?:Cable}[]} [connections] Connections to other components with optional cable spec
  */
 
 /**


### PR DESCRIPTION
## Summary
- represent one-line connections as `{target, cable}` objects
- prompt for cable template on connection and color lines by cable type
- export links cables to schedule using `setCables`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5ceba7cc832495ecef83b9d6b487