### PR TITLE
Add project save and load support with scoped storage

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -10,6 +10,8 @@ const { sizeToArea } = ampacity;
 // behaviour needed to populate the schedule table.
 
 window.addEventListener('DOMContentLoaded', () => {
+  const projectId = window.currentProjectId || 'default';
+  dataStore.loadProject(projectId);
   initSettings();
   initDarkMode();
   initCompactMode();
@@ -168,6 +170,7 @@ window.addEventListener('DOMContentLoaded', () => {
       markSaved();
       tableData = table.getData();
       dataStore.setCables(tableData); // persist only when user saves
+      dataStore.saveProject(projectId);
     }
   });
 

--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -456,6 +456,57 @@ export const keys = (scenario = currentScenario) => {
   return [];
 };
 
+export function saveProject(projectId, scenario = currentScenario) {
+  if (!projectId || typeof localStorage === 'undefined') return;
+  try {
+    const prefix = `${projectId}:`;
+    const payload = {
+      equipment: getEquipment(),
+      panels: getPanels(),
+      loads: getLoads(),
+      cables: getCables(),
+      raceways: {
+        trays: getTrays(),
+        conduits: getConduits(),
+        ductbanks: getDuctbanks()
+      },
+      oneLine: getOneLine(scenario)
+    };
+    for (const [key, value] of Object.entries(payload)) {
+      localStorage.setItem(prefix + key, JSON.stringify(value));
+    }
+  } catch (e) {
+    console.error('Failed to save project', e);
+  }
+}
+
+export function loadProject(projectId, scenario = currentScenario) {
+  if (!projectId || typeof localStorage === 'undefined') return;
+  try {
+    const prefix = `${projectId}:`;
+    const readKey = k => {
+      const raw = localStorage.getItem(prefix + k);
+      try { return raw ? JSON.parse(raw) : null; } catch { return null; }
+    };
+    const equipment = readKey('equipment') || [];
+    const panels = readKey('panels') || [];
+    const loads = readKey('loads') || [];
+    const cables = readKey('cables') || [];
+    const raceways = readKey('raceways') || {};
+    const oneLine = readKey('oneLine') || [];
+    setEquipment(Array.isArray(equipment) ? equipment : []);
+    setPanels(Array.isArray(panels) ? panels : []);
+    setLoads(Array.isArray(loads) ? loads : []);
+    setCables(Array.isArray(cables) ? cables : []);
+    setTrays(Array.isArray(raceways.trays) ? raceways.trays : []);
+    setConduits(Array.isArray(raceways.conduits) ? raceways.conduits : []);
+    setDuctbanks(Array.isArray(raceways.ductbanks) ? raceways.ductbanks : []);
+    setOneLine(Array.isArray(oneLine) ? oneLine : [], scenario);
+  } catch (e) {
+    console.error('Failed to load project', e);
+  }
+}
+
 // Simple schema validator replacing Ajv. Checks for required fields,
 // disallows extras, and verifies basic types.
 function validateProjectSchema(obj) {
@@ -682,6 +733,8 @@ if (typeof window !== 'undefined') {
     keys,
     exportProject,
     importProject,
+    saveProject,
+    loadProject,
     importFromCad,
     exportToCad
   };

--- a/equipmentlist.js
+++ b/equipmentlist.js
@@ -1,7 +1,10 @@
+import * as dataStore from './dataStore.mjs';
 import './tableUtils.js';
 
 if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', () => {
+    const projectId = window.currentProjectId || 'default';
+    dataStore.loadProject(projectId);
     initSettings();
     initDarkMode();
     initCompactMode();
@@ -44,6 +47,7 @@ if (typeof window !== 'undefined') {
             if (id) fn(id, row);
           });
         }
+        dataStore.saveProject(projectId);
       }
     });
 

