### PR TITLE
Add global table search and dropdown column filters

### DIFF
--- a/dist/equipmentlist.js
+++ b/dist/equipmentlist.js
@@ -1,1 +1,2216 @@
-!function(){"use strict";function e(e){if("string"==typeof e)try{return t(JSON.parse(e))}catch{return function(e){const t=[],n=[],s=/#\d+=IFC([^;]*?)SEGMENT[^;]*?IFCPOLYLINE\(\(([^)]+)\),\(([^)]+)\)\)/gi;let o,a=0;for(;o=s.exec(e);){const e=o[1]||"",s=o[2].split(",").map(e=>parseFloat(e)),i=o[3].split(",").map(e=>parseFloat(e)),r={id:"SEG-"+a++,start_x:s[0],start_y:s[1],start_z:s[2],end_x:i[0],end_y:i[1],end_z:i[2]};/CABLECARRIER/i.test(e)?t.push(r):n.push(r)}return{trays:t,conduits:n}}(e)}return t(e)}function t(e){if(!e||"object"!=typeof e)return{trays:[],conduits:[]};const t=[],n=[],a=e.trays||e.Trays||e.cableTrays||e.CableTrays||[];for(const e of a)t.push(s(e));const i=e.conduits||e.Conduits||e.cableConduits||e.ConduitSegments||[];for(const e of i)n.push(o(e));return{trays:t,conduits:n}}function n(e){const t=parseFloat(e);return Number.isFinite(t)?t:void 0}function s(e={}){return{id:e.id||e.tag||e.tray_id||e.TrayID||e.name||e.Tag||"",start_x:n(e.start_x??e.sx??e.x1??e.StartX??e.start?.x),start_y:n(e.start_y??e.sy??e.y1??e.StartY??e.start?.y),start_z:n(e.start_z??e.sz??e.z1??e.StartZ??e.start?.z),end_x:n(e.end_x??e.ex??e.x2??e.EndX??e.end?.x),end_y:n(e.end_y??e.ey??e.y2??e.EndY??e.end?.y),end_z:n(e.end_z??e.ez??e.z2??e.EndZ??e.end?.z),width:n(e.width??e.w??e.Width??e.size_x),height:n(e.height??e.h??e.Height??e.size_y)}}function o(e={}){return{conduit_id:e.conduit_id||e.id||e.tag||e.ConduitID||"",type:e.type||e.conduit_type||e.Type||"",trade_size:e.trade_size||e.tradeSize||e.size||e.TradeSize||"",start_x:n(e.start_x??e.sx??e.x1??e.start?.x),start_y:n(e.start_y??e.sy??e.y1??e.start?.y),start_z:n(e.start_z??e.sz??e.z1??e.start?.z),end_x:n(e.end_x??e.ex??e.x2??e.end?.x),end_y:n(e.end_y??e.ey??e.y2??e.end?.y),end_z:n(e.end_z??e.ez??e.z2??e.end?.z),capacity:n(e.capacity??e.fill)}}const a={trays:"traySchedule",cables:"cableSchedule",ductbanks:"ductbankSchedule",conduits:"conduitSchedule",panels:"panelSchedule",loads:"loadList",equipment:"equipment",oneLine:"oneLineDiagram",traySchedule:"traySchedule",cableSchedule:"cableSchedule",ductbankSchedule:"ductbankSchedule",conduitSchedule:"conduitSchedule",panelSchedule:"panelSchedule",loadList:"loadList",equipmentList:"equipment",oneLineDiagram:"oneLineDiagram"},i={...a,equipmentColumns:"equipmentColumns",collapsedGroups:"collapsedGroups"},r={};function l(e,t){(r[e]||[]).forEach(e=>{try{e(t)}catch(e){console.error(e)}})}function c(e,t){try{const n="undefined"!=typeof localStorage?localStorage.getItem(e):null;return n?JSON.parse(n):t}catch{return t}}function d(e,t){try{"undefined"!=typeof localStorage&&localStorage.setItem(e,JSON.stringify(t)),l(e,t)}catch(t){console.error("Failed to store",e,t)}}const u=()=>c(a.trays,[]),h=e=>d(a.trays,e),p=()=>c(a.cables,[]),m=e=>d(a.cables,e),y=()=>c(a.ductbanks,[]),g=e=>d(a.ductbanks,e),f=()=>c(a.conduits,[]),b=e=>d(a.conduits,e),E=()=>c(a.panels,[]);function v(e){return{id:"",description:"",ref:"",...e}}const w=e=>d(a.panels,e.map(v)),S=()=>c(a.equipment,[]);function C(e){return{id:"",ref:"",description:"",voltage:"",category:"",subCategory:"",x:"",y:"",z:"",manufacturer:"",model:"",phases:"",notes:"",...e}}const k=e=>d(a.equipment,e.map(C)),x=e=>{const t=S();t.push(C(e)),k(t)},L=(e,t)=>{const n=S();e>=0&&e<n.length&&(n[e]=C({...n[e],...t}),k(n))},A=e=>{const t=S();e>=0&&e<t.length&&(t.splice(e,1),k(t))},T=()=>{const e=c(a.oneLine,[]);return Array.isArray(e)?[{name:"Sheet 1",components:e}]:e&&Array.isArray(e.sheets)?e.sheets:[]},O=e=>d(a.oneLine,{sheets:e}),I=()=>{const e=c(a.loads,[]),t=e.map(R);return e.some(e=>e&&"object"==typeof e&&!("source"in e))&&d(a.loads,t),t};function R(e){const t={...e};return"power"in t&&!("kw"in t)&&(t.kw=t.power,delete t.power),{id:"",ref:"",source:"",tag:"",description:"",quantity:"",voltage:"",loadType:"",duty:"",kw:"",powerFactor:"",loadFactor:"",efficiency:"",demandFactor:"",phases:"",circuit:"",manufacturer:"",model:"",notes:"",...t}}function _(e){const t=R(e);return Object.values(t).every(e=>""===e)}const N=e=>{const t=(e.length?e:[{}]).map(R);d(a.loads,t)},j=e=>{const t=I(),n=R(e);1===t.length&&_(t[0])&&!_(n)?t[0]=n:t.push(n),N(t)},B=(e,t)=>{const n=I(),s=R(t),o=Math.max(0,Math.min(e,n.length));n.splice(o,0,s),N(n)},D=(e,t)=>{const n=I();e>=0&&e<n.length&&(n[e]=R({...n[e],...t}),N(n))},J=e=>{const t=I();e>=0&&e<t.length&&(t.splice(e,1),N(t))},M=(e,t=null)=>c(e,t),P=(e,t)=>d(e,t),z=e=>{try{"undefined"!=typeof localStorage&&localStorage.removeItem(e),l(e,null)}catch(t){console.error("Failed to remove",e,t)}},q=()=>{try{if("undefined"!=typeof localStorage)return Object.keys(localStorage)}catch{}return[]};function F(){const e={ductbanks:y(),conduits:f(),trays:u(),cables:p(),panels:E(),equipment:S(),loads:I(),oneLine:T(),settings:{}},t=new Set([...Object.values(a),"CTR_PROJECT_V1"]);for(const n of q())t.has(n)||(e.settings[n]=M(n));return e}function G(e){let t=e;const{valid:n,missing:s,extra:o}=function(e){const t=["ductbanks","conduits","trays","cables","panels","equipment","loads","settings"],n=["oneLine"],s=[],o=[];if(!e||"object"!=typeof e)return s.push(...t),{valid:!1,missing:s,extra:o};for(const n of t)n in e||s.push(n);for(const s of Object.keys(e))t.includes(s)||n.includes(s)||o.push(s);const a=Array.isArray(e.ductbanks)&&Array.isArray(e.conduits)&&Array.isArray(e.trays)&&Array.isArray(e.cables)&&Array.isArray(e.panels)&&Array.isArray(e.equipment)&&Array.isArray(e.loads)&&e.settings&&"object"==typeof e.settings&&!Array.isArray(e.settings)&&(void 0===e.oneLine||Array.isArray(e.oneLine));return{valid:0===s.length&&0===o.length&&a,missing:s,extra:o}}(t);if(!n){const n=[];s.length&&n.push(`Missing fields: ${s.join(", ")}`),o.length&&n.push(`Extra fields: ${o.join(", ")}`);const a=n.join("\n")||"Invalid project data.";if(!("undefined"!=typeof window&&"function"==typeof window.confirm&&window.confirm(`${a}\nRepair & continue?`)))return!1;t={ductbanks:Array.isArray(e.ductbanks)?e.ductbanks:[],conduits:Array.isArray(e.conduits)?e.conduits:[],trays:Array.isArray(e.trays)?e.trays:[],cables:Array.isArray(e.cables)?e.cables:[],panels:Array.isArray(e.panels)?e.panels:[],equipment:Array.isArray(e.equipment)?e.equipment:[],loads:Array.isArray(e.loads)?e.loads:[],oneLine:Array.isArray(e.oneLine)?e.oneLine:[],settings:e.settings&&"object"==typeof e.settings?e.settings:{}}}g(t.ductbanks),b(t.conduits),h(t.trays),m(t.cables),w(Array.isArray(t.panels)?t.panels:[]),k(Array.isArray(t.equipment)?t.equipment:[]),N(Array.isArray(t.loads)?t.loads:[]),O(Array.isArray(t.oneLine)?t.oneLine:Array.isArray(t.oneLine?.sheets)?t.oneLine.sheets:[]);const i=new Set([...Object.values(a),"CTR_PROJECT_V1"]);for(const e of q())i.has(e)||t.settings&&e in t.settings||z(e);if(t.settings)for(const[e,n]of Object.entries(t.settings))P(e,n);return!0}let U,V;"undefined"!=typeof window&&(window.dataStore={STORAGE_KEYS:i,getTrays:u,setTrays:h,getCables:p,setCables:m,getDuctbanks:y,setDuctbanks:g,getConduits:f,setConduits:b,getPanels:E,setPanels:w,getEquipment:S,setEquipment:k,addEquipment:x,updateEquipment:L,removeEquipment:A,getLoads:I,setLoads:N,addLoad:j,insertLoad:B,updateLoad:D,removeLoad:J,getOneLine:T,setOneLine:O,getItem:M,setItem:P,removeItem:z,on:function(e,t){r[e]||(r[e]=[]),r[e].push(t)},off:function(e,t){const n=r[e];if(!n)return;const s=n.indexOf(t);s>=0&&n.splice(s,1)},keys:q,exportProject:F,importProject:G,importFromCad:async function(t){let n;if("string"==typeof t)n=t;else{if(!t||"function"!=typeof t.text)throw new Error("Unsupported CAD file");n=await t.text()}const{trays:s=[],conduits:o=[]}=e(n);return Array.isArray(s)&&s.length&&h(s),Array.isArray(o)&&o.length&&b(o),{trays:s,conduits:o}},exportToCad:function(e="json"){const t={trays:u(),conduits:f()};let n="application/json",s="json",o=JSON.stringify(t,null,2);if("csv"===e){const e="id,start_x,start_y,start_z,end_x,end_y,end_z,width,height",a=t.trays.map(e=>[e.id,e.start_x,e.start_y,e.start_z,e.end_x,e.end_y,e.end_z,e.width,e.height].join(",")),i="conduit_id,type,trade_size,start_x,start_y,start_z,end_x,end_y,end_z,capacity",r=t.conduits.map(e=>[e.conduit_id,e.type,e.trade_size,e.start_x,e.start_y,e.start_z,e.end_x,e.end_y,e.end_z,e.capacity].join(","));o=`# trays\n${[e,...a].join("\n")}\n# conduits\n${[i,...r].join("\n")}`,n="text/csv",s="csv"}if("undefined"!=typeof document)try{const e=new Blob([o],{type:n}),t=document.createElement("a");t.href=URL.createObjectURL(e),t.download=`raceways.${s}`,document.body.appendChild(t),t.click(),document.body.removeChild(t),URL.revokeObjectURL(t.href)}catch(e){console.error("Failed to export CAD data",e)}return o}}),window.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll(".workflow-grid .workflow-card").forEach(e=>{const t=e.dataset.storageKey,n=e.querySelector(".status");if(!n)return;let s=!1;"racewaySchedule"===t?s=y().length>0||u().length>0||f().length>0:"optimalRoute"===t?s=p().length>0&&u().length>0:t&&(s=!!M(t)),s?(e.classList.add("complete"),n.textContent="✓",n.setAttribute("aria-label","Completed")):n.textContent="Incomplete"})}),function(e){const t=.3048;let n="imperial";function s(){if(e.getProject)try{return e.getProject().settings?.units||"imperial"}catch{return"imperial"}return n}function o(e){return"imperial"===s()?e:e*t}function a(e){return"imperial"===s()?e:25.4*e}function i(){return"imperial"===s()?"ft":"m"}function r(){return"imperial"===s()?"in":"mm"}const l={getUnitSystem:s,setUnitSystem:function(t){const s="metric"===t?"metric":"imperial";if(e.getProject&&e.setProject)try{const t=e.getProject();t.settings=t.settings||{},t.settings.units=s,e.setProject(t)}catch{}n=s},distanceToDisplay:o,distanceFromInput:function(e){return"imperial"===s()?e:e/t},conduitToDisplay:a,conduitFromInput:function(e){return"imperial"===s()?e:e/25.4},distanceLabel:i,conduitLabel:r,formatDistance:function(e,t=2){return`${o(e).toFixed(t)} ${i()}`},formatConduitSize:function(e,t=2){return`${a(e).toFixed(t)} ${r()}`}};"undefined"!=typeof module&&module.exports&&(module.exports=l),e.units=l}("undefined"!=typeof globalThis?globalThis:window);const H="a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex='-1'])",K="CTR_PROJECT_V1";function X(e={}){const t=e.settings||{session:e.session||e.ctrSession||{},collapsedGroups:e.collapsedGroups||{}};return t.units||(t.units="imperial"),{name:e.name||"",ductbanks:e.ductbanks||e.ductbankSchedule||[],conduits:e.conduits||e.conduitSchedule||[],trays:e.trays||e.traySchedule||[],cables:e.cables||e.cableSchedule||[],settings:t}}function $(e){if(Array.isArray(e))return e.map($);if(e&&"object"==typeof e){const t={};return Object.keys(e).sort().forEach(n=>{t[n]=$(e[n])}),t}return e}function Y(e){return JSON.stringify($(e))}function W(e){let t="";for(const n of e)t+=String.fromCharCode(n);return btoa(t)}async function Z(e){try{const t=new CompressionStream("gzip"),n=t.writable.getWriter();await n.write((new TextEncoder).encode(e)),await n.close();const s=await new Response(t.readable).arrayBuffer();return new Uint8Array(s)}catch{return(new TextEncoder).encode(e)}}async function Q(e){const t=function(e){const t=atob(e),n=new Uint8Array(t.length);for(let e=0;e<t.length;e++)n[e]=t.charCodeAt(e);return n}(decodeURIComponent(e)),n=await async function(e){try{const t=new DecompressionStream("gzip"),n=t.writable.getWriter();await n.write(e),await n.close();const s=await new Response(t.readable).arrayBuffer();return(new TextDecoder).decode(s)}catch{return(new TextDecoder).decode(e)}}(t);return JSON.parse(n)}async function ee(){try{const e=Y(getProject()),t=await Z(e);if(t.length>2097152)return void alert("Checkpoint exceeds 2MB limit");globalThis._ctrRealSetItem?.("CTR_CHECKPOINT",W(t))}catch(e){console.error("Checkpoint save failed",e)}}async function te(){if("function"!=typeof getProject)return;const e=getProject(),t=e.name||"Untitled";try{const n=await async function(e){const t=(new TextEncoder).encode(e),n=crypto.subtle||crypto.webcrypto?.subtle,s=await n.digest("SHA-256",t);return Array.from(new Uint8Array(s)).map(e=>e.toString(16).padStart(2,"0")).join("")}(Y(e));let s=document.getElementById("project-display");if(!s){const e=document.querySelector(".top-nav .nav-links"),t=document.getElementById("settings-btn");e&&(s=document.createElement("span"),s.id="project-display",s.style.marginLeft="auto",s.style.marginRight="1rem",e.insertBefore(s,t),t&&(t.style.marginLeft="0"))}s&&(s.textContent=`Project: ${t} (hash: ${n.slice(0,8)})`)}catch(e){console.error("hash failed",e)}}async function ne(){try{const e=getProject?getProject():{name:"",ductbanks:[],conduits:[],trays:[],cables:[],settings:{session:{},collapsedGroups:{},units:"imperial"}},t=Y(e),n=await async function(e){const t=Y(e),n=await Z(t);return encodeURIComponent(W(n))}(e),s=`${location.origin}${location.pathname}#project=${n}`;if(s.length<2e3)await navigator.clipboard.writeText(s),alert("Share link copied to clipboard");else{const e=new Blob([t],{type:"application/json"}),n=document.createElement("a");n.href=URL.createObjectURL(e),n.download="project.ctr.json",n.click(),setTimeout(()=>URL.revokeObjectURL(n.href),0),alert("Project too large for link; downloaded instead")}}catch(e){console.error("share link failed",e)}}function se(e,t){if("Tab"!==e.key)return;const n=t.querySelectorAll(H);if(!n.length)return;const s=n[0],o=n[n.length-1];e.shiftKey&&document.activeElement===s?(e.preventDefault(),o.focus()):e.shiftKey||document.activeElement!==o||(e.preventDefault(),s.focus())}function oe(e){return new Promise((t,n)=>{const s=document.createElement("script");s.src=e,s.onload=()=>t(),s.onerror=n,document.head.appendChild(s)})}async function ae(e="pdf"){const t=[...document.querySelectorAll("input, select, textarea")].map(e=>{return`${t=e.id||e.name||"",document.querySelector(`label[for="${t}"]`)?.textContent.trim()||t}: ${e.value}`;var t}),n=document.getElementById("results")||document.getElementById("output"),s=n?n.innerText.trim():"",o=[...document.querySelectorAll(".method-panel a")].map(e=>e.href);if("pdf"===e){window.jspdf||await oe("https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js");const{jsPDF:e}=window.jspdf,n=new e;let a=10;n.text("Technical Report",10,a),a+=10,n.text("Inputs:",10,a),a+=10,t.forEach(e=>{n.text(e,10,a),a+=10,a>280&&(n.addPage(),a=10)}),s&&(n.addPage(),a=10,n.text("Outputs:",10,a),a+=10,n.text(s,10,a)),o.length&&(n.addPage(),a=10,n.text("References:",10,a),a+=10,o.forEach(e=>{n.text(e,10,a),a+=10,a>280&&(n.addPage(),a=10)})),n.save("technical_report.pdf")}else{window.docx||await oe("https://cdn.jsdelivr.net/npm/docx@8.4.0/build/index.min.js");const{Document:e,Packer:n,Paragraph:a}=window.docx,i=[new a("Technical Report"),new a("Inputs:")];t.forEach(e=>i.push(new a(e))),s&&(i.push(new a("Outputs:")),i.push(new a(s))),o.length&&(i.push(new a("References:")),o.forEach(e=>i.push(new a(e))));const r=new e({sections:[{properties:{},children:i}]}),l=await n.toBlob(r),c=document.createElement("a");c.href=URL.createObjectURL(l),c.download="technical_report.docx",c.click()}}globalThis.migrateProject=X,async function(){const e=await import("https://cdn.jsdelivr.net/npm/fast-json-patch@3.1.0/index.mjs");({applyPatch:U,compare:V}=e)}().then(function(){if("undefined"==typeof localStorage)return;const e=localStorage.getItem.bind(localStorage),t=localStorage.setItem.bind(localStorage),n=localStorage.removeItem.bind(localStorage);globalThis._ctrRealSetItem=t;const s=[],o=[];function a(e,t){const n=V(t,e);n.length&&(s.push(n),o.length=0)}let i;try{i=JSON.parse(e(K))}catch{i=null}if(!i||"object"!=typeof i){const n={cables:JSON.parse(e("cableSchedule")||"[]"),trays:JSON.parse(e("traySchedule")||"[]"),conduits:JSON.parse(e("conduitSchedule")||"[]"),ductbanks:JSON.parse(e("ductbankSchedule")||"[]"),settings:{session:JSON.parse(e("ctrSession")||"{}"),collapsedGroups:JSON.parse(e("collapsedGroups")||"{}"),conduitFillData:JSON.parse(e("conduitFillData")||"null"),trayFillData:JSON.parse(e("trayFillData")||"null"),ductbankSession:JSON.parse(e("ductbankSession")||"{}")}};i=X(n);try{t(K,JSON.stringify(i))}catch(e){console.warn("project save failed",e)}}function r(){try{t(K,JSON.stringify(i))}catch(e){console.warn("project save failed",e)}globalThis.updateProjectDisplay?.()}localStorage.getItem=function(t){if(t===K)return e(t);switch(t){case"cableSchedule":return JSON.stringify(i.cables||[]);case"traySchedule":return JSON.stringify(i.trays||[]);case"conduitSchedule":return JSON.stringify(i.conduits||[]);case"ductbankSchedule":return JSON.stringify(i.ductbanks||[]);case"collapsedGroups":return JSON.stringify(i.settings?.collapsedGroups||{});case"ctrSession":return JSON.stringify(i.settings?.session||{});default:return i.settings&&t in i.settings?JSON.stringify(i.settings[t]):null}},localStorage.setItem=function(e,n){const s=JSON.parse(JSON.stringify(i));if(e!==K){switch(e){case"cableSchedule":i.cables=JSON.parse(n);break;case"traySchedule":i.trays=JSON.parse(n);break;case"conduitSchedule":i.conduits=JSON.parse(n);break;case"ductbankSchedule":i.ductbanks=JSON.parse(n);break;case"collapsedGroups":i.settings.collapsedGroups=JSON.parse(n);break;case"ctrSession":i.settings.session=JSON.parse(n);break;default:i.settings||(i.settings={});try{i.settings[e]=JSON.parse(n)}catch{i.settings[e]=n}}a(s,i),r()}else try{t(e,n)}catch(e){console.warn("project save failed",e)}},localStorage.removeItem=function(e){const t=JSON.parse(JSON.stringify(i));if(e!==K){switch(e){case"cableSchedule":i.cables=[];break;case"traySchedule":i.trays=[];break;case"conduitSchedule":i.conduits=[];break;case"ductbankSchedule":i.ductbanks=[];break;case"collapsedGroups":delete i.settings.collapsedGroups;break;case"ctrSession":delete i.settings.session;break;default:i.settings&&delete i.settings[e]}a(t,i),r()}else n(e)},globalThis.getProject=()=>JSON.parse(JSON.stringify(i)),globalThis.setProject=e=>{const t=JSON.parse(JSON.stringify(i));i=X(e),a(t,i),r()},globalThis.undoProject=()=>{if(!s.length)return;const e=s.pop(),t=JSON.parse(JSON.stringify(i)),n=U(t,e,!0).newDocument;o.push(V(n,i)),i=n,r()},globalThis.redoProject=()=>{if(!o.length)return;const e=o.pop(),t=JSON.parse(JSON.stringify(i)),n=U(t,e,!0).newDocument;s.push(V(n,i)),i=n,r()},globalThis.addEventListener("beforeunload",()=>{s.length=0,o.length=0})}).catch(e=>console.error("fast-json-patch load failed",e)),globalThis.updateProjectDisplay=te;const ie="CTR_CONDUITS";function re(){const e=globalThis.units?.getUnitSystem()?globalThis.units.getUnitSystem():"imperial",t="imperial"===e?"ft":"m",n="imperial"===e?"in":"mm";document.querySelectorAll('[data-unit="distance"]').forEach(e=>e.textContent=t),document.querySelectorAll('[data-unit="conduit"]').forEach(e=>e.textContent=n)}globalThis.document?.addEventListener("DOMContentLoaded",function(){document.addEventListener("keydown",e=>{if("ArrowUp"!==e.key&&"ArrowDown"!==e.key)return;const t=e.target;if(!["INPUT","SELECT","TEXTAREA"].includes(t.tagName))return;const n=t.closest("td");if(!n||!n.closest("table"))return;const s=n.parentElement,o=n.cellIndex,a="ArrowUp"===e.key?s.previousElementSibling:s.nextElementSibling;if(!a)return;const i=a.cells[o];if(!i)return;const r=i.querySelector("input, select, textarea");r&&(e.preventDefault(),r.focus(),"function"==typeof r.select&&r.select())})}),globalThis.addEventListener?.("DOMContentLoaded",function(){!async function(){if(location.hash.startsWith("#project="))try{const e=location.hash.slice(9),t=await Q(e);globalThis.setProject&&globalThis.setProject(t),location.hash="",location.reload()}catch(e){console.error("load share failed",e)}}();const e=document.getElementById("export-project-btn");if(e){const t=document.createElement("button");t.id="save-checkpoint-btn",t.textContent="Save Checkpoint",e.insertAdjacentElement("afterend",t),t.addEventListener("click",ee)}const t=document.getElementById("import-project-btn"),n=document.getElementById("import-project-input");e&&e.addEventListener("click",()=>{try{const e=F(),t=new Blob([JSON.stringify(e,null,2)],{type:"application/json"}),n=document.createElement("a");n.href=URL.createObjectURL(t),n.download="project.ctr.json",n.click(),setTimeout(()=>URL.revokeObjectURL(n.href),0)}catch(e){console.error("Export failed",e)}}),t&&n&&(t.addEventListener("click",()=>n.click()),n.addEventListener("change",e=>{const t=e.target.files[0];if(!t)return;const s=new FileReader;s.onload=e=>{try{G(JSON.parse(e.target.result))&&location.reload()}catch(e){console.error("Import failed",e)}},s.readAsText(t),n.value=""}))}),globalThis.initSettings=function(){const e=document.getElementById("settings-btn"),t=document.getElementById("settings-menu");if(e&&t){t.setAttribute("role","dialog"),t.setAttribute("aria-modal","true"),t.setAttribute("aria-hidden","true");let n=!1;const s=e=>{"Escape"===e.key?a():se(e,t)},o=()=>{n=!0,t.style.display="flex",t.setAttribute("aria-hidden","false"),e.setAttribute("aria-expanded","true"),document.addEventListener("keydown",s);const o=t.querySelectorAll(H);o.length&&o[0].focus()},a=()=>{n&&(n=!1,t.style.display="none",t.setAttribute("aria-hidden","true"),e.setAttribute("aria-expanded","false"),document.removeEventListener("keydown",s),e.focus())};e.addEventListener("click",()=>{n?a():o()}),document.addEventListener("click",s=>{n&&!t.contains(s.target)&&s.target!==e&&a()});const i=document.createElement("label");i.textContent="Project Name";const r=document.createElement("input");r.type="text",r.id="project-name-input";try{r.value=getProject().name||""}catch{}i.appendChild(r),t.insertBefore(i,t.firstChild),r.addEventListener("input",e=>{try{const t=getProject();t.name=e.target.value,setProject(t),te()}catch{}});const l=document.getElementById("export-project-btn"),c=document.createElement("button");c.id="copy-share-link-btn",c.textContent="Copy Share Link",l?l.insertAdjacentElement("beforebegin",c):t.appendChild(c),c.addEventListener("click",ne);const d=document.createElement("button");d.id="run-self-check-btn",d.textContent="Run Self-Check",t.appendChild(d),d.addEventListener("click",()=>{location.href="optimalRoute.html?selfcheck=1"});const u=document.createElement("button");u.id="generate-report-btn",u.textContent="Generate Technical Report",t.appendChild(u),u.addEventListener("click",async()=>{const e=confirm("Generate DOCX? Cancel for PDF");await ae(e?"docx":"pdf")})}const n=document.getElementById("unit-select");if(n){try{n.value=getProject().settings?.units||"imperial"}catch{}n.addEventListener("change",e=>{try{const t=getProject();t.settings=t.settings||{},t.settings.units=e.target.value,setProject(t)}catch{}re()})}re(),te(),window.addEventListener("storage",e=>{e.key===K&&te()})},globalThis.initDarkMode=function(){const e=document.getElementById("dark-toggle"),t=JSON.parse(localStorage.getItem("ctrSession")||"{}");if(void 0===t.darkMode){const e=window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches;t.darkMode=e,localStorage.setItem("ctrSession",JSON.stringify(t))}document.body.classList.toggle("dark-mode",t.darkMode),e&&(e.checked=!!t.darkMode),e&&e.addEventListener("change",()=>{document.body.classList.toggle("dark-mode",e.checked),t.darkMode=e.checked,localStorage.setItem("ctrSession",JSON.stringify(t)),"function"==typeof window.saveSession&&window.saveSession(),"function"==typeof window.saveDuctbankSession&&window.saveDuctbankSession()}),window.addEventListener("storage",t=>{if("ctrSession"===t.key)try{const n=JSON.parse(t.newValue);document.body.classList.toggle("dark-mode",n&&n.darkMode),e&&(e.checked=!(!n||!n.darkMode))}catch{}})},globalThis.initCompactMode=function(){const e=document.getElementById("compact-toggle"),t=JSON.parse(localStorage.getItem("ctrSession")||"{}");void 0===t.compactMode&&(t.compactMode=!1,localStorage.setItem("ctrSession",JSON.stringify(t))),document.body.classList.toggle("compact-mode",t.compactMode),e&&(e.checked=!!t.compactMode),e&&e.addEventListener("change",()=>{document.body.classList.toggle("compact-mode",e.checked),t.compactMode=e.checked,localStorage.setItem("ctrSession",JSON.stringify(t)),"function"==typeof window.saveSession&&window.saveSession(),"function"==typeof window.saveDuctbankSession&&window.saveDuctbankSession()}),window.addEventListener("storage",t=>{if("ctrSession"===t.key)try{const n=JSON.parse(t.newValue);document.body.classList.toggle("compact-mode",n&&n.compactMode),e&&(e.checked=!(!n||!n.compactMode))}catch{}})},globalThis.initHelpModal=function(e="help-btn",t="help-modal",n){const s=document.getElementById(e),o=document.getElementById(t),a=n?document.getElementById(n):o?o.querySelector(".close-btn"):null;if(s&&o&&a){o.setAttribute("role","dialog"),o.setAttribute("aria-modal","true"),o.setAttribute("aria-hidden","true");const e=o.querySelector(".modal-content"),t=Array.from(e.children);let n=null;const i=e=>{"Escape"===e.key?l():se(e,o)},r=()=>{o.style.display="flex",o.setAttribute("aria-hidden","false"),s.setAttribute("aria-expanded","true"),document.addEventListener("keydown",i);const e=o.querySelectorAll(H);e.length&&e[0].focus()},l=()=>{o.style.display="none",o.setAttribute("aria-hidden","true"),s.setAttribute("aria-expanded","false"),document.removeEventListener("keydown",i),s.focus(),n&&(n.style.display="none",n.src=""),t.forEach(e=>{e!==a&&(e.style.display="")})};globalThis.showHelpDoc=s=>{n||(n=document.createElement("iframe"),n.id="help-iframe",n.style.width="100%",n.style.height="80vh",e.appendChild(n)),t.forEach(e=>{e!==a&&(e.style.display="none")}),n.style.display="block",n.src=s,r()},s.addEventListener("click",r),a.addEventListener("click",l),o.addEventListener("click",e=>{e.target===o&&l()})}},globalThis.initNavToggle=function(){const e=document.querySelector(".nav-toggle");if(!e)return;const t=document.getElementById(e.getAttribute("aria-controls"));t&&(e.addEventListener("click",()=>{const n="true"===e.getAttribute("aria-expanded");e.setAttribute("aria-expanded",String(!n)),t.classList.toggle("open",!n)}),document.addEventListener("keydown",n=>{"Escape"===n.key&&(e.setAttribute("aria-expanded","false"),t.classList.remove("open"))}))},globalThis.checkPrereqs=function(e=[]){},globalThis.persistConduits=function(e){try{localStorage.setItem(ie,JSON.stringify(e));const t=globalThis.TableUtils?.STORAGE_KEYS?.conduitSchedule||"conduitSchedule";localStorage.setItem(t,JSON.stringify(e.conduits||[]))}catch(e){console.error("Failed to persist conduits",e)}},globalThis.loadConduits=function(){try{const e=localStorage.getItem(ie);if(e){const t=JSON.parse(e);return{ductbanks:t.ductbanks||[],conduits:t.conduits||[]}}}catch(e){}const e=globalThis.TableUtils?.STORAGE_KEYS?.ductbankSchedule||"ductbankSchedule",t=globalThis.TableUtils?.STORAGE_KEYS?.conduitSchedule||"conduitSchedule";let n=[],s=[];try{n=JSON.parse(localStorage.getItem(e)||"[]")}catch(e){}try{s=JSON.parse(localStorage.getItem(t)||"[]")}catch(e){}const o=[];return n=n.map(e=>{(e.conduits||[]).forEach(t=>{o.push({ductbankTag:e.tag,conduit_id:t.conduit_id,tray_id:`${e.tag}-${t.conduit_id}`,type:t.type,trade_size:t.trade_size,start_x:t.start_x,start_y:t.start_y,start_z:t.start_z,end_x:t.end_x,end_y:t.end_y,end_z:t.end_z,allowed_cable_group:t.allowed_cable_group})});const{conduits:t,...n}=e;return n}),{ductbanks:n,conduits:[...o,...s]}},globalThis.applyUnitLabels=re,globalThis.showSelfCheckModal=function(e){const t=document.createElement("div");t.className="modal",t.id="self-check-modal";const n=document.createElement("div");n.className="modal-content";const s=document.createElement("button");s.className="close-btn",s.textContent="×",s.addEventListener("click",()=>t.remove());const o=document.createElement("h2");o.textContent=e.pass?"Self-Check PASSED":"Self-Check FAILED";const a=document.createElement("pre"),i=JSON.stringify(e,null,2);a.textContent=i;const r=document.createElement("div");r.className="modal-actions";const l=document.createElement("button");l.textContent="Copy Diagnostics",l.addEventListener("click",()=>navigator.clipboard.writeText(i)),r.appendChild(l),n.appendChild(s),n.appendChild(o),n.appendChild(a),n.appendChild(r),t.appendChild(n),document.body.appendChild(t),t.style.display="flex"};class le{constructor(e=[]){this.items=e,this.menu=document.createElement("ul"),this.menu.className="context-menu",Object.assign(this.menu.style,{position:"absolute",display:"none",listStyle:"none",margin:"0",padding:"4px 0",background:"#fff",border:"1px solid #ccc",zIndex:1e3,color:"#000"}),document.body.appendChild(this.menu),document.addEventListener("click",()=>this.hide()),document.addEventListener("keydown",e=>{"Escape"===e.key&&this.hide()})}setItems(e){this.items=e,this.menu.innerHTML="",e.forEach(({label:e,action:t})=>{const n=document.createElement("li");n.textContent=e,Object.assign(n.style,{padding:"4px 12px",cursor:"pointer",background:"#fff",color:"#000"}),n.tabIndex=0,n.addEventListener("click",()=>{const e=this.target;this.hide(),t(e)}),n.addEventListener("mouseenter",()=>{n.style.background="#eee",n.style.color="#000"}),n.addEventListener("mouseleave",()=>{n.style.background="#fff",n.style.color="#000"}),this.menu.appendChild(n)})}show(e,t,n){this.target=n,this.menu.style.left=`${e}px`,this.menu.style.top=`${t}px`,this.menu.style.display="block"}hide(){this.menu.style.display="none",this.target=null}}class ce{constructor(e){if(this.table=document.getElementById(e.tableId),this.thead=this.table.createTHead(),this.tbody=this.table.tBodies[0]||this.table.createTBody(),this.columnsKey=e.columnsKey||null,this.columns=e.columns||[],this.columnsKey)try{const e=M(this.columnsKey,null);Array.isArray(e)&&e.length?this.columns=e:P(this.columnsKey,this.columns)}catch(e){}this.storageKey=e.storageKey||e.tableId,this.onChange=e.onChange||null,this.onSave=e.onSave||null,this.onView=e.onView||null,this.rowCountEl=e.rowCountId?document.getElementById(e.rowCountId):null,this.selectable=e.selectable||!1,this.colOffset=this.selectable?1:0,this.enableContextMenu=e.enableContextMenu||!1,this.handleHeaderDragStart=this.handleHeaderDragStart.bind(this),this.handleHeaderDragOver=this.handleHeaderDragOver.bind(this),this.handleHeaderDrop=this.handleHeaderDrop.bind(this),this.buildHeader(),this.initButtons(e),this.load(),this.enableContextMenu&&this.initContextMenu(),this.hiddenGroups=new Set,this.loadGroupState(),this.updateRowCount()}initButtons(e){e.addRowBtnId&&document.getElementById(e.addRowBtnId).addEventListener("click",()=>{this.addRow(),this.onChange&&this.onChange()}),e.saveBtnId&&document.getElementById(e.saveBtnId).addEventListener("click",()=>{this.save(),this.onSave&&this.onSave()}),e.loadBtnId&&document.getElementById(e.loadBtnId).addEventListener("click",()=>{this.tbody.innerHTML="",this.load(),this.onSave&&this.onSave()}),e.clearFiltersBtnId&&document.getElementById(e.clearFiltersBtnId).addEventListener("click",()=>this.clearFilters()),e.exportBtnId&&document.getElementById(e.exportBtnId).addEventListener("click",()=>{this.exportXlsx(),this.onSave&&this.onSave()}),e.importBtnId&&e.importInputId&&(document.getElementById(e.importBtnId).addEventListener("click",()=>document.getElementById(e.importInputId).click()),document.getElementById(e.importInputId).addEventListener("change",e=>{this.importXlsx(e.target.files[0]),e.target.value="",this.onChange&&this.onChange()})),e.deleteAllBtnId&&document.getElementById(e.deleteAllBtnId).addEventListener("click",()=>{this.deleteAll(),this.onChange&&this.onChange()}),e.deleteSelectedBtnId&&document.getElementById(e.deleteSelectedBtnId).addEventListener("click",()=>{this.deleteSelected(),this.onChange&&this.onChange()})}buildHeader(){this.thead.innerHTML="";const e=this.columns.some(e=>e.group);let t;e&&(t=this.thead.insertRow(),this.selectable&&t.appendChild(document.createElement("th")),this.groupRow=t);const n=this.thead.insertRow();this.headerRow=n,this.filters=Array(this.columns.length).fill(""),this.filterButtons=[],this.groupCols={},this.groupThs={},this.groupToggles={},this.groupFirstIndex={},this.groupLastIndex={},this.groupOrder=[];const s=this.colOffset;if(this.selectable){const e=document.createElement("th"),t=document.createElement("input");t.type="checkbox",t.id=`${this.table.id}-select-all`,t.className="select-all",t.setAttribute("aria-label","Select all rows"),t.addEventListener("change",()=>{this.tbody.querySelectorAll(".row-select").forEach(e=>{e.checked=t.checked})}),e.appendChild(t),n.appendChild(e),this.selectAll=t}if(e){const e=[];let n=null,s=0;this.columns.forEach(t=>{t.group?(n&&n.name===t.group?n.span++:(n={name:t.group,span:1},e.push(n),this.groupCols[t.group]||(this.groupCols[t.group]=[],this.groupFirstIndex[t.group]=s,this.groupOrder.push(t.group))),this.groupCols[t.group].push(s),this.groupLastIndex[t.group]=s):(e.push({name:"",span:1}),n=null),s++}),e.forEach(e=>{const n=document.createElement("th");if(n.colSpan=e.span,n.classList.add("group-header"),e.name){const t=document.createElement("span");t.textContent=e.name,n.appendChild(t);const s=document.createElement("button");s.className="group-toggle",s.textContent="-",s.setAttribute("aria-label","Toggle group"),s.addEventListener("click",t=>{t.stopPropagation(),this.toggleGroup(e.name)}),n.appendChild(s),this.groupThs[e.name]=n,this.groupToggles[e.name]=s,this.groupOrder.indexOf(e.name)>0&&n.classList.add("category-separator"),n.classList.add("category-separator-right")}t.appendChild(n)})}if(this.columns.forEach((e,t)=>{const o=document.createElement("th");o.style.position="relative",o.draggable=!0,o.dataset.index=t;const a=document.createElement("span");a.textContent=e.label,o.appendChild(a);const i=document.createElement("button");i.className="filter-btn",i.innerHTML="▼",i.setAttribute("aria-label","Filter column"),i.addEventListener("click",e=>{e.stopPropagation(),this.showFilterPopup(i,t)}),o.appendChild(i);const r=document.createElement("span");let l,c;r.className="col-resizer",o.appendChild(r);const d=e=>{const n=Math.max(30,c+e.pageX-l);o.style.width=n+"px",Array.from(this.tbody.rows).forEach(e=>{e.cells[t+s]&&(e.cells[t+s].style.width=n+"px")})};r.addEventListener("mousedown",e=>{l=e.pageX,c=o.offsetWidth,document.addEventListener("mousemove",d),document.addEventListener("mouseup",()=>{document.removeEventListener("mousemove",d)},{once:!0})}),e.group&&t===this.groupFirstIndex[e.group]&&this.groupOrder.indexOf(e.group)>0&&o.classList.add("category-separator"),e.group&&t===this.groupLastIndex[e.group]&&o.classList.add("category-separator-right"),n.appendChild(o),this.filterButtons.push(i)}),e){const e=document.createElement("th");e.rowSpan=1,e.style.position="relative",t.appendChild(e),this.groupBlankTh=e}const o=document.createElement("th");o.textContent="Actions",o.style.position="relative";const a=document.createElement("span");let i,r;a.className="col-resizer",o.appendChild(a);const l=e=>{const t=Math.max(30,r+e.pageX-i);o.style.width=t+"px";const n=this.columns.length+s;Array.from(this.tbody.rows).forEach(e=>{e.cells[n]&&(e.cells[n].style.width=t+"px")}),this.groupBlankTh&&(this.groupBlankTh.style.width=t+"px")};a.addEventListener("mousedown",e=>{i=e.pageX,r=o.offsetWidth,document.addEventListener("mousemove",l),document.addEventListener("mouseup",()=>{document.removeEventListener("mousemove",l)},{once:!0})}),n.appendChild(o),n.addEventListener("dragstart",this.handleHeaderDragStart),n.addEventListener("dragover",this.handleHeaderDragOver),n.addEventListener("drop",this.handleHeaderDrop),this.syncGroupBlankWidth()}setGroupVisibility(e,t){const n=this.colOffset,s=this.groupCols[e]||[];s.forEach(e=>{this.headerRow&&this.headerRow.cells[e+n]&&this.headerRow.cells[e+n].classList.toggle("group-hidden",t),Array.from(this.tbody.rows).forEach(s=>{s.cells[e+n]&&s.cells[e+n].classList.toggle("group-hidden",t)})}),this.groupThs[e]&&(this.groupThs[e].classList.toggle("group-collapsed",t),this.groupThs[e].colSpan=t?1:s.length),this.groupToggles[e]&&(this.groupToggles[e].textContent=t?"+":"-"),t?this.hiddenGroups.add(e):this.hiddenGroups.delete(e),this.syncGroupBlankWidth()}toggleGroup(e){const t=!this.hiddenGroups.has(e);this.setGroupVisibility(e,t),this.saveGroupState()}saveGroupState(){let e={};try{e=M(i.collapsedGroups,{})}catch(e){}e[this.storageKey]=Array.from(this.hiddenGroups);try{P(i.collapsedGroups,e)}catch(e){}}loadGroupState(){let e={};try{e=M(i.collapsedGroups,{})}catch(e){}(e[this.storageKey]||[]).forEach(e=>this.setGroupVisibility(e,!0))}syncGroupBlankWidth(){const e=this.columns.length+this.colOffset;if(this.groupBlankTh&&this.headerRow&&this.headerRow.cells[e]){const t=this.headerRow.cells[e].offsetWidth;this.groupBlankTh.style.width=t+"px"}}updateRowCount(){this.rowCountEl&&(this.rowCountEl.textContent=`Rows: ${this.tbody.querySelectorAll("tr").length}`)}persistColumns(){if(this.columnsKey)try{P(this.columnsKey,this.columns)}catch(e){}}handleHeaderDragStart(e){const t=e.target.closest("th");t&&void 0!==t.dataset.index&&e.dataTransfer.setData("text/plain",t.dataset.index)}handleHeaderDragOver(e){e.target.closest("th")&&e.preventDefault()}handleHeaderDrop(e){const t=e.target.closest("th");if(!t||void 0===t.dataset.index)return;e.preventDefault();const n=parseInt(e.dataTransfer.getData("text/plain"),10),s=parseInt(t.dataset.index,10);if(isNaN(n)||isNaN(s)||n===s)return;const o=this.columns.splice(n,1)[0];this.columns.splice(s,0,o),this.persistColumns();const a=this.getData();this.buildHeader(),this.tbody.innerHTML="",a.forEach(e=>this.addRow(e)),this.save()}addColumn(e){const t=this.getData();this.columns.push(e),this.persistColumns(),this.buildHeader(),this.tbody.innerHTML="",t.forEach(e=>this.addRow(e)),this.save(),this.updateRowCount(),this.onChange&&this.onChange()}removeColumn(e){const t=this.columns.findIndex(t=>t.key===e);if(-1===t)return;const n=this.getData();n.forEach(t=>{delete t[e]}),this.columns.splice(t,1),this.persistColumns(),this.buildHeader(),this.tbody.innerHTML="",n.forEach(e=>this.addRow(e)),this.save(),this.updateRowCount(),this.onChange&&this.onChange()}showFilterPopup(e,t){document.querySelectorAll(".filter-popup").forEach(e=>e.remove());const n=document.createElement("div");n.className="filter-popup";const s=document.createElement("input");let o;s.type="text",s.value=this.filters[t],n.appendChild(s);const a=()=>{this.filters[t]=s.value.trim(),this.filters[t]?e.classList.add("filtered"):e.classList.remove("filtered"),this.applyFilters()};s.addEventListener("input",()=>{clearTimeout(o),o=setTimeout(a,300)});const i=document.createElement("button");i.textContent="Apply",i.setAttribute("aria-label","Apply filter"),i.addEventListener("click",()=>{clearTimeout(o),a(),n.remove()}),n.appendChild(i);const r=document.createElement("button");r.textContent="Clear",r.setAttribute("aria-label","Clear filter"),r.addEventListener("click",()=>{s.value="",this.filters[t]="",e.classList.remove("filtered"),this.applyFilters(),n.remove()}),n.appendChild(r);const l=e.getBoundingClientRect();n.style.top=l.bottom+window.scrollY+"px",n.style.left=l.left+window.scrollX+"px",document.body.appendChild(n);const c=e=>{n.contains(e.target)||(n.remove(),document.removeEventListener("click",c))};setTimeout(()=>document.addEventListener("click",c),0)}showRacewayModal(e,t){const n=document.createElement("div");n.className="modal",n.setAttribute("role","dialog"),n.setAttribute("aria-modal","true"),n.setAttribute("aria-hidden","false");const s=document.createElement("div");s.className="modal-content",n.appendChild(s);const o=document.createElement("div");o.className="dual-listbox",s.appendChild(o);const a=e=>{const t=document.createElement("div");t.className="list-container";const n=document.createElement("h3");n.textContent=e,t.appendChild(n);const s=document.createElement("input");s.type="text",s.placeholder="Search",t.appendChild(s);const o=document.createElement("select");return o.multiple=!0,o.setAttribute("role","listbox"),o.setAttribute("aria-multiselectable","true"),t.appendChild(o),{wrap:t,search:s,list:o}},i=a("Available Raceways"),r=a("Selected Raceways");Array.from(e.options).map(e=>({value:e.value,text:e.text,selected:e.selected})).forEach(e=>{const t=document.createElement("option");t.value=e.value,t.textContent=e.text,(e.selected?r.list:i.list).appendChild(t)}),o.appendChild(i.wrap);const l=document.createElement("div");l.className="button-column";const c=(e,t)=>{const n=document.createElement("button");return n.type="button",n.textContent=e,t&&n.setAttribute("aria-label",t),n.addEventListener("keydown",e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),n.click())}),n},d=c(">>","Move all to selected"),u=c(">","Move selected to selected"),h=c("<","Move selected to available"),p=c("<<","Move all to available");[d,u,h,p].forEach(e=>l.appendChild(e)),o.appendChild(l),o.appendChild(r.wrap);const m=(e,t)=>{Array.from(e.selectedOptions).forEach(e=>t.appendChild(e))},y=(e,t)=>{Array.from(e.options).forEach(e=>t.appendChild(e))};d.addEventListener("click",()=>y(i.list,r.list)),u.addEventListener("click",()=>m(i.list,r.list)),h.addEventListener("click",()=>m(r.list,i.list)),p.addEventListener("click",()=>y(r.list,i.list));const g=(e,t)=>{const n=t.toLowerCase();Array.from(e.options).forEach(e=>e.style.display=e.text.toLowerCase().includes(n)?"":"none")};i.search.addEventListener("input",()=>g(i.list,i.search.value)),r.search.addEventListener("input",()=>g(r.list,r.search.value));const f=document.createElement("div");f.style.marginTop="1rem",f.style.textAlign="right";const b=document.createElement("button");b.type="button",b.textContent="Save",b.setAttribute("aria-label","Save selection");const E=document.createElement("button");E.type="button",E.textContent="Cancel",E.setAttribute("aria-label","Cancel selection"),f.appendChild(b),f.appendChild(E),s.appendChild(f);const v=()=>{n.remove(),document.removeEventListener("keydown",w),t&&t.focus()};E.addEventListener("click",v),n.addEventListener("click",e=>{e.target===n&&v()}),b.addEventListener("click",()=>{const t=Array.from(r.list.options).map(e=>e.value);Array.from(e.options).forEach(e=>e.selected=t.includes(e.value)),e.dispatchEvent(new Event("change",{bubbles:!0})),v()});const w=e=>{"Escape"===e.key?(e.preventDefault(),v()):trapFocus(e,s)};document.addEventListener("keydown",w),document.body.appendChild(n),n.style.display="flex",i.search.focus()}addRow(e={}){const t=this.tbody.insertRow();if(void 0!==e.ref&&(t.dataset.ref=e.ref),void 0!==e.id&&(t.dataset.id=e.id),this.selectable){const e=t.insertCell(),n=document.createElement("input");n.type="checkbox",n.className="row-select",n.addEventListener("change",()=>{!n.checked&&this.selectAll&&(this.selectAll.checked=!1)}),e.appendChild(n)}this.columns.forEach((n,s)=>{const o=t.insertCell();let a;if(n.group&&s===this.groupFirstIndex[n.group]&&this.groupOrder.indexOf(n.group)>0&&o.classList.add("category-separator"),n.group&&s===this.groupLastIndex[n.group]&&o.classList.add("category-separator-right"),"select"===n.type){const s="function"==typeof n.options?n.options(t,e):n.options||[];n.multiple?(a=document.createElement("select"),a.multiple=!0,n.size&&(a.size=n.size),s.forEach(e=>{const t=document.createElement("option");t.value=e,t.textContent=e,a.appendChild(t)}),a.style.display="none",a.getSelectedValues=()=>Array.from(a.selectedOptions).map(e=>e.value),a.setSelectedValues=e=>{Array.from(a.options).forEach(t=>{t.selected=(e||[]).includes(t.value)})}):(a=document.createElement("select"),s.forEach(e=>{const t=document.createElement("option");t.value=e,t.textContent=e,a.appendChild(t)}))}else if(a=document.createElement("input"),a.type=n.type||"text","number"===a.type&&(a.step=n.step||"1"),n.datalist){const s=`${n.key}-datalist`;a.setAttribute("list",s);let o=document.getElementById(s);o||(o=document.createElement("datalist"),o.id=s,document.body.appendChild(o));const i="function"==typeof n.datalist?n.datalist(t,e):n.datalist;o.innerHTML="",(i||[]).forEach(e=>{const t=document.createElement("option");t.value=e,o.appendChild(t)})}a.name=n.key;const i=void 0!==e[n.key]?e[n.key]:n.default;if(void 0!==i)if(n.multiple){const e=Array.isArray(i)?i:[i];a.setSelectedValues?a.setSelectedValues(e):a.options&&Array.from(a.options).forEach(t=>{t.selected=e.includes(t.value)})}else a.value=i;else"SELECT"===a.tagName&&a.options.length&&!n.multiple&&(a.value=a.options[0].value);let r,l;if(this.headerRow&&this.headerRow.cells[s+this.colOffset]&&this.headerRow.cells[s+this.colOffset].style.width&&(o.style.width=this.headerRow.cells[s+this.colOffset].style.width),o.appendChild(a),n.multiple?(r=document.createElement("button"),r.type="button",r.className="raceway-summary",r.setAttribute("aria-label","View selected raceways"),r.addEventListener("click",e=>{e.stopPropagation(),this.showRacewayModal(a,r)}),r.addEventListener("keydown",e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this.showRacewayModal(a,r))}),o.addEventListener("click",()=>{this.showRacewayModal(a,r)}),o.appendChild(r),l=()=>{const e=a.getSelectedValues?a.getSelectedValues():[];e.length?(r.textContent=e.join(", "),r.classList.remove("placeholder")):(r.textContent="Select Raceways",r.classList.add("placeholder"))},a.addEventListener("change",()=>{l(),this.onChange&&this.onChange()}),l()):a.addEventListener("input",()=>{this.onChange&&this.onChange()}),a.addEventListener("focus",()=>{a.dataset.prevValue=a.value}),a.addEventListener("keydown",e=>{const n=s+this.colOffset;if("ArrowLeft"===e.key||"ArrowRight"===e.key){let t=!0;if("INPUT"===e.target.tagName||"TEXTAREA"===e.target.tagName){const n=e.target.selectionStart??0,s=e.target.selectionEnd??0,o=(e.target.value||"").length;t=0===n&&s===o}if(t){e.preventDefault();const t="ArrowLeft"===e.key?o.previousElementSibling:o.nextElementSibling;if(t){const e=t.querySelector("input,select,textarea");e&&(e.focus(),"function"==typeof e.select&&e.select())}}}else if("ArrowUp"===e.key||"ArrowDown"===e.key){e.preventDefault();let s=t;const o="ArrowUp"===e.key?"previousElementSibling":"nextElementSibling";do{s=s[o]}while(s&&"none"===s.style.display);if(s&&s.cells[n]){const e=s.cells[n].querySelector("input,select,textarea");e&&(e.focus(),"function"==typeof e.select&&e.select())}}else if("Enter"===e.key){e.preventDefault();let s=t.nextElementSibling;if(s||(s=this.addRow(),this.onChange&&this.onChange()),s&&s.cells[n]){const e=s.cells[n].querySelector("input,select,textarea");e&&(e.focus(),"function"==typeof e.select&&e.select())}}else"Escape"===e.key&&(e.preventDefault(),void 0!==a.dataset.prevValue&&(a.value=a.dataset.prevValue,this.onChange&&this.onChange()))}),n.onChange&&a.addEventListener("change",()=>{n.onChange(a,t)}),n.validate){const e=Array.isArray(n.validate)?n.validate:[n.validate];a.addEventListener(n.multiple?"change":"input",()=>de(a,e)),de(a,e)}});const n=t.insertCell(),s=this.columns.length+this.colOffset;if(this.headerRow&&this.headerRow.cells[s]&&this.headerRow.cells[s].style.width&&(n.style.width=this.headerRow.cells[s].style.width),this.onView){const e=document.createElement("button");e.textContent="👁",e.className="viewBtn",e.title="View row",e.setAttribute("aria-label","View row"),e.addEventListener("click",()=>{const e={};this.columns.forEach((n,s)=>{const o=t.cells[s+this.colOffset].firstChild;o&&(n.multiple?"function"==typeof o.getSelectedValues?e[n.key]=o.getSelectedValues():e[n.key]=Array.from(o.selectedOptions||[]).map(e=>e.value):e[n.key]=o.value)}),this.onView(e,t)}),n.appendChild(e)}const o=document.createElement("button");o.textContent="+",o.className="insertBelowBtn",o.title="Add row",o.setAttribute("aria-label","Add row"),o.addEventListener("click",()=>{const e=this.addRow();e&&this.tbody.insertBefore(e,t.nextSibling),this.onChange&&this.onChange()}),n.appendChild(o);const a=document.createElement("button");a.textContent="⧉",a.className="duplicateBtn",a.title="Duplicate row",a.setAttribute("aria-label","Duplicate row"),a.addEventListener("click",()=>{const e={};this.columns.forEach((n,s)=>{const o=t.cells[s+this.colOffset].firstChild;o&&(n.multiple?"function"==typeof o.getSelectedValues?e[n.key]=o.getSelectedValues():e[n.key]=Array.from(o.selectedOptions||[]).map(e=>e.value):e[n.key]=o.value)});const n=this.addRow(e);n&&this.tbody.insertBefore(n,t.nextSibling),this.onChange&&this.onChange()}),n.appendChild(a);const i=document.createElement("button");return i.textContent="✖",i.className="removeBtn",i.title="Delete row",i.setAttribute("aria-label","Delete row"),i.addEventListener("click",()=>{t.remove(),this.save(),this.updateRowCount(),this.onChange&&this.onChange()}),n.appendChild(i),Object.keys(this.groupCols||{}).forEach(e=>{this.hiddenGroups&&this.hiddenGroups.has(e)&&(this.groupCols[e]||[]).forEach(e=>{t.cells[e+this.colOffset]&&t.cells[e+this.colOffset].classList.add("group-hidden")})}),this.updateRowCount(),t}getRowData(e){const t={},n=this.colOffset;return this.columns.forEach((s,o)=>{const a=e.cells[o+n]?e.cells[o+n].firstChild:null;a&&(s.multiple?"function"==typeof a.getSelectedValues?t[s.key]=a.getSelectedValues():t[s.key]=Array.from(a.selectedOptions||[]).map(e=>e.value):t[s.key]=a.value)}),t}getData(){const e=[],t=this.colOffset;return Array.from(this.tbody.rows).forEach(n=>{const s={};this.columns.forEach((e,o)=>{const a=n.cells[o+t].firstChild;if(a){const t=a.value;if(e.multiple)"function"==typeof a.getSelectedValues?s[e.key]=a.getSelectedValues():s[e.key]=Array.from(a.selectedOptions||[]).map(e=>e.value);else if("number"===e.type){const n=parseFloat(t);s[e.key]=""===t?"":isNaN(n)?null:n}else s[e.key]=t}else s[e.key]=""}),e.push(s),void 0!==n.dataset.ref&&(s.ref=n.dataset.ref),void 0!==n.dataset.id&&void 0===s.id&&(s.id=n.dataset.id)}),e}save(){this.validateAll();try{P(this.storageKey,this.getData())}catch(e){console.error("save failed",e)}}load(){let e=[];try{e=M(this.storageKey,[])}catch(e){}e.forEach(e=>this.addRow(e)),this.updateRowCount()}clearFilters(){this.filters=this.filters.map(()=>""),this.filterButtons.forEach(e=>e.classList.remove("filtered")),this.applyFilters()}applyFilters(){const e=this.colOffset;Array.from(this.tbody.rows).forEach(t=>{let n=!0;this.filters.forEach((s,o)=>{const a=s.toLowerCase();a&&!String(t.cells[o+e].firstChild.value).toLowerCase().includes(a)&&(n=!1)}),t.style.display=n?"":"none"})}deleteAll(){this.tbody.innerHTML="",this.selectAll&&(this.selectAll.checked=!1),this.save(),this.updateRowCount(),this.onChange&&this.onChange()}deleteSelected(){Array.from(this.tbody.querySelectorAll(".row-select:checked")).forEach(e=>e.closest("tr").remove()),this.selectAll&&(this.selectAll.checked=!1),this.save(),this.updateRowCount()}initContextMenu(){const e=new le;let t=null;e.setItems([{label:"Insert Row Above",action:e=>{if(!e)return;const t=this.addRow();this.tbody.insertBefore(t,e),this.onChange&&this.onChange()}},{label:"Insert Row Below",action:e=>{if(!e)return;const t=this.addRow();this.tbody.insertBefore(t,e.nextSibling),this.onChange&&this.onChange()}},{label:"Copy Row",action:e=>{e&&(t=this.getRowData(e))}},{label:"Paste Row",action:e=>{if(!e||!t)return;const n=this.addRow(t);this.tbody.insertBefore(n,e.nextSibling),this.onChange&&this.onChange()}},{label:"Delete Row",action:e=>{e&&(e.remove(),this.save(),this.updateRowCount(),this.onChange&&this.onChange())}}]),this.table.addEventListener("contextmenu",t=>{const n=t.target.closest("tbody tr");n?(t.preventDefault(),e.show(t.pageX,t.pageY,n)):t.target.closest(`#${this.table.id}`)&&t.preventDefault()}),document.addEventListener("keydown",e=>{const n=document.activeElement.tagName;if(["INPUT","TEXTAREA","SELECT"].includes(n))return;const s=document.activeElement.closest(`#${this.table.id} tbody tr`);if(s)if(e.ctrlKey&&"c"===e.key.toLowerCase())t=this.getRowData(s),e.preventDefault();else if(e.ctrlKey&&"v"===e.key.toLowerCase()){if(!t)return;const n=this.addRow(t);this.tbody.insertBefore(n,s.nextSibling),this.onChange&&this.onChange(),e.preventDefault()}})}exportXlsx(){const e=[this.columns.map(e=>e.label)];this.getData().forEach(t=>{e.push(this.columns.map(e=>t[e.key]||""))});const t=XLSX.utils.book_new(),n=XLSX.utils.aoa_to_sheet(e);XLSX.utils.book_append_sheet(t,n,"Sheet1"),XLSX.writeFile(t,`${this.storageKey}.xlsx`)}importXlsx(e){if(!e)return;const t=new FileReader;t.onload=e=>{const t=XLSX.read(e.target.result,{type:"binary"}),n=t.Sheets[t.SheetNames[0]],s=XLSX.utils.sheet_to_json(n,{defval:""});this.tbody.innerHTML="",s.forEach(e=>{const t={};this.columns.forEach(n=>t[n.key]=e[n.label]||""),this.addRow(t)}),this.applyFilters(),this.save(),this.onChange&&this.onChange()},t.readAsBinaryString(e)}validateAll(){let e=!0;const t=this.colOffset;return Array.from(this.tbody.rows).forEach(n=>{this.columns.forEach((s,o)=>{const a=n.cells[o+t].firstChild;s.validate&&!de(a,Array.isArray(s.validate)?s.validate:[s.validate])&&(e=!1)})}),e}}function de(e,t=[]){const n=(e.value||"").trim();let s="";t.forEach(e=>{if(!s)if("function"==typeof e){const t=e(n);t&&(s=t)}else"required"===e?n||(s="Required"):"numeric"===e&&(""===n||isNaN(Number(n)))&&(s="Must be numeric")});const o=e.nextElementSibling;if(s){e.classList.add("input-error");let t=o&&o.classList&&o.classList.contains("error-message")?o:null;return t||(t=document.createElement("span"),t.className="error-message",e.insertAdjacentElement("afterend",t)),t.textContent=s,!1}return e.classList.remove("input-error"),o&&o.classList&&o.classList.contains("error-message")&&o.remove(),!0}window.TableUtils={createTable:function(e){return new ce(e)},saveToStorage:function(e,t){try{P(e,t)}catch(e){}},loadFromStorage:function(e){try{return M(e,[])}catch(e){return[]}},applyValidation:de,STORAGE_KEYS:i},"undefined"!=typeof window&&window.addEventListener("DOMContentLoaded",()=>{initSettings(),initDarkMode(),initCompactMode(),initNavToggle();let e;e=TableUtils.createTable({tableId:"equipment-table",storageKey:TableUtils.STORAGE_KEYS.equipment,columnsKey:TableUtils.STORAGE_KEYS.equipmentColumns,addRowBtnId:"add-row-btn",deleteSelectedBtnId:"delete-selected-btn",exportBtnId:"export-xlsx-btn",importInputId:"import-xlsx-input",importBtnId:"import-xlsx-btn",selectable:!0,enableContextMenu:!0,columns:[{key:"id",label:"ID",type:"text"},{key:"description",label:"Description",type:"text"},{key:"voltage",label:"Voltage (V)",type:"text"},{key:"category",label:"Category",type:"text"},{key:"subCategory",label:"Sub-Category",type:"text"},{key:"manufacturer",label:"Manufacturer",type:"text"},{key:"model",label:"Model",type:"text"},{key:"phases",label:"Phases",type:"text"},{key:"notes",label:"Notes",type:"text"},{key:"x",label:"X",type:"number"},{key:"y",label:"Y",type:"number"},{key:"z",label:"Z",type:"number"}],onChange:()=>{e.save();const t=window.opener?.updateComponent||window.updateComponent;t&&e.getData().forEach(e=>{const n=e.ref||e.id;n&&t(n,e)})}});const t=document.getElementById("add-column-btn"),n=document.getElementById("add-column-modal"),s=document.getElementById("new-col-key"),o=document.getElementById("new-col-label"),a=document.getElementById("new-col-type"),i=document.getElementById("confirm-add-column");t.addEventListener("click",()=>{n.style.display="flex",s.value="",o.value="",a.value="text",s.focus()}),i.addEventListener("click",()=>{const t=s.value.trim(),i=o.value.trim(),r=a.value;t&&i&&(e.addColumn({key:t,label:i,type:r}),n.style.display="none")}),n.addEventListener("click",e=>{e.target===n&&(n.style.display="none")})})}();
+(function () {
+  'use strict';
+
+  /**
+   * Simple parser for Revit/IFC exports that extracts tray and conduit
+   * geometry. The goal is not to support the full schemas but to pull out
+   * basic start/end coordinates used by the app. The function accepts
+   * either a JSON object/string or raw IFC STEP text.
+   *
+   * Returned geometry objects use the field names already consumed by the
+   * data store (start_x, start_y, ...).
+   *
+   * @param {string|object} input - IFC STEP text or Revit JSON.
+   * @returns {{trays:Array, conduits:Array}}
+   */
+  function parseRevit(input) {
+    if (typeof input === "string") {
+      // Try JSON first – many exporters can emit JSON directly.
+      try {
+        const obj = JSON.parse(input);
+        return parseRevitJSON(obj);
+      } catch {
+        // Treat as IFC STEP text
+        return parseIFC(input);
+      }
+    }
+    // Already an object – assume JSON structure
+    return parseRevitJSON(input);
+  }
+
+  /**
+   * Parse a Revit style JSON export. The exporter format is not
+   * standardized so we try a few common field names.
+   * @param {any} obj
+   */
+  function parseRevitJSON(obj) {
+    if (!obj || typeof obj !== "object") return { trays: [], conduits: [] };
+    const trays = [];
+    const conduits = [];
+
+    const traySrc =
+      obj.trays || obj.Trays || obj.cableTrays || obj.CableTrays || [];
+    for (const t of traySrc) {
+      trays.push(normalizeTray(t));
+    }
+
+    const conduitSrc =
+      obj.conduits ||
+      obj.Conduits ||
+      obj.cableConduits ||
+      obj.ConduitSegments ||
+      [];
+    for (const c of conduitSrc) {
+      conduits.push(normalizeConduit(c));
+    }
+
+    return { trays, conduits };
+  }
+
+  function num(val) {
+    const n = parseFloat(val);
+    return Number.isFinite(n) ? n : undefined;
+  }
+
+  function normalizeTray(t = {}) {
+    return {
+      id: t.id || t.tag || t.tray_id || t.TrayID || t.name || t.Tag || "",
+      start_x: num(t.start_x ?? t.sx ?? t.x1 ?? t.StartX ?? t.start?.x),
+      start_y: num(t.start_y ?? t.sy ?? t.y1 ?? t.StartY ?? t.start?.y),
+      start_z: num(t.start_z ?? t.sz ?? t.z1 ?? t.StartZ ?? t.start?.z),
+      end_x: num(t.end_x ?? t.ex ?? t.x2 ?? t.EndX ?? t.end?.x),
+      end_y: num(t.end_y ?? t.ey ?? t.y2 ?? t.EndY ?? t.end?.y),
+      end_z: num(t.end_z ?? t.ez ?? t.z2 ?? t.EndZ ?? t.end?.z),
+      width: num(t.width ?? t.w ?? t.Width ?? t.size_x),
+      height: num(t.height ?? t.h ?? t.Height ?? t.size_y),
+    };
+  }
+
+  function normalizeConduit(c = {}) {
+    return {
+      conduit_id: c.conduit_id || c.id || c.tag || c.ConduitID || "",
+      type: c.type || c.conduit_type || c.Type || "",
+      trade_size: c.trade_size || c.tradeSize || c.size || c.TradeSize || "",
+      start_x: num(c.start_x ?? c.sx ?? c.x1 ?? c.start?.x),
+      start_y: num(c.start_y ?? c.sy ?? c.y1 ?? c.start?.y),
+      start_z: num(c.start_z ?? c.sz ?? c.z1 ?? c.start?.z),
+      end_x: num(c.end_x ?? c.ex ?? c.x2 ?? c.end?.x),
+      end_y: num(c.end_y ?? c.ey ?? c.y2 ?? c.end?.y),
+      end_z: num(c.end_z ?? c.ez ?? c.z2 ?? c.end?.z),
+      capacity: num(c.capacity ?? c.fill),
+    };
+  }
+
+  /**
+   * Extremely small IFC STEP parser. It looks for entities that contain an
+   * `IFCPOLYLINE` with two points – the start and end of a segment. If the
+   * entity name includes `CABLECARRIER` it is treated as a tray; otherwise
+   * it is treated as a conduit segment.
+   *
+   * This is a best‑effort helper and is not meant to cover the entire IFC
+   * specification, but it is sufficient for small test files and demos.
+   *
+   * @param {string} text
+   */
+  function parseIFC(text) {
+    const trays = [];
+    const conduits = [];
+    const segRegex =
+      /#\d+=IFC([^;]*?)SEGMENT[^;]*?IFCPOLYLINE\(\(([^)]+)\),\(([^)]+)\)\)/gi;
+    let match;
+    let i = 0;
+    while ((match = segRegex.exec(text))) {
+      const kind = match[1] || "";
+      const start = match[2].split(",").map((v) => parseFloat(v));
+      const end = match[3].split(",").map((v) => parseFloat(v));
+      const seg = {
+        id: `SEG-${i++}`,
+        start_x: start[0],
+        start_y: start[1],
+        start_z: start[2],
+        end_x: end[0],
+        end_y: end[1],
+        end_z: end[2],
+      };
+      if (/CABLECARRIER/i.test(kind)) trays.push(seg);
+      else conduits.push(seg);
+    }
+    return { trays, conduits };
+  }
+
+  /**
+   * Centralized data store wrapper around localStorage with typed getters and setters
+   * for core schedule data. Emits simple change events.
+   */
+
+
+  // scenario management keys
+  const SCENARIOS_KEY = 'ctr_scenarios_v1';
+  const CURRENT_SCENARIO_KEY = 'ctr_current_scenario_v1';
+
+  function readGlobal(key, fallback) {
+    try {
+      const raw = (typeof localStorage !== 'undefined') ? localStorage.getItem(key) : null;
+      return raw ? JSON.parse(raw) : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  function writeGlobal(key, value) {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, JSON.stringify(value));
+      }
+    } catch {}
+  }
+
+  let currentScenario = readGlobal(CURRENT_SCENARIO_KEY, 'base');
+  let scenarioList = readGlobal(SCENARIOS_KEY, ['base']);
+  if (!scenarioList.includes(currentScenario)) scenarioList.push(currentScenario);
+  writeGlobal(SCENARIOS_KEY, scenarioList);
+  writeGlobal(CURRENT_SCENARIO_KEY, currentScenario);
+
+  function scenarioKey(key, scenario = currentScenario) {
+    return `${scenario}:${key}`;
+  }
+
+  function listScenarios() {
+    return [...scenarioList];
+  }
+
+  function getCurrentScenario() {
+    return currentScenario;
+  }
+
+  function switchScenario(name) {
+    if (!scenarioList.includes(name)) scenarioList.push(name);
+    currentScenario = name;
+    writeGlobal(CURRENT_SCENARIO_KEY, currentScenario);
+    writeGlobal(SCENARIOS_KEY, scenarioList);
+    emit('scenario', name);
+  }
+
+  function cloneScenario(newName, from = currentScenario) {
+    const prefixFrom = `${from}:`;
+    const prefixTo = `${newName}:`;
+    const allKeys = Object.keys(localStorage || {});
+    for (const key of allKeys) {
+      if (key.startsWith(prefixFrom)) {
+        const value = localStorage.getItem(key);
+        const dest = prefixTo + key.slice(prefixFrom.length);
+        localStorage.setItem(dest, value);
+      }
+    }
+    if (!scenarioList.includes(newName)) scenarioList.push(newName);
+    writeGlobal(SCENARIOS_KEY, scenarioList);
+  }
+
+  function compareStudies(a, b) {
+    const first = read(KEYS.studies, {}, a);
+    const second = read(KEYS.studies, {}, b);
+    return { [a]: first, [b]: second };
+  }
+
+  const KEYS = {
+    // Preferred property names
+    trays: 'traySchedule',
+    cables: 'cableSchedule',
+    ductbanks: 'ductbankSchedule',
+    conduits: 'conduitSchedule',
+    panels: 'panelSchedule',
+    loads: 'loadList',
+    equipment: 'equipment',
+    oneLine: 'oneLineDiagram',
+    studies: 'studyResults',
+    // Legacy aliases for backward compatibility
+    traySchedule: 'traySchedule',
+    cableSchedule: 'cableSchedule',
+    ductbankSchedule: 'ductbankSchedule',
+    conduitSchedule: 'conduitSchedule',
+    panelSchedule: 'panelSchedule',
+    loadList: 'loadList',
+    equipmentList: 'equipment',
+    oneLineDiagram: 'oneLineDiagram'
+  };
+
+  const EXTRA_KEYS = {
+    equipmentColumns: 'equipmentColumns',
+    collapsedGroups: 'collapsedGroups'
+  };
+
+  const STORAGE_KEYS = { ...KEYS, ...EXTRA_KEYS };
+
+  const listeners = {};
+
+  function emit(event, detail) {
+    (listeners[event] || []).forEach(fn => {
+      try { fn(detail); } catch (e) { console.error(e); }
+    });
+  }
+
+  /**
+   * Subscribe to change events.
+   * @param {string} event
+   * @param {(data:any)=>void} handler
+   */
+  function on(event, handler) {
+    if (!listeners[event]) listeners[event] = [];
+    listeners[event].push(handler);
+  }
+
+  /**
+   * Remove an event listener.
+   * @param {string} event
+   * @param {(data:any)=>void} handler
+   */
+  function off(event, handler) {
+    const arr = listeners[event];
+    if (!arr) return;
+    const idx = arr.indexOf(handler);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
+  function read(key, fallback, scenario = currentScenario) {
+    try {
+      const raw = (typeof localStorage !== 'undefined') ? localStorage.getItem(scenarioKey(key, scenario)) : null;
+      return raw ? JSON.parse(raw) : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  function write(key, value, scenario = currentScenario) {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(scenarioKey(key, scenario), JSON.stringify(value));
+      }
+      emit(key, value);
+    } catch (e) {
+      console.error('Failed to store', key, e);
+    }
+  }
+
+  /**
+   * @returns {Tray[]}
+   */
+  const getTrays = () => read(KEYS.trays, []);
+  /**
+   * @param {Tray[]} trays
+   */
+  const setTrays = trays => write(KEYS.trays, trays);
+
+  /**
+   * @returns {Cable[]}
+   */
+  const getCables = () => read(KEYS.cables, []);
+  /**
+   * @param {Cable[]} cables
+   */
+  const setCables = cables => write(KEYS.cables, cables);
+
+  /**
+   * Append a cable record to the existing cable schedule.
+   * @param {Cable} cable
+   */
+  const addCable = cable => {
+    const list = getCables();
+    list.push(cable);
+    setCables(list);
+  };
+
+  /**
+   * @returns {Ductbank[]}
+   */
+  const getDuctbanks = () => read(KEYS.ductbanks, []);
+  /**
+   * @param {Ductbank[]} banks
+   */
+  const setDuctbanks = banks => write(KEYS.ductbanks, banks);
+
+  /**
+   * @returns {Conduit[]}
+   */
+  const getConduits = () => read(KEYS.conduits, []);
+  /**
+   * @param {Conduit[]} conduits
+   */
+  const setConduits = conduits => write(KEYS.conduits, conduits);
+
+  /**
+   * Append a raceway record. If the object contains `tray_id` it is stored
+   * with trays; otherwise it is assumed to be a conduit.
+   * @param {Tray|Conduit} raceway
+   */
+  const addRaceway = raceway => {
+    if (!raceway) return;
+    if (raceway.tray_id) {
+      const trays = getTrays();
+      trays.push(raceway);
+      setTrays(trays);
+    } else {
+      const conduits = getConduits();
+      conduits.push(raceway);
+      setConduits(conduits);
+    }
+  };
+
+  /**
+   * @returns {GenericRecord[]}
+   */
+  const getPanels = () => read(KEYS.panels, []);
+  /**
+   * @param {GenericRecord} panel
+   */
+  function ensurePanelFields(panel) {
+    return {
+      id: '',
+      description: '',
+      ref: '',
+      voltage: '',
+      mainRating: '',
+      circuitCount: 42,
+      ...panel
+    };
+  }
+  /**
+   * @param {GenericRecord[]} panels
+   */
+  const setPanels = panels => write(KEYS.panels, panels.map(ensurePanelFields));
+
+  /**
+   * @returns {GenericRecord[]}
+   */
+  const getEquipment = () => read(KEYS.equipment, []);
+  /**
+   * @param {GenericRecord[]} equipment
+   */
+  function ensureEquipmentFields(eq) {
+    return {
+      id: '',
+      ref: '',
+      description: '',
+      voltage: '',
+      category: '',
+      subCategory: '',
+      x: '',
+      y: '',
+      z: '',
+      manufacturer: '',
+      model: '',
+      phases: '',
+      notes: '',
+      ...eq
+    };
+  }
+
+  const setEquipment = list => write(KEYS.equipment, list.map(ensureEquipmentFields));
+
+  const addEquipment = item => {
+    const list = getEquipment();
+    list.push(ensureEquipmentFields(item));
+    setEquipment(list);
+  };
+
+  const updateEquipment = (index, item) => {
+    const list = getEquipment();
+    if (index >= 0 && index < list.length) {
+      list[index] = ensureEquipmentFields({ ...list[index], ...item });
+      setEquipment(list);
+    }
+  };
+
+  const removeEquipment = index => {
+    const list = getEquipment();
+    if (index >= 0 && index < list.length) {
+      list.splice(index, 1);
+      setEquipment(list);
+    }
+  };
+
+  /**
+   * @typedef {Object} OneLineComponent
+   * @property {string} id Unique identifier
+   * @property {string} type Component type (equipment, panel, load)
+   * @property {number} x X coordinate
+   * @property {number} y Y coordinate
+   * @property {string} [label] Display label
+   * @property {string} [ref] Linked schedule id
+   * @property {{target:string, cable?:Cable}[]} [connections] Connections to other components with optional cable spec
+   */
+
+  /**
+   * @typedef {Object} OneLineSheet
+   * @property {string} name
+   * @property {OneLineComponent[]} components
+   */
+
+  /**
+   * Retrieve saved one-line sheets. Supports legacy single-sheet format.
+   * @returns {OneLineSheet[]}
+   */
+  const getOneLine = (scenario = currentScenario) => {
+    const data = read(KEYS.oneLine, {}, scenario);
+    if (Array.isArray(data)) {
+      // legacy array of components
+      return { activeSheet: 0, sheets: [{ name: 'Sheet 1', components: data, connections: [] }] };
+    }
+    if (data && Array.isArray(data.sheets)) {
+      return {
+        activeSheet: data.activeSheet || 0,
+        sheets: data.sheets.map(s => ({
+          name: s.name,
+          components: Array.isArray(s.components) ? s.components : [],
+          connections: Array.isArray(s.connections) ? s.connections : []
+        }))
+      };
+    }
+    return { activeSheet: 0, sheets: [] };
+  };
+  /**
+   * Persist one-line sheets
+   * @param {OneLineSheet[]} sheets
+   */
+  const REVISION_KEY = 'oneLineRevisions';
+
+  const getRevisions = (scenario = currentScenario) => read(REVISION_KEY, [], scenario);
+
+  function addRevision(sheets, scenario = currentScenario) {
+    const revs = getRevisions(scenario);
+    revs.push({ time: Date.now(), sheets: JSON.parse(JSON.stringify(sheets)) });
+    write(REVISION_KEY, revs, scenario);
+  }
+
+  const restoreRevision = (index, scenario = currentScenario) => {
+    const revs = getRevisions(scenario);
+    const rev = revs[index];
+    if (rev) {
+      write(KEYS.oneLine, { activeSheet: 0, sheets: rev.sheets }, scenario);
+    }
+    return rev ? rev.sheets : null;
+  };
+
+  const setOneLine = (data, scenario = currentScenario) => {
+    const prev = getOneLine(scenario);
+    if (Array.isArray(prev.sheets) && prev.sheets.length) addRevision(prev.sheets, scenario);
+    const payload = {
+      activeSheet: data.activeSheet || 0,
+      sheets: Array.isArray(data.sheets) ? data.sheets : []
+    };
+    write(KEYS.oneLine, payload, scenario);
+  };
+
+  /**
+   * Retrieve persisted study results.
+   * @returns {Object}
+   */
+  const getStudies = () => read(KEYS.studies, {});
+  /**
+   * Store study results.
+   * @param {Object} results
+   */
+  const setStudies = results => write(KEYS.studies, results);
+
+  /**
+   * @returns {GenericRecord[]}
+   */
+  const getLoads = () => {
+    const raw = read(KEYS.loads, []);
+    const loads = raw.map(ensureLoadFields);
+    if (raw.some(l => l && typeof l === 'object' && !('source' in l))) {
+      write(KEYS.loads, loads);
+    }
+    return loads;
+  };
+  /**
+   * @param {GenericRecord[]} loads
+   */
+  function ensureLoadFields(load) {
+    const l = { ...load };
+    if ('power' in l && !('kw' in l)) {
+      l.kw = l.power;
+      delete l.power;
+    }
+    return {
+      id: '',
+      ref: '',
+      source: '',
+      tag: '',
+      description: '',
+      quantity: '',
+      voltage: '',
+      loadType: '',
+      duty: '',
+      kw: '',
+      powerFactor: '',
+      loadFactor: '',
+      efficiency: '',
+      demandFactor: '',
+      phases: '',
+      circuit: '',
+      manufacturer: '',
+      model: '',
+      notes: '',
+      ...l
+    };
+  }
+
+  function isEmptyLoad(load) {
+    const l = ensureLoadFields(load);
+    return Object.values(l).every(v => v === '');
+  }
+
+  const setLoads = loads => {
+    const list = (loads.length ? loads : [{}]).map(ensureLoadFields);
+    write(KEYS.loads, list);
+  };
+
+  const addLoad = load => {
+    const loads = getLoads();
+    const normalized = ensureLoadFields(load);
+    if (loads.length === 1 && isEmptyLoad(loads[0]) && !isEmptyLoad(normalized)) {
+      loads[0] = normalized;
+    } else {
+      loads.push(normalized);
+    }
+    setLoads(loads);
+  };
+
+  const insertLoad = (index, load) => {
+    const loads = getLoads();
+    const normalized = ensureLoadFields(load);
+    const idx = Math.max(0, Math.min(index, loads.length));
+    loads.splice(idx, 0, normalized);
+    setLoads(loads);
+  };
+
+  const updateLoad = (index, load) => {
+    const loads = getLoads();
+    if (index >= 0 && index < loads.length) {
+      loads[index] = ensureLoadFields({ ...loads[index], ...load });
+      setLoads(loads);
+    }
+  };
+
+  const deleteLoad = index => {
+    const loads = getLoads();
+    if (index >= 0 && index < loads.length) {
+      loads.splice(index, 1);
+      setLoads(loads);
+    }
+  };
+
+  // Backward compatibility
+  const removeLoad = deleteLoad;
+
+  // generic access for other values so pages never touch localStorage directly
+  const getItem = (key, fallback = null, scenario) => read(key, fallback, scenario);
+  const setItem = (key, value, scenario) => write(key, value, scenario);
+  const removeItem = (key, scenario = currentScenario) => {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(scenarioKey(key, scenario));
+      }
+      emit(key, null);
+    } catch (e) {
+      console.error('Failed to remove', key, e);
+    }
+  };
+
+
+  const keys = (scenario = currentScenario) => {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        const prefix = `${scenario}:`;
+        return Object.keys(localStorage).filter(k => k.startsWith(prefix)).map(k => k.slice(prefix.length));
+      }
+    } catch {}
+    return [];
+  };
+
+  function saveProject(projectId, scenario = currentScenario) {
+    if (!projectId || typeof localStorage === 'undefined') return;
+    try {
+      const prefix = `${projectId}:`;
+      const payload = {
+        equipment: getEquipment(),
+        panels: getPanels(),
+        loads: getLoads(),
+        cables: getCables(),
+        raceways: {
+          trays: getTrays(),
+          conduits: getConduits(),
+          ductbanks: getDuctbanks()
+        },
+        oneLine: getOneLine(scenario)
+      };
+      for (const [key, value] of Object.entries(payload)) {
+        localStorage.setItem(prefix + key, JSON.stringify(value));
+      }
+    } catch (e) {
+      console.error('Failed to save project', e);
+    }
+  }
+
+  function loadProject(projectId, scenario = currentScenario) {
+    if (!projectId || typeof localStorage === 'undefined') return;
+    try {
+      const prefix = `${projectId}:`;
+      const readKey = k => {
+        const raw = localStorage.getItem(prefix + k);
+        try { return raw ? JSON.parse(raw) : null; } catch { return null; }
+      };
+      const equipment = readKey('equipment');
+      const panels = readKey('panels');
+      const loads = readKey('loads');
+      const cables = readKey('cables');
+      const raceways = readKey('raceways') || {};
+      const oneLine = readKey('oneLine') || {};
+      if (Array.isArray(equipment)) setEquipment(equipment); else setEquipment([]);
+      if (Array.isArray(panels)) setPanels(panels); else setPanels([]);
+      if (Array.isArray(loads)) setLoads(loads);
+      if (Array.isArray(cables)) setCables(cables); else setCables([]);
+      setTrays(Array.isArray(raceways.trays) ? raceways.trays : []);
+      setConduits(Array.isArray(raceways.conduits) ? raceways.conduits : []);
+      setDuctbanks(Array.isArray(raceways.ductbanks) ? raceways.ductbanks : []);
+      if (Array.isArray(oneLine)) {
+        setOneLine({ activeSheet: 0, sheets: oneLine }, scenario);
+      } else {
+        setOneLine(oneLine || { activeSheet: 0, sheets: [] }, scenario);
+      }
+    } catch (e) {
+      console.error('Failed to load project', e);
+    }
+  }
+
+  // Simple schema validator replacing Ajv. Checks for required fields,
+  // disallows extras, and verifies basic types.
+  function validateProjectSchema(obj) {
+    const required = ['ductbanks', 'conduits', 'trays', 'cables', 'panels', 'equipment', 'loads', 'settings'];
+    const optional = ['oneLine'];
+    const missing = [];
+    const extra = [];
+
+    if (!obj || typeof obj !== 'object') {
+      missing.push(...required);
+      return { valid: false, missing, extra };
+    }
+
+    for (const key of required) {
+      if (!(key in obj)) missing.push(key);
+    }
+    for (const key of Object.keys(obj)) {
+      if (!required.includes(key) && !optional.includes(key)) extra.push(key);
+    }
+
+    const typesValid = Array.isArray(obj.ductbanks) &&
+      Array.isArray(obj.conduits) &&
+      Array.isArray(obj.trays) &&
+      Array.isArray(obj.cables) &&
+      Array.isArray(obj.panels) &&
+      Array.isArray(obj.equipment) &&
+      Array.isArray(obj.loads) &&
+      obj.settings && typeof obj.settings === 'object' && !Array.isArray(obj.settings) &&
+      (obj.oneLine === undefined || Array.isArray(obj.oneLine) || Array.isArray(obj.oneLine?.sheets));
+
+    const valid = missing.length === 0 && extra.length === 0 && typesValid;
+    return { valid, missing, extra };
+  }
+
+  /**
+   * Export current project data.
+   */
+  function exportProject() {
+    const project = {
+      ductbanks: getDuctbanks(),
+      conduits: getConduits(),
+      trays: getTrays(),
+      cables: getCables(),
+      panels: getPanels(),
+      equipment: getEquipment(),
+      loads: getLoads(),
+      oneLine: getOneLine(),
+      settings: {}
+    };
+    const reserved = new Set([...Object.values(KEYS), 'CTR_PROJECT_V1']);
+    for (const key of keys()) {
+      if (!reserved.has(key)) {
+        project.settings[key] = getItem(key);
+      }
+    }
+    const meta = { version: 1, scenario: currentScenario, scenarios: listScenarios() };
+    return { meta, ...project };
+  }
+
+  /**
+   * Import tray and conduit geometry from a CAD export file (Revit JSON or IFC).
+   * Updates the current data store schedules.
+   *
+   * @param {File|string} file Input file or raw text
+   * @returns {Promise<{trays:any[], conduits:any[]}>}
+   */
+  async function importFromCad(file) {
+    let text;
+    if (typeof file === 'string') {
+      text = file;
+    } else if (file && typeof file.text === 'function') {
+      text = await file.text();
+    } else {
+      throw new Error('Unsupported CAD file');
+    }
+
+    const { trays = [], conduits = [] } = parseRevit(text);
+    if (Array.isArray(trays) && trays.length) setTrays(trays);
+    if (Array.isArray(conduits) && conduits.length) setConduits(conduits);
+    return { trays, conduits };
+  }
+
+  /**
+   * Export tray and conduit geometry to a CAD-friendly format. Currently
+   * only JSON is supported. When executed in a browser environment the
+   * file is automatically downloaded.
+   *
+   * @param {string} [fileType='json']
+   * @returns {string} serialized content
+   */
+  function exportToCad(fileType = 'json') {
+    const data = { trays: getTrays(), conduits: getConduits() };
+    let mime = 'application/json';
+    let ext = 'json';
+    let content = JSON.stringify(data, null, 2);
+
+    if (fileType === 'csv') {
+      const trayHeader = 'id,start_x,start_y,start_z,end_x,end_y,end_z,width,height';
+      const trayRows = data.trays.map(t => [t.id, t.start_x, t.start_y, t.start_z, t.end_x, t.end_y, t.end_z, t.width, t.height].join(','));
+      const conduitHeader = 'conduit_id,type,trade_size,start_x,start_y,start_z,end_x,end_y,end_z,capacity';
+      const conduitRows = data.conduits.map(c => [c.conduit_id, c.type, c.trade_size, c.start_x, c.start_y, c.start_z, c.end_x, c.end_y, c.end_z, c.capacity].join(','));
+      content = `# trays\n${[trayHeader, ...trayRows].join('\n')}\n# conduits\n${[conduitHeader, ...conduitRows].join('\n')}`;
+      mime = 'text/csv';
+      ext = 'csv';
+    }
+
+    if (typeof document !== 'undefined') {
+      try {
+        const blob = new Blob([content], { type: mime });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = `raceways.${ext}`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(a.href);
+      } catch (e) {
+        console.error('Failed to export CAD data', e);
+      }
+    }
+    return content;
+  }
+
+  /**
+   * Import project data with schema validation.
+   * @param {any} obj
+   * @returns {boolean} success
+   */
+  function importProject(obj) {
+    const { meta, ...rest } = obj || {};
+    if (meta && Array.isArray(meta.scenarios)) {
+      scenarioList = meta.scenarios;
+      writeGlobal(SCENARIOS_KEY, scenarioList);
+    }
+    if (meta && meta.scenario) switchScenario(meta.scenario);
+    let data = rest;
+    const { valid, missing, extra } = validateProjectSchema(data);
+    if (!valid) {
+      const parts = [];
+      if (missing.length) parts.push(`Missing fields: ${missing.join(', ')}`);
+      if (extra.length) parts.push(`Extra fields: ${extra.join(', ')}`);
+      const msg = parts.join('\n') || 'Invalid project data.';
+      const proceed = (typeof window !== 'undefined' && typeof window.confirm === 'function')
+        ? window.confirm(`${msg}\nRepair & continue?`)
+        : false;
+      if (!proceed) return false;
+      data = {
+        ductbanks: Array.isArray(obj.ductbanks) ? obj.ductbanks : [],
+        conduits: Array.isArray(obj.conduits) ? obj.conduits : [],
+        trays: Array.isArray(obj.trays) ? obj.trays : [],
+        cables: Array.isArray(obj.cables) ? obj.cables : [],
+        panels: Array.isArray(obj.panels) ? obj.panels : [],
+        equipment: Array.isArray(obj.equipment) ? obj.equipment : [],
+        loads: Array.isArray(obj.loads) ? obj.loads : [],
+        oneLine: Array.isArray(obj.oneLine) ? obj.oneLine : [],
+        settings: (obj.settings && typeof obj.settings === 'object') ? obj.settings : {}
+      };
+    }
+
+    setDuctbanks(data.ductbanks);
+    setConduits(data.conduits);
+    setTrays(data.trays);
+    setCables(data.cables);
+    setPanels(Array.isArray(data.panels) ? data.panels : []);
+    setEquipment(Array.isArray(data.equipment) ? data.equipment : []);
+    setLoads(Array.isArray(data.loads) ? data.loads : []);
+    if (Array.isArray(data.oneLine)) {
+      setOneLine({ activeSheet: 0, sheets: data.oneLine });
+    } else if (data.oneLine && Array.isArray(data.oneLine.sheets)) {
+      setOneLine({ activeSheet: data.oneLine.activeSheet || 0, sheets: data.oneLine.sheets });
+    } else {
+      setOneLine({ activeSheet: 0, sheets: [] });
+    }
+
+    const reserved = new Set([...Object.values(KEYS), 'CTR_PROJECT_V1']);
+    for (const key of keys()) {
+      if (!reserved.has(key) && !(data.settings && key in data.settings)) {
+        removeItem(key);
+      }
+    }
+    if (data.settings) {
+      for (const [k, v] of Object.entries(data.settings)) {
+        setItem(k, v);
+      }
+    }
+    return true;
+  }
+
+  // expose on window for non-module scripts
+  if (typeof window !== 'undefined') {
+    window.dataStore = {
+      STORAGE_KEYS,
+      getTrays,
+      setTrays,
+      getCables,
+      setCables,
+      addCable,
+      getDuctbanks,
+      setDuctbanks,
+      getConduits,
+      setConduits,
+      addRaceway,
+      getPanels,
+      setPanels,
+      getEquipment,
+      setEquipment,
+      addEquipment,
+      updateEquipment,
+      removeEquipment,
+      getLoads,
+      setLoads,
+      addLoad,
+      insertLoad,
+      updateLoad,
+      removeLoad,
+      getOneLine,
+      setOneLine,
+      getRevisions,
+      restoreRevision,
+      getStudies,
+      setStudies,
+      getItem,
+      setItem,
+      removeItem,
+      listScenarios,
+      getCurrentScenario,
+      switchScenario,
+      cloneScenario,
+      compareStudies,
+      on,
+      off,
+      keys,
+      exportProject,
+      importProject,
+      saveProject,
+      loadProject,
+      importFromCad,
+      exportToCad
+    };
+  }
+
+  class ContextMenu {
+    constructor(items = []) {
+      this.items = items;
+      this.menu = document.createElement('ul');
+      this.menu.className = 'context-menu';
+      Object.assign(this.menu.style, {
+        position: 'absolute',
+        display: 'none',
+        listStyle: 'none',
+        margin: '0',
+        padding: '4px 0',
+        background: '#fff',
+        border: '1px solid #ccc',
+        zIndex: 1000,
+        color: '#000'
+      });
+      document.body.appendChild(this.menu);
+      document.addEventListener('click', () => this.hide());
+      document.addEventListener('keydown', e => { if (e.key === 'Escape') this.hide(); });
+    }
+
+    setItems(items) {
+      this.items = items;
+      this.menu.innerHTML = '';
+      items.forEach(({ label, action }) => {
+        const li = document.createElement('li');
+        li.textContent = label;
+        Object.assign(li.style, {
+          padding: '4px 12px',
+          cursor: 'pointer',
+          background: '#fff',
+          color: '#000'
+        });
+        li.tabIndex = 0;
+        li.addEventListener('click', () => {
+          const target = this.target;
+          this.hide();
+          action(target);
+        });
+        li.addEventListener('mouseenter', () => {
+          li.style.background = '#eee';
+          li.style.color = '#000';
+        });
+        li.addEventListener('mouseleave', () => {
+          li.style.background = '#fff';
+          li.style.color = '#000';
+        });
+        this.menu.appendChild(li);
+      });
+    }
+
+    show(x, y, target) {
+      this.target = target;
+      this.menu.style.left = `${x}px`;
+      this.menu.style.top = `${y}px`;
+      this.menu.style.display = 'block';
+    }
+
+    hide() {
+      this.menu.style.display = 'none';
+      this.target = null;
+    }
+  }
+
+  class TableManager {
+    constructor(opts) {
+      this.table = document.getElementById(opts.tableId);
+      this.thead = this.table.createTHead();
+      this.tbody = this.table.tBodies[0] || this.table.createTBody();
+      this.columnsKey = opts.columnsKey || null;
+      this.columns = opts.columns || [];
+      if (this.columnsKey) {
+        try {
+          const savedCols = getItem(this.columnsKey, null);
+          if (Array.isArray(savedCols) && savedCols.length) {
+            this.columns = savedCols;
+          } else {
+            setItem(this.columnsKey, this.columns);
+          }
+        } catch(e) {}
+      }
+      this.storageKey = opts.storageKey || opts.tableId;
+      this.onChange = opts.onChange || null;
+      this.onSave = opts.onSave || null;
+      this.onView = opts.onView || null;
+      this.rowCountEl = opts.rowCountId ? document.getElementById(opts.rowCountId) : null;
+      this.selectable = opts.selectable || false;
+      this.colOffset = this.selectable ? 1 : 0;
+      this.enableContextMenu = opts.enableContextMenu || false;
+      this.handleHeaderDragStart = this.handleHeaderDragStart.bind(this);
+      this.handleHeaderDragOver = this.handleHeaderDragOver.bind(this);
+      this.handleHeaderDrop = this.handleHeaderDrop.bind(this);
+      this.buildHeader();
+      this.initButtons(opts);
+      this.load();
+      if (this.enableContextMenu) this.initContextMenu();
+      this.hiddenGroups = new Set();
+      this.loadGroupState();
+      this.updateRowCount();
+    }
+
+    initButtons(opts){
+      if (opts.addRowBtnId) document.getElementById(opts.addRowBtnId).addEventListener('click', () => { this.addRow(); if (this.onChange) this.onChange(); });
+      if (opts.saveBtnId) document.getElementById(opts.saveBtnId).addEventListener('click', () => { this.save(); if (this.onSave) this.onSave(); });
+      if (opts.loadBtnId) document.getElementById(opts.loadBtnId).addEventListener('click', () => { this.tbody.innerHTML=''; this.load(); if (this.onSave) this.onSave(); });
+      if (opts.clearFiltersBtnId) document.getElementById(opts.clearFiltersBtnId).addEventListener('click', () => this.clearFilters());
+      if (opts.exportBtnId) document.getElementById(opts.exportBtnId).addEventListener('click', () => { this.exportXlsx(); if (this.onSave) this.onSave(); });
+      if (opts.importBtnId && opts.importInputId){
+        document.getElementById(opts.importBtnId).addEventListener('click', () => document.getElementById(opts.importInputId).click());
+        document.getElementById(opts.importInputId).addEventListener('change', e => { this.importXlsx(e.target.files[0]); e.target.value=''; if (this.onChange) this.onChange(); });
+      }
+      if (opts.deleteAllBtnId) document.getElementById(opts.deleteAllBtnId).addEventListener('click', () => { this.deleteAll(); if (this.onChange) this.onChange(); });
+      if (opts.deleteSelectedBtnId) document.getElementById(opts.deleteSelectedBtnId).addEventListener('click', () => { this.deleteSelected(); if (this.onChange) this.onChange(); });
+    }
+
+    buildHeader() {
+      this.thead.innerHTML='';
+      const hasGroups = this.columns.some(c=>c.group);
+      let groupRow;
+      if (hasGroups) {
+        groupRow = this.thead.insertRow();
+        if (this.selectable) {
+          groupRow.appendChild(document.createElement('th'));
+        }
+        this.groupRow = groupRow;
+      }
+      const headerRow = this.thead.insertRow();
+      this.headerRow = headerRow;
+      this.filters = Array(this.columns.length).fill('');
+      this.filterButtons = [];
+      this.globalFilter = '';
+      this.globalFilterCols = [];
+      this.groupCols = {};
+      this.groupThs = {};
+      this.groupToggles = {};
+      this.groupFirstIndex = {};
+      this.groupLastIndex = {};
+      this.groupOrder = [];
+      const offset = this.colOffset;
+
+      if (this.selectable) {
+        const selTh = document.createElement('th');
+        const selAll = document.createElement('input');
+        selAll.type = 'checkbox';
+        selAll.id = `${this.table.id}-select-all`;
+        selAll.className = 'select-all';
+        selAll.setAttribute('aria-label','Select all rows');
+        selAll.addEventListener('change', () => {
+          this.tbody.querySelectorAll('.row-select').forEach(cb => { cb.checked = selAll.checked; });
+        });
+        selTh.appendChild(selAll);
+        headerRow.appendChild(selTh);
+        this.selectAll = selAll;
+      }
+      
+      if (hasGroups){
+        const groups = [];
+        let current = null;
+        let colIndex = 0;
+        this.columns.forEach(col => {
+          if (col.group){
+            if (!current || current.name !== col.group){
+              current = {name:col.group, span:1};
+              groups.push(current);
+              if (!this.groupCols[col.group]){
+                this.groupCols[col.group] = [];
+                this.groupFirstIndex[col.group] = colIndex;
+                this.groupOrder.push(col.group);
+              }
+            } else {
+              current.span++;
+            }
+            this.groupCols[col.group].push(colIndex);
+            this.groupLastIndex[col.group] = colIndex;
+          } else {
+            groups.push({name:'', span:1});
+            current = null;
+          }
+          colIndex++;
+        });
+        groups.forEach(g => {
+          const th = document.createElement('th');
+          th.colSpan = g.span;
+          th.classList.add('group-header');
+          if (g.name){
+            const label = document.createElement('span');
+            label.textContent = g.name;
+            th.appendChild(label);
+            const toggle = document.createElement('button');
+            toggle.className = 'group-toggle';
+            toggle.textContent = '-';
+            toggle.setAttribute('aria-label','Toggle group');
+            toggle.addEventListener('click', e => { e.stopPropagation(); this.toggleGroup(g.name); });
+            th.appendChild(toggle);
+            this.groupThs[g.name] = th;
+            this.groupToggles[g.name] = toggle;
+            if (this.groupOrder.indexOf(g.name) > 0) th.classList.add('category-separator');
+            th.classList.add('category-separator-right');
+          }
+          groupRow.appendChild(th);
+        });
+      }
+
+      this.columns.forEach((col,idx) => {
+        const th = document.createElement('th');
+        th.style.position = 'relative';
+        th.draggable = true;
+        th.dataset.index = idx;
+        const labelSpan=document.createElement('span');
+        labelSpan.textContent=col.label;
+        th.appendChild(labelSpan);
+        const btn=document.createElement('button');
+        btn.className='filter-btn';
+        btn.innerHTML='\u25BC';
+        btn.setAttribute('aria-label','Filter column');
+        btn.addEventListener('click',e=>{e.stopPropagation();this.showFilterPopup(btn,idx);});
+        th.appendChild(btn);
+        const resizer=document.createElement('span');
+        resizer.className='col-resizer';
+        th.appendChild(resizer);
+        let startX,startWidth;
+        const onMove=e=>{
+          const newWidth=Math.max(30,startWidth+e.pageX-startX);
+          th.style.width=newWidth+'px';
+          Array.from(this.tbody.rows).forEach(r=>{if(r.cells[idx+offset]) r.cells[idx+offset].style.width=newWidth+'px';});
+        };
+        resizer.addEventListener('mousedown',e=>{
+          startX=e.pageX;startWidth=th.offsetWidth;
+          document.addEventListener('mousemove',onMove);
+          document.addEventListener('mouseup',()=>{
+            document.removeEventListener('mousemove',onMove);
+          },{once:true});
+        });
+        if (col.group && idx === this.groupFirstIndex[col.group] && this.groupOrder.indexOf(col.group) > 0) {
+          th.classList.add('category-separator');
+        }
+        if (col.group && idx === this.groupLastIndex[col.group]) {
+          th.classList.add('category-separator-right');
+        }
+        headerRow.appendChild(th);
+        this.filterButtons.push(btn);
+      });
+
+      if (hasGroups){
+        const blank = document.createElement('th');
+        blank.rowSpan = 1;
+        blank.style.position='relative';
+        groupRow.appendChild(blank);
+        this.groupBlankTh = blank;
+      }
+      const actTh = document.createElement('th');
+      actTh.textContent = 'Actions';
+      actTh.style.position='relative';
+      const res=document.createElement('span');
+      res.className='col-resizer';
+      actTh.appendChild(res);
+      let startX,startWidth;
+      const move=e=>{
+        const newWidth=Math.max(30,startWidth+e.pageX-startX);
+        actTh.style.width=newWidth+'px';
+        const idx = this.columns.length + offset;
+        Array.from(this.tbody.rows).forEach(r=>{if(r.cells[idx]) r.cells[idx].style.width=newWidth+'px';});
+        if(this.groupBlankTh) this.groupBlankTh.style.width=newWidth+'px';
+      };
+      res.addEventListener('mousedown',e=>{startX=e.pageX;startWidth=actTh.offsetWidth;document.addEventListener('mousemove',move);document.addEventListener('mouseup',()=>{document.removeEventListener('mousemove',move);},{once:true});});
+      headerRow.appendChild(actTh);
+      headerRow.addEventListener('dragstart', this.handleHeaderDragStart);
+      headerRow.addEventListener('dragover', this.handleHeaderDragOver);
+      headerRow.addEventListener('drop', this.handleHeaderDrop);
+      this.syncGroupBlankWidth();
+    }
+
+    setGroupVisibility(name, hide) {
+      const offset = this.colOffset;
+      const indices = this.groupCols[name] || [];
+      indices.forEach(i => {
+        if (this.headerRow && this.headerRow.cells[i + offset]) this.headerRow.cells[i + offset].classList.toggle('group-hidden', hide);
+        Array.from(this.tbody.rows).forEach(row => {
+          if (row.cells[i + offset]) row.cells[i + offset].classList.toggle('group-hidden', hide);
+        });
+      });
+      if (this.groupThs[name]) {
+        this.groupThs[name].classList.toggle('group-collapsed', hide);
+        this.groupThs[name].colSpan = hide ? 1 : indices.length;
+      }
+      if (this.groupToggles[name]) this.groupToggles[name].textContent = hide ? '+' : '-';
+      if (hide) this.hiddenGroups.add(name); else this.hiddenGroups.delete(name);
+      this.syncGroupBlankWidth();
+    }
+
+    toggleGroup(name) {
+      const hide = !this.hiddenGroups.has(name);
+      this.setGroupVisibility(name, hide);
+      this.saveGroupState();
+    }
+
+    saveGroupState() {
+      let all = {};
+      try { all = getItem(STORAGE_KEYS.collapsedGroups, {}); } catch(e) {}
+      all[this.storageKey] = Array.from(this.hiddenGroups);
+      try { setItem(STORAGE_KEYS.collapsedGroups, all); } catch(e) {}
+    }
+
+    loadGroupState() {
+      let all = {};
+      try { all = getItem(STORAGE_KEYS.collapsedGroups, {}); } catch(e) {}
+      const hidden = all[this.storageKey] || [];
+      hidden.forEach(g => this.setGroupVisibility(g, true));
+    }
+
+    syncGroupBlankWidth(){
+      const idx = this.columns.length + this.colOffset;
+      if(this.groupBlankTh && this.headerRow && this.headerRow.cells[idx]){
+        const w=this.headerRow.cells[idx].offsetWidth;
+        this.groupBlankTh.style.width=w+'px';
+      }
+    }
+
+    updateRowCount() {
+      if (this.rowCountEl) {
+        this.rowCountEl.textContent = `Rows: ${this.tbody.querySelectorAll('tr').length}`;
+      }
+    }
+
+    persistColumns() {
+      if (this.columnsKey) {
+        try { setItem(this.columnsKey, this.columns); } catch(e) {}
+      }
+    }
+
+    handleHeaderDragStart(e) {
+      const th = e.target.closest('th');
+      if (!th || th.dataset.index === undefined) return;
+      e.dataTransfer.setData('text/plain', th.dataset.index);
+    }
+
+    handleHeaderDragOver(e) {
+      if (e.target.closest('th')) e.preventDefault();
+    }
+
+    handleHeaderDrop(e) {
+      const th = e.target.closest('th');
+      if (!th || th.dataset.index === undefined) return;
+      e.preventDefault();
+      const from = parseInt(e.dataTransfer.getData('text/plain'), 10);
+      const to = parseInt(th.dataset.index, 10);
+      if (isNaN(from) || isNaN(to) || from === to) return;
+      const col = this.columns.splice(from, 1)[0];
+      this.columns.splice(to, 0, col);
+      this.persistColumns();
+      const data = this.getData();
+      this.buildHeader();
+      this.tbody.innerHTML = '';
+      data.forEach(row => this.addRow(row));
+      this.save();
+    }
+
+    addColumn(col) {
+      const data = this.getData();
+      this.columns.push(col);
+      this.persistColumns();
+      this.buildHeader();
+      this.tbody.innerHTML = '';
+      data.forEach(row => this.addRow(row));
+      this.save();
+      this.updateRowCount();
+      if (this.onChange) this.onChange();
+    }
+
+    removeColumn(key) {
+      const idx = this.columns.findIndex(c => c.key === key);
+      if (idx === -1) return;
+      const data = this.getData();
+      data.forEach(r => { delete r[key]; });
+      this.columns.splice(idx, 1);
+      this.persistColumns();
+      this.buildHeader();
+      this.tbody.innerHTML = '';
+      data.forEach(row => this.addRow(row));
+      this.save();
+      this.updateRowCount();
+      if (this.onChange) this.onChange();
+    }
+
+    showFilterPopup(btn, index){
+      document.querySelectorAll('.filter-popup').forEach(p=>p.remove());
+      const popup=document.createElement('div');
+      popup.className='filter-popup';
+      const col=this.columns[index];
+      const offset=this.colOffset;
+      let control;
+      if(col.filter==='dropdown'){
+        control=document.createElement('select');
+        const allOpt=document.createElement('option');
+        allOpt.value='';
+        allOpt.textContent='All';
+        control.appendChild(allOpt);
+        const values=[...new Set(Array.from(this.tbody.rows).map(r=>{
+          const cell=r.cells[index+offset];
+          return cell?cell.firstChild.value:'';
+        }).filter(v=>v))].sort();
+        values.forEach(v=>{
+          const opt=document.createElement('option');
+          opt.value=v;
+          opt.textContent=v;
+          control.appendChild(opt);
+        });
+        control.value=this.filters[index];
+      }else {
+        control=document.createElement('input');
+        control.type='text';
+        control.value=this.filters[index];
+      }
+      popup.appendChild(control);
+      let debounceTimer;
+      const applyFilter=()=>{
+        this.filters[index]=control.value.trim();
+        if(this.filters[index]) btn.classList.add('filtered'); else btn.classList.remove('filtered');
+        this.applyFilters();
+      };
+      if(col.filter==='dropdown'){
+        control.addEventListener('change',applyFilter);
+      }else {
+        control.addEventListener('input',()=>{
+          clearTimeout(debounceTimer);
+          debounceTimer=setTimeout(applyFilter,300);
+        });
+      }
+      const apply=document.createElement('button');
+      apply.textContent='Apply';
+      apply.setAttribute('aria-label','Apply filter');
+      apply.addEventListener('click',()=>{
+        clearTimeout(debounceTimer);
+        applyFilter();
+        popup.remove();
+      });
+      popup.appendChild(apply);
+      const clear=document.createElement('button');
+      clear.textContent='Clear';
+      clear.setAttribute('aria-label','Clear filter');
+      clear.addEventListener('click',()=>{
+        control.value='';
+        this.filters[index]='';
+        btn.classList.remove('filtered');
+        this.applyFilters();
+        popup.remove();
+      });
+      popup.appendChild(clear);
+      const rect=btn.getBoundingClientRect();
+      popup.style.top=(rect.bottom+window.scrollY)+'px';
+      popup.style.left=(rect.left+window.scrollX)+'px';
+      document.body.appendChild(popup);
+      const close=e=>{if(!popup.contains(e.target)){popup.remove();document.removeEventListener('click',close);}};
+      setTimeout(()=>document.addEventListener('click',close),0);
+    }
+
+    showRacewayModal(selectEl, originBtn){
+      const modal=document.createElement('div');
+      modal.className='modal';
+      modal.setAttribute('role','dialog');
+      modal.setAttribute('aria-modal','true');
+      modal.setAttribute('aria-hidden','false');
+      const content=document.createElement('div');
+      content.className='modal-content';
+      modal.appendChild(content);
+
+      const dual=document.createElement('div');
+      dual.className='dual-listbox';
+      content.appendChild(dual);
+
+      const buildSection=title=>{
+        const wrap=document.createElement('div');
+        wrap.className='list-container';
+        const hdr=document.createElement('h3');
+        hdr.textContent=title;
+        wrap.appendChild(hdr);
+        const search=document.createElement('input');
+        search.type='text';
+        search.placeholder='Search';
+        wrap.appendChild(search);
+        const list=document.createElement('select');
+        list.multiple=true;
+        list.setAttribute('role','listbox');
+        list.setAttribute('aria-multiselectable','true');
+        wrap.appendChild(list);
+        return {wrap,search,list};
+      };
+
+      const avail=buildSection('Available Raceways');
+      const chosen=buildSection('Selected Raceways');
+
+      const opts=Array.from(selectEl.options).map(o=>({value:o.value,text:o.text,selected:o.selected}));
+      opts.forEach(o=>{
+        const opt=document.createElement('option');
+        opt.value=o.value;opt.textContent=o.text;
+        (o.selected?chosen.list:avail.list).appendChild(opt);
+      });
+
+      dual.appendChild(avail.wrap);
+
+      const btnCol=document.createElement('div');
+      btnCol.className='button-column';
+      const mkBtn=(txt,label)=>{
+        const b=document.createElement('button');
+        b.type='button';
+        b.textContent=txt;
+        if(label) b.setAttribute('aria-label',label);
+        b.addEventListener('keydown',e=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();b.click();}});
+        return b;
+      };
+      const allR=mkBtn('>>','Move all to selected');
+      const someR=mkBtn('>','Move selected to selected');
+      const someL=mkBtn('<','Move selected to available');
+      const allL=mkBtn('<<','Move all to available');
+      [allR,someR,someL,allL].forEach(b=>btnCol.appendChild(b));
+      dual.appendChild(btnCol);
+      dual.appendChild(chosen.wrap);
+
+      const moveSelected=(from,to)=>{Array.from(from.selectedOptions).forEach(o=>to.appendChild(o));};
+      const moveAll=(from,to)=>{Array.from(from.options).forEach(o=>to.appendChild(o));};
+      allR.addEventListener('click',()=>moveAll(avail.list,chosen.list));
+      someR.addEventListener('click',()=>moveSelected(avail.list,chosen.list));
+      someL.addEventListener('click',()=>moveSelected(chosen.list,avail.list));
+      allL.addEventListener('click',()=>moveAll(chosen.list,avail.list));
+
+      const filter=(list,term)=>{
+        const t=term.toLowerCase();
+        Array.from(list.options).forEach(o=>o.style.display=o.text.toLowerCase().includes(t)?'':'none');
+      };
+      avail.search.addEventListener('input',()=>filter(avail.list,avail.search.value));
+      chosen.search.addEventListener('input',()=>filter(chosen.list,chosen.search.value));
+
+      const actions=document.createElement('div');
+      actions.style.marginTop='1rem';
+      actions.style.textAlign='right';
+      const saveBtn=document.createElement('button');
+      saveBtn.type='button';
+      saveBtn.textContent='Save';
+      saveBtn.setAttribute('aria-label','Save selection');
+      const cancelBtn=document.createElement('button');
+      cancelBtn.type='button';
+      cancelBtn.textContent='Cancel';
+      cancelBtn.setAttribute('aria-label','Cancel selection');
+      actions.appendChild(saveBtn);
+      actions.appendChild(cancelBtn);
+      content.appendChild(actions);
+
+      const close=()=>{
+        modal.remove();
+        document.removeEventListener('keydown',handleKey);
+        if(originBtn) originBtn.focus();
+      };
+      cancelBtn.addEventListener('click',close);
+      modal.addEventListener('click',e=>{if(e.target===modal)close();});
+
+      saveBtn.addEventListener('click',()=>{
+        const values=Array.from(chosen.list.options).map(o=>o.value);
+        Array.from(selectEl.options).forEach(o=>o.selected=values.includes(o.value));
+        selectEl.dispatchEvent(new Event('change',{bubbles:true}));
+        close();
+      });
+
+      const handleKey=e=>{if(e.key==='Escape'){e.preventDefault();close();}else trapFocus(e,content);};
+      document.addEventListener('keydown',handleKey);
+
+      document.body.appendChild(modal);
+      modal.style.display='flex';
+      avail.search.focus();
+    }
+
+    addRow(data = {}) {
+      const tr = this.tbody.insertRow();
+      if (data.ref !== undefined) tr.dataset.ref = data.ref;
+      if (data.id !== undefined) tr.dataset.id = data.id;
+      if (this.selectable) {
+        const selTd = tr.insertCell();
+        const chk = document.createElement('input');
+        chk.type = 'checkbox';
+        chk.className = 'row-select';
+        chk.addEventListener('change', () => {
+          if (!chk.checked && this.selectAll) this.selectAll.checked = false;
+        });
+        selTd.appendChild(chk);
+      }
+      this.columns.forEach((col, idx) => {
+        const td = tr.insertCell();
+        if (col.group && idx === this.groupFirstIndex[col.group] && this.groupOrder.indexOf(col.group) > 0) {
+          td.classList.add('category-separator');
+        }
+        if (col.group && idx === this.groupLastIndex[col.group]) {
+          td.classList.add('category-separator-right');
+        }
+        let el;
+        if (col.type === 'select') {
+          const opts = typeof col.options === 'function' ? col.options(tr, data) : (col.options || []);
+          if (col.multiple) {
+            el = document.createElement('select');
+            el.multiple = true;
+            if (col.size) el.size = col.size;
+            opts.forEach(opt => {
+              const o = document.createElement('option');
+              o.value = opt;
+              o.textContent = opt;
+              el.appendChild(o);
+            });
+            el.style.display = 'none';
+            el.getSelectedValues = () => Array.from(el.selectedOptions).map(o => o.value);
+            el.setSelectedValues = vals => {
+              Array.from(el.options).forEach(o => { o.selected = (vals || []).includes(o.value); });
+            };
+          } else {
+            el = document.createElement('select');
+            opts.forEach(opt => {
+              const o = document.createElement('option');
+              o.value = opt;
+              o.textContent = opt;
+              el.appendChild(o);
+            });
+          }
+        } else {
+          el = document.createElement('input');
+          el.type = col.type || 'text';
+          if (el.type === 'number') {
+            el.step = col.step || 'any';
+          }
+          if (col.maxlength) el.maxLength = col.maxlength;
+          if (col.className) el.className = col.className;
+          if (col.datalist) {
+            const listId = `${col.key}-datalist`;
+            el.setAttribute('list', listId);
+            let dl = document.getElementById(listId);
+            if (!dl) {
+              dl = document.createElement('datalist');
+              dl.id = listId;
+              document.body.appendChild(dl);
+            }
+            const opts = typeof col.datalist === 'function' ? col.datalist(tr, data) : col.datalist;
+            dl.innerHTML = '';
+            (opts || []).forEach(opt => {
+              const o = document.createElement('option');
+              o.value = opt;
+              dl.appendChild(o);
+            });
+          }
+        }
+        el.name = col.key;
+        const val = data[col.key] !== undefined ? data[col.key] : col.default;
+        if (val !== undefined) {
+          if (col.multiple) {
+            const vals = Array.isArray(val) ? val : [val];
+            if (el.setSelectedValues) {
+              el.setSelectedValues(vals);
+            } else if (el.options) {
+              Array.from(el.options).forEach(o => { o.selected = vals.includes(o.value); });
+            }
+          } else {
+            el.value = val;
+          }
+        } else if (el.tagName === 'SELECT' && el.options.length && !col.multiple) {
+          el.value = el.options[0].value;
+        }
+        if (this.headerRow && this.headerRow.cells[idx + this.colOffset] && this.headerRow.cells[idx + this.colOffset].style.width) {
+          td.style.width = this.headerRow.cells[idx + this.colOffset].style.width;
+        }
+        td.appendChild(el);
+        let summaryEl, updateSummary;
+        if (col.multiple) {
+          summaryEl = document.createElement('button');
+          summaryEl.type = 'button';
+          summaryEl.className = 'raceway-summary';
+          summaryEl.setAttribute('aria-label','View selected raceways');
+          summaryEl.addEventListener('click', e => {
+            e.stopPropagation();
+            this.showRacewayModal(el, summaryEl);
+          });
+          summaryEl.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              this.showRacewayModal(el, summaryEl);
+            }
+          });
+          td.addEventListener('click', () => {
+            this.showRacewayModal(el, summaryEl);
+          });
+          td.appendChild(summaryEl);
+          updateSummary = () => {
+            const vals = el.getSelectedValues ? el.getSelectedValues() : [];
+            if (vals.length) {
+              summaryEl.textContent = vals.join(', ');
+              summaryEl.classList.remove('placeholder');
+            } else {
+              summaryEl.textContent = 'Select Raceways';
+              summaryEl.classList.add('placeholder');
+            }
+          };
+          el.addEventListener('change', () => {
+            updateSummary();
+            if (this.onChange) this.onChange();
+          });
+          updateSummary();
+        } else {
+          el.addEventListener('input', () => { if (this.onChange) this.onChange(); });
+        }
+        el.addEventListener('focus',()=>{el.dataset.prevValue=el.value;});
+        el.addEventListener('keydown', e => {
+          const cellIdx = idx + this.colOffset;
+          if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+            let allSelected = true;
+            if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
+              const start = e.target.selectionStart ?? 0;
+              const end = e.target.selectionEnd ?? 0;
+              const len = (e.target.value || '').length;
+              allSelected = start === 0 && end === len;
+            }
+            if (allSelected) {
+              e.preventDefault();
+              const sib = e.key === 'ArrowLeft' ? td.previousElementSibling : td.nextElementSibling;
+              if (sib) {
+                const next = sib.querySelector('input,select,textarea');
+                if (next) {
+                  next.focus();
+                  if (typeof next.select === 'function') next.select();
+                }
+              }
+            }
+          } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            let targetRow = tr;
+            const dir = e.key === 'ArrowUp' ? 'previousElementSibling' : 'nextElementSibling';
+            do{targetRow = targetRow[dir];}while(targetRow && targetRow.style.display==='none');
+            if(targetRow && targetRow.cells[cellIdx]){
+              const next = targetRow.cells[cellIdx].querySelector('input,select,textarea');
+              if(next){next.focus(); if(typeof next.select==='function') next.select();}
+            }
+          } else if (e.key === 'Enter') {
+            e.preventDefault();
+            let nextRow = tr.nextElementSibling;
+            if (!nextRow) {
+              nextRow = this.addRow();
+              if (this.onChange) this.onChange();
+            }
+            if (nextRow && nextRow.cells[cellIdx]) {
+              const next = nextRow.cells[cellIdx].querySelector('input,select,textarea');
+              if (next) {
+                next.focus();
+                if (typeof next.select === 'function') next.select();
+              }
+            }
+          } else if (e.key === 'Escape') {
+            e.preventDefault();
+            if(el.dataset.prevValue!==undefined){
+              el.value = el.dataset.prevValue;
+              if (this.onChange) this.onChange();
+            }
+          }
+        });
+        if (col.onChange) el.addEventListener('change', () => { col.onChange(el, tr); });
+        if (col.validate) {
+          const rules = Array.isArray(col.validate) ? col.validate : [col.validate];
+          el.addEventListener(col.multiple ? 'change' : 'input', () => applyValidation(el, rules));
+          applyValidation(el, rules);
+        }
+      });
+      const actTd = tr.insertCell();
+      const actIdx = this.columns.length + this.colOffset;
+      if (this.headerRow && this.headerRow.cells[actIdx] && this.headerRow.cells[actIdx].style.width) {
+        actTd.style.width = this.headerRow.cells[actIdx].style.width;
+      }
+      if(this.onView){
+        const viewBtn=document.createElement('button');
+        viewBtn.textContent='👁';
+        viewBtn.className='viewBtn';
+        viewBtn.title='View row';
+        viewBtn.setAttribute('aria-label','View row');
+        viewBtn.addEventListener('click',()=>{
+          const row={};
+          this.columns.forEach((col,i)=>{
+            const el=tr.cells[i + this.colOffset].firstChild;
+            if(!el) return;
+            if(col.multiple){
+              if(typeof el.getSelectedValues==='function') row[col.key]=el.getSelectedValues();
+              else row[col.key]=Array.from(el.selectedOptions||[]).map(o=>o.value);
+            }else {
+              row[col.key]=el.value;
+            }
+          });
+          this.onView(row,tr);
+        });
+        actTd.appendChild(viewBtn);
+      }
+      const addBtn=document.createElement('button');
+      addBtn.textContent='+';
+      addBtn.className='insertBelowBtn';
+      addBtn.title='Add row';
+      addBtn.setAttribute('aria-label','Add row');
+      addBtn.addEventListener('click',()=>{const newRow=this.addRow();if(newRow) this.tbody.insertBefore(newRow,tr.nextSibling);if(this.onChange) this.onChange();});
+      actTd.appendChild(addBtn);
+
+      const dupBtn = document.createElement('button');
+      dupBtn.textContent = '\u29C9';
+      dupBtn.className='duplicateBtn';
+      dupBtn.title='Duplicate row';
+      dupBtn.setAttribute('aria-label','Duplicate row');
+      dupBtn.addEventListener('click', () => {
+        const row = {};
+        this.columns.forEach((col,i) => {
+          const el = tr.cells[i + this.colOffset].firstChild;
+          if (!el) return;
+          if (col.multiple) {
+            if (typeof el.getSelectedValues === 'function') {
+              row[col.key] = el.getSelectedValues();
+            } else {
+              row[col.key] = Array.from(el.selectedOptions || []).map(o=>o.value);
+            }
+          } else {
+            row[col.key] = el.value;
+          }
+        });
+        const newRow = this.addRow(row);
+        if (newRow) this.tbody.insertBefore(newRow, tr.nextSibling);
+        if (this.onChange) this.onChange();
+      });
+      actTd.appendChild(dupBtn);
+
+      const delBtn = document.createElement('button');
+      delBtn.textContent = '\u2716';
+      delBtn.className='removeBtn';
+      delBtn.title='Delete row';
+      delBtn.setAttribute('aria-label','Delete row');
+      delBtn.addEventListener('click', () => { tr.remove(); this.save(); this.updateRowCount(); if (this.onChange) this.onChange(); });
+      actTd.appendChild(delBtn);
+
+      Object.keys(this.groupCols || {}).forEach(g => {
+        if (this.hiddenGroups && this.hiddenGroups.has(g)) {
+          (this.groupCols[g] || []).forEach(i => {
+            if (tr.cells[i + this.colOffset]) tr.cells[i + this.colOffset].classList.add('group-hidden');
+          });
+        }
+      });
+      this.updateRowCount();
+      return tr;
+    }
+
+    getRowData(tr) {
+      const row = {};
+      const offset = this.colOffset;
+      this.columns.forEach((col,i) => {
+        const el = tr.cells[i + offset] ? tr.cells[i + offset].firstChild : null;
+        if (!el) return;
+        if (col.multiple) {
+          if (typeof el.getSelectedValues === 'function') {
+            row[col.key] = el.getSelectedValues();
+          } else {
+            row[col.key] = Array.from(el.selectedOptions || []).map(o=>o.value);
+          }
+        } else {
+          row[col.key] = el.value;
+        }
+      });
+      return row;
+    }
+
+    getData() {
+      const rows = [];
+      const offset = this.colOffset;
+      Array.from(this.tbody.rows).forEach(tr => {
+        const row = {};
+        this.columns.forEach((col,i) => {
+          const el = tr.cells[i + offset].firstChild;
+          if (el) {
+            const val = el.value;
+            if (col.multiple) {
+              if (typeof el.getSelectedValues === 'function') {
+                row[col.key] = el.getSelectedValues();
+              } else {
+                row[col.key] = Array.from(el.selectedOptions || []).map(o => o.value);
+              }
+            } else if (col.type === 'number') {
+              const num = parseFloat(val);
+              if (val === '') {
+                row[col.key] = '';
+              } else {
+                row[col.key] = isNaN(num) ? null : num;
+              }
+            } else {
+              row[col.key] = val;
+            }
+          } else {
+            row[col.key] = '';
+          }
+        });
+        rows.push(row);
+        if (tr.dataset.ref !== undefined) row.ref = tr.dataset.ref;
+        if (tr.dataset.id !== undefined && row.id === undefined) row.id = tr.dataset.id;
+      });
+      return rows;
+    }
+
+    save() {
+      this.validateAll();
+      try {
+        setItem(this.storageKey, this.getData());
+      } catch(e) { console.error('save failed', e); }
+    }
+
+    load() {
+      let data = [];
+      try { data = getItem(this.storageKey, []); } catch(e) {}
+      data.forEach(row => this.addRow(row));
+      this.updateRowCount();
+    }
+
+    clearFilters() {
+      this.filters=this.filters.map(()=> '');
+      this.filterButtons.forEach(btn=>btn.classList.remove('filtered'));
+      this.applyFilters();
+    }
+
+    applyFilters() {
+      const offset = this.colOffset;
+      Array.from(this.tbody.rows).forEach(row => {
+        let visible = true;
+        this.filters.forEach((val,i) => {
+          const v = val.toLowerCase();
+          if (v && !String(row.cells[i + offset].firstChild.value).toLowerCase().includes(v)) visible = false;
+        });
+        if (visible && this.globalFilter) {
+          const term = this.globalFilter.toLowerCase();
+          const cols = this.globalFilterCols.length ? this.globalFilterCols : this.columns.map(c=>c.key);
+          const match = cols.some(key => {
+            const idx = this.columns.findIndex(c=>c.key === key);
+            if (idx === -1) return false;
+            const cell = row.cells[idx + offset];
+            if (!cell) return false;
+            return String(cell.firstChild.value || '').toLowerCase().includes(term);
+          });
+          if (!match) visible = false;
+        }
+        row.style.display = visible ? '' : 'none';
+      });
+    }
+
+    deleteAll() {
+      this.tbody.innerHTML='';
+      if (this.selectAll) this.selectAll.checked = false;
+      this.save();
+      this.updateRowCount();
+      if (this.onChange) this.onChange();
+    }
+
+    deleteSelected() {
+      Array.from(this.tbody.querySelectorAll('.row-select:checked')).forEach(cb => cb.closest('tr').remove());
+      if (this.selectAll) this.selectAll.checked = false;
+      this.save();
+      this.updateRowCount();
+    }
+
+    initContextMenu() {
+      const menu = new ContextMenu();
+      let clipboard = null;
+      menu.setItems([
+        { label: 'Insert Row Above', action: tr => { if (!tr) return; const newRow = this.addRow(); this.tbody.insertBefore(newRow, tr); if (this.onChange) this.onChange(); } },
+        { label: 'Insert Row Below', action: tr => { if (!tr) return; const newRow = this.addRow(); this.tbody.insertBefore(newRow, tr.nextSibling); if (this.onChange) this.onChange(); } },
+        { label: 'Copy Row', action: tr => { if (!tr) return; clipboard = this.getRowData(tr); } },
+        { label: 'Paste Row', action: tr => { if (!tr || !clipboard) return; const newRow = this.addRow(clipboard); this.tbody.insertBefore(newRow, tr.nextSibling); if (this.onChange) this.onChange(); } },
+        { label: 'Delete Row', action: tr => { if (!tr) return; tr.remove(); this.save(); this.updateRowCount(); if (this.onChange) this.onChange(); } }
+      ]);
+
+      this.table.addEventListener('contextmenu', e => {
+        const row = e.target.closest('tbody tr');
+        if (row) {
+          e.preventDefault();
+          menu.show(e.pageX, e.pageY, row);
+        } else if (e.target.closest(`#${this.table.id}`)) {
+          e.preventDefault();
+        }
+      });
+
+      document.addEventListener('keydown', e => {
+        const tag = document.activeElement.tagName;
+        if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return;
+        const row = document.activeElement.closest(`#${this.table.id} tbody tr`);
+        if (!row) return;
+        if (e.ctrlKey && e.key.toLowerCase() === 'c') {
+          clipboard = this.getRowData(row);
+          e.preventDefault();
+        } else if (e.ctrlKey && e.key.toLowerCase() === 'v') {
+          if (!clipboard) return;
+          const newRow = this.addRow(clipboard);
+          this.tbody.insertBefore(newRow, row.nextSibling);
+          if (this.onChange) this.onChange();
+          e.preventDefault();
+        }
+      });
+    }
+
+    exportXlsx() {
+      const data = [this.columns.map(c=>c.label)];
+      this.getData().forEach(row => {
+        data.push(this.columns.map(c => row[c.key] || ''));
+      });
+      const wb = XLSX.utils.book_new();
+      const ws = XLSX.utils.aoa_to_sheet(data);
+      XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+      XLSX.writeFile(wb, `${this.storageKey}.xlsx`);
+    }
+
+    importXlsx(file) {
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        const wb = XLSX.read(e.target.result, {type:'binary'});
+        const sheet = wb.Sheets[wb.SheetNames[0]];
+        const json = XLSX.utils.sheet_to_json(sheet, {defval:''});
+        this.tbody.innerHTML='';
+        json.forEach(obj => {
+          const row = {};
+          this.columns.forEach(col => row[col.key] = obj[col.label] || '');
+          this.addRow(row);
+        });
+        this.applyFilters();
+        this.save();
+        if (this.onChange) this.onChange();
+      };
+      reader.readAsBinaryString(file);
+    }
+
+    validateAll() {
+      let valid = true;
+      const offset = this.colOffset;
+      Array.from(this.tbody.rows).forEach(row => {
+        this.columns.forEach((col,i) => {
+          const el = row.cells[i + offset].firstChild;
+          if (col.validate && !applyValidation(el, Array.isArray(col.validate) ? col.validate : [col.validate])) valid = false;
+        });
+      });
+      return valid;
+    }
+  }
+
+  function saveToStorage(key, data){
+    try { setItem(key, data); } catch(e){}
+  }
+  function loadFromStorage(key){
+    try { return getItem(key, []); } catch(e){ return []; }
+  }
+
+  function createTable(opts){ return new TableManager(opts); }
+
+  function applyValidation(el, rules = []) {
+    const value = (el.value || '').trim();
+    let error = '';
+    rules.forEach(rule => {
+      if (error) return;
+      if (typeof rule === 'function') {
+        const msg = rule(value);
+        if (msg) error = msg;
+      } else if (rule === 'required') {
+        if (!value) error = 'Required';
+      } else if (rule === 'numeric') {
+        if (value === '' || isNaN(Number(value))) error = 'Must be numeric';
+      }
+    });
+    const existing = el.nextElementSibling;
+    if (error) {
+      el.classList.add('input-error');
+      let msg = existing && existing.classList && existing.classList.contains('error-message') ? existing : null;
+      if (!msg) {
+        msg = document.createElement('span');
+        msg.className = 'error-message';
+        el.insertAdjacentElement('afterend', msg);
+      }
+      msg.textContent = error;
+      return false;
+    } else {
+      el.classList.remove('input-error');
+      if (existing && existing.classList && existing.classList.contains('error-message')) existing.remove();
+      return true;
+    }
+  }
+
+  window.TableUtils = { createTable, saveToStorage, loadFromStorage, applyValidation, STORAGE_KEYS };
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('DOMContentLoaded', () => {
+      const projectId = window.currentProjectId || 'default';
+      loadProject(projectId);
+      initSettings();
+      initDarkMode();
+      initCompactMode();
+      initNavToggle();
+
+      const columns = [
+        { key: 'id', label: 'ID', type: 'text' },
+        { key: 'description', label: 'Description', type: 'text' },
+        { key: 'voltage', label: 'Voltage (V)', type: 'text' },
+        { key: 'category', label: 'Category', type: 'text' },
+        { key: 'subCategory', label: 'Sub-Category', type: 'text' },
+        { key: 'manufacturer', label: 'Manufacturer', type: 'text', className: 'manufacturer-input', filter: 'dropdown' },
+        { key: 'model', label: 'Model', type: 'text', className: 'model-input' },
+        { key: 'phases', label: 'Phases', type: 'text' },
+        { key: 'notes', label: 'Notes', type: 'text' },
+        { key: 'x', label: 'X', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
+        { key: 'y', label: 'Y', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
+        { key: 'z', label: 'Z', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' }
+      ];
+
+      let table;
+      table = TableUtils.createTable({
+        tableId: 'equipment-table',
+        storageKey: TableUtils.STORAGE_KEYS.equipment,
+        columnsKey: TableUtils.STORAGE_KEYS.equipmentColumns,
+        addRowBtnId: 'add-row-btn',
+        deleteSelectedBtnId: 'delete-selected-btn',
+        exportBtnId: 'export-xlsx-btn',
+        importInputId: 'import-xlsx-input',
+        importBtnId: 'import-xlsx-btn',
+        selectable: true,
+        enableContextMenu: true,
+        columns,
+        onChange: () => {
+          table.save();
+          const fn = window.opener?.updateComponent || window.updateComponent;
+          if (fn) {
+            table.getData().forEach(row => {
+              const id = row.ref || row.id;
+              if (id) fn(id, row);
+            });
+          }
+          saveProject(projectId);
+        }
+      });
+
+      const searchInput = document.getElementById('equipment-search');
+      if (searchInput) {
+        table.globalFilterCols = ['id', 'description', 'manufacturer'];
+        searchInput.addEventListener('input', e => {
+          table.globalFilter = e.target.value;
+          table.applyFilters();
+        });
+      }
+
+      function generateId(existing, base) {
+        let id = base || 'item';
+        let i = 1;
+        while (existing.includes(id)) {
+          id = `${base || 'item'}_${i++}`;
+        }
+        return id;
+      }
+
+      table.tbody.addEventListener('click', e => {
+        const btn = e.target;
+        const tr = btn.closest('tr');
+        if (!tr) return;
+        if (btn.classList.contains('duplicateBtn')) {
+          e.stopImmediatePropagation();
+          const data = table.getData();
+          const idx = Array.from(table.tbody.rows).indexOf(tr);
+          const clone = { ...data[idx] };
+          const ids = data.map(r => r.id).filter(Boolean);
+          clone.id = generateId(ids, clone.id);
+          data.splice(idx + 1, 0, clone);
+          table.setData(data);
+          table.save();
+          if (table.onChange) table.onChange();
+        } else if (btn.classList.contains('removeBtn')) {
+          e.stopImmediatePropagation();
+          const data = table.getData();
+          const idx = Array.from(table.tbody.rows).indexOf(tr);
+          data.splice(idx, 1);
+          table.setData(data);
+          table.save();
+          if (table.onChange) table.onChange();
+        }
+      });
+
+      const addColBtn = document.getElementById('add-column-btn');
+      const modal = document.getElementById('add-column-modal');
+      const keyInput = document.getElementById('new-col-key');
+      const labelInput = document.getElementById('new-col-label');
+      const typeInput = document.getElementById('new-col-type');
+      const confirmBtn = document.getElementById('confirm-add-column');
+
+      addColBtn.addEventListener('click', () => {
+        modal.style.display = 'flex';
+        keyInput.value = '';
+        labelInput.value = '';
+        typeInput.value = 'text';
+        keyInput.focus();
+      });
+
+      confirmBtn.addEventListener('click', () => {
+        const key = keyInput.value.trim();
+        const label = labelInput.value.trim();
+        const type = typeInput.value;
+        if (!key || !label) return;
+        table.addColumn({ key, label, type });
+        modal.style.display = 'none';
+      });
+
+      modal.addEventListener('click', e => {
+        if (e.target === modal) modal.style.display = 'none';
+      });
+
+      const fieldMap = {
+        'EquipmentID': 'id',
+        'ID': 'id',
+        'Description': 'description',
+        'Voltage': 'voltage',
+        'Category': 'category',
+        'Sub-Category': 'subCategory',
+        'Manufacturer': 'manufacturer',
+        'Model': 'model',
+        'Phases': 'phases',
+        'Notes': 'notes',
+        'X': 'x',
+        'Y': 'y',
+        'Z': 'z'
+      };
+
+      const csvBtn = document.getElementById('import-csv-btn');
+      const csvInput = document.getElementById('import-csv-input');
+      if (csvBtn && csvInput) {
+        csvBtn.addEventListener('click', () => csvInput.click());
+        csvInput.addEventListener('change', e => {
+          importCsv(e.target.files[0]);
+          e.target.value = '';
+        });
+      }
+
+      const xmlBtn = document.getElementById('import-xml-btn');
+      const xmlInput = document.getElementById('import-xml-input');
+      if (xmlBtn && xmlInput) {
+        xmlBtn.addEventListener('click', () => xmlInput.click());
+        xmlInput.addEventListener('change', e => {
+          importXml(e.target.files[0]);
+          e.target.value = '';
+        });
+      }
+
+      function mapExternal(obj = {}) {
+        const row = {};
+        Object.keys(fieldMap).forEach(key => {
+          const internal = fieldMap[key];
+          row[internal] = obj[key] || obj[key.toLowerCase()] || '';
+        });
+        return row;
+      }
+
+      function importCsv(file) {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = e => {
+          const text = e.target.result;
+          const lines = text.split(/\r?\n/).filter(l => l.trim());
+          if (!lines.length) return;
+          const headers = lines.shift().split(',').map(h => h.trim());
+          const rows = lines.map(line => {
+            const cells = line.split(',');
+            const obj = {};
+            headers.forEach((h, i) => obj[h] = cells[i] ? cells[i].trim() : '');
+            return obj;
+          });
+          table.tbody.innerHTML = '';
+          rows.forEach(r => table.addRow(mapExternal(r)));
+          table.applyFilters();
+          table.save();
+          if (table.onChange) table.onChange();
+        };
+        reader.readAsText(file);
+      }
+
+      function importXml(file) {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = e => {
+          const text = e.target.result;
+          const doc = new DOMParser().parseFromString(text, 'application/xml');
+          const items = Array.from(doc.getElementsByTagName('equipment'))
+            .concat(Array.from(doc.getElementsByTagName('item')));
+          table.tbody.innerHTML = '';
+          items.forEach(el => {
+            const obj = {};
+            Object.keys(fieldMap).forEach(key => {
+              const n = el.getElementsByTagName(key)[0];
+              if (n) obj[key] = n.textContent;
+            });
+            table.addRow(mapExternal(obj));
+          });
+          table.applyFilters();
+          table.save();
+          if (table.onChange) table.onChange();
+        };
+        reader.readAsText(file);
+      }
+    });
+  }
+
+})();

