### PR TITLE
Add methodology docs and cross-links

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -63,6 +63,7 @@
         </ul>
         <p>Citations: <a href="docs/templates.html">Template documentation</a></p>
         <p>Applicability: tabular organization only; no capacity limits.</p>
+        <p>See also: <a href="docs/load_calculation_formulas.html">Load Calculation Formulas</a>, <a href="docs/cable_fill_rules.html">Cable Fill Rules</a>, <a href="docs/routing_assumptions.html">Routing Assumptions</a>.</p>
       </details>
       <section class="card">
         <div class="mb-1">

--- a/cabletrayfill.html
+++ b/cabletrayfill.html
@@ -64,6 +64,7 @@
           </ul>
           <p>Citations: <a href="docs/standards.html">NEC 392</a></p>
           <p>Applicability: valid for uniform cable loading with fill below 50%.</p>
+          <p>See also: <a href="docs/load_calculation_formulas.html">Load Calculation Formulas</a>, <a href="docs/cable_fill_rules.html">Cable Fill Rules</a>, <a href="docs/routing_assumptions.html">Routing Assumptions</a>.</p>
         </details>
 
         <!-- TRAY PARAMETERS -->

--- a/conduitfill.html
+++ b/conduitfill.html
@@ -61,6 +61,7 @@
         </ul>
         <p>Citations: <a href="docs/standards.html">NEC Chapter 9</a></p>
         <p>Applicability: circular conduits with fill up to 40%.</p>
+        <p>See also: <a href="docs/load_calculation_formulas.html">Load Calculation Formulas</a>, <a href="docs/cable_fill_rules.html">Cable Fill Rules</a>, <a href="docs/routing_assumptions.html">Routing Assumptions</a>.</p>
       </details>
 
       <fieldset>

--- a/docs/cable_fill_rules.html
+++ b/docs/cable_fill_rules.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Documentation</title>
+  <title>Cable Fill Rules</title>
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
@@ -18,60 +18,22 @@
       <a href="../cabletrayfill.html">Tray Fill</a>
       <a href="../conduitfill.html">Conduit Fill</a>
       <a href="../optimalRoute.html">Optimal Route</a>
-      <a href="index.html" class="active" aria-current="page">Docs</a>
+      <a href="index.html" aria-current="page">Docs</a>
     </div>
   </nav>
   <header class="hero">
-    <h1>Documentation</h1>
-    <p>Guides and references for CableTrayRoute.</p>
+    <h1>Cable Fill Rules</h1>
+    <p>How cable areas are compared with available space.</p>
   </header>
-  <div class="doc-content">
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
-    <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation">
-    <div id="doc-list">
-      <section>
-        <h2>Getting Started</h2>
-        <ul class="doc-list">
-          <li><a href="quickstart.html">Quick Start</a></li>
-          <li><a href="tutorial.html">From empty to routed</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Data &amp; Templates</h2>
-        <ul class="doc-list">
-          <li><a href="templates.html">CSV/XLSX Templates</a></li>
-          <li><a href="geometry-fields.html">Geometry Fields</a></li>
-          <li><a href="tray_id_convention.html">Tray ID Convention</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Advanced Topics</h2>
-        <ul class="doc-list">
-          <li><a href="AMPACITY_METHOD.html">Ampacity Method</a></li>
-          <li><a href="soil_resistivity.html">Soil Resistivity</a></li>
-          <li><a href="math.html">Math References</a></li>
-          <li><a href="load_calculation_formulas.html">Load Calculation</a></li>
-          <li><a href="cable_fill_rules.html">Cable Fill Rules</a></li>
-          <li><a href="routing_assumptions.html">Routing Assumptions</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Standards</h2>
-        <ul class="doc-list">
-          <li><a href="standards.html">Engineering References</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Support</h2>
-        <ul class="doc-list">
-          <li><a href="troubleshooting.html">Troubleshooting</a></li>
-        </ul>
-      </section>
-    </div>
-    <footer class="doc-footer">Docs last updated: <span id="last-updated"></span></footer>
+    <p>Cable trays and conduits are evaluated by comparing the total cross-sectional area of installed cables against the available area.</p>
+    <p>Fill percentage is computed as:</p>
+    <p>F = 100 × Σ A<sub>cable</sub> / A<sub>space</sub></p>
+    <p>Where A<sub>cable</sub> is the area of each cable and A<sub>space</sub> is the usable area of the tray or conduit. The tool follows NEC guidance: conduits are typically limited to 40% fill and cable trays to 50% unless noted otherwise.</p>
   </main>
-  </div>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">

