### PR TITLE
feat: add undo redo history

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -53,6 +53,8 @@
         <div id="palette" class="palette" style="margin-bottom:10px;">
           <div id="component-buttons"></div>
           <button id="connect-btn">Connect</button>
+          <button id="undo-btn">Undo</button>
+          <button id="redo-btn">Redo</button>
           <button id="export-btn">Export</button>
           <input type="file" id="import-input" accept=".json" style="display:none;">
           <button id="import-btn">Import</button>


### PR DESCRIPTION
## Summary
- add history tracking to one-line editor with undo/redo shortcuts
- expose toolbar buttons to undo or redo edits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb621dac94832491cb345cf887683d