### PR TITLE
feat: add responsive palette grid

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -31,12 +31,10 @@
 }
 
 .palette {
-  width: 200px;
   display: flex;
   flex-direction: column;
   gap: var(--ol-spacing);
   font-family: var(--ol-font);
-  margin-right: var(--ol-spacing);
 }
 
 #palette-search {
@@ -139,7 +137,7 @@
 
 .oneline-editor {
   position: relative;
-  flex: 1;
+  min-height: 600px;
 }
 
 .toolbar {
@@ -151,12 +149,32 @@
 }
 
 .workspace {
-  display: flex;
+  --palette-width: 250px;
+  display: grid;
+  grid-template-columns: var(--palette-width) 1fr;
+  position: relative;
+}
+
+.splitter {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--palette-width);
+  width: 5px;
+  cursor: col-resize;
+  background: var(--ol-border-color);
+}
+
+.palette-toggle {
+  display: none;
+  margin-bottom: var(--ol-spacing);
 }
 
 .oneline-editor #diagram {
   border: 1px solid var(--ol-border-color);
   border-radius: var(--ol-radius);
+  width: 100%;
+  height: 100%;
 }
 
 .btn.icon-button {
@@ -301,4 +319,24 @@ g.component.scenario-diff > * {
   position: relative;
   z-index: 1001;
   box-shadow: 0 0 0 4px orange;
+}
+
+@media (max-width: 600px) {
+  .palette-toggle {
+    display: inline-block;
+  }
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+  .workspace #palette,
+  .workspace .splitter {
+    display: none;
+  }
+  .workspace.show-palette {
+    grid-template-columns: var(--palette-width) 1fr;
+  }
+  .workspace.show-palette #palette,
+  .workspace.show-palette .splitter {
+    display: block;
+  }
 }

--- a/oneline.html
+++ b/oneline.html
@@ -100,6 +100,7 @@
           <label class="scale-label">1 px = <input type="number" id="scale-value" value="1" step="0.01" min="0"> <input type="text" id="scale-unit" value="in" size="3" aria-label="Scale unit"></label>
           <label class="slack-label">Slack % <input type="number" id="slack-pct" value="0" step="0.1" min="0"></label>
         </div>
+        <button id="palette-toggle" class="palette-toggle" aria-label="Toggle palette" aria-controls="palette" aria-expanded="false">☰</button>
         <div class="workspace">
           <aside id="palette" class="palette">
             <div id="component-buttons">
@@ -138,8 +139,9 @@
                 </div>
             </div>
           </aside>
+          <div class="splitter"></div>
           <div class="oneline-editor">
-            <svg id="diagram" width="800" height="600">
+            <svg id="diagram" width="100%" height="100%">
             <defs>
               <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
                 <path d="M20 0 L0 0 0 20" fill="none" stroke="#ccc" stroke-width="0.5" />

--- a/oneline.js
+++ b/oneline.js
@@ -27,6 +27,9 @@ let componentTypes = {};
 let manufacturerDefaults = {};
 let protectiveDevices = [];
 
+let paletteWidth = 250;
+let resizingPalette = false;
+
 const kvClasses = ['0.48 kV', '5 kV', '15 kV', '25 kV'];
 const thermalRatings = ['75C', '90C', '105C'];
 const manufacturerModels = {
@@ -2124,6 +2127,39 @@ async function init() {
     setItem('cableSlackPct', cableSlackPct);
     syncSchedules(false);
     render();
+  });
+
+  const workspaceEl = document.querySelector('.workspace');
+  const splitter = document.querySelector('.splitter');
+  const paletteToggle = document.getElementById('palette-toggle');
+
+  splitter?.addEventListener('mousedown', e => {
+    resizingPalette = true;
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', e => {
+    if (!resizingPalette) return;
+    const rect = workspaceEl.getBoundingClientRect();
+    paletteWidth = Math.min(Math.max(e.clientX - rect.left, 100), 500);
+    workspaceEl.style.gridTemplateColumns = `${paletteWidth}px 1fr`;
+    splitter.style.left = `${paletteWidth}px`;
+  });
+
+  document.addEventListener('mouseup', () => {
+    resizingPalette = false;
+  });
+
+  paletteToggle?.addEventListener('click', () => {
+    const show = !workspaceEl.classList.contains('show-palette');
+    workspaceEl.classList.toggle('show-palette', show);
+    paletteToggle.setAttribute('aria-expanded', show);
+    if (show) {
+      workspaceEl.style.gridTemplateColumns = `${paletteWidth}px 1fr`;
+      splitter.style.left = `${paletteWidth}px`;
+    } else {
+      workspaceEl.style.gridTemplateColumns = '1fr';
+    }
   });
 
   const svg = document.getElementById('diagram');


### PR DESCRIPTION
## Summary
- place palette and diagram in CSS grid and make SVG scale to its container
- enable dragging splitter to resize palette
- collapse palette on small screens with toggle button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcdd71a7708324b0936b6c2a0d71a3