### PR TITLE
Align scale and slack controls to right in oneline toolbar

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -206,6 +206,13 @@
   gap: var(--ol-spacing);
 }
 
+.toolbar-group-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--ol-spacing);
+}
+
 .sheet-controls {
   display: flex;
   align-items: center;

--- a/oneline.html
+++ b/oneline.html
@@ -112,8 +112,10 @@
               <input type="number" id="grid-size" value="20" min="1">
             </label>
           </div>
-          <label class="scale-label">1 px = <input type="number" id="scale-value" value="1" step="0.01" min="0"> <input type="text" id="scale-unit" value="in" size="3" aria-label="Scale unit"></label>
-          <label class="slack-label">Slack % <input type="number" id="slack-pct" value="0" step="0.1" min="0"></label>
+          <div class="toolbar-group toolbar-group-right">
+            <label class="scale-label">1 px = <input type="number" id="scale-value" value="1" step="0.01" min="0" placeholder="Scale"> <input type="text" id="scale-unit" value="in" size="3" aria-label="Scale unit"></label>
+            <label class="slack-label">Slack % <input type="number" id="slack-pct" value="0" step="0.1" min="0" placeholder="Slack %"></label>
+          </div>
         </div>
         <button id="palette-toggle" class="palette-toggle" aria-label="Toggle palette" aria-controls="palette" aria-expanded="false">☰</button>
         <div class="workspace">


### PR DESCRIPTION
## Summary
- Wrap scale and slack controls in a right-aligned toolbar group
- Add `.toolbar-group-right` styles and placeholders for clarity

## Testing
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc3324a508324bf1032e3c96b62ad