### PR TITLE
feat: add dimension annotations

### DIFF
--- a/icons/toolbar/dimension.svg
+++ b/icons/toolbar/dimension.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 12h16" stroke="black" stroke-width="2" fill="none"/>
+  <path d="M4 12l4-4M4 12l4 4" stroke="black" stroke-width="2" fill="none"/>
+  <path d="M20 12l-4-4M20 12l-4 4" stroke="black" stroke-width="2" fill="none"/>
+</svg>

--- a/oneline.css
+++ b/oneline.css
@@ -65,6 +65,10 @@
   margin-left: var(--ol-spacing);
 }
 
+.scale-label {
+  margin-left: var(--ol-spacing);
+}
+
 .hidden-input {
   display: none;
 }
@@ -190,6 +194,16 @@
   height: 12px;
   border: 1px solid var(--ol-border-color);
   display: inline-block;
+}
+
+.dimension {
+  stroke: #000;
+}
+
+.dim-label {
+  font-size: 10px;
+  fill: #000;
+  pointer-events: none;
 }
 
 @keyframes fadeIn {

--- a/oneline.html
+++ b/oneline.html
@@ -89,6 +89,7 @@
             </details>
           </div>
           <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
+          <button id="dimension-btn" class="icon-button" title="Dimension" aria-label="Dimension"><img src="icons/toolbar/dimension.svg" alt=""></button>
           <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
           <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
           <button id="align-left-btn" class="icon-button" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
@@ -104,6 +105,7 @@
           <button id="validate-btn" class="icon-button" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
           <label class="grid-label"><input type="checkbox" id="grid-toggle" checked> Grid</label>
           <input type="number" id="grid-size" value="20" min="1" title="Grid size">
+          <label class="scale-label">1 px = <input type="number" id="scale-value" value="1" step="0.01" min="0"> <input type="text" id="scale-unit" value="in" size="3" aria-label="Scale unit"></label>
         </div>
         <div class="oneline-editor">
           <svg id="diagram" width="800" height="600">


### PR DESCRIPTION
## Summary
- add palette button to create dimension lines
- support custom diagram scale for measurements
- export dimension annotations with diagram state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bba89719548324ba42af7b3f6e3329