### PR TITLE
feat: scenario management and project metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
       <a href="mailto:contact@example.com">Contact</a>
     </nav>
   </footer>
+  <script type="module" src="scenarios.js"></script>
   <script src="dist/index.js" defer></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,0 +1,54 @@
+import { listScenarios, getCurrentScenario, switchScenario, cloneScenario, compareStudies } from './dataStore.mjs';
+
+function initScenarioUI() {
+  const container = document.createElement('div');
+  container.id = 'scenario-controls';
+  const select = document.createElement('select');
+  select.id = 'scenario-select';
+  for (const name of listScenarios()) {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    select.appendChild(opt);
+  }
+  select.value = getCurrentScenario();
+  select.addEventListener('change', e => {
+    switchScenario(e.target.value);
+    location.reload();
+  });
+
+  const cloneBtn = document.createElement('button');
+  cloneBtn.id = 'clone-scenario-btn';
+  cloneBtn.textContent = 'Clone';
+  cloneBtn.addEventListener('click', () => {
+    const name = prompt('New scenario name');
+    if (name) {
+      cloneScenario(name);
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      select.appendChild(opt);
+      select.value = name;
+      switchScenario(name);
+      location.reload();
+    }
+  });
+
+  const compareBtn = document.createElement('button');
+  compareBtn.id = 'compare-scenario-btn';
+  compareBtn.textContent = 'Compare Studies';
+  compareBtn.addEventListener('click', () => {
+    const other = prompt('Compare current with which scenario?', listScenarios().join(', '));
+    if (other) {
+      const diff = compareStudies(getCurrentScenario(), other);
+      alert(JSON.stringify(diff, null, 2));
+    }
+  });
+
+  container.appendChild(select);
+  container.appendChild(cloneBtn);
+  container.appendChild(compareBtn);
+  document.body.insertBefore(container, document.body.firstChild);
+}
+
+document.addEventListener('DOMContentLoaded', initScenarioUI);

--- a/serverSync.mjs
+++ b/serverSync.mjs
@@ -1,0 +1,21 @@
+import { exportProject, importProject } from './dataStore.mjs';
+
+export async function saveProjectToServer(url) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(exportProject())
+  });
+  return res.ok;
+}
+
+export async function loadProjectFromServer(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to load project');
+  const data = await res.json();
+  return importProject(data);
+}
+
+if (typeof window !== 'undefined') {
+  window.serverSync = { saveProjectToServer, loadProjectFromServer };
+}


### PR DESCRIPTION
## Summary
- extend data store with multi-scenario support, cloning, and study comparisons
- add scenario selection UI and project export metadata
- provide optional server sync helpers for multi-user workflows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbbbfc228c832489e4cf2bc3486400