### PR TITLE
feat: add cable size catalog and dropdown

### DIFF
--- a/data/cableSizes.json
+++ b/data/cableSizes.json
@@ -1,0 +1,16 @@
+[
+  { "label": "3/C – #8 AWG",     "conductors": 3, "size": "#8 AWG",     "OD": 0.66, "weight": 0.33 },
+  { "label": "3/C – #6 AWG",     "conductors": 3, "size": "#6 AWG",     "OD": 0.74, "weight": 0.45 },
+  { "label": "3/C – #4 AWG",     "conductors": 3, "size": "#4 AWG",     "OD": 0.88, "weight": 0.66 },
+  { "label": "3/C – #2 AWG",     "conductors": 3, "size": "#2 AWG",     "OD": 1.00, "weight": 0.96 },
+  { "label": "3/C – #1 AWG",     "conductors": 3, "size": "#1 AWG",     "OD": 1.13, "weight": 1.17 },
+  { "label": "3/C – 1/0 AWG",    "conductors": 3, "size": "1/0 AWG",    "OD": 1.22, "weight": 1.43 },
+  { "label": "3/C – 2/0 AWG",    "conductors": 3, "size": "2/0 AWG",    "OD": 1.31, "weight": 1.72 },
+  { "label": "3/C – 3/0 AWG",    "conductors": 3, "size": "3/0 AWG",    "OD": 1.42, "weight": 2.14 },
+  { "label": "3/C – 4/0 AWG",    "conductors": 3, "size": "4/0 AWG",    "OD": 1.55, "weight": 2.64 },
+  { "label": "3/C – 250 kcmil",  "conductors": 3, "size": "250 kcmil",  "OD": 1.76, "weight": 3.18 },
+  { "label": "3/C – 350 kcmil",  "conductors": 3, "size": "350 kcmil",  "OD": 1.98, "weight": 4.29 },
+  { "label": "3/C – 500 kcmil",  "conductors": 3, "size": "500 kcmil",  "OD": 2.26, "weight": 5.94 },
+  { "label": "3/C – 750 kcmil",  "conductors": 3, "size": "750 kcmil",  "OD": 2.71, "weight": 9.01 },
+  { "label": "3/C – 1000 kcmil", "conductors": 3, "size": "1000 kcmil", "OD": 3.10, "weight": 11.70 }
+]

--- a/ductbankTable.js
+++ b/ductbankTable.js
@@ -8,6 +8,8 @@ import { getDuctbanks as readStoredDuctbanks, setDuctbanks, setItem, getItem } f
   let filters=[];
   let filterButtons=[];
   let headerCells;
+  let cableSizes=[];
+  fetch('data/cableSizes.json').then(r=>r.json()).then(d=>{cableSizes=d;});
 
   function iconBtn(sym,cls,label,handler){
     const b=document.createElement('button');
@@ -598,13 +600,59 @@ import { getDuctbanks as readStoredDuctbanks, setDuctbanks, setItem, getItem } f
       tagInput.value=cb.tag||'';
       tagInput.addEventListener('input',e=>{cb.tag=e.target.value;});
       cell.appendChild(tagInput);
+
+      cell=tr.insertCell();
+      const sel=document.createElement('select');
+      const empty=document.createElement('option');
+      empty.value='';
+      empty.textContent='-- select --';
+      sel.appendChild(empty);
+      cableSizes.forEach(cs=>{
+        const o=document.createElement('option');
+        const label=cs.label||cs.type;
+        o.value=label;
+        o.textContent=label;
+        o.dataset.od=cs.OD||cs.od;
+        o.dataset.weight=cs.weight;
+        sel.appendChild(o);
+      });
+      sel.value=cb.size||'';
+      cell.appendChild(sel);
+
+      cell=tr.insertCell();
+      const odInput=document.createElement('input');
+      odInput.type='number';
+      odInput.step='0.01';
+      odInput.readOnly=true;
+      odInput.style.width='80px';
+      odInput.value=cb.od||'';
+      cell.appendChild(odInput);
+
+      cell=tr.insertCell();
+      const wtInput=document.createElement('input');
+      wtInput.type='number';
+      wtInput.step='0.01';
+      wtInput.readOnly=true;
+      wtInput.style.width='80px';
+      wtInput.value=cb.weight||'';
+      cell.appendChild(wtInput);
+
       cell=tr.insertCell();
       cell.appendChild(iconBtn('\u2716','removeBtn','Delete Cable',()=>{cableRows.splice(i,1);renderCableTable();}));
+
+      sel.addEventListener('change',e=>{
+        const opt=e.target.selectedOptions[0];
+        cb.size=e.target.value;
+        cb.od=opt.dataset.od||'';
+        cb.weight=opt.dataset.weight||'';
+        odInput.value=cb.od;
+        wtInput.value=cb.weight;
+      });
     });
   }
 
   function addCable(){
-    cableRows.push({tag:''});
+    cableRows.push({tag:'',size:'',od:'',weight:''});
     renderCableTable();
   }
 


### PR DESCRIPTION
## Summary
- add reusable `data/cableSizes.json` for common cable diameters and weights
- use cable size dropdowns in tray fill and ductbank tables to auto-fill OD and weight

## Testing
- `npm run build` *(fails: Invalid value "iife" for option "output.format")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcfe8ffd548324839405253b1db7a5