--- a/loadlist.js
+++ b/loadlist.js
@@ -101,6 +101,9 @@ export function aggregateLoadsBySource(loads) {
 // Inline load list editor
 if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', () => {
+    const projectId = window.currentProjectId || 'default';
+    dataStore.loadProject(projectId);
+    dataStore.on(dataStore.STORAGE_KEYS.loads, () => dataStore.saveProject(projectId));
     initSettings();
     initDarkMode();
     initCompactMode();

--- a/oneline.js
+++ b/oneline.js
@@ -1,4 +1,4 @@
-import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, getItem, setItem, getStudies, setStudies, on, getCurrentScenario, switchScenario } from './dataStore.mjs';
+import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, getItem, setItem, getStudies, setStudies, on, getCurrentScenario, switchScenario, STORAGE_KEYS, loadProject, saveProject } from './dataStore.mjs';
 import { runLoadFlow } from './analysis/loadFlow.js';
 import { runShortCircuit } from './analysis/shortCircuit.js';
 import { runArcFlash } from './analysis/arcFlash.js';
@@ -11,6 +11,14 @@ import { sizeConductor } from './sizing.js';
 import { runValidation } from './validation/rules.js';
 
 let componentMeta = {};
+
+const projectId = typeof window !== 'undefined' ? (window.currentProjectId || 'default') : undefined;
+if (projectId) {
+  loadProject(projectId);
+  [STORAGE_KEYS.oneLine, STORAGE_KEYS.equipment, STORAGE_KEYS.panels, STORAGE_KEYS.loads, STORAGE_KEYS.cables, STORAGE_KEYS.trays, STORAGE_KEYS.conduits, STORAGE_KEYS.ductbanks].forEach(k => {
+    on(k, () => saveProject(projectId));
+  });
+}
 
 const typeIcons = {
   panel: 'icons/panel.svg',

--- a/panelschedule.js
+++ b/panelschedule.js
@@ -1,6 +1,8 @@
 import * as dataStore from './dataStore.mjs';
 import { exportPanelSchedule } from './exportPanelSchedule.js';
 
+const projectId = typeof window !== 'undefined' ? (window.currentProjectId || 'default') : undefined;
+
 /**
  * Assign a load to a breaker within a panel.
  * Updates the stored load with panel and breaker information.
@@ -24,6 +26,7 @@ export function assignLoadToBreaker(panelId, loadIndex, breaker) {
   load.panelId = panelId;
   load.breaker = breaker;
   dataStore.setLoads(loads);
+  dataStore.saveProject(projectId);
   const fn = window.opener?.updateComponent || window.updateComponent;
   if (fn) {
     const id = load.ref || load.id || load.tag;
@@ -101,6 +104,7 @@ function updateTotals(panelId) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+  dataStore.loadProject(projectId);
   const panelId = 'P1';
   render(panelId);
   document.getElementById('export-panel-btn').addEventListener('click', () => exportPanelSchedule(panelId));
@@ -122,6 +126,7 @@ window.addEventListener('DOMContentLoaded', () => {
           }
         });
         dataStore.setLoads(loads);
+        dataStore.saveProject(projectId);
         const fn = window.opener?.updateComponent || window.updateComponent;
         if (fn) {
           changed.forEach(l => {

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -26,6 +26,10 @@ const TRAY_DEPTH_OPTIONS=['2','3','4','5','6','7','8','9','10','11','12'];
 const TRAY_TYPE_OPTIONS=['Ladder (50 % fill)','Solid Bottom (40 % fill)'];
 
 document.addEventListener('DOMContentLoaded',()=>{
+  const projectId = window.currentProjectId || 'default';
+  dataStore.loadProject(projectId);
+  const save = () => dataStore.saveProject(projectId);
+  [dataStore.STORAGE_KEYS.ductbanks, dataStore.STORAGE_KEYS.trays, dataStore.STORAGE_KEYS.conduits].forEach(k => dataStore.on(k, save));
   initSettings();
   initDarkMode();
   initCompactMode();


### PR DESCRIPTION
## Summary
- add `saveProject`/`loadProject` to `dataStore` for project-scoped persistence
- call project save/load across schedule and one-line pages
- scope raceway, load, equipment, panel, cable data to project identifiers

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce26d81f483249335c602b1619054