### PR TITLE
Add power system study modules with reporting

### DIFF
--- a/arcFlash.html
+++ b/arcFlash.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Arc flash study using IEEE 1584.">
+  <title>Arc Flash</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+  <script type="module" src="dataStore.mjs" defer></script>
+  <script type="module" src="studies/arcFlash.js" defer></script>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <div id="nav-links" class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="equipmentlist.html">Equipment List</a>
+      <a href="loadlist.html">Load List</a>
+      <a href="cableschedule.html">Cable Schedule</a>
+      <a href="panelschedule.html">Panel Schedule</a>
+      <a href="racewayschedule.html">Raceway Schedule</a>
+      <a href="ductbankroute.html">Ductbank</a>
+      <a href="cabletrayfill.html">Tray Fill</a>
+      <a href="conduitfill.html">Conduit Fill</a>
+      <a href="optimalRoute.html">Optimal Route</a>
+      <a href="oneline.html">One-Line</a>
+      <a href="tcc.html">TCC</a>
+      <a href="harmonics.html">Harmonics</a>
+      <a href="motorStart.html">Motor Start</a>
+      <a href="loadFlow.html">Load Flow</a>
+      <a href="shortCircuit.html">Short Circuit</a>
+      <a href="arcFlash.html" class="active" aria-current="page">Arc Flash</a>
+      <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+    </div>
+  </nav>
+  <div id="settings-menu" class="settings-menu">
+    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+    <label><input type="checkbox" id="compact-toggle" aria-label="Enable compact table mode"> Compact Mode</label>
+    <label for="unit-select">Units
+      <select id="unit-select">
+        <option value="imperial">Imperial</option>
+        <option value="metric">Metric</option>
+      </select>
+    </label>
+    <button id="help-btn" aria-expanded="false">Site Help</button>
+    <button id="new-project-btn">New Project</button>
+    <button id="save-project-btn">Save Project</button>
+    <button id="load-project-btn">Load Project</button>
+    <button id="export-project-btn">Export Project</button>
+    <button id="import-project-btn">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
+  </div>
+  <div class="container">
+    <main id="main-content" class="main-content">
+      <header class="page-header">
+        <h1>Arc Flash</h1>
+        <p>Estimate incident energy per IEEE 1584.</p>
+      </header>
+      <section class="card">
+        <form id="arcflash-form">
+          <button type="submit">Run Study</button>
+        </form>
+        <pre id="arcflash-output"></pre>
+      </section>
+    </main>
+  </div>
+  <script type="module" src="projectManager.js"></script>
+</body>
+</html>

--- a/loadFlow.html
+++ b/loadFlow.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Load flow study using Newton–Raphson.">
+  <title>Load Flow</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+  <script type="module" src="dataStore.mjs" defer></script>
+  <script type="module" src="studies/loadFlow.js" defer></script>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <div id="nav-links" class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="equipmentlist.html">Equipment List</a>
+      <a href="loadlist.html">Load List</a>
+      <a href="cableschedule.html">Cable Schedule</a>
+      <a href="panelschedule.html">Panel Schedule</a>
+      <a href="racewayschedule.html">Raceway Schedule</a>
+      <a href="ductbankroute.html">Ductbank</a>
+      <a href="cabletrayfill.html">Tray Fill</a>
+      <a href="conduitfill.html">Conduit Fill</a>
+      <a href="optimalRoute.html">Optimal Route</a>
+      <a href="oneline.html">One-Line</a>
+      <a href="tcc.html">TCC</a>
+      <a href="harmonics.html">Harmonics</a>
+      <a href="motorStart.html">Motor Start</a>
+      <a href="loadFlow.html" class="active" aria-current="page">Load Flow</a>
+      <a href="shortCircuit.html">Short Circuit</a>
+      <a href="arcFlash.html">Arc Flash</a>
+      <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+    </div>
+  </nav>
+  <div id="settings-menu" class="settings-menu">
+    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+    <label><input type="checkbox" id="compact-toggle" aria-label="Enable compact table mode"> Compact Mode</label>
+    <label for="unit-select">Units
+      <select id="unit-select">
+        <option value="imperial">Imperial</option>
+        <option value="metric">Metric</option>
+      </select>
+    </label>
+    <button id="help-btn" aria-expanded="false">Site Help</button>
+    <button id="new-project-btn">New Project</button>
+    <button id="save-project-btn">Save Project</button>
+    <button id="load-project-btn">Load Project</button>
+    <button id="export-project-btn">Export Project</button>
+    <button id="import-project-btn">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
+  </div>
+  <div class="container">
+    <main id="main-content" class="main-content">
+      <header class="page-header">
+        <h1>Load Flow</h1>
+        <p>Run a Newton–Raphson load flow analysis.</p>
+      </header>
+      <section class="card">
+        <form id="loadflow-form">
+          <label>Base MVA <input type="number" name="baseMVA" value="100"></label>
+          <label><input type="checkbox" name="balanced" checked> Balanced</label>
+          <button type="submit">Run Study</button>
+        </form>
+        <pre id="loadflow-output"></pre>
+      </section>
+    </main>
+  </div>
+  <script type="module" src="projectManager.js"></script>
+</body>
+</html>

