### PR TITLE
feat: add table row duplicate and delete handlers

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -222,6 +222,41 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  function generateId(existing, base) {
+    let id = base || 'item';
+    let i = 1;
+    while (existing.includes(id)) {
+      id = `${base || 'item'}_${i++}`;
+    }
+    return id;
+  }
+
+  table.tbody.addEventListener('click', e => {
+    const btn = e.target;
+    const tr = btn.closest('tr');
+    if (!tr) return;
+    if (btn.classList.contains('duplicateBtn')) {
+      e.stopImmediatePropagation();
+      const data = table.getData();
+      const idx = Array.from(table.tbody.rows).indexOf(tr);
+      const clone = { ...data[idx] };
+      const ids = data.map(r => r.tag).filter(Boolean);
+      clone.tag = generateId(ids, clone.tag);
+      data.splice(idx + 1, 0, clone);
+      table.setData(data);
+      table.save();
+      if (table.onChange) table.onChange();
+    } else if (btn.classList.contains('removeBtn')) {
+      e.stopImmediatePropagation();
+      const data = table.getData();
+      const idx = Array.from(table.tbody.rows).indexOf(tr);
+      data.splice(idx, 1);
+      table.setData(data);
+      table.save();
+      if (table.onChange) table.onChange();
+    }
+  });
+
   // Provide a setData method similar to Tabulator for convenience.
   table.setData = function(rows){
     this.tbody.innerHTML='';

--- a/equipmentlist.js
+++ b/equipmentlist.js
@@ -51,6 +51,41 @@ if (typeof window !== 'undefined') {
       }
     });
 
+    function generateId(existing, base) {
+      let id = base || 'item';
+      let i = 1;
+      while (existing.includes(id)) {
+        id = `${base || 'item'}_${i++}`;
+      }
+      return id;
+    }
+
+    table.tbody.addEventListener('click', e => {
+      const btn = e.target;
+      const tr = btn.closest('tr');
+      if (!tr) return;
+      if (btn.classList.contains('duplicateBtn')) {
+        e.stopImmediatePropagation();
+        const data = table.getData();
+        const idx = Array.from(table.tbody.rows).indexOf(tr);
+        const clone = { ...data[idx] };
+        const ids = data.map(r => r.id).filter(Boolean);
+        clone.id = generateId(ids, clone.id);
+        data.splice(idx + 1, 0, clone);
+        table.setData(data);
+        table.save();
+        if (table.onChange) table.onChange();
+      } else if (btn.classList.contains('removeBtn')) {
+        e.stopImmediatePropagation();
+        const data = table.getData();
+        const idx = Array.from(table.tbody.rows).indexOf(tr);
+        data.splice(idx, 1);
+        table.setData(data);
+        table.save();
+        if (table.onChange) table.onChange();
+      }
+    });
+
     const addColBtn = document.getElementById('add-column-btn');
     const modal = document.getElementById('add-column-modal');
     const keyInput = document.getElementById('new-col-key');

--- a/loadlist.js
+++ b/loadlist.js
@@ -215,6 +215,32 @@ if (typeof window !== 'undefined') {
     }
   }
 
+  function generateId(existing, base) {
+    let id = base || 'item';
+    let i = 1;
+    while (existing.includes(id)) {
+      id = `${base || 'item'}_${i++}`;
+    }
+    return id;
+  }
+
+  tbody.addEventListener('click', e => {
+    const btn = e.target;
+    const tr = btn.closest('tr');
+    if (!tr) return;
+    const idx = Number(tr.dataset.index);
+    if (btn.classList.contains('duplicateBtn')) {
+      const load = gatherRow(tr);
+      const ids = dataStore.getLoads().map(l => l.id).filter(Boolean);
+      load.id = generateId(ids, load.id || load.tag);
+      dataStore.insertLoad(idx + 1, load);
+      render();
+    } else if (btn.classList.contains('removeBtn')) {
+      dataStore.deleteLoad(idx);
+      render();
+    }
+  });
+
   function handleNav(e, td) {
     if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
       let allSelected = true;


### PR DESCRIPTION
## Summary
- implement custom Dup/Del button handlers for equipment list table
- add Dup/Del button logic for cable schedule table
- hook Dup/Del buttons into load list data store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdbb05fab4832480ee360a501aa2f3