### PR TITLE
Improve numeric input handling and validation

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -102,6 +102,14 @@ window.addEventListener('DOMContentLoaded', () => {
     {key:'notes',label:'Notes',type:'text',group:'Notes',tooltip:'Additional comments or notes'}
   ];
 
+  columns.forEach(col => {
+    if (col.type === 'number') {
+      col.step = 'any';
+      col.maxlength = 15;
+      col.validate = col.validate || 'numeric';
+    }
+  });
+
   // Retrieve existing cables from project storage.
   let tableData = dataStore.getCables();
   const vdLimitIn = document.getElementById('vd-limit');

--- a/equipmentlist.js
+++ b/equipmentlist.js
@@ -16,13 +16,13 @@ if (typeof window !== 'undefined') {
       { key: 'voltage', label: 'Voltage (V)', type: 'text' },
       { key: 'category', label: 'Category', type: 'text' },
       { key: 'subCategory', label: 'Sub-Category', type: 'text' },
-      { key: 'manufacturer', label: 'Manufacturer', type: 'text' },
-      { key: 'model', label: 'Model', type: 'text' },
+      { key: 'manufacturer', label: 'Manufacturer', type: 'text', className: 'manufacturer-input' },
+      { key: 'model', label: 'Model', type: 'text', className: 'model-input' },
       { key: 'phases', label: 'Phases', type: 'text' },
       { key: 'notes', label: 'Notes', type: 'text' },
-      { key: 'x', label: 'X', type: 'number' },
-      { key: 'y', label: 'Y', type: 'number' },
-      { key: 'z', label: 'Z', type: 'number' }
+      { key: 'x', label: 'X', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
+      { key: 'y', label: 'Y', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
+      { key: 'z', label: 'Z', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' }
     ];
 
     let table;

--- a/loadlist.js
+++ b/loadlist.js
@@ -170,6 +170,24 @@ if (typeof window !== 'undefined') {
   function saveRow(tr) {
     const idx = Number(tr.dataset.index);
     const load = gatherRow(tr);
+    const numericFields = ['quantity','voltage','kw','powerFactor','loadFactor','efficiency','demandFactor','phases'];
+    let valid = true;
+    numericFields.forEach(name => {
+      const input = tr.querySelector(`input[name="${name}"]`);
+      if (input) {
+        const val = input.value.trim();
+        if (val !== '' && isNaN(Number(val))) {
+          input.classList.add('input-error');
+          valid = false;
+        } else {
+          input.classList.remove('input-error');
+        }
+      }
+    });
+    if (!valid) {
+      alert('Please correct highlighted numeric fields.');
+      return;
+    }
     const computed = calculateDerived(load);
     Object.assign(load, computed);
     dataStore.updateLoad(idx, load);
@@ -242,10 +260,10 @@ if (typeof window !== 'undefined') {
       <td><input name="source" type="text" value="${load.source || ''}"></td>
       <td><input name="tag" type="text" value="${load.tag || ''}"></td>
       <td><input name="description" type="text" value="${load.description || ''}"></td>
-      <td><input name="manufacturer" type="text" value="${load.manufacturer || ''}"></td>
-      <td><input name="model" type="text" value="${load.model || ''}"></td>
-      <td><input name="quantity" type="number" step="any" value="${load.quantity || ''}"></td>
-      <td><input name="voltage" type="number" step="any" value="${load.voltage || ''}"></td>
+      <td><input name="manufacturer" type="text" class="manufacturer-input" value="${load.manufacturer || ''}"></td>
+      <td><input name="model" type="text" class="model-input" value="${load.model || ''}"></td>
+      <td><input name="quantity" type="number" step="any" maxlength="15" value="${load.quantity || ''}"></td>
+      <td><input name="voltage" type="number" step="any" maxlength="15" value="${load.voltage || ''}"></td>
       <td><input name="loadType" type="text" value="${load.loadType || ''}"></td>
       <td><select name="duty">
         <option value=""></option>
@@ -253,12 +271,12 @@ if (typeof window !== 'undefined') {
         <option value="Intermittent"${load.duty === 'Intermittent' ? ' selected' : ''}>Intermittent</option>
         <option value="Stand-by"${load.duty === 'Stand-by' ? ' selected' : ''}>Stand-by</option>
       </select></td>
-      <td><input name="kw" type="number" step="any" value="${load.kw || ''}"></td>
-      <td><input name="powerFactor" type="number" step="any" value="${load.powerFactor || ''}"></td>
-      <td><input name="loadFactor" type="number" step="any" value="${load.loadFactor || ''}"></td>
-      <td><input name="efficiency" type="number" step="any" value="${load.efficiency || ''}"></td>
-      <td><input name="demandFactor" type="number" step="any" value="${load.demandFactor || ''}"></td>
-      <td><input name="phases" type="text" value="${load.phases || ''}"></td>
+      <td><input name="kw" type="number" step="any" maxlength="15" value="${load.kw || ''}"></td>
+      <td><input name="powerFactor" type="number" step="any" maxlength="15" value="${load.powerFactor || ''}"></td>
+      <td><input name="loadFactor" type="number" step="any" maxlength="15" value="${load.loadFactor || ''}"></td>
+      <td><input name="efficiency" type="number" step="any" maxlength="15" value="${load.efficiency || ''}"></td>
+      <td><input name="demandFactor" type="number" step="any" maxlength="15" value="${load.demandFactor || ''}"></td>
+      <td><input name="phases" type="number" step="any" maxlength="15" value="${load.phases || ''}"></td>
       <td><input name="circuit" type="text" value="${load.circuit || ''}"></td>
       <td><textarea name="notes">${load.notes || ''}</textarea></td>
       <td class="kva">${format(load.kva)}</td>

--- a/style.css
+++ b/style.css
@@ -259,6 +259,11 @@ input[type="number"], input[type="text"], select {
     border-color: red;
 }
 
+.manufacturer-input,
+.model-input {
+    text-align: left;
+}
+
 .error-message {
     color: red;
     font-size: 0.85em;

--- a/tableUtils.js
+++ b/tableUtils.js
@@ -594,7 +594,11 @@ class TableManager {
       } else {
         el = document.createElement('input');
         el.type = col.type || 'text';
-        if(el.type==='number') el.step = col.step || '1';
+        if (el.type === 'number') {
+          el.step = col.step || 'any';
+        }
+        if (col.maxlength) el.maxLength = col.maxlength;
+        if (col.className) el.className = col.className;
         if (col.datalist) {
           const listId = `${col.key}-datalist`;
           el.setAttribute('list', listId);


### PR DESCRIPTION
## Summary
- add step="any" and length limits to numeric table inputs
- style manufacturer/model fields as text inputs with alignment classes
- validate numeric fields on save and display user-friendly errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcf1f72d7083249213300827c5b6eb