### PR TITLE
Add orthogonal connection routing with arrowheads and labels

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -66,6 +66,9 @@
               <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
                 <path d="M20 0 L0 0 0 20" fill="none" stroke="#ccc" stroke-width="0.5" />
               </pattern>
+              <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto" markerUnits="strokeWidth">
+                <path d="M0,0 L10,5 L0,10 Z" fill="context-stroke" />
+              </marker>
             </defs>
             <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
           </svg>


### PR DESCRIPTION
## Summary
- Render connection paths as orthogonal polylines that avoid component rectangles and snap to centers
- Display cable tag/type at each connection's midpoint and add arrowhead markers for direction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb644e6be48324ad0d13b50ca83209