### PR TITLE
Add export dropdown for diagram toolbar

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -167,6 +167,39 @@
   display: none;
 }
 
+.export-group {
+  position: relative;
+}
+
+.export-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: var(--ol-card-bg);
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  box-shadow: var(--ol-shadow);
+  display: none;
+}
+
+.export-menu li {
+  padding: 0.25rem 0.75rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.export-menu li:hover,
+.export-menu li:focus {
+  background: var(--ol-hover-bg);
+}
+
+.export-menu.show {
+  display: block;
+}
+
 .toolbar-group {
   display: flex;
   align-items: center;

--- a/oneline.html
+++ b/oneline.html
@@ -91,10 +91,14 @@
           <button id="align-bottom-btn" class="icon-button" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
           <button id="distribute-h-btn" class="icon-button" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
           <button id="distribute-v-btn" class="icon-button" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
-          <button id="export-btn" class="icon-button" title="Export" aria-label="Export"><img src="icons/toolbar/export.svg" alt=""></button>
-          <button id="export-pdf-btn" class="btn" title="Export PDF" aria-label="Export PDF">Export PDF</button>
-          <button id="export-dxf-btn" class="btn" title="Export DXF" aria-label="Export DXF">Export DXF</button>
-          <button id="export-dwg-btn" class="btn" title="Export DWG" aria-label="Export DWG">Export DWG</button>
+          <div class="export-group">
+            <button id="export-btn" class="icon-button" title="Export" aria-label="Export" aria-haspopup="true" aria-expanded="false"><img src="icons/toolbar/export.svg" alt=""></button>
+            <ul id="export-menu" class="export-menu" role="menu">
+              <li data-format="pdf" role="menuitem">Export PDF</li>
+              <li data-format="dxf" role="menuitem">Export DXF</li>
+              <li data-format="dwg" role="menuitem">Export DWG</li>
+            </ul>
+          </div>
           <input type="file" id="import-input" accept=".json" class="hidden-input">
           <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
           <button id="validate-btn" class="icon-button" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>

--- a/oneline.js
+++ b/oneline.js
@@ -2279,28 +2279,33 @@ async function init() {
   document.getElementById('distribute-h-btn').addEventListener('click', () => distributeSelection('h'));
   document.getElementById('distribute-v-btn').addEventListener('click', () => distributeSelection('v'));
   const exportBtn = document.getElementById('export-btn');
-  if (exportBtn) exportBtn.addEventListener('click', exportDiagram);
-  const exportPdfBtn = document.getElementById('export-pdf-btn');
-  if (exportPdfBtn)
-    exportPdfBtn.addEventListener('click', () =>
-      exportPDF({
-        svgEl: document.getElementById('diagram'),
-        sheets,
-        loadSheet,
-        serializeDiagram,
-        activeSheet
-      })
-    );
-  const exportDxfBtn = document.getElementById('export-dxf-btn');
-  if (exportDxfBtn)
-    exportDxfBtn.addEventListener('click', () =>
-      exportDXF(sheets[activeSheet]?.components || [])
-    );
-  const exportDwgBtn = document.getElementById('export-dwg-btn');
-  if (exportDwgBtn)
-    exportDwgBtn.addEventListener('click', () =>
-      exportDWG(sheets[activeSheet]?.components || [])
-    );
+  const exportMenu = document.getElementById('export-menu');
+  if (exportBtn && exportMenu) {
+    exportBtn.addEventListener('click', () => {
+      const expanded = exportBtn.getAttribute('aria-expanded') === 'true';
+      exportBtn.setAttribute('aria-expanded', String(!expanded));
+      exportMenu.classList.toggle('show');
+    });
+    exportMenu.addEventListener('click', e => {
+      const format = e.target?.dataset?.format;
+      if (!format) return;
+      exportMenu.classList.remove('show');
+      exportBtn.setAttribute('aria-expanded', 'false');
+      if (format === 'pdf') {
+        exportPDF({
+          svgEl: document.getElementById('diagram'),
+          sheets,
+          loadSheet,
+          serializeDiagram,
+          activeSheet
+        });
+      } else if (format === 'dxf') {
+        exportDXF(sheets[activeSheet]?.components || []);
+      } else if (format === 'dwg') {
+        exportDWG(sheets[activeSheet]?.components || []);
+      }
+    });
+  }
   const importBtn = document.getElementById('import-btn');
   if (importBtn) importBtn.addEventListener('click', () => document.getElementById('import-input').click());
   const importInput = document.getElementById('import-input');


### PR DESCRIPTION
## Summary
- Replace individual PDF/DXF/DWG export buttons with a single export dropdown
- Style dropdown menu to match toolbar aesthetics
- Trigger specific export actions based on selected format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc28edf888324af7a62b062fe89ca