### PR TITLE
Add panel metadata and dynamic circuit count

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -211,6 +211,9 @@ function ensurePanelFields(panel) {
     id: '',
     description: '',
     ref: '',
+    voltage: '',
+    mainRating: '',
+    circuitCount: 42,
     ...panel
   };
 }

--- a/exportPanelSchedule.js
+++ b/exportPanelSchedule.js
@@ -18,10 +18,12 @@ export function exportPanelSchedule(panelId) {
   data.push(['Panel', panelId]);
   data.push(['Voltage', panel.voltage || panel.voltage_rating || '']);
   data.push(['Main Rating (A)', panel.mainRating || panel.main_rating || '']);
+  const circuitCount = panel.circuitCount || panel.breakers?.length || 42;
+  data.push(['Circuit Count', circuitCount]);
   data.push([]);
   data.push(['Circuit', 'Poles', 'Description', 'Demand (kVA)']);
 
-  for (let circuit = 1; circuit <= 42; circuit++) {
+  for (let circuit = 1; circuit <= circuitCount; circuit++) {
     const load = loads.find(l => Number(l.breaker) === circuit);
     const poles = load ? (load.poles || load.phases || '') : '';
     const desc = load ? (load.description || '') : '';

--- a/panelschedule.html
+++ b/panelschedule.html
@@ -54,6 +54,11 @@
         <p>Assign loads from the load list to panel breakers.</p>
       </header>
       <section class="card">
+        <div id="panel-info" style="margin-bottom:10px;">
+          <label>Voltage <input id="panel-voltage" type="text"></label>
+          <label>Main Breaker Rating (A) <input id="panel-main-rating" type="number" min="0"></label>
+          <label>Number of Circuits <input id="panel-circuit-count" type="number" min="1"></label>
+        </div>
         <div id="panel-container"></div>
         <div id="panel-totals" style="margin-top:10px;"></div>
         <button id="export-panel-btn">Export to Excel</button>


### PR DESCRIPTION
## Summary
- add voltage, main breaker rating, and circuit count inputs to panel schedule
- persist new panel fields and render circuit headers 1..n
- include panel details and circuit count in panel schedule export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcf7244e7c8324b0d9afa20a44eb6e