### PR TITLE
feat: centralize theme and cleanup inline styles

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -14,7 +14,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
-    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
       <a href="equipmentlist.html">Equipment List</a>
@@ -27,7 +27,7 @@
       <a href="conduitfill.html">Conduit Fill</a>
       <a href="optimalRoute.html">Optimal Route</a>
             <a href="oneline.html">One-Line</a>
-<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
   </nav>
   <div id="settings-menu" class="settings-menu">
@@ -39,13 +39,13 @@
         <option value="metric">Metric</option>
       </select>
     </label>
-    <button id="help-btn" aria-expanded="false">Site Help</button>
-    <button id="new-project-btn">New Project</button>
-    <button id="save-project-btn">Save Project</button>
-    <button id="load-project-btn">Load Project</button>
-    <button id="export-project-btn">Export Project</button>
-    <button id="import-project-btn">Import Project</button>
-    <input type="file" id="import-project-input" accept=".ctr.json" style="display:none;">
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">Site Help</button>
+    <button id="new-project-btn" class="btn" title="Start a new project">New Project</button>
+    <button id="save-project-btn" class="btn" title="Save current project">Save Project</button>
+    <button id="load-project-btn" class="btn" title="Load an existing project">Load Project</button>
+    <button id="export-project-btn" class="btn" title="Export project data">Export Project</button>
+    <button id="import-project-btn" class="btn" title="Import project data">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden" title="Select project file">
   </div>
   <div class="container">
     <main id="main-content" class="main-content">
@@ -65,26 +65,26 @@
         <p>Applicability: tabular organization only; no capacity limits.</p>
       </details>
       <section class="card">
-        <div style="margin-bottom:10px;">
-          <button id="save-schedule-btn">Save Schedule</button>
-          <button id="load-schedule-btn">Load Schedule</button>
-          <button id="load-sample-cables-btn">Load Sample Data</button>
-          <button id="clear-filters-btn">Clear Filters</button>
-          <button id="export-xlsx-btn">Export XLSX</button>
-          <input type="file" id="import-xlsx-input" accept=".xlsx" style="display:none;">
-          <button id="import-xlsx-btn">Import XLSX</button>
-          <button id="delete-all-btn">Delete All Rows</button>
-          <label for="vd-limit" style="margin-left:10px;">VD Limit (%)</label>
-          <input type="number" id="vd-limit" value="3" step="0.1" style="width:60px;">
+        <div class="mb-1">
+          <button id="save-schedule-btn" class="btn" title="Save schedule">Save Schedule</button>
+          <button id="load-schedule-btn" class="btn" title="Load schedule">Load Schedule</button>
+          <button id="load-sample-cables-btn" class="btn" title="Load sample cables">Load Sample Data</button>
+          <button id="clear-filters-btn" class="btn" title="Clear filters">Clear Filters</button>
+          <button id="export-xlsx-btn" class="btn" title="Export as Excel">Export XLSX</button>
+          <input type="file" id="import-xlsx-input" accept=".xlsx" class="hidden" title="Import from Excel">
+          <button id="import-xlsx-btn" class="btn" title="Import from Excel">Import XLSX</button>
+          <button id="delete-all-btn" class="btn" title="Delete all rows">Delete All Rows</button>
+          <label for="vd-limit" class="ml-1">VD Limit (%)</label>
+          <input type="number" id="vd-limit" value="3" step="0.1" class="w-60">
         </div>
-        <div style="overflow-x:auto;">
+        <div class="overflow-x-auto">
           <table id="cableScheduleTable" class="sticky-table">
             <thead></thead>
             <tbody></tbody>
           </table>
         </div>
-        <div style="margin-top:10px;">
-          <button id="add-row-btn" class="primary-btn add-row-btn">Add Cable</button>
+        <div class="mt-1">
+          <button id="add-row-btn" class="btn primary-btn add-row-btn" title="Add cable">Add Cable</button>
         </div>
       </section>
       <nav class="step-nav">
@@ -96,7 +96,7 @@
   </div>
   <div id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="help-title">
     <div class="modal-content">
