### PR TITLE
Snap connections to component ports

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -73,6 +73,13 @@
   opacity: 1;
 }
 
+.port {
+  fill: #666;
+  stroke: #fff;
+  stroke-width: 1;
+  pointer-events: none;
+}
+
 #prop-modal {
   top: 10px;
   right: 10px;


### PR DESCRIPTION
## Summary
- add left/right port definitions for all components
- snap new connections to nearest ports and store port indices
- display port markers when connecting for visual guidance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb8d622aa48324b1a55f8cffc4dfdb