### PR TITLE
Skip beforeunload prompt when auto-save is active

### DIFF
--- a/dirtyTracker.js
+++ b/dirtyTracker.js
@@ -1,12 +1,13 @@
 function createDirtyTracker(win = (typeof window !== 'undefined' ? window : undefined)) {
   if (!win) throw new Error('Window object required');
   let dirty = false;
+  const message = 'Project is auto-saved; you can safely leave.';
   const handler = e => {
     e.preventDefault();
-    e.returnValue = '';
+    e.returnValue = message;
   };
   const update = () => {
-    if (dirty) {
+    if (dirty && !win.autoSaveEnabled) {
       win.addEventListener('beforeunload', handler);
     } else {
       win.removeEventListener('beforeunload', handler);

--- a/tests/dirtyTracker.test.js
+++ b/tests/dirtyTracker.test.js
@@ -46,12 +46,22 @@ describe("dirty state tracker", () => {
     assert.strictEqual(e.defaultPrevented, false);
   });
 
+  it("auto-save enabled -> no prompt", () => {
+    const win = makeWindow();
+    win.autoSaveEnabled = true;
+    const tracker = createDirtyTracker(win);
+    tracker.markDirty();
+    const e = win.fire();
+    assert.strictEqual(e.defaultPrevented, false);
+  });
+
   it("edit a cell -> prompt", () => {
     const win = makeWindow();
     const tracker = createDirtyTracker(win);
     tracker.markDirty();
     const e = win.fire();
     assert.strictEqual(e.defaultPrevented, true);
+    assert.strictEqual(e.returnValue, "Project is auto-saved; you can safely leave.");
   });
 
   it("Save -> no prompt", () => {


### PR DESCRIPTION
## Summary
- Skip the `beforeunload` prompt when `autoSaveEnabled` is true
- Show a friendly message "Project is auto-saved; you can safely leave." when prompting
- Cover auto-save and prompt message in dirty tracker tests

## Testing
- `npm test` *(fails: Expected values to be strictly deep-equal in tests/loadlistPersistence.test.js:108)*
- `node tests/dirtyTracker.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bce6ba7818832491f9dff2251bf6c1