-      <button id="close-help-btn" class="close-btn" aria-label="Close Help">&times;</button>
+      <button id="close-help-btn" class="close-btn" aria-label="Close Help" title="Close help">&times;</button>
       <h2 id="help-title">Cable Schedule Help</h2>
       <p>This table allows managing cable data. Use the import/export buttons to work with Excel files. Select one or more raceway IDs in the "Raceway(s)" column; options are pulled from the Raceway Schedule page.</p>
     </div>

--- a/equipmentlist.html
+++ b/equipmentlist.html
@@ -15,7 +15,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
-    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
       <a href="equipmentlist.html" class="active" aria-current="page">Equipment List</a>
@@ -28,7 +28,7 @@
       <a href="conduitfill.html">Conduit Fill</a>
       <a href="optimalRoute.html">Optimal Route</a>
             <a href="oneline.html">One-Line</a>
-<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
   </nav>
   <div id="settings-menu" class="settings-menu">
@@ -40,13 +40,13 @@
         <option value="metric">Metric</option>
       </select>
     </label>
-    <button id="help-btn" aria-expanded="false">Site Help</button>
-    <button id="new-project-btn">New Project</button>
-    <button id="save-project-btn">Save Project</button>
-    <button id="load-project-btn">Load Project</button>
-    <button id="export-project-btn">Export Project</button>
-    <button id="import-project-btn">Import Project</button>
-    <input type="file" id="import-project-input" accept=".ctr.json" style="display:none;">
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">Site Help</button>
+    <button id="new-project-btn" class="btn" title="Start a new project">New Project</button>
+    <button id="save-project-btn" class="btn" title="Save current project">Save Project</button>
+    <button id="load-project-btn" class="btn" title="Load an existing project">Load Project</button>
+    <button id="export-project-btn" class="btn" title="Export project data">Export Project</button>
+    <button id="import-project-btn" class="btn" title="Import project data">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden" title="Select project file">
   </div>
   <div class="container">
     <main id="main-content" class="main-content">
@@ -55,25 +55,25 @@
         <p>Manage equipment items with basic details.</p>
       </header>
       <section class="card">
-        <div style="margin-bottom:10px;">
-          <button id="add-row-btn" class="primary-btn add-row-btn">Add Row</button>
-          <button id="add-column-btn">Add Column</button>
-          <button id="delete-selected-btn">Delete Selected</button>
-          <button id="export-xlsx-btn">Export XLSX</button>
-          <input type="file" id="import-xlsx-input" accept=".xlsx" style="display:none;">
-          <button id="import-xlsx-btn">Import XLSX</button>
-          <input type="file" id="import-csv-input" accept=".csv" style="display:none;">
-          <button id="import-csv-btn">Import CSV</button>
-          <input type="file" id="import-xml-input" accept=".xml" style="display:none;">
-          <button id="import-xml-btn">Import XML</button>
+        <div class="mb-1">
+          <button id="add-row-btn" class="btn primary-btn add-row-btn" title="Add a new row">Add Row</button>
+          <button id="add-column-btn" class="btn" title="Add a new column">Add Column</button>
+          <button id="delete-selected-btn" class="btn" title="Delete selected rows">Delete Selected</button>
+          <button id="export-xlsx-btn" class="btn" title="Export as Excel">Export XLSX</button>
+          <input type="file" id="import-xlsx-input" accept=".xlsx" class="hidden" title="Import from Excel">
+          <button id="import-xlsx-btn" class="btn" title="Import from Excel">Import XLSX</button>
+          <input type="file" id="import-csv-input" accept=".csv" class="hidden" title="Import from CSV">
+          <button id="import-csv-btn" class="btn" title="Import from CSV">Import CSV</button>
+          <input type="file" id="import-xml-input" accept=".xml" class="hidden" title="Import from XML">
+          <button id="import-xml-btn" class="btn" title="Import from XML">Import XML</button>
         </div>
-        <div style="overflow-x:auto;">
+        <div class="overflow-x-auto">
           <table id="equipment-table" class="sticky-table">
             <thead></thead>
             <tbody></tbody>
           </table>
         </div>
-        <div id="add-column-modal" class="modal" style="display:none;">
+        <div id="add-column-modal" class="modal hidden">
           <div class="modal-content">
             <label>Key <input type="text" id="new-col-key"></label>
             <label>Label <input type="text" id="new-col-label"></label>