--- a/docs/cable_fill_rules.md
+++ b/docs/cable_fill_rules.md
@@ -1,0 +1,9 @@
+# Cable Fill Rules
+
+Cable trays and conduits are evaluated by comparing the total cross-sectional area of installed cables against the available area.
+
+Fill percentage is computed as:
+
+\[ F = 100 \times \frac{\sum A_{\text{cable}}}{A_{\text{space}}} \]
+
+Where \(A_{\text{cable}}\) is the area of each cable and \(A_{\text{space}}\) is the usable area of the tray or conduit. The tool follows NEC guidance: conduits are typically limited to 40% fill and cable trays to 50% unless noted otherwise.

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -25,6 +25,9 @@ const DOC_NAV = [
       { href: "AMPACITY_METHOD.html", title: "Ampacity Method" },
       { href: "soil_resistivity.html", title: "Soil Resistivity" },
       { href: "math.html", title: "Math References" },
+      { href: "load_calculation_formulas.html", title: "Load Calculation" },
+      { href: "cable_fill_rules.html", title: "Cable Fill Rules" },
+      { href: "routing_assumptions.html", title: "Routing Assumptions" },
     ],
   },
   {

--- a/docs/load_calculation_formulas.html
+++ b/docs/load_calculation_formulas.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Documentation</title>
+  <title>Load Calculation Formulas</title>
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
@@ -18,60 +18,26 @@
       <a href="../cabletrayfill.html">Tray Fill</a>
       <a href="../conduitfill.html">Conduit Fill</a>
       <a href="../optimalRoute.html">Optimal Route</a>
-      <a href="index.html" class="active" aria-current="page">Docs</a>
+      <a href="index.html" aria-current="page">Docs</a>
     </div>
   </nav>
   <header class="hero">
-    <h1>Documentation</h1>
-    <p>Guides and references for CableTrayRoute.</p>
+    <h1>Load Calculation Formulas</h1>
+    <p>Power equations used in load summaries.</p>
   </header>
-  <div class="doc-content">
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
-    <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation">
-    <div id="doc-list">
-      <section>
-        <h2>Getting Started</h2>
-        <ul class="doc-list">
-          <li><a href="quickstart.html">Quick Start</a></li>
-          <li><a href="tutorial.html">From empty to routed</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Data &amp; Templates</h2>
-        <ul class="doc-list">
-          <li><a href="templates.html">CSV/XLSX Templates</a></li>
-          <li><a href="geometry-fields.html">Geometry Fields</a></li>
-          <li><a href="tray_id_convention.html">Tray ID Convention</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Advanced Topics</h2>
-        <ul class="doc-list">
-          <li><a href="AMPACITY_METHOD.html">Ampacity Method</a></li>
-          <li><a href="soil_resistivity.html">Soil Resistivity</a></li>
-          <li><a href="math.html">Math References</a></li>
-          <li><a href="load_calculation_formulas.html">Load Calculation</a></li>
-          <li><a href="cable_fill_rules.html">Cable Fill Rules</a></li>
-          <li><a href="routing_assumptions.html">Routing Assumptions</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Standards</h2>
-        <ul class="doc-list">
-          <li><a href="standards.html">Engineering References</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Support</h2>
-        <ul class="doc-list">
-          <li><a href="troubleshooting.html">Troubleshooting</a></li>
-        </ul>
-      </section>
-    </div>
-    <footer class="doc-footer">Docs last updated: <span id="last-updated"></span></footer>
+    <p>This project evaluates electrical load using standard relationships.</p>
+    <ul>
+      <li><strong>Single-phase power</strong>: P = V × I</li>
+      <li><strong>Three-phase power</strong>: P = √3 × V × I</li>
+      <li><strong>Apparent power</strong>: S = V × I</li>
+      <li><strong>Demand load</strong>: P<sub>demand</sub> = Σ P × f<sub>demand</sub></li>
+    </ul>
+    <p>Voltages are in volts, current in amperes, and power in watts. Balanced systems and steady-state conditions are assumed.</p>
   </main>
-  </div>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">

--- a/docs/load_calculation_formulas.md
+++ b/docs/load_calculation_formulas.md
@@ -1,0 +1,10 @@
+# Load Calculation Formulas
+
+This project evaluates electrical load using standard relationships.
+
+- **Single-phase power**: \( P = V \times I \)
+- **Three-phase power**: \( P = \sqrt{3} \times V \times I \)
+- **Apparent power**: \( S = V \times I \)
+- **Demand load**: \( P_{\text{demand}} = \sum P \times f_{\text{demand}} \)
+
+Voltages are in volts, current in amperes, and power in watts. Balanced systems and steady-state conditions are assumed.

--- a/docs/routing_assumptions.html
+++ b/docs/routing_assumptions.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Documentation</title>
+  <title>Routing Assumptions</title>
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
@@ -18,60 +18,26 @@
       <a href="../cabletrayfill.html">Tray Fill</a>
       <a href="../conduitfill.html">Conduit Fill</a>
       <a href="../optimalRoute.html">Optimal Route</a>
-      <a href="index.html" class="active" aria-current="page">Docs</a>
+      <a href="index.html" aria-current="page">Docs</a>
     </div>
   </nav>
   <header class="hero">
-    <h1>Documentation</h1>
-    <p>Guides and references for CableTrayRoute.</p>
+    <h1>Routing Assumptions</h1>
+    <p>Simplifications used for path calculations.</p>
   </header>
-  <div class="doc-content">
+<div class="doc-content">
   <nav id="doc-nav" class="doc-nav"></nav>
   <main id="main-content" class="doc-main">
-    <input type="search" id="doc-search" placeholder="Search docs..." aria-label="Search documentation">
-    <div id="doc-list">
-      <section>
-        <h2>Getting Started</h2>
-        <ul class="doc-list">
-          <li><a href="quickstart.html">Quick Start</a></li>
-          <li><a href="tutorial.html">From empty to routed</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Data &amp; Templates</h2>
-        <ul class="doc-list">
-          <li><a href="templates.html">CSV/XLSX Templates</a></li>
-          <li><a href="geometry-fields.html">Geometry Fields</a></li>
-          <li><a href="tray_id_convention.html">Tray ID Convention</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Advanced Topics</h2>
-        <ul class="doc-list">
-          <li><a href="AMPACITY_METHOD.html">Ampacity Method</a></li>
-          <li><a href="soil_resistivity.html">Soil Resistivity</a></li>
-          <li><a href="math.html">Math References</a></li>
-          <li><a href="load_calculation_formulas.html">Load Calculation</a></li>
-          <li><a href="cable_fill_rules.html">Cable Fill Rules</a></li>
-          <li><a href="routing_assumptions.html">Routing Assumptions</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Standards</h2>
-        <ul class="doc-list">
-          <li><a href="standards.html">Engineering References</a></li>
-        </ul>
-      </section>
-      <section>
-        <h2>Support</h2>
-        <ul class="doc-list">
-          <li><a href="troubleshooting.html">Troubleshooting</a></li>
-        </ul>
-      </section>
-    </div>
-    <footer class="doc-footer">Docs last updated: <span id="last-updated"></span></footer>
+    <p>Routing calculations simplify the physical environment to speed analysis.</p>
+    <ul>
+      <li>Paths are modeled as straight segments between defined nodes.</li>
+      <li>The solver ignores elevation changes, obstacles, and congestion.</li>
+      <li>Dijkstra's algorithm is applied with non‑negative edge weights.</li>
+      <li>Coordinates are treated as planar and use consistent units.</li>
+    </ul>
+    <p>These assumptions suit early design estimates; field conditions may require adjustment.</p>
   </main>
-  </div>
+</div>
   <footer class="site-footer">
     <div class="footer-left">
       <img src="../icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">

--- a/docs/routing_assumptions.md
+++ b/docs/routing_assumptions.md
@@ -1,0 +1,10 @@
+# Routing Assumptions
+
+Routing calculations simplify the physical environment to speed analysis.
+
+- Paths are modeled as straight segments between defined nodes.
+- The solver ignores elevation changes, obstacles, and congestion.
+- Dijkstra's algorithm is applied with non‑negative edge weights.
+- Coordinates are treated as planar and use consistent units.
+
+These assumptions suit early design estimates; field conditions may require adjustment.

--- a/ductbankroute.html
+++ b/ductbankroute.html
@@ -66,6 +66,7 @@
   </ul>
   <p>Citations: <a href="docs/AMPACITY_METHOD.html">IEEE 835</a></p>
   <p>Applicability: homogeneous soil and steady-state current.</p>
+  <p>See also: <a href="docs/load_calculation_formulas.html">Load Calculation Formulas</a>, <a href="docs/cable_fill_rules.html">Cable Fill Rules</a>, <a href="docs/routing_assumptions.html">Routing Assumptions</a>.</p>
 </details>
 <details id="infoSection" open>
  <summary><strong>Ductbank Info</strong></summary>

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -143,6 +143,7 @@
                 </ul>
                 <p>Citations: <a href="docs/math.html">Shortest path algorithms</a></p>
                 <p>Applicability: non-negative weights and connected graphs.</p>
+                <p>See also: <a href="docs/load_calculation_formulas.html">Load Calculation Formulas</a>, <a href="docs/cable_fill_rules.html">Cable Fill Rules</a>, <a href="docs/routing_assumptions.html">Routing Assumptions</a>.</p>
             </details>
 
             <div id="conduit-count" class="message info"></div>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -70,6 +70,7 @@
         </ul>
         <p>Citations: <a href="docs/geometry-fields.html">Geometry fields</a></p>
         <p>Applicability: inventory tracking only.</p>
+        <p>See also: <a href="docs/load_calculation_formulas.html">Load Calculation Formulas</a>, <a href="docs/cable_fill_rules.html">Cable Fill Rules</a>, <a href="docs/routing_assumptions.html">Routing Assumptions</a>.</p>
       </details>
 
       <!-- Ductbank / Conduit Hierarchy -->


### PR DESCRIPTION
## Summary
- document load calculation formulas, cable fill rules, and routing assumptions
- link methodology docs from Method & Assumptions sections across pages
- expand docs navigation to include new references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb2a2ff8c832492d31af395625f59