### PR TITLE
feat: add configurable component libraries

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -7,6 +7,10 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["100A", "225A", "400A", "600A", "800A", "1200A"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["150A", "250A", "400A", "600A", "800A", "1200A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -21,6 +25,10 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["200A", "400A", "600A", "800A", "1200A"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["250A", "400A", "600A", "800A", "1200A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -36,6 +44,10 @@
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
       { "name": "kW", "label": "Power (kW)", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["100kW", "250kW", "500kW", "750kW", "1000kW"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["250A", "400A", "600A", "800A", "1200A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -51,6 +63,10 @@
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
       { "name": "kVA", "label": "Capacity (kVA)", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["50kVA", "100kVA", "200kVA", "500kVA", "1000kVA"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["250A", "400A", "600A", "800A", "1200A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -65,7 +81,10 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
-      { "name": "rating", "label": "Rating", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["45kVA", "75kVA", "112.5kVA", "150kVA", "225kVA", "300kVA"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["250A", "400A", "600A", "800A", "1200A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -80,6 +99,10 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["400A", "600A", "800A", "1200A", "2000A"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["400A", "600A", "800A", "1200A", "2000A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -94,6 +117,10 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["5HP", "10HP", "20HP", "50HP", "100HP"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["100A", "225A", "400A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -109,6 +136,10 @@
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
       { "name": "kVAR", "label": "Reactive Power (kVAR)", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["25kVAR", "50kVAR", "75kVAR", "100kVAR"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["100A", "225A", "400A", "600A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -124,6 +155,10 @@
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
       { "name": "kW", "label": "Power (kW)", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["25kW", "50kW", "75kW", "100kW"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["100A", "225A", "400A", "600A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -138,6 +173,10 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["5kW", "10kW", "20kW", "50kW"] },
+      { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["100A", "225A", "400A"] },
+      { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },
+      { "name": "cable_assembly", "label": "Cable Assembly", "type": "select", "options": ["Tray Cable", "MC Cable", "SER Cable"] },
       { "name": "manufacturer", "label": "Manufacturer", "type": "text" },
       { "name": "model", "label": "Model", "type": "text" },
       { "name": "phases", "label": "Phases", "type": "select", "options": ["1", "3"] },
@@ -145,3 +184,4 @@
     ]
   }
 ]
+

--- a/library.html
+++ b/library.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Library Manager</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Library Manager</h1>
+  <section>
+    <h2>Component Library</h2>
+    <textarea id="component-text" rows="20" cols="80"></textarea><br>
+    <button id="component-save">Save</button>
+    <button id="component-download">Download</button>
+  </section>
+  <section>
+    <h2>Manufacturer Library</h2>
+    <textarea id="manufacturer-text" rows="20" cols="80"></textarea><br>
+    <button id="manufacturer-save">Save</button>
+    <button id="manufacturer-download">Download</button>
+  </section>
+  <script type="module">
+    import { getItem, setItem } from './dataStore.mjs';
+
+    async function load() {
+      const compArea = document.getElementById('component-text');
+      const manufArea = document.getElementById('manufacturer-text');
+      try {
+        const res = await fetch('componentLibrary.json');
+        const data = await res.json();
+        const stored = getItem('componentLibrary', null);
+        compArea.value = JSON.stringify(stored || data, null, 2);
+      } catch {
+        compArea.value = '[]';
+      }
+      try {
+        const res2 = await fetch('manufacturerLibrary.json');
+        const data2 = await res2.json();
+        const stored2 = getItem('manufacturerDefaults', null);
+        manufArea.value = JSON.stringify(stored2 || data2, null, 2);
+      } catch {
+        manufArea.value = '{}';
+      }
+    }
+
+    function save(id, key) {
+      const area = document.getElementById(id);
+      try {
+        const json = JSON.parse(area.value);
+        setItem(key, json);
+        alert('Saved');
+      } catch {
+        alert('Invalid JSON');
+      }
+    }
+
+    function download(id, filename) {
+      const area = document.getElementById(id);
+      const blob = new Blob([area.value], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(a.href);
+    }
+
+    document.getElementById('component-save').addEventListener('click', () => save('component-text', 'componentLibrary'));
+    document.getElementById('manufacturer-save').addEventListener('click', () => save('manufacturer-text', 'manufacturerDefaults'));
+    document.getElementById('component-download').addEventListener('click', () => download('component-text', 'componentLibrary.json'));
+    document.getElementById('manufacturer-download').addEventListener('click', () => download('manufacturer-text', 'manufacturerLibrary.json'));
+
+    load();
+  </script>
+</body>
+</html>
+

--- a/manufacturerLibrary.json
+++ b/manufacturerLibrary.json
@@ -3,60 +3,91 @@
     "manufacturer": "Generic",
     "model": "MLO-1000",
     "voltage": 480,
-    "ratings": "1000A"
+    "rating": "1000A",
+    "breaker_frame": "400A",
+    "conductor_type": "THHN",
+    "cable_assembly": "Tray Cable"
   },
   "MCC": {
     "manufacturer": "Generic",
     "model": "MCC-200",
     "voltage": 480,
-    "ratings": "200A"
+    "rating": "200A",
+    "breaker_frame": "250A",
+    "conductor_type": "THHN",
+    "cable_assembly": "Tray Cable"
   },
   "Generator": {
     "manufacturer": "Generic",
     "model": "GEN-500",
     "voltage": 480,
-    "ratings": "500kW"
+    "rating": "500kW",
+    "breaker_frame": "400A",
+    "conductor_type": "XHHW",
+    "cable_assembly": "MC Cable"
   },
   "UPS": {
     "manufacturer": "Generic",
     "model": "UPS-100",
     "voltage": 480,
-    "ratings": "100kVA"
+    "rating": "100kVA",
+    "breaker_frame": "250A",
+    "conductor_type": "THHN",
+    "cable_assembly": "Tray Cable"
   },
   "Transformer": {
     "manufacturer": "Generic",
     "model": "XFMR-75",
     "voltage": 480,
-    "ratings": "75kVA"
+    "rating": "75kVA",
+    "breaker_frame": "250A",
+    "conductor_type": "XHHW",
+    "cable_assembly": "MC Cable"
   },
   "Switchgear": {
     "manufacturer": "Generic",
     "model": "SWG-1200",
     "voltage": 480,
-    "ratings": "1200A"
+    "rating": "1200A",
+    "breaker_frame": "1200A",
+    "conductor_type": "THHN",
+    "cable_assembly": "Tray Cable"
   },
   "Motor": {
     "manufacturer": "Generic",
     "model": "MTR-10",
     "voltage": 480,
-    "ratings": "10HP"
+    "rating": "10HP",
+    "breaker_frame": "100A",
+    "conductor_type": "THHN",
+    "cable_assembly": "MC Cable"
   },
   "CapacitorBank": {
     "manufacturer": "Generic",
     "model": "CAP-50",
     "voltage": 480,
-    "ratings": "50kVAR"
+    "rating": "50kVAR",
+    "breaker_frame": "225A",
+    "conductor_type": "THHN",
+    "cable_assembly": "Tray Cable"
   },
   "PVArray": {
     "manufacturer": "Generic",
     "model": "PV-100",
     "voltage": 600,
-    "ratings": "100kW"
+    "rating": "100kW",
+    "breaker_frame": "225A",
+    "conductor_type": "XHHW",
+    "cable_assembly": "SER Cable"
   },
   "Load": {
     "manufacturer": "Generic",
     "model": "LOAD-1",
     "voltage": 480,
-    "ratings": "10kW"
+    "rating": "10kW",
+    "breaker_frame": "100A",
+    "conductor_type": "THHN",
+    "cable_assembly": "Tray Cable"
   }
 }
+

--- a/oneline.js
+++ b/oneline.js
@@ -14,22 +14,25 @@ let componentTypes = {};
 let manufacturerDefaults = {};
 
 async function loadComponentLibrary() {
+  let data = [];
   try {
     const res = await fetch('componentLibrary.json');
-    const data = await res.json();
-    data.forEach(c => {
-      componentMeta[c.subtype] = {
-        icon: c.icon,
-        label: c.label,
-        category: c.category,
-        ports: c.ports
-      };
-      propSchemas[c.subtype] = c.schema || [];
-    });
-    rebuildComponentMaps();
+    data = await res.json();
   } catch (err) {
     console.error('Failed to load component library', err);
   }
+  const stored = getItem('componentLibrary', null);
+  if (stored) data = stored;
+  data.forEach(c => {
+    componentMeta[c.subtype] = {
+      icon: c.icon,
+      label: c.label,
+      category: c.category,
+      ports: c.ports
+    };
+    propSchemas[c.subtype] = c.schema || [];
+  });
+  rebuildComponentMaps();
 }
 
 async function loadManufacturerLibrary() {


### PR DESCRIPTION
## Summary
- expand component and manufacturer libraries with typical ratings, breaker frames, conductor types and cable assemblies
- prefill new fields from library defaults when adding diagram components
- add browser-based library manager for maintaining JSON libraries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb660386083249fb4ed6edb734b5a