### PR TITLE
feat: add multi-sheet oneline editor

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -196,13 +196,29 @@ export const removeEquipment = index => {
  */
 
 /**
- * @returns {OneLineComponent[]}
+ * @typedef {Object} OneLineSheet
+ * @property {string} name
+ * @property {OneLineComponent[]} components
  */
-export const getOneLine = () => read(KEYS.oneLine, []);
+
 /**
- * @param {OneLineComponent[]} comps
+ * Retrieve saved one-line sheets. Supports legacy single-sheet format.
+ * @returns {OneLineSheet[]}
  */
-export const setOneLine = comps => write(KEYS.oneLine, comps);
+export const getOneLine = () => {
+  const data = read(KEYS.oneLine, []);
+  if (Array.isArray(data)) {
+    // legacy array of components
+    return [{ name: 'Sheet 1', components: data }];
+  }
+  if (data && Array.isArray(data.sheets)) return data.sheets;
+  return [];
+};
+/**
+ * Persist one-line sheets
+ * @param {OneLineSheet[]} sheets
+ */
+export const setOneLine = sheets => write(KEYS.oneLine, { sheets });
 
 /**
  * @returns {GenericRecord[]}
@@ -474,7 +490,7 @@ export function importProject(obj) {
   setPanels(Array.isArray(data.panels) ? data.panels : []);
   setEquipment(Array.isArray(data.equipment) ? data.equipment : []);
   setLoads(Array.isArray(data.loads) ? data.loads : []);
-  setOneLine(Array.isArray(data.oneLine) ? data.oneLine : []);
+  setOneLine(Array.isArray(data.oneLine) ? data.oneLine : Array.isArray(data.oneLine?.sheets) ? data.oneLine.sheets : []);
 
   const reserved = new Set([...Object.values(KEYS), 'CTR_PROJECT_V1']);
   for (const key of keys()) {

--- a/oneline.css
+++ b/oneline.css
@@ -36,6 +36,30 @@
   display: none;
 }
 
+.sheet-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--ol-spacing);
+  margin-bottom: var(--ol-spacing);
+}
+
+.sheet-tabs {
+  display: flex;
+  gap: var(--ol-spacing);
+}
+
+.sheet-tab {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--ol-border-color);
+  background: var(--ol-card-bg);
+  cursor: pointer;
+}
+
+.sheet-tab.active {
+  background: var(--ol-hover-bg);
+  font-weight: bold;
+}
+
 .oneline-editor {
   position: relative;
 }

--- a/oneline.html
+++ b/oneline.html
@@ -51,6 +51,12 @@
         <p>Create and link components to schedules.</p>
       </header>
       <section class="card">
+        <div class="sheet-controls">
+          <div id="sheet-tabs" class="sheet-tabs"></div>
+          <button id="add-sheet-btn">Add Sheet</button>
+          <button id="rename-sheet-btn">Rename Sheet</button>
+          <button id="delete-sheet-btn">Delete Sheet</button>
+        </div>
         <div id="palette" class="palette">
           <div id="component-buttons">
             <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">


### PR DESCRIPTION
## Summary
- add dataStore sheet persistence with legacy support
- introduce multi-sheet editing with tab controls and management actions
- export all sheets and schedules in oneline export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb8f9d64a88324ae61a7f3a6c45889