### PR TITLE
Improve icon button styling

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -39,6 +39,30 @@
   color: var(--primary-color);
 }
 
+.icon-button {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+.icon-button img {
+  width: 100%;
+  height: 100%;
+}
+
+.icon-button:hover,
+.icon-button:focus {
+  background: var(--ol-hover-bg);
+  border-radius: 4px;
+}
+
 .card {
   background: var(--ol-card-bg);
   border: 1px solid var(--ol-border-color);
@@ -219,16 +243,6 @@
   border-radius: var(--ol-radius);
   width: 100%;
   height: 100%;
-}
-
-.btn.icon-button {
-  transition: transform 0.2s, background-color 0.2s;
-}
-
-.btn.icon-button:hover,
-.btn.icon-button:focus {
-  background-color: var(--ol-hover-bg);
-  transform: scale(1.05);
 }
 
 #snap-indicator {

--- a/oneline.html
+++ b/oneline.html
@@ -70,40 +70,40 @@
           </div>
           <div id="sheet-tabs" class="sheet-tabs" role="tablist"></div>
           <div class="sheet-action-group">
-            <button id="add-sheet-btn" class="btn icon-button" title="Add Sheet" aria-label="Add Sheet">+</button>
-            <button id="rename-sheet-btn" class="btn icon-button" title="Rename Sheet" aria-label="Rename Sheet">✎</button>
-            <button id="delete-sheet-btn" class="btn icon-button" title="Delete Sheet" aria-label="Delete Sheet">🗑</button>
-            <button id="diagram-export-btn" type="button" class="btn icon-button" title="Export Diagram" aria-label="Export Diagram"><img src="icons/toolbar/export.svg" alt=""></button>
+            <button id="add-sheet-btn" class="icon-button" title="Add Sheet" aria-label="Add Sheet">+</button>
+            <button id="rename-sheet-btn" class="icon-button" title="Rename Sheet" aria-label="Rename Sheet">✎</button>
+            <button id="delete-sheet-btn" class="icon-button" title="Delete Sheet" aria-label="Delete Sheet">🗑</button>
+            <button id="diagram-export-btn" type="button" class="icon-button" title="Export Diagram" aria-label="Export Diagram"><img src="icons/toolbar/export.svg" alt=""></button>
             <input type="file" id="diagram-import-input" accept=".json" class="hidden-input">
-            <button id="diagram-import-btn" type="button" class="btn icon-button" title="Import Diagram" aria-label="Import Diagram"><img src="icons/toolbar/import.svg" alt=""></button>
+            <button id="diagram-import-btn" type="button" class="icon-button" title="Import Diagram" aria-label="Import Diagram"><img src="icons/toolbar/import.svg" alt=""></button>
             <button id="diagram-share-btn" type="button" class="btn" title="Share diagram">Share</button>
             <button id="tour-btn" type="button" class="btn" title="Start tour">Tour</button>
           </div>
         </div>
         <div class="toolbar">
-          <button id="connect-btn" class="icon-button btn" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
-          <button id="dimension-btn" class="icon-button btn" title="Dimension" aria-label="Dimension"><img src="icons/toolbar/dimension.svg" alt=""></button>
-          <button id="undo-btn" class="icon-button btn" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
-          <button id="redo-btn" class="icon-button btn" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
-          <button id="align-left-btn" class="icon-button btn" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
-          <button id="align-right-btn" class="icon-button btn" title="Align Right" aria-label="Align Right"><img src="icons/toolbar/align-right.svg" alt=""></button>
-          <button id="align-top-btn" class="icon-button btn" title="Align Top" aria-label="Align Top"><img src="icons/toolbar/align-top.svg" alt=""></button>
-          <button id="align-bottom-btn" class="icon-button btn" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
-          <button id="distribute-h-btn" class="icon-button btn" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
-          <button id="distribute-v-btn" class="icon-button btn" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
-          <button id="export-btn" class="icon-button btn" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
+          <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
+          <button id="dimension-btn" class="icon-button" title="Dimension" aria-label="Dimension"><img src="icons/toolbar/dimension.svg" alt=""></button>
+          <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
+          <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
+          <button id="align-left-btn" class="icon-button" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
+          <button id="align-right-btn" class="icon-button" title="Align Right" aria-label="Align Right"><img src="icons/toolbar/align-right.svg" alt=""></button>
+          <button id="align-top-btn" class="icon-button" title="Align Top" aria-label="Align Top"><img src="icons/toolbar/align-top.svg" alt=""></button>
+          <button id="align-bottom-btn" class="icon-button" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
+          <button id="distribute-h-btn" class="icon-button" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
+          <button id="distribute-v-btn" class="icon-button" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
+          <button id="export-btn" class="icon-button" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
           <button id="export-pdf-btn" class="btn" title="Export PDF" aria-label="Export PDF">Export PDF</button>
           <button id="export-dxf-btn" class="btn" title="Export DXF" aria-label="Export DXF">Export DXF</button>
           <button id="export-dwg-btn" class="btn" title="Export DWG" aria-label="Export DWG">Export DWG</button>
           <input type="file" id="import-input" accept=".json" class="hidden-input">
-          <button id="import-btn" class="icon-button btn" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
-          <button id="validate-btn" class="icon-button btn" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
+          <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
+          <button id="validate-btn" class="icon-button" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
           <div class="grid-controls toolbar-group">
-            <label class="btn icon-button" title="Toggle Grid" aria-label="Toggle Grid">
+            <label class="icon-button" title="Toggle Grid" aria-label="Toggle Grid">
               <input type="checkbox" id="grid-toggle" class="hidden-input" checked>
               <img src="icons/toolbar/grid.svg" alt="">
             </label>
-            <label class="btn icon-button" title="Grid size" aria-label="Grid size">
+            <label class="icon-button" title="Grid size" aria-label="Grid size">
               <img src="icons/toolbar/grid-size.svg" alt="">
               <input type="number" id="grid-size" value="20" min="1">
             </label>


### PR DESCRIPTION
## Summary
- add `.icon-button` style to strip default button chrome, fix icon sizing and provide hover feedback
- drop `.btn` class from decorative toolbar and sheet action buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc18d3d9c832494f3d8dc76a587ef