### PR TITLE
Expand mapped fields in schedule synchronization

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -1799,14 +1799,26 @@ function focusComponent(id) {
 
 function syncSchedules(notify = true) {
   const all = sheets.flatMap(s => s.components);
-  const mapFields = c => ({
-    id: c.ref || c.id,
-    description: c.label,
-    manufacturer: c.manufacturer || '',
-    model: c.model || '',
-    phases: c.phases || '',
-    notes: c.notes || ''
-  });
+  const mapFields = c => {
+    const fields = {
+      id: c.ref || c.id,
+      description: c.label,
+      manufacturer: c.manufacturer ?? '',
+      model: c.model ?? '',
+      phases: c.phases ?? '',
+      notes: c.notes ?? '',
+      voltage: c.voltage ?? '',
+      category: getCategory(c),
+      subCategory: c.subtype ?? '',
+      x: c.x ?? '',
+      y: c.y ?? '',
+      z: c.z ?? ''
+    };
+    (propSchemas[c.subtype] || []).forEach(f => {
+      fields[f.name] = c[f.name] ?? fields[f.name] ?? '';
+    });
+    return fields;
+  };
   const equipment = all
     .filter(c => getCategory(c) === 'equipment')
     .map(mapFields);
@@ -1840,14 +1852,26 @@ function syncSchedules(notify = true) {
 function serializeState() {
   save(false);
   function extractSchedules(comps) {
-    const mapFields = c => ({
-      id: c.ref || c.id,
-      description: c.label,
-      manufacturer: c.manufacturer || '',
-      model: c.model || '',
-      phases: c.phases || '',
-      notes: c.notes || ''
-    });
+    const mapFields = c => {
+      const fields = {
+        id: c.ref || c.id,
+        description: c.label,
+        manufacturer: c.manufacturer ?? '',
+        model: c.model ?? '',
+        phases: c.phases ?? '',
+        notes: c.notes ?? '',
+        voltage: c.voltage ?? '',
+        category: getCategory(c),
+        subCategory: c.subtype ?? '',
+        x: c.x ?? '',
+        y: c.y ?? '',
+        z: c.z ?? ''
+      };
+      (propSchemas[c.subtype] || []).forEach(f => {
+        fields[f.name] = c[f.name] ?? fields[f.name] ?? '';
+      });
+      return fields;
+    };
     const equipment = comps
       .filter(c => getCategory(c) === 'equipment')
       .map(mapFields);


### PR DESCRIPTION
## Summary
- Include voltage, category, subCategory, and coordinates when mapping components for schedules
- Dynamically copy schema-defined properties so equipment, panel, and load tables show custom fields
- Extend serialization to output the enriched schedule records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbac6c068883248a3e2daaa6c7c6c9