### PR TITLE
Add row validation for cable schedule

### DIFF
--- a/style.css
+++ b/style.css
@@ -658,6 +658,7 @@ body.dark-mode .sticky-table tbody tr:hover {
 
 .over-limit-row { background-color: var(--error-bg); }
 .missing-tag-row { background-color: var(--error-bg); }
+.missing-row { background-color: var(--warning-bg); }
 
 .toast {
     position: fixed;


### PR DESCRIPTION
## Summary
- add row validation to flag missing tag, size, length, and raceway fields
- highlight invalid inputs and rows and block export until validation passes
- style for highlighting missing rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcfc5e15bc83248a6d1fa989b2d949