### PR TITLE
Refactor one-line controls with reusable button class

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -8,6 +8,21 @@
   --ol-hover-bg: rgba(0,0,0,0.05);
 }
 
+.btn {
+  background: #f0f0f0;
+  color: #333;
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn:hover,
+.btn:focus {
+  background-color: var(--ol-hover-bg);
+}
+
 .card {
   background: var(--ol-card-bg);
   border: 1px solid var(--ol-border-color);
@@ -16,11 +31,12 @@
 }
 
 .palette {
+  width: 200px;
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: var(--ol-spacing);
-  margin-bottom: var(--ol-spacing);
   font-family: var(--ol-font);
+  margin-right: var(--ol-spacing);
 }
 
 #palette-search {
@@ -84,6 +100,12 @@
   margin-bottom: var(--ol-spacing);
 }
 
+.sheet-action-group {
+  display: flex;
+  align-items: center;
+  gap: var(--ol-spacing);
+}
+
 .sheet-tabs {
   display: flex;
   gap: var(--ol-spacing);
@@ -103,6 +125,19 @@
 
 .oneline-editor {
   position: relative;
+  flex: 1;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ol-spacing);
+  margin-bottom: var(--ol-spacing);
+}
+
+.workspace {
+  display: flex;
 }
 
 .oneline-editor #diagram {
@@ -110,12 +145,12 @@
   border-radius: var(--ol-radius);
 }
 
