### PR TITLE
feat: add category label prefixes

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -45,6 +45,7 @@
     <button id="export-project-btn">Export Project</button>
     <button id="import-project-btn">Import Project</button>
     <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
+    <button id="prefix-settings-btn">Label Prefixes</button>
   </div>
   <div class="container">
     <main id="main-content" class="main-content">


### PR DESCRIPTION
## Summary
- allow configuring default label prefixes per component type
- auto-assign labels with persistent counters
- validate diagram warns on duplicate labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9862edcc83249b2289dbee54028d