### PR TITLE
Add generator, UPS, motor, capacitor bank, and PV array components

### DIFF
--- a/icons/CapacitorBank.svg
+++ b/icons/CapacitorBank.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="30" y1="10" x2="30" y2="30" stroke="#333" stroke-width="2"/>
+  <line x1="40" y1="10" x2="40" y2="30" stroke="#333" stroke-width="2"/>
+  <line x1="50" y1="10" x2="50" y2="30" stroke="#333" stroke-width="2"/>
+  <line x1="20" y1="10" x2="60" y2="10" stroke="#333" stroke-width="2"/>
+  <line x1="20" y1="30" x2="60" y2="30" stroke="#333" stroke-width="2"/>
+</svg>

--- a/icons/Generator.svg
+++ b/icons/Generator.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <circle cx="40" cy="20" r="12" fill="none" stroke="#333" stroke-width="2"/>
+  <path d="M28 20h24M40 8v24" stroke="#333" stroke-width="2"/>
+</svg>

--- a/icons/Motor.svg
+++ b/icons/Motor.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <circle cx="40" cy="20" r="12" fill="#fff" stroke="#333" stroke-width="2"/>
+  <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">M</text>
+</svg>

--- a/icons/PVArray.svg
+++ b/icons/PVArray.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <rect x="15" y="8" width="50" height="24" fill="none" stroke="#333" stroke-width="2"/>
+  <line x1="30" y1="8" x2="30" y2="32" stroke="#333" stroke-width="1"/>
+  <line x1="45" y1="8" x2="45" y2="32" stroke="#333" stroke-width="1"/>
+  <line x1="15" y1="16" x2="65" y2="16" stroke="#333" stroke-width="1"/>
+  <line x1="15" y1="24" x2="65" y2="24" stroke="#333" stroke-width="1"/>
+</svg>

--- a/icons/UPS.svg
+++ b/icons/UPS.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <rect x="20" y="10" width="40" height="20" fill="none" stroke="#333" stroke-width="2"/>
+  <line x1="26" y1="20" x2="34" y2="20" stroke="#333" stroke-width="2"/>
+  <line x1="30" y1="16" x2="30" y2="24" stroke="#333" stroke-width="2"/>
+  <line x1="46" y1="20" x2="54" y2="20" stroke="#333" stroke-width="2"/>
+</svg>

--- a/oneline.js
+++ b/oneline.js
@@ -19,6 +19,24 @@ const componentMeta = {
       { x: 80, y: 20 }
     ]
   },
+  Generator: {
+    icon: 'icons/Generator.svg',
+    label: 'Generator',
+    category: 'equipment',
+    ports: [
+      { x: 0, y: 20 },
+      { x: 80, y: 20 }
+    ]
+  },
+  UPS: {
+    icon: 'icons/UPS.svg',
+    label: 'UPS',
+    category: 'equipment',
+    ports: [
+      { x: 0, y: 20 },
+      { x: 80, y: 20 }
+    ]
+  },
   Transformer: {
     icon: 'icons/Transformer.svg',
     label: 'Transformer',
@@ -31,6 +49,33 @@ const componentMeta = {
   Switchgear: {
     icon: 'icons/Switchgear.svg',
     label: 'Switchgear',
+    category: 'equipment',
+    ports: [
+      { x: 0, y: 20 },
+      { x: 80, y: 20 }
+    ]
+  },
+  Motor: {
+    icon: 'icons/Motor.svg',
+    label: 'Motor',
+    category: 'load',
+    ports: [
+      { x: 0, y: 20 },
+      { x: 80, y: 20 }
+    ]
+  },
+  CapacitorBank: {
+    icon: 'icons/CapacitorBank.svg',
+    label: 'Capacitor Bank',
+    category: 'equipment',
+    ports: [
+      { x: 0, y: 20 },
+      { x: 80, y: 20 }
+    ]
+  },
+  PVArray: {
+    icon: 'icons/PVArray.svg',
+    label: 'PV Array',
     category: 'equipment',
     ports: [
       { x: 0, y: 20 },
@@ -62,7 +107,27 @@ const propSchemas = {
   Switchgear: [{ name: 'voltage', label: 'Voltage', type: 'number' }],
   Load: [{ name: 'voltage', label: 'Voltage', type: 'number' }],
   MLO: [{ name: 'voltage', label: 'Voltage', type: 'number' }],
-  MCC: [{ name: 'voltage', label: 'Voltage', type: 'number' }]
+  MCC: [{ name: 'voltage', label: 'Voltage', type: 'number' }],
+  Generator: [
+    { name: 'voltage', label: 'Voltage', type: 'number' },
+    { name: 'kW', label: 'Power (kW)', type: 'number' }
+  ],
+  UPS: [
+    { name: 'voltage', label: 'Voltage', type: 'number' },
+    { name: 'kVA', label: 'Capacity (kVA)', type: 'number' }
+  ],
+  Motor: [
+    { name: 'voltage', label: 'Voltage', type: 'number' },
+    { name: 'phases', label: 'Phases', type: 'number' }
+  ],
+  CapacitorBank: [
+    { name: 'voltage', label: 'Voltage', type: 'number' },
+    { name: 'kVAR', label: 'Reactive Power (kVAR)', type: 'number' }
+  ],
+  PVArray: [
+    { name: 'voltage', label: 'Voltage', type: 'number' },
+    { name: 'kW', label: 'Power (kW)', type: 'number' }
+  ]
 };
 
 const subtypeCategory = {};


### PR DESCRIPTION
## Summary
- extend component metadata and property schemas with Generator, UPS, Motor, Capacitor Bank, and PV Array
- add matching SVG icons for new component subtypes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb94d58be4832482d429b2f56a5c08