### PR TITLE
Add guided tour to one-line diagram

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -216,3 +216,31 @@
     animation: fadeIn 0.3s ease-out;
   }
 }
+
+.tour-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.tour-modal {
+  background: var(--ol-card-bg);
+  padding: 1rem;
+  border-radius: var(--ol-radius);
+  max-width: 300px;
+  text-align: center;
+  z-index: 1002;
+}
+
+.tour-highlight {
+  position: relative;
+  z-index: 1001;
+  box-shadow: 0 0 0 4px orange;
+}

--- a/oneline.html
+++ b/oneline.html
@@ -64,6 +64,7 @@
           <input type="file" id="diagram-import-input" accept=".json" class="hidden-input">
           <button id="diagram-import-btn" type="button">Import Diagram</button>
           <button id="diagram-share-btn" type="button">Share Diagram</button>
+          <button id="tour-btn" type="button">Tour</button>
         </div>
         <div id="palette" class="palette">
           <div id="component-buttons">

--- a/oneline.js
+++ b/oneline.js
@@ -96,6 +96,49 @@ const lintList = document.getElementById('lint-list');
 const lintCloseBtn = document.getElementById('lint-close-btn');
 if (lintCloseBtn) lintCloseBtn.addEventListener('click', () => lintPanel.classList.add('hidden'));
 
+// Guided tour steps
+const tourSteps = [
+  { element: '#component-buttons', text: 'Add components from the palette.' },
+  { element: '#connect-btn', text: 'Connect components using this button then selecting two components.' },
+  { element: '#diagram', text: 'Select a component to edit its properties.' },
+  { element: '#export-btn', text: 'Use Export to download your diagram.' }
+];
+let tourIndex = 0;
+let tourOverlay = null;
+
+function showTourStep() {
+  const step = tourSteps[tourIndex];
+  tourOverlay.querySelector('#tour-text').textContent = step.text;
+  document.querySelectorAll('.tour-highlight').forEach(el => el.classList.remove('tour-highlight'));
+  const el = document.querySelector(step.element);
+  if (el) el.classList.add('tour-highlight');
+  const next = tourOverlay.querySelector('#tour-next');
+  next.textContent = tourIndex === tourSteps.length - 1 ? 'Finish' : 'Next';
+}
+
+function endTour() {
+  document.querySelectorAll('.tour-highlight').forEach(el => el.classList.remove('tour-highlight'));
+  tourOverlay?.remove();
+  tourOverlay = null;
+}
+
+function startTour() {
+  tourIndex = 0;
+  tourOverlay = document.createElement('div');
+  tourOverlay.className = 'tour-overlay';
+  tourOverlay.innerHTML = `<div class="tour-modal"><p id="tour-text"></p><button id="tour-next">Next</button></div>`;
+  document.body.appendChild(tourOverlay);
+  tourOverlay.querySelector('#tour-next').addEventListener('click', () => {
+    tourIndex++;
+    if (tourIndex >= tourSteps.length) {
+      endTour();
+    } else {
+      showTourStep();
+    }
+  });
+  showTourStep();
+}
+
 // Prefix settings and counters for component labels
 let labelPrefixes = getItem('labelPrefixes', {});
 let labelCounters = getItem('labelCounters', {});
@@ -1606,6 +1649,16 @@ async function init() {
       }
     }
   });
+
+  const tourBtn = document.getElementById('tour-btn');
+  if (tourBtn) tourBtn.addEventListener('click', () => {
+    startTour();
+    localStorage.setItem('onelineTourDone', 'true');
+  });
+  if (!localStorage.getItem('onelineTourDone')) {
+    startTour();
+    localStorage.setItem('onelineTourDone', 'true');
+  }
 
   initSettings();
   initDarkMode();


### PR DESCRIPTION
## Summary
- add Tour button to one-line editor
- implement step-by-step overlay guiding basic actions
- run tour once per browser session using localStorage flag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba9e41f288324a7e0a968046bfad0