### PR TITLE
Enable manual tray and cable entry

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -160,7 +160,7 @@
                     <div class="table-import-export">
                         <button id="export-trays-btn">Export Trays CSV</button>
                         <button id="download-trays-template-btn">Download Sample</button>
-                        <input type="file" id="import-trays-file" accept=".csv,.xlsx" style="display:none;">
+                        <input type="file" id="import-trays-file" accept=".csv,.xlsx">
                         <button id="import-trays-btn">Import Trays</button>
                         <button id="clear-trays-btn">Clear All Trays</button>
                     </div>
@@ -228,7 +228,7 @@
                         <div class="table-import-export">
                             <button id="export-cables-btn">Export Cables CSV</button>
                             <button id="download-cables-template-btn">Download Sample</button>
-                            <input type="file" id="import-cables-file" accept=".csv,.xlsx" style="display:none;">
+                            <input type="file" id="import-cables-file" accept=".csv,.xlsx">
                             <button id="import-cables-btn">Import Cables</button>
                         </div>
                         <button id="clear-cables-btn">Clear Cable List</button>

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -8,6 +8,9 @@ document.addEventListener('exclusions-found', () => {
   if (details) details.open = true;
 });
 
+const trayData = [];
+const cableData = [];
+
 document.addEventListener('DOMContentLoaded', () => {
   const trayBtn = document.getElementById('load-sample-trays-btn');
   if (trayBtn) {
@@ -22,6 +25,16 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('Failed to load sample tray network', err);
       }
     });
+  }
+
+  const addTrayBtn = document.getElementById('add-tray-btn');
+  if (addTrayBtn) {
+    addTrayBtn.addEventListener('click', addTrayRow);
+  }
+
+  const addCableBtn = document.getElementById('add-cable-btn');
+  if (addCableBtn) {
+    addCableBtn.addEventListener('click', addCableRow);
   }
 
   const cableBtn = document.getElementById('load-sample-cables-btn');
@@ -40,13 +53,56 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+function addTrayRow(){
+  const tray = {
+    tray_id: document.getElementById('t-id')?.value || '',
+    start_x: parseFloat(document.getElementById('t-sx')?.value) || 0,
+    start_y: parseFloat(document.getElementById('t-sy')?.value) || 0,
+    start_z: parseFloat(document.getElementById('t-sz')?.value) || 0,
+    end_x: parseFloat(document.getElementById('t-ex')?.value) || 0,
+    end_y: parseFloat(document.getElementById('t-ey')?.value) || 0,
+    end_z: parseFloat(document.getElementById('t-ez')?.value) || 0,
+    width: parseFloat(document.getElementById('t-w')?.value) || 0,
+    height: parseFloat(document.getElementById('t-h')?.value) || 0,
+    allowed_cable_group: document.getElementById('t-group')?.value || ''
+  };
+  trayData.push(tray);
+  const details = document.getElementById('manual-tray-table-details');
+  if (details) details.open = true;
+  populateTrayTable();
+}
+
+function addCableRow(){
+  const startTag = prompt('Start equipment tag?') || '';
+  const endTag = prompt('End equipment tag?') || '';
+  const cable = {
+    name: `Cable ${cableData.length + 1}`,
+    start_tag: startTag,
+    end_tag: endTag,
+    cable_type: 'Power',
+    allowed_cable_group: ''
+  };
+  cableData.push(cable);
+  const details = document.getElementById('cable-list-details');
+  if (details) details.open = true;
+  populateCableTable();
+}
+
 function populateTrayTable(trays){
+  if (Array.isArray(trays)) {
+    trayData.length = 0;
+    trayData.push(...trays);
+  }
   const container = document.getElementById('manual-tray-table-container');
   if(!container) return;
+  if (trayData.length === 0){
+    container.innerHTML = '';
+    return;
+  }
   let html = '<table class="sticky-table"><thead><tr>'+
     '<th>Tray ID</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th>'+
     '<th>Width</th><th>Height</th><th>Group</th></tr></thead><tbody>';
-  trays.forEach(t => {
+  trayData.forEach(t => {
     html += `<tr><td>${t.tray_id||''}</td>`+
       `<td>${t.start_x},${t.start_y},${t.start_z}</td>`+
       `<td>${t.end_x},${t.end_y},${t.end_z}</td>`+
@@ -58,15 +114,23 @@ function populateTrayTable(trays){
 }
 
 function populateCableTable(cables){
+  if (Array.isArray(cables)) {
+    cableData.length = 0;
+    cableData.push(...cables);
+  }
   const container = document.getElementById('cable-list-container');
   if(!container) return;
+  if (cableData.length === 0){
+    container.innerHTML = '';
+    return;
+  }
   let html = '<table class="sticky-table"><thead><tr>'+
-    '<th>Name</th><th>Start (X,Y,Z)</th><th>End (X,Y,Z)</th>'+
+    '<th>Name</th><th>Start Equipment</th><th>End Equipment</th>'+
     '<th>Type</th><th>Group</th></tr></thead><tbody>';
-  cables.forEach(c => {
+  cableData.forEach(c => {
     html += `<tr><td>${c.name||''}</td>`+
-      `<td>${(c.start||[]).join(',')}</td>`+
-      `<td>${(c.end||[]).join(',')}</td>`+
+      `<td>${c.start_tag||''}</td>`+
+      `<td>${c.end_tag||''}</td>`+
       `<td>${c.cable_type||''}</td>`+
       `<td>${c.allowed_cable_group||''}</td></tr>`;
   });


### PR DESCRIPTION
## Summary
- Expose tray and cable file inputs by removing `display:none`
- Add state tracking and row addition logic for manual tray/cable entry
- Render cable table with start/end equipment fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdae17f6148324b4ea5bbefc162bc9