### PR TITLE
Add manufacturer defaults library and update panel

### DIFF
--- a/manufacturerLibrary.json
+++ b/manufacturerLibrary.json
@@ -1,0 +1,62 @@
+{
+  "MLO": {
+    "manufacturer": "Generic",
+    "model": "MLO-1000",
+    "voltage": 480,
+    "ratings": "1000A"
+  },
+  "MCC": {
+    "manufacturer": "Generic",
+    "model": "MCC-200",
+    "voltage": 480,
+    "ratings": "200A"
+  },
+  "Generator": {
+    "manufacturer": "Generic",
+    "model": "GEN-500",
+    "voltage": 480,
+    "ratings": "500kW"
+  },
+  "UPS": {
+    "manufacturer": "Generic",
+    "model": "UPS-100",
+    "voltage": 480,
+    "ratings": "100kVA"
+  },
+  "Transformer": {
+    "manufacturer": "Generic",
+    "model": "XFMR-75",
+    "voltage": 480,
+    "ratings": "75kVA"
+  },
+  "Switchgear": {
+    "manufacturer": "Generic",
+    "model": "SWG-1200",
+    "voltage": 480,
+    "ratings": "1200A"
+  },
+  "Motor": {
+    "manufacturer": "Generic",
+    "model": "MTR-10",
+    "voltage": 480,
+    "ratings": "10HP"
+  },
+  "CapacitorBank": {
+    "manufacturer": "Generic",
+    "model": "CAP-50",
+    "voltage": 480,
+    "ratings": "50kVAR"
+  },
+  "PVArray": {
+    "manufacturer": "Generic",
+    "model": "PV-100",
+    "voltage": 600,
+    "ratings": "100kW"
+  },
+  "Load": {
+    "manufacturer": "Generic",
+    "model": "LOAD-1",
+    "voltage": 480,
+    "ratings": "10kW"
+  }
+}

--- a/oneline.html
+++ b/oneline.html
@@ -46,6 +46,7 @@
     <button id="import-project-btn">Import Project</button>
     <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
     <button id="prefix-settings-btn">Label Prefixes</button>
+    <button id="update-defaults-btn">Update Defaults</button>
   </div>
   <div class="container">
     <main id="main-content" class="main-content">
@@ -142,6 +143,7 @@
           <div id="prop-modal" class="prop-modal"></div>
           <div id="cable-modal" class="prop-modal"></div>
           <div id="validation-modal" class="prop-modal"></div>
+          <div id="defaults-modal" class="prop-modal"></div>
           <ul id="context-menu" class="context-menu">
             <li data-action="edit" data-context="component">Edit Properties</li>
             <li data-action="delete" data-context="component">Delete</li>


### PR DESCRIPTION
## Summary
- introduce `manufacturerLibrary.json` with default manufacturer data for each component subtype
- preload component properties with these defaults in one-line editor and allow overrides
- add an Update Defaults admin panel to manage manufacturer templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba1bd64fc8324be6283297a66debd