### PR TITLE
Add diagram validation with UI feedback

### DIFF
--- a/icons/toolbar/validate.svg
+++ b/icons/toolbar/validate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="20 6 9 17 4 12"/>
+</svg>

--- a/oneline.css
+++ b/oneline.css
@@ -83,6 +83,16 @@
   right: 10px;
 }
 
+#validation-modal {
+  top: 90px;
+  right: 10px;
+  max-width: 300px;
+}
+
+.component.invalid text {
+  fill: #c00;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/oneline.html
+++ b/oneline.html
@@ -67,6 +67,7 @@
           <button id="export-btn" class="icon-button" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
           <input type="file" id="import-input" accept=".json" class="hidden-input">
           <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
+          <button id="validate-btn" class="icon-button" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
           <label class="grid-label"><input type="checkbox" id="grid-toggle" checked> Grid</label>
           <input type="number" id="grid-size" value="20" min="1" title="Grid size">
         </div>
@@ -110,6 +111,7 @@
           </svg>
           <div id="prop-modal" class="prop-modal"></div>
           <div id="cable-modal" class="prop-modal"></div>
+          <div id="validation-modal" class="prop-modal"></div>
           <ul id="context-menu" class="context-menu">
             <li data-action="edit" data-context="component">Edit Properties</li>
             <li data-action="delete" data-context="component">Delete</li>

--- a/oneline.js
+++ b/oneline.js
@@ -47,6 +47,7 @@ let gridSize = Number(getItem('gridSize', 20));
 let gridEnabled = true;
 let history = [];
 let historyIndex = -1;
+let validationIssues = [];
 const compWidth = 80;
 const compHeight = 40;
 
@@ -355,6 +356,7 @@ function save(notify = true) {
   }));
   setOneLine(comps);
   syncSchedules(notify);
+  validateDiagram();
 }
 
 function addComponent(subtype) {
@@ -674,6 +676,7 @@ function init() {
   pushHistory();
   render();
   syncSchedules(false);
+  validateDiagram();
 
   const palette = document.getElementById('component-buttons');
   Object.entries(componentTypes).forEach(([type, subs]) => {
@@ -718,6 +721,34 @@ function init() {
   document.getElementById('export-btn').addEventListener('click', exportDiagram);
   document.getElementById('import-btn').addEventListener('click', () => document.getElementById('import-input').click());
   document.getElementById('import-input').addEventListener('change', importDiagram);
+  document.getElementById('validate-btn').addEventListener('click', () => {
+    const issues = validateDiagram();
+    const modal = document.getElementById('validation-modal');
+    modal.innerHTML = '';
+    const header = document.createElement('h3');
+    header.textContent = issues.length ? 'Validation Issues' : 'No issues found';
+    modal.appendChild(header);
+    if (issues.length) {
+      const list = document.createElement('ul');
+      issues.forEach(issue => {
+        const li = document.createElement('li');
+        li.textContent = issue.message;
+        li.style.cursor = 'pointer';
+        li.addEventListener('click', () => {
+          modal.classList.remove('show');
+          focusComponent(issue.component);
+        });
+        list.appendChild(li);
+      });
+      modal.appendChild(list);
+    }
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.textContent = 'Close';
+    closeBtn.addEventListener('click', () => modal.classList.remove('show'));
+    modal.appendChild(closeBtn);
+    modal.classList.add('show');
+  });
 
   const gridToggle = document.getElementById('grid-toggle');
   const gridSizeInput = document.getElementById('grid-size');
@@ -1033,6 +1064,101 @@ function showToast(msg) {
   t.textContent = msg;
   t.classList.add('show');
   setTimeout(() => t.classList.remove('show'), 3000);
+}
+
+function validateDiagram() {
+  validationIssues = [];
+  const svg = document.getElementById('diagram');
+  if (!svg) return validationIssues;
+  // reset any previous markers
+  svg.querySelectorAll('g.component').forEach(g => {
+    g.classList.remove('invalid');
+    const comp = components.find(c => c.id === g.dataset.id);
+    if (!comp) return;
+    const tip = [];
+    if (comp.label) tip.push(`Label: ${comp.label}`);
+    if (comp.voltage) tip.push(`Voltage: ${comp.voltage}`);
+    if (comp.rating) tip.push(`Rating: ${comp.rating}`);
+    g.setAttribute('data-tooltip', tip.join('\n'));
+  });
+
+  const labelMap = new Map();
+  const refMap = new Map();
+  const inbound = new Map();
+  components.forEach(c => {
+    if (c.label) labelMap.set(c.label, (labelMap.get(c.label) || 0) + 1);
+    if (c.ref) refMap.set(c.ref, (refMap.get(c.ref) || 0) + 1);
+    inbound.set(c.id, 0);
+  });
+
+  components.forEach(c => {
+    (c.connections || []).forEach(conn => {
+      inbound.set(conn.target, (inbound.get(conn.target) || 0) + 1);
+      const target = components.find(t => t.id === conn.target);
+      if (target && c.voltage && target.voltage && c.voltage !== target.voltage) {
+        validationIssues.push({
+          component: c.id,
+          message: `Voltage mismatch with ${target.label || target.subtype || target.id}`
+        });
+        validationIssues.push({
+          component: target.id,
+          message: `Voltage mismatch with ${c.label || c.subtype || c.id}`
+        });
+      }
+    });
+  });
+
+  components.forEach(c => {
+    if ((c.connections || []).length + (inbound.get(c.id) || 0) === 0) {
+      validationIssues.push({ component: c.id, message: 'Unconnected component' });
+    }
+  });
+
+  labelMap.forEach((count, label) => {
+    if (count > 1) {
+      components.filter(c => c.label === label).forEach(c => {
+        validationIssues.push({ component: c.id, message: `Duplicate label "${label}"` });
+      });
+    }
+  });
+
+  refMap.forEach((count, ref) => {
+    if (count > 1) {
+      components.filter(c => c.ref === ref).forEach(c => {
+        validationIssues.push({ component: c.id, message: `Duplicate ref "${ref}"` });
+      });
+    }
+  });
+
+  const byComp = {};
+  validationIssues.forEach(issue => {
+    if (!byComp[issue.component]) byComp[issue.component] = [];
+    byComp[issue.component].push(issue.message);
+  });
+
+  Object.entries(byComp).forEach(([id, msgs]) => {
+    const g = svg.querySelector(`g.component[data-id="${id}"]`);
+    if (!g) return;
+    g.classList.add('invalid');
+    const existing = g.getAttribute('data-tooltip');
+    const tip = existing ? existing + '\n' + msgs.join('\n') : msgs.join('\n');
+    g.setAttribute('data-tooltip', tip);
+  });
+
+  showToast(validationIssues.length ? `Validation found ${validationIssues.length} issue${validationIssues.length === 1 ? '' : 's'}` : 'Diagram valid');
+  return validationIssues;
+}
+
+function focusComponent(id) {
+  const comp = components.find(c => c.id === id);
+  if (!comp) return;
+  selection = [comp];
+  selected = comp;
+  selectedConnection = null;
+  render();
+  const svg = document.getElementById('diagram');
+  const g = svg.querySelector(`g.component[data-id="${id}"]`);
+  if (g && g.scrollIntoView) g.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
 }
 
 function syncSchedules(notify = true) {


### PR DESCRIPTION
## Summary
- validate diagrams for unconnected components, duplicate refs/labels, and voltage mismatches
- run validation after saves and surface issues via tooltips and toasts
- add toolbar Validate button and modal to navigate to problem components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb8e84847c83248a22f1d1e7be143a