--- a/shortCircuit.html
+++ b/shortCircuit.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Short circuit study using ANSI/IEC methods.">
+  <title>Short Circuit</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+  <script type="module" src="dataStore.mjs" defer></script>
+  <script type="module" src="studies/shortCircuit.js" defer></script>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav">
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">☰</button>
+    <div id="nav-links" class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="equipmentlist.html">Equipment List</a>
+      <a href="loadlist.html">Load List</a>
+      <a href="cableschedule.html">Cable Schedule</a>
+      <a href="panelschedule.html">Panel Schedule</a>
+      <a href="racewayschedule.html">Raceway Schedule</a>
+      <a href="ductbankroute.html">Ductbank</a>
+      <a href="cabletrayfill.html">Tray Fill</a>
+      <a href="conduitfill.html">Conduit Fill</a>
+      <a href="optimalRoute.html">Optimal Route</a>
+      <a href="oneline.html">One-Line</a>
+      <a href="tcc.html">TCC</a>
+      <a href="harmonics.html">Harmonics</a>
+      <a href="motorStart.html">Motor Start</a>
+      <a href="loadFlow.html">Load Flow</a>
+      <a href="shortCircuit.html" class="active" aria-current="page">Short Circuit</a>
+      <a href="arcFlash.html">Arc Flash</a>
+      <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false">⚙</button>
+    </div>
+  </nav>
+  <div id="settings-menu" class="settings-menu">
+    <label><input type="checkbox" id="dark-toggle"> Dark Mode</label>
+    <label><input type="checkbox" id="compact-toggle" aria-label="Enable compact table mode"> Compact Mode</label>
+    <label for="unit-select">Units
+      <select id="unit-select">
+        <option value="imperial">Imperial</option>
+        <option value="metric">Metric</option>
+      </select>
+    </label>
+    <button id="help-btn" aria-expanded="false">Site Help</button>
+    <button id="new-project-btn">New Project</button>
+    <button id="save-project-btn">Save Project</button>
+    <button id="load-project-btn">Load Project</button>
+    <button id="export-project-btn">Export Project</button>
+    <button id="import-project-btn">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden-input">
+  </div>
+  <div class="container">
+    <main id="main-content" class="main-content">
+      <header class="page-header">
+        <h1>Short Circuit</h1>
+        <p>Compute fault currents using ANSI or IEC methods.</p>
+      </header>
+      <section class="card">
+        <form id="shortcircuit-form">
+          <label for="method">Method
+            <select id="method" name="method">
+              <option value="ANSI">ANSI</option>
+              <option value="IEC">IEC</option>
+            </select>
+          </label>
+          <button type="submit">Run Study</button>
+        </form>
+        <pre id="shortcircuit-output"></pre>
+      </section>
+    </main>
+  </div>
+  <script type="module" src="projectManager.js"></script>
+</body>
+</html>