--- a/equipmentlist.html
+++ b/equipmentlist.html
@@ -67,6 +67,9 @@
           <input type="file" id="import-xml-input" accept=".xml" class="hidden" title="Import from XML">
           <button id="import-xml-btn" class="btn" title="Import from XML">Import XML</button>
         </div>
+        <div class="mb-1">
+          <input type="text" id="equipment-search" class="table-search" placeholder="Search..." title="Search by tag, description, or manufacturer">
+        </div>
         <div class="overflow-x-auto">
           <table id="equipment-table" class="sticky-table">
             <thead></thead>

--- a/equipmentlist.js
+++ b/equipmentlist.js
@@ -16,7 +16,7 @@ if (typeof window !== 'undefined') {
       { key: 'voltage', label: 'Voltage (V)', type: 'text' },
       { key: 'category', label: 'Category', type: 'text' },
       { key: 'subCategory', label: 'Sub-Category', type: 'text' },
-      { key: 'manufacturer', label: 'Manufacturer', type: 'text', className: 'manufacturer-input' },
+      { key: 'manufacturer', label: 'Manufacturer', type: 'text', className: 'manufacturer-input', filter: 'dropdown' },
       { key: 'model', label: 'Model', type: 'text', className: 'model-input' },
       { key: 'phases', label: 'Phases', type: 'text' },
       { key: 'notes', label: 'Notes', type: 'text' },
@@ -50,6 +50,15 @@ if (typeof window !== 'undefined') {
         dataStore.saveProject(projectId);
       }
     });
+
+    const searchInput = document.getElementById('equipment-search');
+    if (searchInput) {
+      table.globalFilterCols = ['id', 'description', 'manufacturer'];
+      searchInput.addEventListener('input', e => {
+        table.globalFilter = e.target.value;
+        table.applyFilters();
+      });
+    }
 
     function generateId(existing, base) {
       let id = base || 'item';


### PR DESCRIPTION
## Summary
- add search box to equipment list page and wire it to table filtering
- allow dropdown-based column filtering and global searches in table utilities

## Testing
- `npm run build` *(fails: Invalid value "iife" for option "output.format" - UMD and IIFE output formats are not supported for code-splitting builds)*
- `npx rollup equipmentlist.js --file dist/equipmentlist.js --format iife`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc2dfc4c8324af67d9f732010a38