### PR TITLE
feat(oneline): add diagram import-export with versioning

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -60,6 +60,10 @@
           <button id="add-sheet-btn">Add Sheet</button>
           <button id="rename-sheet-btn">Rename Sheet</button>
           <button id="delete-sheet-btn">Delete Sheet</button>
+          <button id="diagram-export-btn" type="button">Export Diagram</button>
+          <input type="file" id="diagram-import-input" accept=".json" class="hidden-input">
+          <button id="diagram-import-btn" type="button">Import Diagram</button>
+          <button id="diagram-share-btn" type="button">Share Diagram</button>
         </div>
         <div id="palette" class="palette">
           <div id="component-buttons">


### PR DESCRIPTION
## Summary
- add explicit Export/Import/Share Diagram controls to one-line editor
- serialize full diagram with templates and schema version
- migrate older diagram JSON and support sharing via GitHub Gist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bba6369838832494d3bbd4ad5d5872