### PR TITLE
Add validation rules with automatic checks and report export

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -1,8 +1,9 @@
-import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, getItem, setItem, getStudies, setStudies } from './dataStore.mjs';
+import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, getItem, setItem, getStudies, setStudies, on } from './dataStore.mjs';
 import { runLoadFlow } from './analysis/loadFlow.js';
 import { runShortCircuit } from './analysis/shortCircuit.js';
 import { runArcFlash } from './analysis/arcFlash.js';
 import { sizeConductor } from './sizing.js';
+import { runValidation } from './validation/rules.js';
 
 let componentMeta = {};
 
@@ -102,6 +103,10 @@ const lintPanel = document.getElementById('lint-panel');
 const lintList = document.getElementById('lint-list');
 const lintCloseBtn = document.getElementById('lint-close-btn');
 if (lintCloseBtn) lintCloseBtn.addEventListener('click', () => lintPanel.classList.add('hidden'));
+
+// Re-run validation whenever diagram or study results change
+on('oneLineDiagram', validateDiagram);
+on('studyResults', validateDiagram);
 
 // Studies panel setup
 const studiesPanel = document.getElementById('studies-panel');
@@ -1915,6 +1920,9 @@ function validateDiagram() {
       });
     }
   });
+
+  // Run additional validation rules
+  validationIssues.push(...runValidation(components, getStudies()));
 
   const byComp = {};
   validationIssues.forEach(issue => {

--- a/site.js
+++ b/site.js
@@ -1,5 +1,6 @@
 import "./units.js";
-import { exportProject, importProject } from "./dataStore.mjs";
+import { exportProject, importProject, getOneLine, getStudies } from "./dataStore.mjs";
+import { runValidation } from "./validation/rules.js";
 // fast-json-patch is loaded dynamically so the bundle does not expect a
 // build-time dependency. This avoids "index_mjs is not defined" errors in
 // the minified output when the raceway schedule loads sample data.
@@ -476,6 +477,10 @@ function initSettings(){
       const headers=['sample'];
       const rows=[{sample:'demo'}];
       downloadCSV(headers,rows,'reports.csv');
+      const issues=runValidation(getOneLine(),getStudies());
+      const vHeaders=['component','message'];
+      const vRows=issues.length?issues:[{component:'-',message:'No issues'}];
+      downloadCSV(vHeaders,vRows,'validation-report.csv');
     });
 
     const printLabelsBtn=document.createElement('button');

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -1,0 +1,43 @@
+export function runValidation(components = [], studies = {}) {
+  const issues = [];
+
+  // Map inbound connections for bus connectivity check
+  const inbound = new Map();
+  components.forEach(c => {
+    if (c.type === 'bus') inbound.set(c.id, 0);
+  });
+  components.forEach(c => {
+    (c.connections || []).forEach(conn => {
+      if (inbound.has(conn.target)) {
+        inbound.set(conn.target, (inbound.get(conn.target) || 0) + 1);
+      }
+    });
+  });
+  inbound.forEach((cnt, id) => {
+    if (cnt === 0) {
+      issues.push({ component: id, message: 'Unconnected bus' });
+    }
+  });
+
+  // Transformer loading check
+  components.forEach(c => {
+    if (c.type !== 'transformer') return;
+    const load = Number(c.load_kva || c.load || 0);
+    const rating = Number(c.kva || c.rating || 0);
+    if (rating && load > rating) {
+      issues.push({ component: c.id, message: `Transformer overloaded (${load}kVA > ${rating}kVA)` });
+    }
+  });
+
+  // Breaker interrupting rating check
+  components.forEach(c => {
+    if (c.type !== 'breaker') return;
+    const interrupt = Number(c.interrupt_rating || 0);
+    const fault = Number(c.fault_current || 0);
+    if (interrupt && fault > interrupt) {
+      issues.push({ component: c.id, message: `Breaker interrupt rating exceeded (${fault}A > ${interrupt}A)` });
+    }
+  });
+
+  return issues;
+}


### PR DESCRIPTION
## Summary
- add reusable validation rules for buses, transformers, and breakers
- rerun validation when diagrams or studies change
- export validation reports alongside other study reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbbe19f9988324b045cda4376dea13