### PR TITLE
feat: modular one-line styling with animations

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -1,0 +1,90 @@
+:root {
+  --ol-font: 'Segoe UI', Arial, sans-serif;
+  --ol-spacing: 0.5rem;
+  --ol-card-bg: #fdfdfd;
+  --ol-border-color: #dcdcdc;
+  --ol-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  --ol-radius: 8px;
+  --ol-hover-bg: rgba(0,0,0,0.05);
+}
+
+.card {
+  background: var(--ol-card-bg);
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  box-shadow: var(--ol-shadow);
+}
+
+.palette {
+  display: flex;
+  align-items: center;
+  gap: var(--ol-spacing);
+  margin-bottom: var(--ol-spacing);
+  font-family: var(--ol-font);
+}
+
+.grid-label {
+  margin-left: var(--ol-spacing);
+}
+
+.hidden-input {
+  display: none;
+}
+
+.oneline-editor {
+  position: relative;
+}
+
+.oneline-editor #diagram {
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+}
+
+.palette .icon-button {
+  transition: transform 0.2s, background-color 0.2s;
+}
+
+.palette .icon-button:hover,
+.palette .icon-button:focus {
+  background-color: var(--ol-hover-bg);
+  transform: scale(1.05);
+}
+
+.prop-modal {
+  position: absolute;
+  background: var(--ol-card-bg);
+  padding: var(--ol-spacing);
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  box-shadow: var(--ol-shadow);
+  opacity: 0;
+  display: none;
+  font-family: var(--ol-font);
+  transition: opacity 0.3s ease;
+}
+
+.prop-modal.show {
+  display: block;
+  opacity: 1;
+}
+
+#prop-modal {
+  top: 10px;
+  right: 10px;
+}
+
+#cable-modal {
+  top: 50px;
+  right: 10px;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .prop-modal.show {
+    animation: fadeIn 0.3s ease-out;
+  }
+}

--- a/oneline.html
+++ b/oneline.html
@@ -7,6 +7,7 @@
   <title>One-Line Diagram</title>
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="oneline.css">
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="oneline.js" defer></script>
 </head>
@@ -41,7 +42,7 @@
     <button id="help-btn" aria-expanded="false">Site Help</button>
     <button id="export-project-btn">Export Project</button>
     <button id="import-project-btn">Import Project</button>
-    <input type="file" id="import-project-input" accept=".ctr.json" style="display:none;">
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
   </div>
   <div class="container">
     <main id="main-content" class="main-content">
@@ -50,7 +51,7 @@
         <p>Create and link components to schedules.</p>
       </header>
       <section class="card">
-        <div id="palette" class="palette" style="margin-bottom:10px;">
+        <div id="palette" class="palette">
           <div id="component-buttons"></div>
           <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
           <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
@@ -62,12 +63,12 @@
           <button id="distribute-h-btn" class="icon-button" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
           <button id="distribute-v-btn" class="icon-button" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
           <button id="export-btn" class="icon-button" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
-          <input type="file" id="import-input" accept=".json" style="display:none;">
+          <input type="file" id="import-input" accept=".json" class="hidden-input">
           <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
-          <label style="margin-left:10px;"><input type="checkbox" id="grid-toggle" checked> Grid</label>
+          <label class="grid-label"><input type="checkbox" id="grid-toggle" checked> Grid</label>
         </div>
-        <div class="oneline-editor" style="position:relative;">
-          <svg id="diagram" width="800" height="600" style="border:1px solid #ccc;">
+        <div class="oneline-editor">
+          <svg id="diagram" width="800" height="600">
             <defs>
               <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
                 <path d="M20 0 L0 0 0 20" fill="none" stroke="#ccc" stroke-width="0.5" />
@@ -78,8 +79,8 @@
             </defs>
             <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
           </svg>
-          <div id="prop-modal" class="prop-modal" style="position:absolute;top:10px;right:10px;background:#fff;padding:5px;border:1px solid #ccc;display:none;"></div>
-          <div id="cable-modal" class="prop-modal" style="position:absolute;top:50px;right:10px;background:#fff;padding:5px;border:1px solid #ccc;display:none;"></div>
+          <div id="prop-modal" class="prop-modal"></div>
+          <div id="cable-modal" class="prop-modal"></div>
           <ul id="context-menu" class="context-menu">
             <li data-action="edit" data-context="component">Edit Properties</li>
             <li data-action="delete" data-context="component">Delete</li>

--- a/oneline.js
+++ b/oneline.js
@@ -470,7 +470,7 @@ function selectComponent(comp) {
   cancelBtn.type = 'button';
   cancelBtn.textContent = 'Cancel';
   cancelBtn.addEventListener('click', () => {
-    modal.style.display = 'none';
+    modal.classList.remove('show');
     selected = null;
     selection = [];
     selectedConnection = null;
@@ -484,7 +484,7 @@ function selectComponent(comp) {
     components.forEach(c => {
       c.connections = (c.connections || []).filter(conn => conn.target !== comp.id);
     });
-    modal.style.display = 'none';
+    modal.classList.remove('show');
     selected = null;
     selection = [];
     selectedConnection = null;
@@ -504,13 +504,13 @@ function selectComponent(comp) {
     pushHistory();
     render();
     save();
-    modal.style.display = 'none';
+    modal.classList.remove('show');
     selected = null;
     selection = [];
     selectedConnection = null;
   });
   modal.appendChild(form);
-  modal.style.display = 'block';
+  modal.classList.add('show');
 }
 
 function chooseCable(source, target, existing = null) {
@@ -605,7 +605,7 @@ function chooseCable(source, target, existing = null) {
     cancelBtn.type = 'button';
     cancelBtn.textContent = 'Cancel';
     cancelBtn.addEventListener('click', () => {
-      modal.style.display = 'none';
+      modal.classList.remove('show');
       resolve(null);
     });
     form.appendChild(saveBtn);
@@ -618,12 +618,12 @@ function chooseCable(source, target, existing = null) {
         cable_type: typeInput.value,
         color: colorInput.value
       };
-      modal.style.display = 'none';
+      modal.classList.remove('show');
       resolve({ ...cable, from_tag: source.ref || source.id, to_tag: target.ref || target.id });
     });
 
     modal.appendChild(form);
-    modal.style.display = 'block';
+    modal.classList.add('show');
   });
 }
 
@@ -795,7 +795,7 @@ function init() {
       render();
       save();
       const modal = document.getElementById('prop-modal');
-      if (modal) modal.style.display = 'none';
+      if (modal) modal.classList.remove('show');
     } else if (action === 'duplicate' && contextTarget) {
       const copy = {
         ...JSON.parse(JSON.stringify(contextTarget)),
@@ -884,7 +884,7 @@ function init() {
       render();
       save();
       const modal = document.getElementById('prop-modal');
-      if (modal) modal.style.display = 'none';
+      if (modal) modal.classList.remove('show');
     }
   });
 


### PR DESCRIPTION
## Summary
- add dedicated `oneline.css` with neutral palette, shared variables, and animated components
- refactor `oneline.html` to remove inline styles and use the new stylesheet
- animate modals and buttons via class-based toggling in `oneline.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb859cdd6c8324a74b2fd99cb2826f