### PR TITLE
feat: enhance property modal grouping and style

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -295,21 +295,43 @@
 }
 
 .prop-modal {
-  position: absolute;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  font-family: var(--ol-font);
+}
+
+.prop-modal.show {
+  display: flex;
+  opacity: 1;
+}
+
+.prop-modal form {
   background: var(--ol-card-bg);
   padding: var(--ol-spacing);
   border: 1px solid var(--ol-border-color);
   border-radius: var(--ol-radius);
   box-shadow: var(--ol-shadow);
-  opacity: 0;
-  display: none;
-  font-family: var(--ol-font);
-  transition: opacity 0.3s ease;
+  max-height: 90%;
+  overflow: auto;
 }
 
-.prop-modal.show {
-  display: block;
-  opacity: 1;
+.prop-modal .modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.prop-modal .modal-header h3 {
+  margin: 0;
 }
 
 .port {
@@ -319,21 +341,7 @@
   pointer-events: none;
 }
 
-#prop-modal {
-  top: 10px;
-  right: 10px;
-}
 
-#cable-modal {
-  top: 50px;
-  right: 10px;
-}
-
-#validation-modal {
-  top: 90px;
-  right: 10px;
-  max-width: 300px;
-}
 
 .component.invalid text {
   fill: #c00;


### PR DESCRIPTION
## Summary
- add modal header and close button showing component label
- group property fields into fieldsets driven by schema
- center property modal with semi-transparent backdrop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc42d4cbc8324bfb314169793f33d