### PR TITLE
Add basic backend auth and project syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+server_data/

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,38 @@
+async function signup(e) {
+  e.preventDefault();
+  const username = document.getElementById('signup-user').value.trim();
+  const password = document.getElementById('signup-pass').value;
+  const res = await fetch('/signup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    alert('Signup successful. You may now log in.');
+  } else {
+    alert('Signup failed');
+  }
+}
+
+async function login(e) {
+  e.preventDefault();
+  const username = document.getElementById('login-user').value.trim();
+  const password = document.getElementById('login-pass').value;
+  const res = await fetch('/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    const { token } = await res.json();
+    localStorage.setItem('authToken', token);
+    localStorage.setItem('authUser', username);
+    window.location.href = 'index.html';
+  } else {
+    alert('Login failed');
+  }
+}
+
+document.getElementById('signup-form').addEventListener('submit', signup);
+document.getElementById('login-form').addEventListener('submit', login);
+

--- a/login.html
+++ b/login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Login or Sign Up</h1>
+    <section class="card">
+      <form id="signup-form">
+        <h2>Sign Up</h2>
+        <input id="signup-user" placeholder="Username" required>
+        <input id="signup-pass" type="password" placeholder="Password" required>
+        <button type="submit">Sign Up</button>
+      </form>
+    </section>
+    <section class="card">
+      <form id="login-form">
+        <h2>Log In</h2>
+        <input id="login-user" placeholder="Username" required>
+        <input id="login-pass" type="password" placeholder="Password" required>
+        <button type="submit">Log In</button>
+      </form>
+    </section>
+  </main>
+  <script type="module" src="auth.js"></script>
+</body>
+</html>
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "rollup -c",
     "test": "node tests/ampacity.test.js && node tests/ductbankSolver.test.js && node tests/ieee835.test.js && node tests/tableUtilsNavigation.test.js && node tests/racewayRoute.test.js && node tests/rebuildTrayData.test.js && node tests/conduitCount.test.js && node tests/dirtyTracker.test.js && node tests/units.test.js && node tests/resultsExporter.test.js && node tests/sampleLinks.test.js && node tests/racewaySampleMapper.test.js && node tests/selfCheckRestore.test.js && node tests/equipmentColumns.test.js && node tests/equipmentPersistence.test.js && node tests/loadlistPersistence.test.js && node tests/reporting.test.js && node tests/shortcircuit/shortCircuit.test.js && node tests/arcflash/arcFlashExample.test.js && node tests/exportAllReports.test.js && node tests/tcc/tccUtils.test.js && node tests/analysis.test.js",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "server": "node server.mjs"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",
@@ -17,6 +18,7 @@
     "svg2pdf.js": "^2.0.1",
     "handlebars": "^4.7.8",
     "pdfkit": "^0.13.0",
-    "dxf-writer": "^1.0.0"
+    "dxf-writer": "^1.0.0",
+    "express": "^4.19.2"
   }
 }

