### PR TITLE
feat: add component template support

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -60,6 +60,13 @@
         <div id="palette" class="palette">
           <div id="component-buttons">
             <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
+            <details id="template-section">
+              <summary>Templates</summary>
+              <div id="template-buttons"></div>
+              <button id="template-export-btn" type="button">Export</button>
+              <input type="file" id="template-import-input" accept=".json" class="hidden-input">
+              <button id="template-import-btn" type="button">Import</button>
+            </details>
           </div>
           <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
           <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>


### PR DESCRIPTION
## Summary
- save component properties as reusable templates
- manage templates in a new palette section with import/export
- create components from templates at the cursor location

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb910a54a88324bdc0b621f0d36055