--- a/studies/arcFlash.js
+++ b/studies/arcFlash.js
@@ -1,0 +1,29 @@
+import { runArcFlash } from '../analysis/arcFlash.js';
+import { getStudies, setStudies } from '../dataStore.mjs';
+import { generateArcFlashReport } from '../reports/arcFlashReport.mjs';
+
+/**
+ * Perform an IEEE 1584 arc‑flash study based on the current project data.
+ * Results are persisted and a PDF/CSV report with labels is generated.
+ * @returns {Object}
+ */
+export function runArcFlashStudy() {
+  const res = runArcFlash();
+  const studies = getStudies();
+  studies.arcFlash = res;
+  setStudies(studies);
+  generateArcFlashReport(res);
+  return res;
+}
+
+if (typeof document !== 'undefined') {
+  const form = document.getElementById('arcflash-form');
+  const out = document.getElementById('arcflash-output');
+  if (form && out) {
+    form.addEventListener('submit', ev => {
+      ev.preventDefault();
+      const res = runArcFlashStudy();
+      out.textContent = JSON.stringify(res, null, 2);
+    });
+  }
+}

--- a/studies/loadFlow.js
+++ b/studies/loadFlow.js
@@ -1,0 +1,41 @@
+import { runLoadFlow } from '../analysis/loadFlow.js';
+import { getStudies, setStudies } from '../dataStore.mjs';
+import { downloadPDF } from '../reports/reporting.mjs';
+
+/**
+ * Run a Newton–Raphson power flow using network data from dataStore.
+ * Results are stored in the global studies object and a PDF report is generated.
+ * @param {{baseMVA?:number, balanced?:boolean}} opts
+ * @returns {Object}
+ */
+export function runLoadFlowStudy(opts = {}) {
+  const res = runLoadFlow(opts);
+  const studies = getStudies();
+  studies.loadFlow = res;
+  setStudies(studies);
+  const headers = ['bus', 'Vm', 'Va'];
+  const rows = res.buses.map(b => ({
+    bus: b.id,
+    Vm: Number(b.Vm.toFixed(4)),
+    Va: Number(b.Va.toFixed(2))
+  }));
+  if (rows.length) {
+    downloadPDF('Load Flow Report', headers, rows, 'loadflow.pdf');
+  }
+  return res;
+}
+
+// Browser hook: wire up form submission
+if (typeof document !== 'undefined') {
+  const form = document.getElementById('loadflow-form');
+  const out = document.getElementById('loadflow-output');
+  if (form && out) {
+    form.addEventListener('submit', ev => {
+      ev.preventDefault();
+      const baseMVA = Number(form.baseMVA.value) || 100;
+      const balanced = form.balanced.checked;
+      const res = runLoadFlowStudy({ baseMVA, balanced });
+      out.textContent = JSON.stringify(res, null, 2);
+    });
+  }
+}

--- a/studies/shortCircuit.js
+++ b/studies/shortCircuit.js
@@ -1,0 +1,41 @@
+import { runShortCircuit } from '../analysis/shortCircuit.js';
+import { getStudies, setStudies } from '../dataStore.mjs';
+import { downloadPDF } from '../reports/reporting.mjs';
+
+/**
+ * Execute an ANSI/IEC short‑circuit study using data from dataStore.
+ * Results are saved and a PDF report is produced.
+ * @param {{method?:string}} opts
+ * @returns {Object}
+ */
+export function runShortCircuitStudy(opts = {}) {
+  const res = runShortCircuit(opts);
+  const studies = getStudies();
+  studies.shortCircuit = res;
+  setStudies(studies);
+  const headers = ['bus', 'threePhaseKA', 'lineToGroundKA', 'lineToLineKA', 'doubleLineGroundKA'];
+  const rows = Object.entries(res).map(([id, r]) => ({
+    bus: id,
+    threePhaseKA: r.threePhaseKA,
+    lineToGroundKA: r.lineToGroundKA,
+    lineToLineKA: r.lineToLineKA,
+    doubleLineGroundKA: r.doubleLineGroundKA
+  }));
+  if (rows.length) {
+    downloadPDF('Short Circuit Report', headers, rows, 'shortcircuit.pdf');
+  }
+  return res;
+}
+
+if (typeof document !== 'undefined') {
+  const form = document.getElementById('shortcircuit-form');
+  const out = document.getElementById('shortcircuit-output');
+  if (form && out) {
+    form.addEventListener('submit', ev => {
+      ev.preventDefault();
+      const method = form.method.value;
+      const res = runShortCircuitStudy({ method });
+      out.textContent = JSON.stringify(res, null, 2);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add web pages and JS modules to run load flow, short circuit, and arc flash studies
- store computed results in dataStore and export PDF reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb6e88e608324b00e5b34fe21d436