### PR TITLE
Use icon buttons for oneline palette

### DIFF
--- a/icons/toolbar/align-bottom.svg
+++ b/icons/toolbar/align-bottom.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="3" y1="20" x2="21" y2="20"/>
+  <line x1="7" y1="4" x2="7" y2="20"/>
+  <line x1="12" y1="10" x2="12" y2="20"/>
+  <line x1="17" y1="6" x2="17" y2="20"/>
+</svg>

--- a/icons/toolbar/align-left.svg
+++ b/icons/toolbar/align-left.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="4" y1="3" x2="4" y2="21"/>
+  <line x1="4" y1="6" x2="20" y2="6"/>
+  <line x1="4" y1="12" x2="16" y2="12"/>
+  <line x1="4" y1="18" x2="12" y2="18"/>
+</svg>

--- a/icons/toolbar/align-right.svg
+++ b/icons/toolbar/align-right.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="20" y1="3" x2="20" y2="21"/>
+  <line x1="4" y1="6" x2="20" y2="6"/>
+  <line x1="8" y1="12" x2="20" y2="12"/>
+  <line x1="12" y1="18" x2="20" y2="18"/>
+</svg>

--- a/icons/toolbar/align-top.svg
+++ b/icons/toolbar/align-top.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="3" y1="4" x2="21" y2="4"/>
+  <line x1="7" y1="4" x2="7" y2="20"/>
+  <line x1="12" y1="4" x2="12" y2="14"/>
+  <line x1="17" y1="4" x2="17" y2="16"/>
+</svg>

--- a/icons/toolbar/connect.svg
+++ b/icons/toolbar/connect.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="8" cy="12" r="3"/>
+  <circle cx="16" cy="12" r="3"/>
+  <path d="M11 12h2"/>
+</svg>

--- a/icons/toolbar/distribute-h.svg
+++ b/icons/toolbar/distribute-h.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="5" width="3" height="14"/>
+  <rect x="10.5" y="5" width="3" height="14"/>
+  <rect x="17" y="5" width="3" height="14"/>
+  <polyline points="4 10 2 12 4 14"/>
+  <polyline points="20 10 22 12 20 14"/>
+</svg>

--- a/icons/toolbar/distribute-v.svg
+++ b/icons/toolbar/distribute-v.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="5" y="4" width="14" height="3"/>
+  <rect x="5" y="10.5" width="14" height="3"/>
+  <rect x="5" y="17" width="14" height="3"/>
+  <polyline points="10 4 12 2 14 4"/>
+  <polyline points="10 20 12 22 14 20"/>
+</svg>

--- a/icons/toolbar/export.svg
+++ b/icons/toolbar/export.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3v11"/>
+  <polyline points="8 7 12 3 16 7"/>
+  <rect x="5" y="14" width="14" height="7"/>
+</svg>

--- a/icons/toolbar/import.svg
+++ b/icons/toolbar/import.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 21V10"/>
+  <polyline points="8 17 12 21 16 17"/>
+  <rect x="5" y="3" width="14" height="7"/>
+</svg>

--- a/icons/toolbar/redo.svg
+++ b/icons/toolbar/redo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="9 6 15 12 9 18"/>
+</svg>

--- a/icons/toolbar/undo.svg
+++ b/icons/toolbar/undo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="15 6 9 12 15 18"/>
+</svg>

--- a/oneline.html
+++ b/oneline.html
@@ -52,18 +52,18 @@
       <section class="card">
         <div id="palette" class="palette" style="margin-bottom:10px;">
           <div id="component-buttons"></div>
-          <button id="connect-btn">Connect</button>
-          <button id="undo-btn">Undo</button>
-          <button id="redo-btn">Redo</button>
-          <button id="align-left-btn">Align Left</button>
-          <button id="align-right-btn">Align Right</button>
-          <button id="align-top-btn">Align Top</button>
-          <button id="align-bottom-btn">Align Bottom</button>
-          <button id="distribute-h-btn">Distribute H</button>
-          <button id="distribute-v-btn">Distribute V</button>
-          <button id="export-btn">Export</button>
+          <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
+          <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
+          <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
+          <button id="align-left-btn" class="icon-button" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
+          <button id="align-right-btn" class="icon-button" title="Align Right" aria-label="Align Right"><img src="icons/toolbar/align-right.svg" alt=""></button>
+          <button id="align-top-btn" class="icon-button" title="Align Top" aria-label="Align Top"><img src="icons/toolbar/align-top.svg" alt=""></button>
+          <button id="align-bottom-btn" class="icon-button" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
+          <button id="distribute-h-btn" class="icon-button" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
+          <button id="distribute-v-btn" class="icon-button" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
+          <button id="export-btn" class="icon-button" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
           <input type="file" id="import-input" accept=".json" style="display:none;">
-          <button id="import-btn">Import</button>
+          <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
           <label style="margin-left:10px;"><input type="checkbox" id="grid-toggle" checked> Grid</label>
         </div>
         <div class="oneline-editor" style="position:relative;">

--- a/style.css
+++ b/style.css
@@ -282,29 +282,48 @@ button:focus-visible, .primary-btn:focus-visible {
     outline-offset: 2px;
 }
 
-/* Palette buttons with icons */
+/* Palette buttons */
 #palette button {
     display: inline-flex;
     align-items: center;
+    background: none;
+    border: none;
+    color: var(--text-color);
+    margin: var(--button-margin);
 }
-#palette button img {
+#palette button:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+#palette button:not(.icon-button) img {
     width: 1.2em;
     height: 1.2em;
     margin-right: 0.25rem;
 }
-body.compact-mode #palette button img {
+body.compact-mode #palette button:not(.icon-button) img {
     width: 1em;
     height: 1em;
 }
 
 /* Icon style buttons */
 .icon-button {
-    background: none;
+    background: transparent;
     border: none;
-    padding: 0 4px;
+    width: 32px;
+    height: 32px;
+    padding: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
-    font-size: 1rem;
-    color: var(--text-color); /* Ensure icons are visible */
+}
+.icon-button img,
+.icon-button svg {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+.icon-button:hover {
+    background-color: rgba(0, 0, 0, 0.1);
 }
 .icon-delete {
     color: red;


### PR DESCRIPTION
## Summary
- Replace oneline diagram palette text buttons with SVG icon buttons and add tooltips
- Add toolbar action icons for connect, undo/redo, alignment, distribution, export and import
- Style icon buttons with transparent backgrounds and hover highlight while removing blue background in palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb7f275fd88324b7393df71970ea52