### PR TITLE
feat: add card styling to palette sections

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -48,33 +48,47 @@
   display: flex;
   flex-direction: column;
 }
+.palette-card {
+  margin-bottom: var(--ol-spacing);
+}
 
-#component-buttons details {
+.palette-card h3 {
+  margin: 0 0 0.25rem;
+}
+
+.palette-section {
   border: 1px solid var(--ol-border-color);
   border-radius: var(--ol-radius);
-  margin-bottom: var(--ol-spacing);
   background: var(--ol-card-bg);
 }
 
-#component-buttons details summary {
+.palette-section summary {
   padding: 0.25rem 0.5rem;
   cursor: pointer;
   list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
-#component-buttons details[open] > summary {
+.palette-section[open] > summary {
   border-bottom: 1px solid var(--ol-border-color);
 }
 
-#component-buttons details summary::-webkit-details-marker {
+.palette-section summary::-webkit-details-marker {
   display: none;
 }
 
-#component-buttons .section-buttons {
+.palette-section .section-buttons {
   display: flex;
   flex-wrap: wrap;
   gap: var(--ol-spacing);
   padding: var(--ol-spacing);
+}
+
+.summary-icon {
+  width: 16px;
+  height: 16px;
 }
 
 .grid-label {

--- a/oneline.html
+++ b/oneline.html
@@ -104,25 +104,37 @@
           <aside id="palette" class="palette">
             <div id="component-buttons">
               <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
-              <details id="panel-section" class="palette-section">
-                <summary>Panel</summary>
-                <div id="panel-buttons" class="section-buttons"></div>
-              </details>
-              <details id="equipment-section" class="palette-section">
-                <summary>Equipment</summary>
-                <div id="equipment-buttons" class="section-buttons"></div>
-              </details>
-              <details id="load-section" class="palette-section">
-                <summary>Load</summary>
-                <div id="load-buttons" class="section-buttons"></div>
-              </details>
-              <details id="template-section" class="palette-section">
-                <summary>Templates</summary>
-                <div id="template-buttons" class="section-buttons"></div>
-                <button id="template-export-btn" type="button" class="btn">Export</button>
-                <input type="file" id="template-import-input" accept=".json" class="hidden-input">
-                <button id="template-import-btn" type="button" class="btn">Import</button>
-              </details>
+                <div class="palette-card card">
+                  <h3>Panel</h3>
+                  <details id="panel-section" class="palette-section">
+                    <summary><img src="icons/panel.svg" alt="" class="summary-icon"> Panel</summary>
+                    <div id="panel-buttons" class="section-buttons"></div>
+                  </details>
+                </div>
+                <div class="palette-card card">
+                  <h3>Equipment</h3>
+                  <details id="equipment-section" class="palette-section">
+                    <summary><img src="icons/equipment.svg" alt="" class="summary-icon"> Equipment</summary>
+                    <div id="equipment-buttons" class="section-buttons"></div>
+                  </details>
+                </div>
+                <div class="palette-card card">
+                  <h3>Load</h3>
+                  <details id="load-section" class="palette-section">
+                    <summary><img src="icons/load.svg" alt="" class="summary-icon"> Load</summary>
+                    <div id="load-buttons" class="section-buttons"></div>
+                  </details>
+                </div>
+                <div class="palette-card card">
+                  <h3>Templates</h3>
+                  <details id="template-section" class="palette-section">
+                    <summary><img src="icons/oneline.svg" alt="" class="summary-icon"> Templates</summary>
+                    <div id="template-buttons" class="section-buttons"></div>
+                    <button id="template-export-btn" type="button" class="btn">Export</button>
+                    <input type="file" id="template-import-input" accept=".json" class="hidden-input">
+                    <button id="template-import-btn" type="button" class="btn">Import</button>
+                  </details>
+                </div>
             </div>
           </aside>
           <div class="oneline-editor">


### PR DESCRIPTION
## Summary
- wrap panel, equipment, load and template palettes in card containers with headings
- add icons to palette section summaries for quicker recognition
- style palette sections with borders and spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc521675448324b21df944b8c1a59f