### PR TITLE
Add search filter for one-line component palette

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -23,6 +23,11 @@
   font-family: var(--ol-font);
 }
 
+#palette-search {
+  display: block;
+  margin-bottom: var(--ol-spacing);
+}
+
 .grid-label {
   margin-left: var(--ol-spacing);
 }

--- a/oneline.html
+++ b/oneline.html
@@ -52,7 +52,9 @@
       </header>
       <section class="card">
         <div id="palette" class="palette">
-          <div id="component-buttons"></div>
+          <div id="component-buttons">
+            <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
+          </div>
           <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
           <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
           <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>

--- a/oneline.js
+++ b/oneline.js
@@ -669,6 +669,21 @@ function init() {
       palette.appendChild(btn);
     });
   });
+  const paletteSearch = document.getElementById('palette-search');
+  paletteSearch.addEventListener('input', () => {
+    const term = paletteSearch.value.trim().toLowerCase();
+    palette.querySelectorAll('button').forEach(btn => {
+      const sub = btn.dataset.subtype.toLowerCase();
+      const label = (componentMeta[btn.dataset.subtype]?.label || '').toLowerCase();
+      btn.style.display = !term || sub.includes(term) || label.includes(term) ? '' : 'none';
+    });
+  });
+  paletteSearch.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+      paletteSearch.value = '';
+      paletteSearch.dispatchEvent(new Event('input'));
+    }
+  });
   document.getElementById('connect-btn').addEventListener('click', () => {
     connectMode = true;
     connectSource = null;


### PR DESCRIPTION
## Summary
- add palette-search input above component buttons on one-line editor
- filter component buttons by search text and reset on Esc
- style palette search field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb8aa5e64c8324aa74cfaabe59a95f