### PR TITLE
Compute and export cable lengths with slack tolerance

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -69,6 +69,10 @@
   margin-left: var(--ol-spacing);
 }
 
+.slack-label {
+  margin-left: var(--ol-spacing);
+}
+
 .hidden-input {
   display: none;
 }

--- a/oneline.html
+++ b/oneline.html
@@ -118,6 +118,7 @@
           <label class="grid-label"><input type="checkbox" id="grid-toggle" checked> Grid</label>
           <input type="number" id="grid-size" value="20" min="1" title="Grid size">
           <label class="scale-label">1 px = <input type="number" id="scale-value" value="1" step="0.01" min="0"> <input type="text" id="scale-unit" value="in" size="3" aria-label="Scale unit"></label>
+          <label class="slack-label">Slack % <input type="number" id="slack-pct" value="0" step="0.1" min="0"></label>
         </div>
         <div class="oneline-editor">
           <svg id="diagram" width="800" height="600">


### PR DESCRIPTION
## Summary
- measure connection polylines and store `conn.length`
- add slack percentage setting and manual cable length overrides
- export scaled cable lengths and rerun voltage-drop checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4681c5bc832494e4a00fb48693a1