### PR TITLE
Use SVG symbols for one-line components

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -76,6 +76,32 @@
               <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto" markerUnits="strokeWidth">
                 <path d="M0,0 L10,5 L0,10 Z" fill="context-stroke" />
               </marker>
+              <symbol id="icon-MLO" viewBox="0 0 80 40">
+                <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#333" stroke-width="2"/>
+                <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">MLO</text>
+              </symbol>
+              <symbol id="icon-MCC" viewBox="0 0 80 40">
+                <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#333" stroke-width="2"/>
+                <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">MCC</text>
+              </symbol>
+              <symbol id="icon-Transformer" viewBox="0 0 80 40">
+                <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+                <circle cx="30" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
+                <circle cx="50" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
+              </symbol>
+              <symbol id="icon-Switchgear" viewBox="0 0 80 40">
+                <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+                <rect x="20" y="10" width="40" height="20" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
+              </symbol>
+              <symbol id="icon-Load" viewBox="0 0 80 40">
+                <circle cx="40" cy="20" r="18" fill="#fff" stroke="#333" stroke-width="2"/>
+                <polyline points="40 8 32 20 44 20 36 32" fill="none" stroke="#333" stroke-width="2"/>
+              </symbol>
+              <symbol id="icon-equipment" viewBox="0 0 80 40">
+                <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+                <circle cx="26" cy="20" r="8" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
+                <rect x="46" y="12" width="20" height="16" fill="#fff" stroke="#333" stroke-width="2"/>
+              </symbol>
             </defs>
             <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
           </svg>

--- a/oneline.js
+++ b/oneline.js
@@ -14,26 +14,6 @@ const typeIcons = {
   load: 'icons/load.svg'
 };
 
-const iconCache = {};
-function preloadIcons() {
-  const iconPaths = new Set([
-    ...Object.values(typeIcons),
-    ...Object.values(componentMeta).map(m => m.icon)
-  ]);
-  iconPaths.forEach(path => {
-    fetch(path, { method: 'HEAD' })
-      .then(res => {
-        iconCache[path] = res.ok;
-        if (!res.ok) console.warn(`Missing icon file: ${path}`);
-      })
-      .catch(() => {
-        iconCache[path] = false;
-        console.warn(`Missing icon file: ${path}`);
-      });
-  });
-}
-if (typeof fetch === 'function') preloadIcons();
-
 const propSchemas = {
   Transformer: [
     { name: 'voltage', label: 'Voltage', type: 'number' },
@@ -326,29 +306,29 @@ function render() {
     g.addEventListener('mouseenter', showTooltip);
     g.addEventListener('mousemove', moveTooltip);
     g.addEventListener('mouseleave', hideTooltip);
-    const img = document.createElementNS(svgNS, 'image');
-    img.setAttribute('x', c.x);
-    img.setAttribute('y', c.y);
-    img.setAttribute('width', compWidth);
-    img.setAttribute('height', compHeight);
+    const use = document.createElementNS(svgNS, 'use');
+    use.setAttribute('x', c.x);
+    use.setAttribute('y', c.y);
+    use.setAttribute('width', compWidth);
+    use.setAttribute('height', compHeight);
     const meta = componentMeta[c.subtype] || {};
-    let icon = meta.icon;
-    if (!icon || iconCache[icon] === false) {
-      console.warn(`Missing icon for subtype '${c.subtype}'`);
-      icon = 'icons/equipment.svg';
+    let href = `#icon-${c.subtype}`;
+    if (!document.getElementById(`icon-${c.subtype}`)) {
+      console.warn(`Missing symbol for subtype '${c.subtype}'`);
+      href = '#icon-equipment';
     }
-    img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', icon);
+    use.setAttributeNS('http://www.w3.org/1999/xlink', 'href', href);
     if (c.rot) {
       const cx = c.x + compWidth / 2;
       const cy = c.y + compHeight / 2;
-      img.setAttribute('transform', `rotate(${c.rot}, ${cx}, ${cy})`);
+      use.setAttribute('transform', `rotate(${c.rot}, ${cx}, ${cy})`);
     }
     const text = document.createElementNS(svgNS, 'text');
     text.setAttribute('x', c.x + compWidth / 2);
     text.setAttribute('y', c.y + compHeight + 15);
     text.setAttribute('text-anchor', 'middle');
     text.textContent = c.label || meta.label || c.subtype || c.type;
-    g.appendChild(img);
+    g.appendChild(use);
     if (selection.includes(c)) {
       const rect = document.createElementNS(svgNS, 'rect');
       rect.setAttribute('x', c.x - 2);


### PR DESCRIPTION
## Summary
- embed MLO, MCC, Transformer, Switchgear and Load SVGs as symbols in oneline.html
- render one-line components with `<use>` elements referencing these symbols
- include fallback equipment symbol and drop unused icon preloading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb89393cc483248baf63cba42033d3