### PR TITLE
feat: integrate protective device duty checks

### DIFF
--- a/analysis/tccUtils.js
+++ b/analysis/tccUtils.js
@@ -1,16 +1,17 @@
 export function scaleCurve(device = {}, overrides = {}) {
   const base = device.settings || {};
   const pickup = overrides.pickup ?? base.pickup ?? 1;
-  const delay = overrides.delay ?? base.delay ?? 1;
+  const time = overrides.time ?? base.time ?? base.delay ?? 1;
   const instantaneous = overrides.instantaneous ?? base.instantaneous ?? 0;
+  const baseTime = base.time ?? base.delay ?? 1;
   const scaleI = base.pickup ? pickup / base.pickup : 1;
-  const scaleT = base.delay ? delay / base.delay : 1;
+  const scaleT = baseTime ? time / baseTime : 1;
   const curve = (device.curve || []).map(p => ({
     current: p.current * scaleI,
     time: p.time * scaleT
   }));
   if (instantaneous) curve.push({ current: instantaneous, time: 0.01 });
-  return { ...device, curve, settings: { pickup, delay, instantaneous } };
+  return { ...device, curve, settings: { pickup, time, instantaneous } };
 }
 
 export function checkDuty(device = {}, faultKA) {

--- a/data/protectiveDevices.json
+++ b/data/protectiveDevices.json
@@ -5,7 +5,7 @@
     "vendor": "ABB",
     "name": "ABB Tmax T3 160A",
     "interruptRating": 65,
-    "settings": { "pickup": 160, "delay": 0.2, "instantaneous": 800 },
+    "settings": { "pickup": 160, "time": 0.2, "instantaneous": 800 },
     "curve": [
       { "current": 160, "time": 100 },
       { "current": 800, "time": 0.2 },
@@ -18,7 +18,7 @@
     "vendor": "Siemens",
     "name": "Siemens 3VA 125A",
     "interruptRating": 35,
-    "settings": { "pickup": 125, "delay": 0.25, "instantaneous": 600 },
+    "settings": { "pickup": 125, "time": 0.25, "instantaneous": 600 },
     "curve": [
       { "current": 125, "time": 100 },
       { "current": 500, "time": 1 },
@@ -31,7 +31,7 @@
     "vendor": "Schneider",
     "name": "Schneider Compact NSX100",
     "interruptRating": 50,
-    "settings": { "pickup": 100, "delay": 0.3, "instantaneous": 500 },
+    "settings": { "pickup": 100, "time": 0.3, "instantaneous": 500 },
     "curve": [
       { "current": 100, "time": 100 },
       { "current": 400, "time": 1 },
@@ -44,7 +44,7 @@
     "vendor": "GE",
     "name": "GE Multilin 750 Relay",
     "interruptRating": 30,
-    "settings": { "pickup": 150, "delay": 0.15, "instantaneous": 600 },
+    "settings": { "pickup": 150, "time": 0.15, "instantaneous": 600 },
     "curve": [
       { "current": 150, "time": 50 },
       { "current": 600, "time": 0.5 },
@@ -57,7 +57,7 @@
     "vendor": "Eaton",
     "name": "Eaton Series C 100A",
     "interruptRating": 25,
-    "settings": { "pickup": 100, "delay": 0.2, "instantaneous": 500 },
+    "settings": { "pickup": 100, "time": 0.2, "instantaneous": 500 },
     "curve": [
       { "current": 100, "time": 80 },
       { "current": 400, "time": 0.4 },
@@ -70,7 +70,7 @@
     "vendor": "Mitsubishi",
     "name": "Mitsubishi WS 225A",
     "interruptRating": 42,
-    "settings": { "pickup": 225, "delay": 0.3, "instantaneous": 1125 },
+    "settings": { "pickup": 225, "time": 0.3, "instantaneous": 1125 },
     "curve": [
       { "current": 225, "time": 100 },
       { "current": 900, "time": 0.4 },

--- a/tests/tcc/tccUtils.test.js
+++ b/tests/tcc/tccUtils.test.js
@@ -16,7 +16,7 @@ function it(name, fn){
 
   describe('tcc utilities', () => {
     it('scales curve points from overrides', () => {
-      const scaled = scaleCurve(abb, { pickup: 200, delay: 0.4, instantaneous: 1000 });
+      const scaled = scaleCurve(abb, { pickup: 200, time: 0.4, instantaneous: 1000 });
       assert.strictEqual(scaled.curve[0].current, 200);
       assert.strictEqual(scaled.curve[0].time, 200);
       const inst = scaled.curve.find(p => p.current === 1000 && p.time === 0.01);

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -39,6 +39,11 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // TCC duty/coordination violations from studies
+  Object.entries(studies.duty || {}).forEach(([id, msgs = []]) => {
+    msgs.forEach(msg => issues.push({ component: id, message: msg }));
+  });
+
   // Single point of failure warnings from reliability study
   if (Array.isArray(studies.reliability?.n1Failures)) {
     studies.reliability.n1Failures.forEach(id => {


### PR DESCRIPTION
## Summary
- add manufacturer protective device data with pickup, time and instantaneous defaults
- allow selecting protective device IDs on one-line components
- auto-load linked curves and perform duty checks using short-circuit results
- surface coordination violations in diagram validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc42fbd2dc83248bf068ca284034f5