### PR TITLE
feat: add multi-selection editing tools

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -55,6 +55,12 @@
           <button id="connect-btn">Connect</button>
           <button id="undo-btn">Undo</button>
           <button id="redo-btn">Redo</button>
+          <button id="align-left-btn">Align Left</button>
+          <button id="align-right-btn">Align Right</button>
+          <button id="align-top-btn">Align Top</button>
+          <button id="align-bottom-btn">Align Bottom</button>
+          <button id="distribute-h-btn">Distribute H</button>
+          <button id="distribute-v-btn">Distribute V</button>
           <button id="export-btn">Export</button>
           <input type="file" id="import-input" accept=".json" style="display:none;">
           <button id="import-btn">Import</button>


### PR DESCRIPTION
## Summary
- Support multi-component selection with shift/ctrl click
- Drag, align, and distribute selected components
- Duplicate selections with Ctrl+C / Ctrl+V

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6618c12483248352ac55ec864fbc