### PR TITLE
Organize palette buttons into collapsible categories

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -28,6 +28,39 @@
   margin-bottom: var(--ol-spacing);
 }
 
+#component-buttons {
+  display: flex;
+  flex-direction: column;
+}
+
+#component-buttons details {
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  margin-bottom: var(--ol-spacing);
+  background: var(--ol-card-bg);
+}
+
+#component-buttons details summary {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+#component-buttons details[open] > summary {
+  border-bottom: 1px solid var(--ol-border-color);
+}
+
+#component-buttons details summary::-webkit-details-marker {
+  display: none;
+}
+
+#component-buttons .section-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ol-spacing);
+  padding: var(--ol-spacing);
+}
+
 .grid-label {
   margin-left: var(--ol-spacing);
 }

--- a/oneline.html
+++ b/oneline.html
@@ -62,9 +62,21 @@
         <div id="palette" class="palette">
           <div id="component-buttons">
             <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
-            <details id="template-section">
+            <details id="panel-section" class="palette-section">
+              <summary>Panel</summary>
+              <div id="panel-buttons" class="section-buttons"></div>
+            </details>
+            <details id="equipment-section" class="palette-section">
+              <summary>Equipment</summary>
+              <div id="equipment-buttons" class="section-buttons"></div>
+            </details>
+            <details id="load-section" class="palette-section">
+              <summary>Load</summary>
+              <div id="load-buttons" class="section-buttons"></div>
+            </details>
+            <details id="template-section" class="palette-section">
               <summary>Templates</summary>
-              <div id="template-buttons"></div>
+              <div id="template-buttons" class="section-buttons"></div>
               <button id="template-export-btn" type="button">Export</button>
               <input type="file" id="template-import-input" accept=".json" class="hidden-input">
               <button id="template-import-btn" type="button">Import</button>

--- a/oneline.js
+++ b/oneline.js
@@ -934,7 +934,17 @@ async function init() {
   validateDiagram();
 
   const palette = document.getElementById('component-buttons');
+  const sectionContainers = {
+    panel: document.getElementById('panel-buttons'),
+    equipment: document.getElementById('equipment-buttons'),
+    load: document.getElementById('load-buttons')
+  };
+  Object.entries(sectionContainers).forEach(([cat, container]) => {
+    const summary = container?.parentElement?.querySelector('summary');
+    if (summary) summary.textContent = cat.charAt(0).toUpperCase() + cat.slice(1);
+  });
   Object.entries(componentTypes).forEach(([type, subs]) => {
+    const container = sectionContainers[type] || palette;
     subs.forEach(sub => {
       const meta = componentMeta[sub];
       const btn = document.createElement('button');
@@ -943,7 +953,15 @@ async function init() {
       btn.title = meta.label;
       btn.innerHTML = `<img src="${meta.icon}" alt="" aria-hidden="true">`;
       btn.addEventListener('click', () => addComponent(sub));
-      palette.appendChild(btn);
+      container.appendChild(btn);
+    });
+  });
+  document.querySelectorAll('#component-buttons details').forEach(det => {
+    const key = `palette-${det.id}-open`;
+    const stored = localStorage.getItem(key);
+    if (stored !== null) det.open = stored === 'true';
+    det.addEventListener('toggle', () => {
+      localStorage.setItem(key, det.open);
     });
   });
   const paletteSearch = document.getElementById('palette-search');


### PR DESCRIPTION
## Summary
- Group oneline palette buttons into Panel, Equipment, and Load sections
- Generate palette buttons within their respective categories and persist section state
- Style new `<details>` sections for compact layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9678481883249c033109675e454c