--- a/projectManager.js
+++ b/projectManager.js
@@ -1,4 +1,4 @@
-import { saveProject as dsSaveProject, loadProject as dsLoadProject } from './dataStore.mjs';
+import { saveProject as dsSaveProject, loadProject as dsLoadProject, exportProject, importProject } from './dataStore.mjs';
 
 function listProjects() {
   if (typeof localStorage === 'undefined') return [];
@@ -34,20 +34,50 @@ function newProject() {
   location.reload();
 }
 
-function saveProject() {
+async function serverSaveProject(name) {
+  const token = localStorage.getItem('authToken');
+  if (!token) return false;
+  const res = await fetch(`/projects/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify(exportProject())
+  });
+  return res.ok;
+}
+
+async function serverLoadProject(name) {
+  const token = localStorage.getItem('authToken');
+  if (!token) return false;
+  const res = await fetch(`/projects/${encodeURIComponent(name)}`, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  if (!res.ok) return false;
+  const { data } = await res.json();
+  importProject(data);
+  return true;
+}
+
+async function saveProject() {
   let name = currentProject();
   if (!name) name = promptProjectName('Save project as');
   if (!name) return;
   setProjectHash(name);
+  // Save locally and attempt server sync if logged in
   dsSaveProject(name);
+  try { await serverSaveProject(name); } catch (e) { console.error(e); }
 }
 
-function loadProject() {
+async function loadProject() {
   const projects = listProjects();
   const name = window.prompt('Load which project?\n' + projects.join('\n'));
   if (!name) return;
   setProjectHash(name);
-  dsLoadProject(name);
+  let loaded = false;
+  try { loaded = await serverLoadProject(name); } catch (e) { console.error(e); }
+  if (!loaded) dsLoadProject(name);
   location.reload();
 }
 
@@ -57,5 +87,25 @@ if (typeof window !== 'undefined') {
     document.getElementById('new-project-btn')?.addEventListener('click', newProject);
     document.getElementById('save-project-btn')?.addEventListener('click', saveProject);
     document.getElementById('load-project-btn')?.addEventListener('click', loadProject);
+
+    // Add login/logout button
+    const menu = document.getElementById('settings-menu');
+    if (menu) {
+      const btn = document.createElement('button');
+      function updateLabel() {
+        btn.textContent = localStorage.getItem('authToken') ? 'Logout' : 'Login';
+      }
+      updateLabel();
+      btn.addEventListener('click', () => {
+        if (localStorage.getItem('authToken')) {
+          localStorage.removeItem('authToken');
+          localStorage.removeItem('authUser');
+          updateLabel();
+        } else {
+          location.href = 'login.html';
+        }
+      });
+      menu.appendChild(btn);
+    }
   });
 }

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,91 @@
+import express from 'express';
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+
+const app = express();
+app.use(express.json());
+
+// Serve static files so the frontend can be loaded from the same server.
+app.use(express.static(process.cwd()));
+
+// Basic in-memory session store
+const sessions = new Map();
+
+// Ensure data directory exists
+const dataDir = path.join(process.cwd(), 'server_data');
+await fs.mkdir(dataDir, { recursive: true });
+
+// Load users from disk if present
+const usersFile = path.join(dataDir, 'users.json');
+let users = {};
+try {
+  users = JSON.parse(await fs.readFile(usersFile, 'utf-8'));
+} catch {
+  users = {};
+}
+
+async function saveUsers() {
+  await fs.writeFile(usersFile, JSON.stringify(users, null, 2));
+}
+
+// --- Auth endpoints ---
+app.post('/signup', async (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) return res.status(400).json({ error: 'Missing credentials' });
+  if (users[username]) return res.status(409).json({ error: 'User exists' });
+  users[username] = { password };
+  await saveUsers();
+  res.status(201).json({ message: 'User created' });
+});
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body || {};
+  const user = users[username];
+  if (!user || user.password !== password) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = crypto.randomBytes(16).toString('hex');
+  sessions.set(token, username);
+  res.json({ token });
+});
+
+function auth(req, res, next) {
+  const header = req.headers.authorization || '';
+  const [, token] = header.split(' ');
+  const username = sessions.get(token);
+  if (!username) return res.status(401).json({ error: 'Unauthorized' });
+  req.username = username;
+  next();
+}
+
+// --- Project endpoints ---
+app.post('/projects/:project', auth, async (req, res) => {
+  const project = req.params.project;
+  const username = req.username;
+  const userDir = path.join(dataDir, username, project);
+  await fs.mkdir(userDir, { recursive: true });
+  const version = Date.now().toString();
+  await fs.writeFile(path.join(userDir, `${version}.json`), JSON.stringify(req.body, null, 2));
+  res.json({ version });
+});
+
+app.get('/projects/:project', auth, async (req, res) => {
+  const project = req.params.project;
+  const username = req.username;
+  const projDir = path.join(dataDir, username, project);
+  try {
+    const files = await fs.readdir(projDir);
+    const versions = files.filter(f => f.endsWith('.json')).sort();
+    if (!versions.length) return res.status(404).json({ error: 'Not found' });
+    const latest = versions[versions.length - 1];
+    const data = JSON.parse(await fs.readFile(path.join(projDir, latest), 'utf-8'));
+    res.json({ version: latest.replace('.json', ''), data });
+  } catch {
+    res.status(404).json({ error: 'Not found' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+


### PR DESCRIPTION
## Summary
- Build Express server with signup/login and project save/load endpoints
- Create login & signup UI storing auth tokens in localStorage
- Sync projects with server when logged in and add login/logout controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdbf9605388324b95daa2fafb91a51