### PR TITLE
Add metadata fields for one-line components

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -6,7 +6,11 @@
     "category": "panel",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
-      { "name": "voltage", "label": "Voltage", "type": "number" }
+      { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -16,7 +20,11 @@
     "category": "panel",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
-      { "name": "voltage", "label": "Voltage", "type": "number" }
+      { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -27,7 +35,11 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
-      { "name": "kW", "label": "Power (kW)", "type": "number" }
+      { "name": "kW", "label": "Power (kW)", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -38,7 +50,11 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
-      { "name": "kVA", "label": "Capacity (kVA)", "type": "number" }
+      { "name": "kVA", "label": "Capacity (kVA)", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -49,7 +65,11 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
-      { "name": "rating", "label": "Rating", "type": "number" }
+      { "name": "rating", "label": "Rating", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -59,7 +79,11 @@
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
-      { "name": "voltage", "label": "Voltage", "type": "number" }
+      { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -70,7 +94,10 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
-      { "name": "phases", "label": "Phases", "type": "number" }
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -81,7 +108,11 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
-      { "name": "kVAR", "label": "Reactive Power (kVAR)", "type": "number" }
+      { "name": "kVAR", "label": "Reactive Power (kVAR)", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -92,7 +123,11 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
-      { "name": "kW", "label": "Power (kW)", "type": "number" }
+      { "name": "kW", "label": "Power (kW)", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   },
   {
@@ -102,7 +137,11 @@
     "category": "load",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
-      { "name": "voltage", "label": "Voltage", "type": "number" }
+      { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
+      { "name": "model", "label": "Model", "type": "text" },
+      { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
     ]
   }
 ]

--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -156,6 +156,10 @@ function ensureEquipmentFields(eq) {
     x: '',
     y: '',
     z: '',
+    manufacturer: '',
+    model: '',
+    phases: '',
+    notes: '',
     ...eq
   };
 }
@@ -255,6 +259,9 @@ function ensureLoadFields(load) {
     demandFactor: '',
     phases: '',
     circuit: '',
+    manufacturer: '',
+    model: '',
+    notes: '',
     ...l
   };
 }

--- a/oneline.js
+++ b/oneline.js
@@ -647,10 +647,25 @@ function selectComponent(comp) {
   [...baseFields, ...schema].forEach(f => {
     const lbl = document.createElement('label');
     lbl.textContent = f.label + ' ';
-    const input = document.createElement('input');
-    input.type = f.type || 'text';
+    let input;
+    if (f.type === 'select') {
+      input = document.createElement('select');
+      (f.options || []).forEach(opt => {
+        const o = document.createElement('option');
+        o.value = opt;
+        o.textContent = opt;
+        if ((comp[f.name] || '') == opt) o.selected = true;
+        input.appendChild(o);
+      });
+    } else if (f.type === 'textarea') {
+      input = document.createElement('textarea');
+      input.value = comp[f.name] || '';
+    } else {
+      input = document.createElement('input');
+      input.type = f.type || 'text';
+      input.value = comp[f.name] || '';
+    }
     input.name = f.name;
-    input.value = comp[f.name] || '';
     lbl.appendChild(input);
     form.appendChild(lbl);
   });
@@ -1449,15 +1464,23 @@ function focusComponent(id) {
 
 function syncSchedules(notify = true) {
   const all = sheets.flatMap(s => s.components);
+  const mapFields = c => ({
+    id: c.ref || c.id,
+    description: c.label,
+    manufacturer: c.manufacturer || '',
+    model: c.model || '',
+    phases: c.phases || '',
+    notes: c.notes || ''
+  });
   const equipment = all
     .filter(c => getCategory(c) === 'equipment')
-    .map(c => ({ id: c.ref || c.id, description: c.label }));
+    .map(mapFields);
   const panels = all
     .filter(c => getCategory(c) === 'panel')
-    .map(c => ({ id: c.ref || c.id, description: c.label }));
+    .map(mapFields);
   const loads = all
     .filter(c => getCategory(c) === 'load')
-    .map(c => ({ id: c.ref || c.id, description: c.label }));
+    .map(mapFields);
   setEquipment(equipment);
   setPanels(panels);
   setLoads(loads);
@@ -1482,15 +1505,23 @@ function syncSchedules(notify = true) {
 function exportDiagram() {
   save(false);
   function extractSchedules(comps) {
+    const mapFields = c => ({
+      id: c.ref || c.id,
+      description: c.label,
+      manufacturer: c.manufacturer || '',
+      model: c.model || '',
+      phases: c.phases || '',
+      notes: c.notes || ''
+    });
     const equipment = comps
       .filter(c => getCategory(c) === 'equipment')
-      .map(c => ({ id: c.ref || c.id, description: c.label }));
+      .map(mapFields);
     const panels = comps
       .filter(c => getCategory(c) === 'panel')
-      .map(c => ({ id: c.ref || c.id, description: c.label }));
+      .map(mapFields);
     const loads = comps
       .filter(c => getCategory(c) === 'load')
-      .map(c => ({ id: c.ref || c.id, description: c.label }));
+      .map(mapFields);
     const cables = [];
     comps.forEach(c => {
       (c.connections || []).forEach(conn => {


### PR DESCRIPTION
## Summary
- include manufacturer, model, phases dropdown, and notes textarea in component schemas
- render new input types in the one-line editor
- store and export the new fields via equipment, panel, and load schedules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb9756477083248c0ef323062ee38d