@@ -83,7 +83,7 @@
                 <option value="number">Number</option>
               </select>
             </label>
-            <button id="confirm-add-column">Add</button>
+            <button id="confirm-add-column" class="btn" title="Add column">Add</button>
           </div>
         </div>
       </section>

--- a/loadlist.html
+++ b/loadlist.html
@@ -13,7 +13,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
-    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
       <a href="equipmentlist.html">Equipment List</a>
@@ -26,7 +26,7 @@
       <a href="conduitfill.html">Conduit Fill</a>
       <a href="optimalRoute.html">Optimal Route</a>
             <a href="oneline.html">One-Line</a>
-<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
   </nav>
   <div id="settings-menu" class="settings-menu">
@@ -38,13 +38,13 @@
         <option value="metric">Metric</option>
       </select>
     </label>
-    <button id="help-btn" aria-expanded="false">Site Help</button>
-    <button id="new-project-btn">New Project</button>
-    <button id="save-project-btn">Save Project</button>
-    <button id="load-project-btn">Load Project</button>
-    <button id="export-project-btn">Export Project</button>
-    <button id="import-project-btn">Import Project</button>
-    <input type="file" id="import-project-input" accept=".ctr.json" style="display:none;">
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">Site Help</button>
+    <button id="new-project-btn" class="btn" title="Start a new project">New Project</button>
+    <button id="save-project-btn" class="btn" title="Save current project">Save Project</button>
+    <button id="load-project-btn" class="btn" title="Load an existing project">Load Project</button>
+    <button id="export-project-btn" class="btn" title="Export project data">Export Project</button>
+    <button id="import-project-btn" class="btn" title="Import project data">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden" title="Select project file">
   </div>
   <div class="container">
     <main id="main-content" class="main-content">
@@ -53,17 +53,17 @@
         <p>Manage connected loads for panels or equipment.</p>
       </header>
       <section class="card">
-        <div style="margin-bottom:10px;">
-          <button id="delete-selected-btn">Delete Selected</button>
-          <button id="export-btn">Export JSON</button>
-          <button id="import-btn">Import JSON</button>
-          <button id="export-csv-btn">Export CSV</button>
-          <button id="import-csv-btn">Import CSV</button>
-          <button id="copy-btn">Copy to Clipboard</button>
-          <input type="file" id="import-input" accept=".json" style="display:none;">
-          <input type="file" id="import-csv-input" accept=".csv" style="display:none;">
+        <div class="mb-1">
+          <button id="delete-selected-btn" class="btn" title="Delete selected rows">Delete Selected</button>
+          <button id="export-btn" class="btn" title="Export as JSON">Export JSON</button>
+          <button id="import-btn" class="btn" title="Import from JSON">Import JSON</button>
+          <button id="export-csv-btn" class="btn" title="Export as CSV">Export CSV</button>
+          <button id="import-csv-btn" class="btn" title="Import from CSV">Import CSV</button>
+          <button id="copy-btn" class="btn" title="Copy to clipboard">Copy to Clipboard</button>
+          <input type="file" id="import-input" accept=".json" class="hidden" title="Import JSON file">
+          <input type="file" id="import-csv-input" accept=".csv" class="hidden" title="Import CSV file">
         </div>
-        <div style="overflow-x:auto;">
+        <div class="overflow-x-auto">
           <table id="load-table" class="sticky-table">
             <thead>
               <tr>
@@ -95,7 +95,7 @@
             <tfoot></tfoot>
           </table>
         </div>
-        <div id="source-summary" style="margin-top:10px;"></div>
+        <div id="source-summary" class="mt-1"></div>
       </section>
       <nav class="step-nav">
         <a href="panelschedule.html">Panel Schedule</a>

--- a/oneline.html
+++ b/oneline.html
@@ -17,7 +17,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
-    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
       <a href="equipmentlist.html">Equipment List</a>
@@ -30,8 +30,8 @@
       <a href="conduitfill.html">Conduit Fill</a>
       <a href="optimalRoute.html">Optimal Route</a>
       <a href="oneline.html" class="active" aria-current="page">One-Line</a>