-.palette .icon-button {
+.btn.icon-button {
   transition: transform 0.2s, background-color 0.2s;
 }
 
-.palette .icon-button:hover,
-.palette .icon-button:focus {
+.btn.icon-button:hover,
+.btn.icon-button:focus {
   background-color: var(--ol-hover-bg);
   transform: scale(1.05);
 }

--- a/oneline.html
+++ b/oneline.html
@@ -61,67 +61,72 @@
         <div class="sheet-controls">
           <div class="scenario-controls">
             <select id="scenario-select"></select>
-            <button id="scenario-duplicate-btn" type="button">Duplicate</button>
-            <button id="scenario-diff-btn" type="button">Diff</button>
-            <button id="revision-btn" type="button">Revisions</button>
+            <button id="scenario-duplicate-btn" type="button" class="btn">Duplicate</button>
+            <button id="scenario-diff-btn" type="button" class="btn">Diff</button>
+            <button id="revision-btn" type="button" class="btn">Revisions</button>
           </div>
           <div id="sheet-tabs" class="sheet-tabs"></div>
-          <button id="add-sheet-btn">Add Sheet</button>
-          <button id="rename-sheet-btn">Rename Sheet</button>
-          <button id="delete-sheet-btn">Delete Sheet</button>
-          <button id="diagram-export-btn" type="button">Export Diagram</button>
-          <input type="file" id="diagram-import-input" accept=".json" class="hidden-input">
-          <button id="diagram-import-btn" type="button">Import Diagram</button>
-          <button id="diagram-share-btn" type="button">Share Diagram</button>
-          <button id="tour-btn" type="button">Tour</button>
-        </div>
-        <div id="palette" class="palette">
-          <div id="component-buttons">
-            <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
-            <details id="panel-section" class="palette-section">
-              <summary>Panel</summary>
-              <div id="panel-buttons" class="section-buttons"></div>
-            </details>
-            <details id="equipment-section" class="palette-section">
-              <summary>Equipment</summary>
-              <div id="equipment-buttons" class="section-buttons"></div>
-            </details>
-            <details id="load-section" class="palette-section">
-              <summary>Load</summary>
-              <div id="load-buttons" class="section-buttons"></div>
-            </details>
-            <details id="template-section" class="palette-section">
-              <summary>Templates</summary>
-              <div id="template-buttons" class="section-buttons"></div>
-              <button id="template-export-btn" type="button">Export</button>
-              <input type="file" id="template-import-input" accept=".json" class="hidden-input">
-              <button id="template-import-btn" type="button">Import</button>
-            </details>
+          <div class="sheet-action-group">
+            <button id="add-sheet-btn" class="btn icon-button" title="Add Sheet" aria-label="Add Sheet">+</button>
+            <button id="rename-sheet-btn" class="btn icon-button" title="Rename Sheet" aria-label="Rename Sheet">✎</button>
+            <button id="delete-sheet-btn" class="btn icon-button" title="Delete Sheet" aria-label="Delete Sheet">🗑</button>
+            <button id="diagram-export-btn" type="button" class="btn icon-button" title="Export Diagram" aria-label="Export Diagram"><img src="icons/toolbar/export.svg" alt=""></button>
+            <input type="file" id="diagram-import-input" accept=".json" class="hidden-input">
+            <button id="diagram-import-btn" type="button" class="btn icon-button" title="Import Diagram" aria-label="Import Diagram"><img src="icons/toolbar/import.svg" alt=""></button>
+            <button id="diagram-share-btn" type="button" class="btn">Share</button>
+            <button id="tour-btn" type="button" class="btn">Tour</button>
           </div>
-          <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
-          <button id="dimension-btn" class="icon-button" title="Dimension" aria-label="Dimension"><img src="icons/toolbar/dimension.svg" alt=""></button>
-          <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
-          <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
-          <button id="align-left-btn" class="icon-button" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
-          <button id="align-right-btn" class="icon-button" title="Align Right" aria-label="Align Right"><img src="icons/toolbar/align-right.svg" alt=""></button>
-          <button id="align-top-btn" class="icon-button" title="Align Top" aria-label="Align Top"><img src="icons/toolbar/align-top.svg" alt=""></button>
-          <button id="align-bottom-btn" class="icon-button" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
-          <button id="distribute-h-btn" class="icon-button" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
-          <button id="distribute-v-btn" class="icon-button" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
-          <button id="export-btn" class="icon-button" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
-          <button id="export-pdf-btn" title="Export PDF" aria-label="Export PDF">Export PDF</button>
-          <button id="export-dxf-btn" title="Export DXF" aria-label="Export DXF">Export DXF</button>
-          <button id="export-dwg-btn" title="Export DWG" aria-label="Export DWG">Export DWG</button>
+        </div>
+        <div class="toolbar">
+          <button id="connect-btn" class="icon-button btn" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
+          <button id="dimension-btn" class="icon-button btn" title="Dimension" aria-label="Dimension"><img src="icons/toolbar/dimension.svg" alt=""></button>
+          <button id="undo-btn" class="icon-button btn" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
+          <button id="redo-btn" class="icon-button btn" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
+          <button id="align-left-btn" class="icon-button btn" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
+          <button id="align-right-btn" class="icon-button btn" title="Align Right" aria-label="Align Right"><img src="icons/toolbar/align-right.svg" alt=""></button>
+          <button id="align-top-btn" class="icon-button btn" title="Align Top" aria-label="Align Top"><img src="icons/toolbar/align-top.svg" alt=""></button>
+          <button id="align-bottom-btn" class="icon-button btn" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
+          <button id="distribute-h-btn" class="icon-button btn" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
+          <button id="distribute-v-btn" class="icon-button btn" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
+          <button id="export-btn" class="icon-button btn" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
+          <button id="export-pdf-btn" class="btn" title="Export PDF" aria-label="Export PDF">Export PDF</button>
+          <button id="export-dxf-btn" class="btn" title="Export DXF" aria-label="Export DXF">Export DXF</button>
+          <button id="export-dwg-btn" class="btn" title="Export DWG" aria-label="Export DWG">Export DWG</button>
           <input type="file" id="import-input" accept=".json" class="hidden-input">
-          <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
-          <button id="validate-btn" class="icon-button" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
+          <button id="import-btn" class="icon-button btn" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
+          <button id="validate-btn" class="icon-button btn" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
           <label class="grid-label"><input type="checkbox" id="grid-toggle" checked> Grid</label>
           <input type="number" id="grid-size" value="20" min="1" title="Grid size">
           <label class="scale-label">1 px = <input type="number" id="scale-value" value="1" step="0.01" min="0"> <input type="text" id="scale-unit" value="in" size="3" aria-label="Scale unit"></label>
           <label class="slack-label">Slack % <input type="number" id="slack-pct" value="0" step="0.1" min="0"></label>
         </div>
-        <div class="oneline-editor">
-          <svg id="diagram" width="800" height="600">
+        <div class="workspace">
+          <aside id="palette" class="palette">
+            <div id="component-buttons">
+              <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
+              <details id="panel-section" class="palette-section">
+                <summary>Panel</summary>
+                <div id="panel-buttons" class="section-buttons"></div>
+              </details>
+              <details id="equipment-section" class="palette-section">
+                <summary>Equipment</summary>
+                <div id="equipment-buttons" class="section-buttons"></div>
+              </details>
+              <details id="load-section" class="palette-section">
+                <summary>Load</summary>
+                <div id="load-buttons" class="section-buttons"></div>
+              </details>
+              <details id="template-section" class="palette-section">
+                <summary>Templates</summary>
+                <div id="template-buttons" class="section-buttons"></div>
+                <button id="template-export-btn" type="button" class="btn">Export</button>
+                <input type="file" id="template-import-input" accept=".json" class="hidden-input">
+                <button id="template-import-btn" type="button" class="btn">Import</button>
+              </details>
+            </div>
+          </aside>
+          <div class="oneline-editor">
+            <svg id="diagram" width="800" height="600">
             <defs>
               <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
                 <path d="M20 0 L0 0 0 20" fill="none" stroke="#ccc" stroke-width="0.5" />
@@ -163,15 +168,16 @@
           <div id="cable-modal" class="prop-modal"></div>
           <div id="validation-modal" class="prop-modal"></div>
           <div id="defaults-modal" class="prop-modal"></div>
-          <ul id="context-menu" class="context-menu">
-            <li data-action="edit" data-context="component">Edit Properties</li>
-            <li data-action="delete" data-context="component">Delete</li>
-            <li data-action="duplicate" data-context="component">Duplicate</li>
-            <li data-action="rotate" data-context="component">Rotate</li>
-            <li data-action="paste" data-context="canvas">Paste</li>
-          </ul>
+            <ul id="context-menu" class="context-menu">
+              <li data-action="edit" data-context="component">Edit Properties</li>
+              <li data-action="delete" data-context="component">Delete</li>
+              <li data-action="duplicate" data-context="component">Duplicate</li>
+              <li data-action="rotate" data-context="component">Rotate</li>
+              <li data-action="paste" data-context="canvas">Paste</li>
+            </ul>
+          </div>
         </div>
-      </section>
+        </section>
     </main>
   </div>
   <aside id="studies-panel" class="studies-panel hidden" aria-label="Studies">


### PR DESCRIPTION
## Summary
- style: add reusable `.btn` class and grid/flex layout for one-line toolbar/palette
- feat: group sheet actions with icon buttons and move toolbar to top bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc50a1c53c8324bc89af19ddf8a951