### PR TITLE
Enable drag and drop palette components

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -115,6 +115,9 @@
         <div class="workspace">
           <aside id="palette" class="palette">
             <div id="component-buttons">
+              <template id="palette-button-template">
+                <button draggable="true" data-subtype=""></button>
+              </template>
               <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
               <button id="reload-library-btn" type="button" class="btn">Reload library</button>
                 <div class="palette-card card">


### PR DESCRIPTION
## Summary
- Make palette buttons draggable with subtype metadata
- Support drag-and-drop onto the diagram by storing subtype on dragstart and adding components on drop
- Update addComponent to accept type, subtype, and coordinates

## Testing
- `npm test` *(fails: Expected values to be strictly deep-equal in loadlistPersistence.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bce92db9e08324bdf746b5d73187f0