### PR TITLE
feat: add collapsible library tools panel

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -91,7 +91,7 @@
 }
 
 .palette-card h3 {
-  margin: 0 0 0.25rem;
+  display: none;
 }
 
 .palette-section {
@@ -101,21 +101,34 @@
 }
 
 .palette-section summary {
-  padding: 0.25rem 0.5rem;
+  padding: 0;
   cursor: pointer;
   list-style: none;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: 0;
+  color: transparent;
 }
 
 .palette-section[open] > summary {
   border-bottom: 1px solid var(--ol-border-color);
 }
 
-.palette-section summary {
-  list-style: none;
+.palette-section summary::before {
+  content: '';
+  width: 24px;
+  height: 24px;
+  background-size: contain;
+  background-repeat: no-repeat;
 }
+
+#panel-section > summary::before { background-image: url('icons/panel.svg'); }
+#equipment-section > summary::before { background-image: url('icons/equipment.svg'); }
+#load-section > summary::before { background-image: url('icons/load.svg'); }
+#template-section > summary::before { background-image: url('icons/oneline.svg'); }
 
 .palette-section .section-buttons {
   display: flex;
@@ -125,8 +138,15 @@
 }
 
 .summary-icon {
-  width: 16px;
-  height: 16px;
+  display: none;
+}
+
+.library-tools {
+  margin-bottom: var(--ol-spacing);
+}
+
+.library-tools summary {
+  cursor: pointer;
 }
 
 

--- a/oneline.html
+++ b/oneline.html
@@ -118,14 +118,20 @@
           </div>
         </div>
         <button id="palette-toggle" class="palette-toggle" aria-label="Toggle palette" aria-controls="palette" aria-expanded="false">☰</button>
+        <details id="library-tools" class="library-tools">
+          <summary>Library Tools</summary>
+          <button id="reload-library-btn" type="button" class="btn">Reload library</button>
+          <button id="template-export-btn" type="button" class="btn">Export Templates</button>
+          <input type="file" id="template-import-input" accept=".json" class="hidden-input">
+          <button id="template-import-btn" type="button" class="btn">Import Templates</button>
+        </details>
         <div class="workspace">
           <aside id="palette" class="palette">
             <div id="component-buttons">
               <template id="palette-button-template">
                 <button draggable="true" data-subtype=""></button>
               </template>
-              <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
-              <button id="reload-library-btn" type="button" class="btn">Reload library</button>
+                <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
                 <div class="palette-card card">
                   <h3>Panel</h3>
                   <details id="panel-section" class="palette-section">
@@ -151,11 +157,8 @@
                   <h3>Templates</h3>
                   <details id="template-section" class="palette-section">
                     <summary><img src="icons/oneline.svg" alt="" class="summary-icon"> Templates</summary>
-                    <div id="template-buttons" class="section-buttons"></div>
-                    <button id="template-export-btn" type="button" class="btn">Export</button>
-                    <input type="file" id="template-import-input" accept=".json" class="hidden-input">
-                    <button id="template-import-btn" type="button" class="btn">Import</button>
-                  </details>
+                      <div id="template-buttons" class="section-buttons"></div>
+                    </details>
                 </div>
             </div>
           </aside>


### PR DESCRIPTION
## Summary
- move library reload and template controls into new collapsible library tools panel
- hide palette headings and section labels so only icons show by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc650d0c0832493ab61671f872cee