### PR TITLE
Add cable selection modal and connection editing

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -70,6 +70,7 @@
             <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
           </svg>
           <div id="prop-modal" class="prop-modal" style="position:absolute;top:10px;right:10px;background:#fff;padding:5px;border:1px solid #ccc;display:none;"></div>
+          <div id="cable-modal" class="prop-modal" style="position:absolute;top:50px;right:10px;background:#fff;padding:5px;border:1px solid #ccc;display:none;"></div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add dedicated cable selection modal to one-line editor
- enable choosing and editing cables with tag, type, and color
- allow editing cable links from property dialog and persist during export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6339157883249d1458e10b0b102f