-      <button id="studies-panel-btn" type="button">Studies</button>
-      <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+      <button id="studies-panel-btn" type="button" class="btn" title="Open studies panel">Studies</button>
+      <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
   </nav>
   <div id="settings-menu" class="settings-menu">
@@ -43,16 +43,16 @@
         <option value="metric">Metric</option>
       </select>
     </label>
-    <button id="help-btn" aria-expanded="false">Site Help</button>
-    <button id="new-project-btn">New Project</button>
-    <button id="save-project-btn">Save Project</button>
-    <button id="load-project-btn">Load Project</button>
-    <button id="export-project-btn">Export Project</button>
-    <button id="import-project-btn">Import Project</button>
-    <button id="export-reports-btn">Export All Reports</button>
-    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
-    <button id="prefix-settings-btn">Label Prefixes</button>
-    <button id="update-defaults-btn">Update Defaults</button>
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">Site Help</button>
+    <button id="new-project-btn" class="btn" title="Start a new project">New Project</button>
+    <button id="save-project-btn" class="btn" title="Save current project">Save Project</button>
+    <button id="load-project-btn" class="btn" title="Load an existing project">Load Project</button>
+    <button id="export-project-btn" class="btn" title="Export project data">Export Project</button>
+    <button id="import-project-btn" class="btn" title="Import project data">Import Project</button>
+    <button id="export-reports-btn" class="btn" title="Export all reports">Export All Reports</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input" title="Select project file">
+    <button id="prefix-settings-btn" class="btn" title="Edit label prefixes">Label Prefixes</button>
+    <button id="update-defaults-btn" class="btn" title="Update default settings">Update Defaults</button>
   </div>
   <div class="container">
     <main id="main-content" class="main-content">
@@ -76,8 +76,8 @@
             <button id="diagram-export-btn" type="button" class="btn icon-button" title="Export Diagram" aria-label="Export Diagram"><img src="icons/toolbar/export.svg" alt=""></button>
             <input type="file" id="diagram-import-input" accept=".json" class="hidden-input">
             <button id="diagram-import-btn" type="button" class="btn icon-button" title="Import Diagram" aria-label="Import Diagram"><img src="icons/toolbar/import.svg" alt=""></button>
-            <button id="diagram-share-btn" type="button" class="btn">Share</button>
-            <button id="tour-btn" type="button" class="btn">Tour</button>
+            <button id="diagram-share-btn" type="button" class="btn" title="Share diagram">Share</button>
+            <button id="tour-btn" type="button" class="btn" title="Start tour">Tour</button>
           </div>
         </div>
         <div class="toolbar">
@@ -212,7 +212,7 @@
   <aside id="studies-panel" class="studies-panel hidden" aria-label="Studies">
     <div class="studies-header">
       <h2>Studies</h2>
-      <button id="studies-close-btn" class="studies-close-btn" aria-label="Close">&times;</button>
+      <button id="studies-close-btn" class="studies-close-btn" aria-label="Close" title="Close">&times;</button>
     </div>
     <div class="studies-controls">
       <button id="run-loadflow-btn" type="button">Load Flow</button>
@@ -221,7 +221,7 @@
         <button id="run-harmonics-btn" type="button">Harmonics</button>
         <button id="run-motorstart-btn" type="button">Motor Start</button>
         <button id="run-reliability-btn" type="button">Reliability</button>
-        <label style="display:block;margin-top:0.5em"><input type="checkbox" id="toggle-overlays" checked> Show Result Overlays</label>
+        <label class="d-block mt-1"><input type="checkbox" id="toggle-overlays" checked> Show Result Overlays</label>
       </div>
       <pre id="study-results" class="study-results"></pre>
       <div id="loadflow-results" class="study-results"></div>
@@ -229,7 +229,7 @@
   <aside id="lint-panel" class="lint-panel hidden" aria-label="Validation issues">
     <div class="lint-header">
       <h2>Fix-it Hints</h2>
-      <button id="lint-close-btn" class="lint-close-btn" aria-label="Close">&times;</button>
+      <button id="lint-close-btn" class="lint-close-btn" aria-label="Close" title="Close">&times;</button>
     </div>
     <ul id="lint-list"></ul>
   </aside>

