### PR TITLE
feat: centralize theme variables

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -1,26 +1,42 @@
 :root {
-  --ol-font: 'Segoe UI', Arial, sans-serif;
-  --ol-spacing: 0.5rem;
-  --ol-card-bg: #fdfdfd;
+  /* shared theme variables */
+  --primary-color: #007bff;
+  --secondary-color: #f8f9fa;
+  --font-family-base: 'Segoe UI', Arial, sans-serif;
+  --spacing-base: 0.5rem;
+
+  /* existing oneline variables leveraging shared tokens */
+  --ol-font: var(--font-family-base);
+  --ol-spacing: var(--spacing-base);
+  --ol-card-bg: var(--secondary-color);
   --ol-border-color: #dcdcdc;
   --ol-shadow: 0 2px 6px rgba(0,0,0,0.1);
   --ol-radius: 8px;
   --ol-hover-bg: rgba(0,0,0,0.05);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary-color: #17a2b8;
+    --secondary-color: #343a40;
+  }
+}
+
 .btn {
-  background: #f0f0f0;
-  color: #333;
-  border: 1px solid var(--ol-border-color);
+  background: var(--primary-color);
+  color: var(--secondary-color);
+  border: 1px solid var(--primary-color);
   border-radius: var(--ol-radius);
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-base) calc(var(--spacing-base) * 2);
   cursor: pointer;
   transition: background-color 0.2s;
+  font-family: var(--font-family-base);
 }
 
 .btn:hover,
 .btn:focus {
-  background-color: var(--ol-hover-bg);
+  background-color: var(--secondary-color);
+  color: var(--primary-color);
 }
 
 .card {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
+@import "./oneline.css";
+
 /* --- Basic Setup --- */
 :root {
-    --primary-color: #007bff;
-    --secondary-color: #f8f9fa;
     --border-color: #dee2e6;
     --text-color: #212529;
     --success-bg: #d4edda;
@@ -11,11 +11,11 @@
     --error-bg: #f8d7da;
     --error-text: #721c24;
     --focus-ring-color: #000;
-    --button-bg: #005a9c;
-    --button-hover-bg: #00457a;
+    --button-bg: var(--primary-color);
+    --button-hover-bg: #0056b3;
     --button-text: #fff;
-    --button-padding: 0.5rem 0.75rem;
-    --button-margin: 0.25rem;
+    --button-padding: var(--spacing-base) calc(var(--spacing-base) * 1.5);
+    --button-margin: calc(var(--spacing-base) / 2);
 }
 
 body.dark-mode {
@@ -26,9 +26,7 @@ body.dark-mode {
     --success-text: #28a745;
     --warning-text: #ffc107;
     --focus-ring-color: #fff;
-    --button-bg: #1a73e8;
     --button-hover-bg: #1558b0;
-    --button-text: #fff;
     background-color: #212529;
 }
 
@@ -68,10 +66,16 @@ body.dark-mode .settings-menu {
     background: var(--secondary-color);
 }
 
+h1, h2, h3 {
+    font-family: var(--font-family-base);
+    color: var(--primary-color);
+    margin-bottom: var(--spacing-base);
+}
+
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-family: var(--font-family-base);
     margin: 0;
-    background-color: #f0f2f5;
+    background-color: var(--secondary-color);
     color: var(--text-color);
 }
 
@@ -485,7 +489,7 @@ details > summary {
 .modal-content {
     background: var(--secondary-color);
     color: var(--text-color);
-    padding: 1rem;
+    padding: calc(var(--spacing-base) * 2);
     border-radius: 4px;
     max-width: 600px;
     width: 90%;
@@ -495,9 +499,9 @@ details > summary {
 }
 
 .modal-actions {
-    margin-top: 1rem;
+    margin-top: calc(var(--spacing-base) * 2);
     display: flex;
-    gap: 0.5rem;
+    gap: var(--spacing-base);
     justify-content: flex-end;
 }
 


### PR DESCRIPTION
## Summary
- define shared color, font, and spacing variables in `oneline.css` and import into `style.css`
- refactor buttons, modals, and headings to consume the shared variables
- add dark-mode overrides for consistent theming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcdf93d05c83249fb4fb1acc6fdc47