### PR TITLE
Populate equipment dropdowns and record one-line connections

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -61,11 +61,17 @@ window.addEventListener('DOMContentLoaded', () => {
     return Array.from(ids);
   }
 
+  function getEquipmentOptions(){
+    const ids=new Set();
+    try{ dataStore.getEquipment().forEach(eq=>{ if(eq.id) ids.add(eq.id); }); }catch(e){}
+    return Array.from(ids);
+  }
+
   const columns=[
     {key:'tag',label:'Tag',type:'text',group:'Identification',tooltip:'Unique identifier for the cable'},
     {key:'service_description',label:'Service Description',type:'text',group:'Identification',tooltip:"Description of the cable's purpose"},
-    {key:'from_tag',label:'From Tag',type:'text',group:'Routing / Termination',tooltip:'Starting equipment or location tag'},
-    {key:'to_tag',label:'To Tag',type:'text',group:'Routing / Termination',tooltip:'Ending equipment or location tag'},
+    {key:'from_tag',label:'From Tag',type:'text',datalist:()=>getEquipmentOptions(),group:'Routing / Termination',tooltip:'Starting equipment or location tag'},
+    {key:'to_tag',label:'To Tag',type:'text',datalist:()=>getEquipmentOptions(),group:'Routing / Termination',tooltip:'Ending equipment or location tag'},
     {key:'start_x',label:'Start X',type:'number',group:'Routing / Termination',tooltip:'X-coordinate of cable start'},
     {key:'start_y',label:'Start Y',type:'number',group:'Routing / Termination',tooltip:'Y-coordinate of cable start'},
     {key:'start_z',label:'Start Z',type:'number',group:'Routing / Termination',tooltip:'Z-coordinate of cable start'},

--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -182,6 +182,16 @@ export const getCables = () => read(KEYS.cables, []);
 export const setCables = cables => write(KEYS.cables, cables);
 
 /**
+ * Append a cable record to the existing cable schedule.
+ * @param {Cable} cable
+ */
+export const addCable = cable => {
+  const list = getCables();
+  list.push(cable);
+  setCables(list);
+};
+
+/**
  * @returns {Ductbank[]}
  */
 export const getDuctbanks = () => read(KEYS.ductbanks, []);
@@ -198,6 +208,24 @@ export const getConduits = () => read(KEYS.conduits, []);
  * @param {Conduit[]} conduits
  */
 export const setConduits = conduits => write(KEYS.conduits, conduits);
+
+/**
+ * Append a raceway record. If the object contains `tray_id` it is stored
+ * with trays; otherwise it is assumed to be a conduit.
+ * @param {Tray|Conduit} raceway
+ */
+export const addRaceway = raceway => {
+  if (!raceway) return;
+  if (raceway.tray_id) {
+    const trays = getTrays();
+    trays.push(raceway);
+    setTrays(trays);
+  } else {
+    const conduits = getConduits();
+    conduits.push(raceway);
+    setConduits(conduits);
+  }
+};
 
 /**
  * @returns {GenericRecord[]}
@@ -723,10 +751,12 @@ if (typeof window !== 'undefined') {
     setTrays,
     getCables,
     setCables,
+    addCable,
     getDuctbanks,
     setDuctbanks,
     getConduits,
     setConduits,
+    addRaceway,
     getPanels,
     setPanels,
     getEquipment,

--- a/oneline.js
+++ b/oneline.js
@@ -1,4 +1,4 @@
-import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, getItem, setItem, getStudies, setStudies, on, getCurrentScenario, switchScenario, STORAGE_KEYS, loadProject, saveProject } from './dataStore.mjs';
+import { getOneLine, setOneLine, setEquipment, setPanels, setLoads, getCables, setCables, addCable, addRaceway, getItem, setItem, getStudies, setStudies, on, getCurrentScenario, switchScenario, STORAGE_KEYS, loadProject, saveProject } from './dataStore.mjs';
 import { runLoadFlow } from './analysis/loadFlow.js';
 import { runShortCircuit } from './analysis/shortCircuit.js';
 import { runArcFlash } from './analysis/arcFlash.js';
@@ -2461,6 +2461,14 @@ async function init() {
           pushHistory();
           render();
           save();
+          try {
+            const fromTag = fromComp.ref || fromComp.id;
+            const toTag = toComp.ref || toComp.id;
+            addCable({ from_tag: fromTag, to_tag: toTag });
+            addRaceway({ conduit_id: `${fromTag}-${toTag}`, from_tag: fromTag, to_tag: toTag });
+          } catch (err) {
+            console.error('Failed to record connection', err);
+          }
         }
         connectSource = null;
         hoverPort = null;

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -38,6 +38,28 @@ document.addEventListener('DOMContentLoaded',()=>{
   initHelpModal('tray-help-btn','tray-help-modal');
   initHelpModal('conduit-help-btn','conduit-help-modal');
   initNavToggle();
+
+  const selectBtn=document.createElement('button');
+  selectBtn.id='select-raceway-btn';
+  selectBtn.textContent='Select Raceway';
+  document.querySelector('.page-header')?.appendChild(selectBtn);
+  const racewaySelect=document.createElement('select');
+  racewaySelect.multiple=true;
+  racewaySelect.style.display='none';
+  document.body.appendChild(racewaySelect);
+
+  function loadRacewayOptions(){
+    const ids=new Set();
+    try{ dataStore.getTrays().forEach(t=>{ if(t.tray_id) ids.add(t.tray_id); }); }catch(e){}
+    try{ dataStore.getConduits().forEach(c=>{ const id=c.tray_id||c.conduit_id; if(id) ids.add(id); }); }catch(e){}
+    racewaySelect.innerHTML='';
+    Array.from(ids).forEach(id=>{const o=document.createElement('option');o.value=id;o.textContent=id;racewaySelect.appendChild(o);});
+  }
+
+  selectBtn.addEventListener('click',()=>{
+    loadRacewayOptions();
+    TableUtils.showRacewayModal(racewaySelect,selectBtn);
+  });
   const tables={};
   function assertTablesReady(){
     for(const [name,t] of Object.entries(tables)){


### PR DESCRIPTION
## Summary
- Fill Cable Schedule from/to fields with equipment IDs from the equipment list
- Provide raceway selector modal populated with tray and conduit IDs
- Capture one-line connections as cable and raceway records in the data store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcf86dd8ec832499a6d3d781b518a5