--- a/panelschedule.html
+++ b/panelschedule.html
@@ -14,7 +14,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <nav class="top-nav">
-    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">☰</button>
     <div id="nav-links" class="nav-links">
       <a href="index.html">Home</a>
       <a href="equipmentlist.html">Equipment List</a>
@@ -27,7 +27,7 @@
       <a href="conduitfill.html">Conduit Fill</a>
       <a href="optimalRoute.html">Optimal Route</a>
             <a href="oneline.html">One-Line</a>
-<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+<button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
   </nav>
   <div id="settings-menu" class="settings-menu">
@@ -39,13 +39,13 @@
         <option value="metric">Metric</option>
       </select>
     </label>
-    <button id="help-btn" aria-expanded="false">Site Help</button>
-    <button id="new-project-btn">New Project</button>
-    <button id="save-project-btn">Save Project</button>
-    <button id="load-project-btn">Load Project</button>
-    <button id="export-project-btn">Export Project</button>
-    <button id="import-project-btn">Import Project</button>
-    <input type="file" id="import-project-input" accept=".ctr.json" style="display:none;">
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">Site Help</button>
+    <button id="new-project-btn" class="btn" title="Start a new project">New Project</button>
+    <button id="save-project-btn" class="btn" title="Save current project">Save Project</button>
+    <button id="load-project-btn" class="btn" title="Load an existing project">Load Project</button>
+    <button id="export-project-btn" class="btn" title="Export project data">Export Project</button>
+    <button id="import-project-btn" class="btn" title="Import project data">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden" title="Select project file">
   </div>
   <div class="container">
     <main id="main-content" class="main-content">
@@ -54,14 +54,14 @@
         <p>Assign loads from the load list to panel breakers.</p>
       </header>
       <section class="card">
-        <div id="panel-info" style="margin-bottom:10px;">
+        <div id="panel-info" class="mb-1">
           <label>Voltage <input id="panel-voltage" type="text"></label>
           <label>Main Breaker Rating (A) <input id="panel-main-rating" type="number" min="0"></label>
           <label>Number of Circuits <input id="panel-circuit-count" type="number" min="1"></label>
         </div>
         <div id="panel-container"></div>
-        <div id="panel-totals" style="margin-top:10px;"></div>
-        <button id="export-panel-btn">Export to Excel</button>
+        <div id="panel-totals" class="mt-1"></div>
+        <button id="export-panel-btn" class="btn" title="Export panel to Excel">Export to Excel</button>
       </section>
       <nav class="step-nav">
         <a href="loadlist.html">Load List</a>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,10 @@
 
 /* --- Basic Setup --- */
 :root {
+    --primary-color: #0d6efd;
+    --secondary-color: #f8f9fa;
+    --font-family-base: Arial, sans-serif;
+    --spacing-base: 8px;
     --border-color: #dee2e6;
     --text-color: #212529;
     --success-bg: #d4edda;
@@ -16,6 +20,47 @@
     --button-text: #fff;
     --button-padding: var(--spacing-base) calc(var(--spacing-base) * 1.5);
     --button-margin: calc(var(--spacing-base) / 2);
+}
+
+/* Utility classes */
+.btn {
+    background: var(--button-bg);
+    color: var(--button-text);
+    padding: var(--button-padding);
+    margin: var(--button-margin);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.btn:hover {
+    background: var(--button-hover-bg);
+}
+.hidden {
+    display: none;
+}
+.d-block {
+    display: block;
+}
+.mt-1 {
+    margin-top: var(--spacing-base);
+}
+.mt-2 {
+    margin-top: calc(var(--spacing-base) * 2);
+}
+.mb-1 {
+    margin-bottom: var(--spacing-base);
+}
+.mb-2 {
+    margin-bottom: calc(var(--spacing-base) * 2);
+}
+.ml-1 {
+    margin-left: var(--spacing-base);
+}
+.overflow-x-auto {
+    overflow-x: auto;
+}
+.w-60 {
+    width: 60px;
 }
 
 body.dark-mode {


### PR DESCRIPTION
## Summary
- add global theme variables and utility utility classes for buttons, spacing, and visibility
- replace inline styles with CSS classes and add tooltips across schedule and equipment pages
- document button behavior with titles on one-line diagram controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb12db1d483248c7655f150f22e55