### PR TITLE
Add consolidated report export and templating API

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -45,6 +45,7 @@
     <button id="help-btn" aria-expanded="false">Site Help</button>
     <button id="export-project-btn">Export Project</button>
     <button id="import-project-btn">Import Project</button>
+    <button id="export-reports-btn">Export All Reports</button>
     <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
     <button id="prefix-settings-btn">Label Prefixes</button>
     <button id="update-defaults-btn">Update Defaults</button>

--- a/oneline.js
+++ b/oneline.js
@@ -6,6 +6,7 @@ import { runHarmonics } from './analysis/harmonics.js';
 import { runMotorStart } from './analysis/motorStart.js';
 import { runReliability } from './analysis/reliability.js';
 import { generateArcFlashReport } from './reports/arcFlashReport.mjs';
+import { exportAllReports } from './reports/exportAll.mjs';
 import { sizeConductor } from './sizing.js';
 import { runValidation } from './validation/rules.js';
 
@@ -1497,6 +1498,9 @@ async function init() {
 
   const defaultsBtn = document.getElementById('update-defaults-btn');
   if (defaultsBtn) defaultsBtn.addEventListener('click', editManufacturerDefaults);
+
+  const exportReportsBtn = document.getElementById('export-reports-btn');
+  if (exportReportsBtn) exportReportsBtn.addEventListener('click', () => exportAllReports());
 
   const palette = document.getElementById('component-buttons');
   const sectionContainers = {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js && node tests/equipmentColumns.test.js && node tests/equipmentPersistence.test.js && node tests/loadlistPersistence.test.js && node tests/reporting.test.js && node tests/arcFlash.test.js",
+    "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js && node tests/equipmentColumns.test.js && node tests/equipmentPersistence.test.js && node tests/loadlistPersistence.test.js && node tests/reporting.test.js && node tests/arcFlash.test.js && node tests/exportAllReports.test.js",
     "e2e": "playwright test"
   },
   "devDependencies": {

--- a/reports/exportAll.mjs
+++ b/reports/exportAll.mjs
@@ -1,0 +1,221 @@
+import { jsPDF } from 'jspdf';
+import { toCSV } from './reporting.mjs';
+import { generateArcFlashLabel } from './labels.mjs';
+import * as dataStore from '../dataStore.mjs';
+
+let branding = { title: 'Project Report', logo: null, company: '' };
+// Default template builder
+let pdfTemplate = (ctx) => {
+  const lines = [];
+  if (ctx.company) lines.push(ctx.company);
+  ctx.sections.forEach(sec => {
+    lines.push(sec.title);
+    sec.rows.forEach(row => {
+      const line = sec.headers.map(h => row[h] ?? '').join(', ');
+      lines.push(line);
+    });
+    lines.push('');
+  });
+  return lines.join('\n');
+};
+
+/** Set branding information */
+export function setBranding(opts = {}) {
+  branding = { ...branding, ...opts };
+}
+
+/**
+ * Set a custom template. Accepts either a function `(ctx)=>string` or a simple
+ * template string with `{{title}}` and `{{company}}` tokens.
+ */
+export function setReportTemplate(tpl) {
+  if (typeof tpl === 'function') pdfTemplate = tpl;
+  else if (typeof tpl === 'string') {
+    pdfTemplate = ctx => tpl
+      .replace(/{{\s*title\s*}}/g, ctx.title || '')
+      .replace(/{{\s*company\s*}}/g, ctx.company || '');
+  }
+}
+
+function buildSections(data = {}) {
+  const sections = [];
+  if (Array.isArray(data.equipment) && data.equipment.length) {
+    const headers = Object.keys(data.equipment[0]);
+    sections.push({ title: 'Equipment Schedule', headers, rows: data.equipment });
+  }
+  if (Array.isArray(data.panels) && data.panels.length) {
+    const headers = Object.keys(data.panels[0]);
+    sections.push({ title: 'Panel Schedule', headers, rows: data.panels });
+  }
+  if (Array.isArray(data.cables) && data.cables.length) {
+    const headers = Object.keys(data.cables[0]);
+    sections.push({ title: 'Cable Schedule', headers, rows: data.cables });
+  }
+  if (data.analyses) {
+    Object.entries(data.analyses).forEach(([name, rows]) => {
+      if (Array.isArray(rows) && rows.length) {
+        const headers = Object.keys(rows[0]);
+        sections.push({ title: `${name} Analysis`, headers, rows });
+      }
+    });
+  }
+  if (Array.isArray(data.tcc) && data.tcc.length) {
+    const headers = Object.keys(data.tcc[0]);
+    sections.push({ title: 'TCC Plots', headers, rows: data.tcc });
+  }
+  return sections;
+}
+
+// Minimal CRC32 implementation
+const crcTable = new Uint32Array(256).map((_, n) => {
+  let c = n;
+  for (let k = 0; k < 8; k++) {
+    c = (c & 1) ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  }
+  return c >>> 0;
+});
+function crc32(buf) {
+  let crc = -1;
+  for (let i = 0; i < buf.length; i++) {
+    crc = (crc >>> 8) ^ crcTable[(crc ^ buf[i]) & 0xff];
+  }
+  return (crc ^ -1) >>> 0;
+}
+
+class SimpleZip {
+  constructor() { this.entries = []; }
+  file(name, data) {
+    if (typeof data === 'string') data = new TextEncoder().encode(data);
+    this.entries.push({ name, data });
+  }
+  async generateAsync({ type = 'nodebuffer' } = {}) {
+    const fileRecords = [];
+    const central = [];
+    let offset = 0;
+    this.entries.forEach(entry => {
+      const nameBuf = Buffer.from(entry.name);
+      const content = Buffer.from(entry.data);
+      const crc = crc32(content);
+      const header = Buffer.alloc(30);
+      header.writeUInt32LE(0x04034b50, 0);
+      header.writeUInt16LE(20, 4);
+      header.writeUInt16LE(0, 6);
+      header.writeUInt16LE(0, 8);
+      header.writeUInt16LE(0, 10);
+      header.writeUInt16LE(0, 12);
+      header.writeUInt32LE(crc, 14);
+      header.writeUInt32LE(content.length, 18);
+      header.writeUInt32LE(content.length, 22);
+      header.writeUInt16LE(nameBuf.length, 26);
+      header.writeUInt16LE(0, 28);
+      fileRecords.push(header, nameBuf, content);
+
+      const centralHdr = Buffer.alloc(46);
+      centralHdr.writeUInt32LE(0x02014b50, 0);
+      centralHdr.writeUInt16LE(20, 4);
+      centralHdr.writeUInt16LE(20, 6);
+      centralHdr.writeUInt16LE(0, 8);
+      centralHdr.writeUInt16LE(0, 10);
+      centralHdr.writeUInt16LE(0, 12);
+      centralHdr.writeUInt16LE(0, 14);
+      centralHdr.writeUInt32LE(crc, 16);
+      centralHdr.writeUInt32LE(content.length, 20);
+      centralHdr.writeUInt32LE(content.length, 24);
+      centralHdr.writeUInt16LE(nameBuf.length, 28);
+      centralHdr.writeUInt16LE(0, 30);
+      centralHdr.writeUInt16LE(0, 32);
+      centralHdr.writeUInt16LE(0, 34);
+      centralHdr.writeUInt16LE(0, 36);
+      centralHdr.writeUInt32LE(0, 38);
+      centralHdr.writeUInt32LE(offset, 42);
+      central.push(centralHdr, nameBuf);
+      offset += header.length + nameBuf.length + content.length;
+    });
+    const centralBuf = Buffer.concat(central);
+    const eocdr = Buffer.alloc(22);
+    eocdr.writeUInt32LE(0x06054b50, 0);
+    eocdr.writeUInt16LE(0, 4);
+    eocdr.writeUInt16LE(0, 6);
+    eocdr.writeUInt16LE(this.entries.length, 8);
+    eocdr.writeUInt16LE(this.entries.length, 10);
+    eocdr.writeUInt32LE(centralBuf.length, 12);
+    eocdr.writeUInt32LE(offset, 16);
+    eocdr.writeUInt16LE(0, 20);
+    const out = Buffer.concat([...fileRecords, centralBuf, eocdr]);
+    if (type === 'blob') return new Blob([out]);
+    if (type === 'arraybuffer') return out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength);
+    return out;
+  }
+  get files() {
+    const map = {};
+    this.entries.forEach(e => { map[e.name] = e; });
+    return map;
+  }
+}
+
+/**
+ * Build a zip file containing consolidated PDF, CSVs, and arc-flash labels.
+ */
+export function buildReportZip(data = {}) {
+  const sections = buildSections(data);
+  const zip = new SimpleZip();
+
+  // Build PDF content
+  const doc = new jsPDF();
+  let y = 10;
+  if (branding.logo) {
+    try { doc.addImage(branding.logo, 'PNG', 10, 10, 30, 15); } catch {}
+    y += 20;
+  }
+  doc.setFontSize(16);
+  doc.text(branding.title || 'Report', 10, y);
+  y += 10;
+  doc.setFontSize(10);
+  const text = pdfTemplate({ ...branding, sections });
+  text.split('\n').forEach(line => {
+    if (y > 270) { doc.addPage(); y = 10; }
+    doc.text(line, 10, y);
+    y += 6;
+  });
+  zip.file('reports.pdf', doc.output('arraybuffer'));
+
+  // Add CSVs for each section
+  sections.forEach(sec => {
+    const csv = toCSV(sec.headers, sec.rows);
+    const name = sec.title.toLowerCase().replace(/\s+/g, '_') + '.csv';
+    zip.file(name, csv);
+  });
+
+  // Arc flash labels
+  if (data.arcFlash) {
+    Object.entries(data.arcFlash).forEach(([id, info]) => {
+      const svg = generateArcFlashLabel({
+        equipment: id,
+        incidentEnergy: info.incidentEnergy,
+        boundary: info.boundary
+      });
+      zip.file(`arcflash_${id}.svg`, svg);
+    });
+  }
+  return zip;
+}
+
+/**
+ * Gather data from the data store and trigger download of all reports as zip.
+ */
+export async function exportAllReports() {
+  const data = {
+    equipment: dataStore.getEquipment(),
+    panels: dataStore.getPanels ? dataStore.getPanels() : [],
+    cables: dataStore.getCables(),
+    analyses: dataStore.getStudies(),
+    arcFlash: (dataStore.getStudies().arcFlash) || {}
+  };
+  const zip = buildReportZip(data);
+  const blob = await zip.generateAsync({ type: 'blob' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'reports.zip';
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(a.href), 0);
+}

--- a/tests/exportAllReports.test.js
+++ b/tests/exportAllReports.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+
+function describe(name, fn){
+  console.log(name); fn();
+}
+function it(name, fn){
+  try { fn(); console.log('  \u2713', name); }
+  catch(err){ console.log('  \u2717', name); console.error(err); }
+}
+
+(async () => {
+  const { buildReportZip, setBranding } = await import('../reports/exportAll.mjs');
+  describe('exportAll reports', () => {
+    it('builds zip with pdf, csv and labels', async () => {
+      setBranding({ title: 'Test', company: 'ACME' });
+      const data = {
+        equipment: [{ id: 'E1', name: 'Motor' }],
+        analyses: { loadFlow: [{ id: 'B1', Vm: 1 }] },
+        arcFlash: { BUS1: { incidentEnergy: 1, boundary: 2 } }
+      };
+      const zip = buildReportZip(data);
+      const files = Object.keys(zip.files);
+      assert(files.includes('reports.pdf'));
+      assert(files.includes('equipment_schedule.csv'));
+      assert(files.includes('loadflow_analysis.csv'));
+      assert(files.includes('arcflash_BUS1.svg'));
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- add exportAll reporting module that assembles equipment schedules, analyses and arc-flash labels into PDF/CSV and zips them for download
- expose branding/template hooks for client-specific report layouts
- add Export All Reports button to oneline editor and test coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbc75ee3dc8324857ec926cfcef307