### PR TITLE
Add sample data loaders for optimal route page

### DIFF
--- a/examples/cableList.json
+++ b/examples/cableList.json
@@ -1,0 +1,7 @@
+[
+  {"name": "Cable 01", "cable_type": "Power", "conductors": 3, "conductor_size": "#12 AWG", "diameter": 1.26, "weight": 1.5, "start": [5,5,5], "end": [110,95,45], "start_tag": "ST1", "end_tag": "ET1", "allowed_cable_group": "HV", "manual_path": "", "raceway_ids": []},
+  {"name": "Cable 02", "cable_type": "Control", "conductors": 3, "conductor_size": "#12 AWG", "diameter": 0.47, "weight": 0.8, "start": [10,0,10], "end": [100,80,25], "start_tag": "ST2", "end_tag": "ET2", "allowed_cable_group": "LV", "manual_path": "", "raceway_ids": []},
+  {"name": "Cable 03", "cable_type": "Signal", "conductors": 3, "conductor_size": "#12 AWG", "diameter": 0.31, "weight": 0.5, "start": [15,5,15], "end": [105,85,30], "start_tag": "ST3", "end_tag": "ET3", "allowed_cable_group": "LV", "manual_path": "", "raceway_ids": []},
+  {"name": "Cable 04", "cable_type": "Power", "conductors": 3, "conductor_size": "#12 AWG", "diameter": 1.10, "weight": 1.3, "start": [20,10,8], "end": [115,90,35], "start_tag": "ST4", "end_tag": "ET4", "allowed_cable_group": "HV", "manual_path": "", "raceway_ids": []},
+  {"name": "Cable 05", "cable_type": "Control", "conductors": 3, "conductor_size": "#12 AWG", "diameter": 0.59, "weight": 0.9, "start": [25,15,12], "end": [95,75,28], "start_tag": "ST5", "end_tag": "ET5", "allowed_cable_group": "LV", "manual_path": "", "raceway_ids": []}
+]

--- a/examples/trayNetwork.json
+++ b/examples/trayNetwork.json
@@ -1,0 +1,7 @@
+[
+  {"tray_id": "H1-A", "start_x": 0, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 9.30, "allowed_cable_group": "HV", "shape": "STR"},
+  {"tray_id": "H1-B", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 80, "end_y": 0, "end_z": 10, "width": 16, "height": 3.94, "current_fill": 6.98, "allowed_cable_group": "HV", "shape": "STR"},
+  {"tray_id": "V1", "start_x": 40, "start_y": 0, "start_z": 10, "end_x": 40, "end_y": 0, "end_z": 30, "width": 8, "height": 2.36, "current_fill": 2.79, "allowed_cable_group": "HV", "shape": "STR"},
+  {"tray_id": "H2-A", "start_x": 0, "start_y": 0, "start_z": 30, "end_x": 40, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 4.96, "allowed_cable_group": "LV", "shape": "STR"},
+  {"tray_id": "H2-B", "start_x": 40, "start_y": 0, "start_z": 30, "end_x": 80, "end_y": 0, "end_z": 30, "width": 12, "height": 3.15, "current_fill": 8.99, "allowed_cable_group": "LV", "shape": "STR"}
+]

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -7,3 +7,69 @@ document.addEventListener('exclusions-found', () => {
   const details = document.getElementById('route-breakdown-details');
   if (details) details.open = true;
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const trayBtn = document.getElementById('load-sample-trays-btn');
+  if (trayBtn) {
+    trayBtn.addEventListener('click', async () => {
+      try {
+        const res = await fetch('examples/trayNetwork.json');
+        const trays = await res.json();
+        const details = document.getElementById('manual-tray-table-details');
+        if (details) details.open = true;
+        populateTrayTable(trays);
+      } catch (err) {
+        console.error('Failed to load sample tray network', err);
+      }
+    });
+  }
+
+  const cableBtn = document.getElementById('load-sample-cables-btn');
+  if (cableBtn) {
+    cableBtn.addEventListener('click', async () => {
+      try {
+        const res = await fetch('examples/cableList.json');
+        const cables = await res.json();
+        const details = document.getElementById('cable-list-details');
+        if (details) details.open = true;
+        populateCableTable(cables);
+      } catch (err) {
+        console.error('Failed to load sample cable list', err);
+      }
+    });
+  }
+});
+
+function populateTrayTable(trays){
+  const container = document.getElementById('manual-tray-table-container');
+  if(!container) return;
+  let html = '<table class="sticky-table"><thead><tr>'+
+    '<th>Tray ID</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th>'+
+    '<th>Width</th><th>Height</th><th>Group</th></tr></thead><tbody>';
+  trays.forEach(t => {
+    html += `<tr><td>${t.tray_id||''}</td>`+
+      `<td>${t.start_x},${t.start_y},${t.start_z}</td>`+
+      `<td>${t.end_x},${t.end_y},${t.end_z}</td>`+
+      `<td>${t.width}</td><td>${t.height}</td>`+
+      `<td>${t.allowed_cable_group||''}</td></tr>`;
+  });
+  html += '</tbody></table>';
+  container.innerHTML = html;
+}
+
+function populateCableTable(cables){
+  const container = document.getElementById('cable-list-container');
+  if(!container) return;
+  let html = '<table class="sticky-table"><thead><tr>'+
+    '<th>Name</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th>'+
+    '<th>Type</th><th>Group</th></tr></thead><tbody>';
+  cables.forEach(c => {
+    html += `<tr><td>${c.name||''}</td>`+
+      `<td>${(c.start||[]).join(',')}</td>`+
+      `<td>${(c.end||[]).join(',')}</td>`+
+      `<td>${c.cable_type||''}</td>`+
+      `<td>${c.allowed_cable_group||''}</td></tr>`;
+  });
+  html += '</tbody></table>';
+  container.innerHTML = html;
+}


### PR DESCRIPTION
## Summary
- Add example tray network and cable list JSON files
- Load sample tray network and cable list in `optimalRoute.js`
- Populate hidden tables when sample buttons are clicked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdaac4c4b883249026db5bcc549a92