### PR TITLE
Add diagram validation with sidebar warnings

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -157,6 +157,10 @@
   fill: #c00;
 }
 
+.issue-badge {
+  pointer-events: none;
+}
+
 .voltage-legend {
   position: absolute;
   top: 10px;

--- a/oneline.html
+++ b/oneline.html
@@ -155,6 +155,13 @@
       </section>
     </main>
   </div>
+  <aside id="lint-panel" class="lint-panel hidden" aria-label="Validation issues">
+    <div class="lint-header">
+      <h2>Fix-it Hints</h2>
+      <button id="lint-close-btn" class="lint-close-btn" aria-label="Close">&times;</button>
+    </div>
+    <ul id="lint-list"></ul>
+  </aside>
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add lint panel and warning badges for diagram validation issues
- Validate diagram on save and on demand; only sync schedules when valid
- Report unconnected components, duplicate IDs, and voltage mismatches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba3f7a20483249c97467cb088ec7f