### PR TITLE
feat: add scenario management and revision history

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -161,6 +161,11 @@
   fill: #c00;
 }
 
+g.component.scenario-diff > * {
+  stroke: #d00 !important;
+  stroke-width: 2;
+}
+
 .issue-badge {
   pointer-events: none;
 }

--- a/oneline.html
+++ b/oneline.html
@@ -12,6 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/svg2pdf.js@2.0.1/dist/svg2pdf.umd.min.js"></script>
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="oneline.js" defer></script>
+  <script type="module" src="scenarios.js" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -58,6 +59,12 @@
       </header>
       <section class="card">
         <div class="sheet-controls">
+          <div class="scenario-controls">
+            <select id="scenario-select"></select>
+            <button id="scenario-duplicate-btn" type="button">Duplicate</button>
+            <button id="scenario-diff-btn" type="button">Diff</button>
+            <button id="revision-btn" type="button">Revisions</button>
+          </div>
           <div id="sheet-tabs" class="sheet-tabs"></div>
           <button id="add-sheet-btn">Add Sheet</button>
           <button id="rename-sheet-btn">Rename Sheet</button>

--- a/oneline.js
+++ b/oneline.js
@@ -1,4 +1,4 @@
-import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, getItem, setItem, getStudies, setStudies, on } from './dataStore.mjs';
+import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, getItem, setItem, getStudies, setStudies, on, getCurrentScenario, switchScenario } from './dataStore.mjs';
 import { runLoadFlow } from './analysis/loadFlow.js';
 import { runShortCircuit } from './analysis/shortCircuit.js';
 import { runArcFlash } from './analysis/arcFlash.js';
@@ -2681,6 +2681,7 @@ function serializeState() {
     return { equipment: [...equipment, ...buses], panels: [...panels, ...buses], loads, cables };
   }
   return {
+    meta: { scenario: getCurrentScenario() },
     version: DIAGRAM_VERSION,
     templates: templates.map(t => ({ ...t })),
     scale: diagramScale,
@@ -2840,6 +2841,9 @@ async function importDiagram(e) {
   const text = await file.text();
   try {
     let data = JSON.parse(text);
+    if (data.meta && data.meta.scenario) {
+      switchScenario(data.meta.scenario);
+    }
     data = migrateDiagram(data);
     diagramScale = data.scale || { unitPerPx: 1, unit: 'in' };
     setItem('diagramScale', diagramScale);

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,10 +1,17 @@
-import { listScenarios, getCurrentScenario, switchScenario, cloneScenario, compareStudies } from './dataStore.mjs';
+import { listScenarios, getCurrentScenario, switchScenario, cloneScenario, getOneLine, getRevisions, restoreRevision } from './dataStore.mjs';
 
-function initScenarioUI() {
-  const container = document.createElement('div');
-  container.id = 'scenario-controls';
-  const select = document.createElement('select');
-  select.id = 'scenario-select';
+function ensureDefaults() {
+  const defaults = ['base', 'future', 'emergency'];
+  const existing = listScenarios();
+  for (const name of defaults) {
+    if (!existing.includes(name)) {
+      cloneScenario(name);
+    }
+  }
+}
+
+function populateSelect(select) {
+  select.innerHTML = '';
   for (const name of listScenarios()) {
     const opt = document.createElement('option');
     opt.value = name;
@@ -12,43 +19,78 @@ function initScenarioUI() {
     select.appendChild(opt);
   }
   select.value = getCurrentScenario();
+}
+
+function diffScenarios(a, b) {
+  const diagram = document.getElementById('diagram');
+  if (!diagram) return;
+  diagram.querySelectorAll('.scenario-diff').forEach(el => el.classList.remove('scenario-diff'));
+  const sheetsA = getOneLine(a);
+  const sheetsB = getOneLine(b);
+  const map = arr => {
+    const m = new Map();
+    for (const s of arr) {
+      for (const c of s.components || []) {
+        m.set(c.id, JSON.stringify(c));
+      }
+    }
+    return m;
+  };
+  const mapA = map(sheetsA);
+  const mapB = map(sheetsB);
+  const diff = new Set();
+  for (const [id, val] of mapA) {
+    if (mapB.get(id) !== val) diff.add(id);
+  }
+  for (const id of mapB.keys()) {
+    if (!mapA.has(id)) diff.add(id);
+  }
+  diff.forEach(id => {
+    const g = diagram.querySelector(`g.component[data-id="${id}"]`);
+    if (g) g.classList.add('scenario-diff');
+  });
+}
+
+function initScenarioUI() {
+  ensureDefaults();
+  const select = document.getElementById('scenario-select');
+  if (!select) return;
+  populateSelect(select);
   select.addEventListener('change', e => {
     switchScenario(e.target.value);
     location.reload();
   });
 
-  const cloneBtn = document.createElement('button');
-  cloneBtn.id = 'clone-scenario-btn';
-  cloneBtn.textContent = 'Clone';
-  cloneBtn.addEventListener('click', () => {
+  const dupBtn = document.getElementById('scenario-duplicate-btn');
+  dupBtn?.addEventListener('click', () => {
     const name = prompt('New scenario name');
     if (name) {
       cloneScenario(name);
-      const opt = document.createElement('option');
-      opt.value = name;
-      opt.textContent = name;
-      select.appendChild(opt);
+      populateSelect(select);
       select.value = name;
       switchScenario(name);
       location.reload();
     }
   });
 
-  const compareBtn = document.createElement('button');
-  compareBtn.id = 'compare-scenario-btn';
-  compareBtn.textContent = 'Compare Studies';
-  compareBtn.addEventListener('click', () => {
-    const other = prompt('Compare current with which scenario?', listScenarios().join(', '));
-    if (other) {
-      const diff = compareStudies(getCurrentScenario(), other);
-      alert(JSON.stringify(diff, null, 2));
-    }
+  const diffBtn = document.getElementById('scenario-diff-btn');
+  diffBtn?.addEventListener('click', () => {
+    const other = prompt('Compare with which scenario?', listScenarios().join(', '));
+    if (other) diffScenarios(getCurrentScenario(), other);
   });
 
-  container.appendChild(select);
-  container.appendChild(cloneBtn);
-  container.appendChild(compareBtn);
-  document.body.insertBefore(container, document.body.firstChild);
+  const revBtn = document.getElementById('revision-btn');
+  revBtn?.addEventListener('click', () => {
+    const revs = getRevisions();
+    if (!revs.length) { alert('No revisions'); return; }
+    const msg = revs.map((r,i) => `${i}: ${new Date(r.time).toLocaleString()}`).join('\n');
+    const choice = prompt(`Restore which revision?\n${msg}`);
+    const idx = Number(choice);
+    if (!Number.isNaN(idx)) {
+      restoreRevision(idx);
+      location.reload();
+    }
+  });
 }
 
 document.addEventListener('DOMContentLoaded', initScenarioUI);


### PR DESCRIPTION
## Summary
- add per-scenario revision history and scenario metadata export/import
- add scenario controls for switching, duplicating, diffing, and restoring revisions
- highlight differences between scenarios on one-line diagrams

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4532bf04832488b30732b9722946