### PR TITLE
refactor: externalize component icons

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -2,7 +2,7 @@
   {
     "subtype": "Bus",
     "label": "Bus",
-    "icon": "icons/Bus.svg",
+    "icon": "icons/components/Bus.svg",
     "category": "bus",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -17,7 +17,7 @@
   {
     "subtype": "MLO",
     "label": "MLO",
-    "icon": "icons/MLO.svg",
+    "icon": "icons/components/MLO.svg",
     "category": "panel",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -37,7 +37,7 @@
   {
     "subtype": "MCC",
     "label": "MCC",
-    "icon": "icons/MCC.svg",
+    "icon": "icons/components/MCC.svg",
     "category": "panel",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -57,7 +57,7 @@
   {
     "subtype": "Generator",
     "label": "Generator",
-    "icon": "icons/Generator.svg",
+    "icon": "icons/components/Generator.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -78,7 +78,7 @@
   {
     "subtype": "UPS",
     "label": "UPS",
-    "icon": "icons/UPS.svg",
+    "icon": "icons/components/UPS.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -97,7 +97,7 @@
   {
     "subtype": "Transformer",
     "label": "Transformer",
-    "icon": "icons/Transformer.svg",
+    "icon": "icons/components/Transformer.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -115,7 +115,7 @@
   {
     "subtype": "Switchgear",
     "label": "Switchgear",
-    "icon": "icons/Switchgear.svg",
+    "icon": "icons/components/Switchgear.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -135,7 +135,7 @@
   {
     "subtype": "Switchboard",
     "label": "Switchboard",
-    "icon": "icons/Switchboard.svg",
+    "icon": "icons/components/Switchboard.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -151,7 +151,7 @@
   {
     "subtype": "Feeder",
     "label": "Feeder",
-    "icon": "icons/Feeder.svg",
+    "icon": "icons/components/Feeder.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -169,7 +169,7 @@
   {
     "subtype": "Motor",
     "label": "Motor",
-    "icon": "icons/Motor.svg",
+    "icon": "icons/components/Motor.svg",
     "category": "load",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -194,7 +194,7 @@
   {
     "subtype": "CapacitorBank",
     "label": "Capacitor Bank",
-    "icon": "icons/CapacitorBank.svg",
+    "icon": "icons/components/CapacitorBank.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -213,7 +213,7 @@
   {
     "subtype": "PVArray",
     "label": "PV Array",
-    "icon": "icons/PVArray.svg",
+    "icon": "icons/components/PVArray.svg",
     "category": "equipment",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
@@ -232,7 +232,7 @@
   {
     "subtype": "Load",
     "label": "Load",
-    "icon": "icons/Load.svg",
+    "icon": "icons/components/Load.svg",
     "category": "load",
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [

--- a/icons/components/Bus.svg
+++ b/icons/components/Bus.svg
@@ -1,0 +1,3 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 20">
+  <rect x="0" y="0" width="200" height="20" fill="none" stroke="black" stroke-width="2"/>
+</svg>

--- a/icons/components/CapacitorBank.svg
+++ b/icons/components/CapacitorBank.svg
@@ -1,0 +1,8 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="30" y1="10" x2="30" y2="30" stroke="#333" stroke-width="2"/>
+  <line x1="40" y1="10" x2="40" y2="30" stroke="#333" stroke-width="2"/>
+  <line x1="50" y1="10" x2="50" y2="30" stroke="#333" stroke-width="2"/>
+  <line x1="20" y1="10" x2="60" y2="10" stroke="#333" stroke-width="2"/>
+  <line x1="20" y1="30" x2="60" y2="30" stroke="#333" stroke-width="2"/>
+</svg>

--- a/icons/components/Feeder.svg
+++ b/icons/components/Feeder.svg
@@ -1,0 +1,4 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40">
+  <line x1="10" y1="20" x2="70" y2="20" stroke="black" />
+  <circle cx="40" cy="20" r="5" fill="none" stroke="black" />
+</svg>

--- a/icons/components/Generator.svg
+++ b/icons/components/Generator.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <circle cx="40" cy="20" r="12" fill="none" stroke="#333" stroke-width="2"/>
+  <path d="M28 20h24M40 8v24" stroke="#333" stroke-width="2"/>
+</svg>

--- a/icons/components/Load.svg
+++ b/icons/components/Load.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <circle cx="40" cy="20" r="18" fill="#fff" stroke="#333" stroke-width="2"/>
+  <polyline points="40 8 32 20 44 20 36 32" fill="none" stroke="#333" stroke-width="2"/>
+</svg>
+

--- a/icons/components/MCC.svg
+++ b/icons/components/MCC.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#333" stroke-width="2"/>
+  <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">MCC</text>
+</svg>
+

--- a/icons/components/MLO.svg
+++ b/icons/components/MLO.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#333" stroke-width="2"/>
+  <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">MLO</text>
+</svg>
+

--- a/icons/components/Motor.svg
+++ b/icons/components/Motor.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <circle cx="40" cy="20" r="12" fill="#fff" stroke="#333" stroke-width="2"/>
+  <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">M</text>
+</svg>

--- a/icons/components/PVArray.svg
+++ b/icons/components/PVArray.svg
@@ -1,0 +1,8 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <rect x="15" y="8" width="50" height="24" fill="none" stroke="#333" stroke-width="2"/>
+  <line x1="30" y1="8" x2="30" y2="32" stroke="#333" stroke-width="1"/>
+  <line x1="45" y1="8" x2="45" y2="32" stroke="#333" stroke-width="1"/>
+  <line x1="15" y1="16" x2="65" y2="16" stroke="#333" stroke-width="1"/>
+  <line x1="15" y1="24" x2="65" y2="24" stroke="#333" stroke-width="1"/>
+</svg>

--- a/icons/components/Switchboard.svg
+++ b/icons/components/Switchboard.svg
@@ -1,0 +1,4 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40">
+  <rect x="5" y="5" width="70" height="30" fill="none" stroke="black"/>
+  <line x1="40" y1="5" x2="40" y2="35" stroke="black"/>
+</svg>

--- a/icons/components/Switchgear.svg
+++ b/icons/components/Switchgear.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <rect x="20" y="10" width="40" height="20" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
+</svg>
+

--- a/icons/components/Transformer.svg
+++ b/icons/components/Transformer.svg
@@ -1,0 +1,6 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <circle cx="30" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
+  <circle cx="50" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
+</svg>
+

--- a/icons/components/UPS.svg
+++ b/icons/components/UPS.svg
@@ -1,0 +1,7 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <rect x="20" y="10" width="40" height="20" fill="none" stroke="#333" stroke-width="2"/>
+  <line x1="26" y1="20" x2="34" y2="20" stroke="#333" stroke-width="2"/>
+  <line x1="30" y1="16" x2="30" y2="24" stroke="#333" stroke-width="2"/>
+  <line x1="46" y1="20" x2="54" y2="20" stroke="#333" stroke-width="2"/>
+</svg>

--- a/oneline.html
+++ b/oneline.html
@@ -169,32 +169,6 @@
               <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto" markerUnits="strokeWidth">
                 <path d="M0,0 L10,5 L0,10 Z" fill="context-stroke" />
               </marker>
-              <symbol id="icon-MLO" viewBox="0 0 80 40">
-                <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#333" stroke-width="2"/>
-                <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">MLO</text>
-              </symbol>
-              <symbol id="icon-MCC" viewBox="0 0 80 40">
-                <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#333" stroke-width="2"/>
-                <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">MCC</text>
-              </symbol>
-              <symbol id="icon-Transformer" viewBox="0 0 80 40">
-                <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
-                <circle cx="30" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
-                <circle cx="50" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
-              </symbol>
-              <symbol id="icon-Switchgear" viewBox="0 0 80 40">
-                <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
-                <rect x="20" y="10" width="40" height="20" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
-              </symbol>
-              <symbol id="icon-Load" viewBox="0 0 80 40">
-                <circle cx="40" cy="20" r="18" fill="#fff" stroke="#333" stroke-width="2"/>
-                <polyline points="40 8 32 20 44 20 36 32" fill="none" stroke="#333" stroke-width="2"/>
-              </symbol>
-              <symbol id="icon-equipment" viewBox="0 0 80 40">
-                <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
-                <circle cx="26" cy="20" r="8" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
-                <rect x="46" y="12" width="20" height="16" fill="#fff" stroke="#333" stroke-width="2"/>
-              </symbol>
             </defs>
             <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
           </svg>

--- a/oneline.js
+++ b/oneline.js
@@ -1219,13 +1219,25 @@ function render() {
     }
     const meta = componentMeta[c.subtype] || {};
     const iconHref = meta.icon || placeholderIcon;
-    const img = document.createElementNS(svgNS, 'image');
-    img.setAttribute('x', c.x);
-    img.setAttribute('y', c.y);
-    img.setAttribute('width', w);
-    img.setAttribute('height', h);
-    img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref);
-    g.appendChild(img);
+    if (iconHref === placeholderIcon) {
+      const img = document.createElementNS(svgNS, 'image');
+      img.setAttribute('x', c.x);
+      img.setAttribute('y', c.y);
+      img.setAttribute('width', w);
+      img.setAttribute('height', h);
+      img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref);
+      g.appendChild(img);
+    } else {
+      const svgEl = document.createElementNS(svgNS, 'svg');
+      svgEl.setAttribute('x', c.x);
+      svgEl.setAttribute('y', c.y);
+      svgEl.setAttribute('width', w);
+      svgEl.setAttribute('height', h);
+      const use = document.createElementNS(svgNS, 'use');
+      use.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref + '#icon');
+      svgEl.appendChild(use);
+      g.appendChild(svgEl);
+    }
     const text = document.createElementNS(svgNS, 'text');
     text.setAttribute('x', c.x + w / 2);
     text.setAttribute('y', c.y + h + 15);


### PR DESCRIPTION
## Summary
- add individual component SVGs under `icons/components`
- reference component icons from library and use `<use>` elements when rendering
- drop inline `<symbol>` definitions from the one-line editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc552995483249cd1380ce6ee7a50