### PR TITLE
feat: overlay study results

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -178,6 +178,7 @@
         <button id="run-harmonics-btn" type="button">Harmonics</button>
         <button id="run-motorstart-btn" type="button">Motor Start</button>
         <button id="run-reliability-btn" type="button">Reliability</button>
+        <label style="display:block;margin-top:0.5em"><input type="checkbox" id="toggle-overlays" checked> Show Result Overlays</label>
       </div>
       <pre id="study-results" class="study-results"></pre>
       <div id="loadflow-results" class="study-results"></div>


### PR DESCRIPTION
## Summary
- add overlay toggle to studies panel and store show state
- persist load flow, short circuit, and arc flash results on diagram components and connections
- render voltage deviation halos and connection labels with load or fault values and show legend

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68bc406f48b483249fa0bb34073105de