### PR TITLE
Add sheet management and persistence for one-line diagrams

### DIFF
--- a/analysis/arcFlash.js
+++ b/analysis/arcFlash.js
@@ -63,7 +63,7 @@ function arcingCurrent(Ibf, V, gap, cfg, enclosure) {
  */
 export function runArcFlash() {
   const sc = runShortCircuit();
-  const sheets = getOneLine();
+  const { sheets } = getOneLine();
   const comps = Array.isArray(sheets[0]?.components)
     ? sheets.flatMap(s => s.components)
     : sheets;

--- a/analysis/harmonics.js
+++ b/analysis/harmonics.js
@@ -39,7 +39,7 @@ function limitForVoltage(kv) {
  * @returns {Object<string,{ithd:number,vthd:number,limit:number,warning:boolean}>}
  */
 export function runHarmonics() {
-  const sheets = getOneLine();
+  const { sheets } = getOneLine();
   const comps = Array.isArray(sheets[0]?.components)
     ? sheets.flatMap(s => s.components)
     : sheets;

--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -235,7 +235,7 @@ function solveLinear(A, b) {
  */
 export function runLoadFlow(opts = {}) {
   const { baseMVA = 100, balanced = true } = opts;
-  const sheets = getOneLine();
+  const { sheets } = getOneLine();
   const comps = Array.isArray(sheets[0]?.components)
     ? sheets.flatMap(s => s.components || [])
     : sheets;

--- a/analysis/motorStart.js
+++ b/analysis/motorStart.js
@@ -47,7 +47,7 @@ function parseTorqueCurve(spec) {
  * @returns {Object<string,{inrushKA:number,voltageSagPct:number,accelTime:number}>}
  */
 export function runMotorStart() {
-  const sheets = getOneLine();
+  const { sheets } = getOneLine();
   const comps = Array.isArray(sheets[0]?.components)
     ? sheets.flatMap(s => s.components)
     : sheets;

--- a/analysis/reliability.js
+++ b/analysis/reliability.js
@@ -86,7 +86,7 @@ export function runReliability(components = []) {
 if (typeof document !== 'undefined') {
   const chartEl = document.getElementById('reliability-chart');
   if (chartEl) {
-    const sheets = getOneLine();
+    const { sheets } = getOneLine();
     const comps = Array.isArray(sheets[0]?.components)
       ? sheets.flatMap(s => s.components)
       : sheets;

--- a/analysis/shortCircuit.js
+++ b/analysis/shortCircuit.js
@@ -29,7 +29,7 @@ function parallel(a, b) {
  *   - `method` ('ANSI' or 'IEC')
  */
 export function runShortCircuit(opts = {}) {
-  const sheets = getOneLine();
+  const { sheets } = getOneLine();
   const comps = Array.isArray(sheets[0]?.components)
     ? sheets.flatMap(s => s.components)
     : sheets;

--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -41,7 +41,7 @@ async function init() {
   setStudies(studies);
   let linked = null;
   if (compId) {
-    const sheets = getOneLine();
+    const { sheets } = getOneLine();
     for (const sheet of sheets) {
       const comp = (sheet.components || []).find(c => c.id === compId);
       if (comp) { linked = comp; break; }
@@ -115,12 +115,12 @@ function linkComponent() {
   const sel = [...deviceSelect.selectedOptions].map(o => o.value);
   const first = sel[0];
   if (!first) return;
-  const sheets = getOneLine();
-  for (const sheet of sheets) {
+  const data = getOneLine();
+  for (const sheet of data.sheets) {
     const comp = (sheet.components || []).find(c => c.id === compId);
     if (comp) {
       comp.tccId = first;
-      setOneLine(sheets);
+      setOneLine(data);
       break;
     }
   }

--- a/oneline.html
+++ b/oneline.html
@@ -68,7 +68,7 @@
             <button id="scenario-diff-btn" type="button" class="btn">Diff</button>
             <button id="revision-btn" type="button" class="btn">Revisions</button>
           </div>
-          <div id="sheet-tabs" class="sheet-tabs"></div>
+          <div id="sheet-tabs" class="sheet-tabs" role="tablist"></div>
           <div class="sheet-action-group">
             <button id="add-sheet-btn" class="btn icon-button" title="Add Sheet" aria-label="Add Sheet">+</button>
             <button id="rename-sheet-btn" class="btn icon-button" title="Rename Sheet" aria-label="Rename Sheet">✎</button>

--- a/scenarios.js
+++ b/scenarios.js
@@ -25,8 +25,8 @@ function diffScenarios(a, b) {
   const diagram = document.getElementById('diagram');
   if (!diagram) return;
   diagram.querySelectorAll('.scenario-diff').forEach(el => el.classList.remove('scenario-diff'));
-  const sheetsA = getOneLine(a);
-  const sheetsB = getOneLine(b);
+  const { sheets: sheetsA } = getOneLine(a);
+  const { sheets: sheetsB } = getOneLine(b);
   const map = arr => {
     const m = new Map();
     for (const s of arr) {

--- a/site.js
+++ b/site.js
@@ -502,7 +502,7 @@ function initSettings(){
       const headers=['sample'];
       const rows=[{sample:'demo'}];
       downloadCSV(headers,rows,'reports.csv');
-      const issues=runValidation(getOneLine(),getStudies());
+      const issues=runValidation(getOneLine().sheets,getStudies());
       const vHeaders=['component','message'];
       const vRows=issues.length?issues:[{component:'-',message:'No issues'}];
       downloadCSV(vHeaders,vRows,'validation-report.csv');

--- a/tests/analysis.test.js
+++ b/tests/analysis.test.js
@@ -63,7 +63,7 @@ function caseToDiagram(data) {
 
   describe('analysis benchmarks', () => {
     it('matches IEEE 14-bus load flow', () => {
-      setOneLine(caseToDiagram(lfBench));
+      setOneLine({ activeSheet: 0, sheets: caseToDiagram(lfBench) });
       const res = runLoadFlow({ baseMVA: lfBench.baseMVA });
       Object.entries(lfBench.expected).forEach(([id, exp]) => {
         const bus = res.buses.find(b => b.id === id);
@@ -74,7 +74,7 @@ function caseToDiagram(data) {
     });
 
     it('matches short-circuit example', () => {
-      setOneLine(scBench.oneLine);
+      setOneLine({ activeSheet: 0, sheets: scBench.oneLine });
       const res = runShortCircuit();
       Object.entries(scBench.expected).forEach(([id, exp]) => {
         const bus = res[id];
@@ -88,7 +88,7 @@ function caseToDiagram(data) {
 
     it('matches arc-flash example', () => {
       setItem('tccSettings', afBench.tccSettings);
-      setOneLine(afBench.oneLine);
+      setOneLine({ activeSheet: 0, sheets: afBench.oneLine });
       const res = runArcFlash();
       Object.entries(afBench.expected).forEach(([id, exp]) => {
         const bus = res[id];

--- a/tests/arcflash/arcFlashExample.test.js
+++ b/tests/arcflash/arcFlashExample.test.js
@@ -20,12 +20,12 @@ global.localStorage = {
   describe('arc flash analysis', () => {
     it('uses protective device clearing time', () => {
       setItem('tccSettings', { devices: ['abb_tmax_160'], settings: { abb_tmax_160: { pickup: 160, delay: 0.2, instantaneous: 800 } } });
-      setOneLine([{ name: 'S1', components: [
+      setOneLine({ activeSheet: 0, sheets: [{ name: 'S1', components: [
         { id: 'BUS1', kV: 0.48, z1: { r: 0, x: 0.05 }, z2: { r: 0, x: 0.05 }, z0: { r: 0, x: 0.05 },
           sources: [{ z1: { r: 0, x: 0.02 }, z2: { r: 0, x: 0.02 }, z0: { r: 0, x: 0.02 } }],
           enclosure: 'Box', gap: 32, working_distance: 455, electrode_config: 'VCB', tccId: 'abb_tmax_160',
           enclosure_height: 508, enclosure_width: 508, enclosure_depth: 508 }
-      ] }]);
+      ] }] });
       const res = runArcFlash();
       const af = res.BUS1;
       assert(Math.abs(af.incidentEnergy - 1.25) < 0.05);

--- a/tests/loadflow/ieeeCases.test.js
+++ b/tests/loadflow/ieeeCases.test.js
@@ -47,13 +47,13 @@ function caseToDiagram(data){
 
   describe('IEEE load flow benchmarks', () => {
     it('solves IEEE 14-bus case', () => {
-      setOneLine(caseToDiagram(case14));
+      setOneLine({ activeSheet: 0, sheets: caseToDiagram(case14) });
       const res = runLoadFlow({ baseMVA: case14.baseMVA });
       assert(res.buses.length === case14.buses.length);
     });
 
     it('loads IEEE 57-bus placeholder', () => {
-      setOneLine(caseToDiagram(case57));
+      setOneLine({ activeSheet: 0, sheets: caseToDiagram(case57) });
       const res = runLoadFlow({ baseMVA: case57.baseMVA });
       assert(Array.isArray(res.buses || res));
     });

--- a/tests/shortcircuit/shortCircuit.test.js
+++ b/tests/shortcircuit/shortCircuit.test.js
@@ -21,12 +21,12 @@ global.localStorage = {
 
   describe('short circuit engine', () => {
     it('handles multiple voltages with X/R and source contributions', () => {
-      setOneLine([{ name: 'S1', components: [
+      setOneLine({ activeSheet: 0, sheets: [{ name: 'S1', components: [
         { id: 'bus13kV', kV: 13.8, z1: { r: 0, x: 1 }, z2: { r: 0, x: 1 }, z0: { r: 0, x: 1 },
           sources: [{ z1: { r: 0, x: 0.5 }, z2: { r: 0, x: 0.5 }, z0: { r: 0, x: 1 } }] },
         { id: 'bus480V', kV: 0.48, z1: { r: 0, x: 0.05 }, z2: { r: 0, x: 0.05 }, z0: { r: 0, x: 0.05 },
           sources: [{ z1: { r: 0, x: 0.02 }, z2: { r: 0, x: 0.02 }, z0: { r: 0, x: 0.02 } }], xr_ratio: 6 }
-      ] }]);
+      ] }] });
       const res = runShortCircuit();
       const a = res.bus13kV;
       assert(Math.abs(a.threePhaseKA - 26.29) < 0.1);


### PR DESCRIPTION
## Summary
- Support multiple one-line sheets each with independent components and connections
- Add addSheet/renameSheet/deleteSheet helpers and persist active sheet
- Store and restore sheet data through `dataStore` and include in project import/export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcedf0a35c8324964caa305974afd1