### PR TITLE
Improve diagram drop feedback

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -481,3 +481,12 @@ g.component.scenario-diff > * {
     display: block;
   }
 }
+
+@keyframes flash {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.flash {
+  animation: flash 0.5s ease-in-out;
+}

--- a/oneline.js
+++ b/oneline.js
@@ -310,11 +310,20 @@ if (diagram) {
     try {
       info = JSON.parse(dataText);
     } catch {
+      showToast('Cannot drop component');
       return;
     }
-    addComponent({ type: info.type, subtype: info.subtype, x: e.offsetX, y: e.offsetY });
+    const { left, top } = diagram.getBoundingClientRect();
+    const x = e.clientX - left;
+    const y = e.clientY - top;
+    const comp = addComponent({ type: info.type, subtype: info.subtype, x, y });
     render();
     save();
+    const elem = diagram.querySelector(`g.component[data-id="${comp.id}"]`);
+    if (elem) {
+      elem.classList.add('flash');
+      setTimeout(() => elem.classList.remove('flash'), 500);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- compute drop coordinates using bounding rect
- guard JSON parse and notify on failure
- flash newly dropped components for visual feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc94f3e0483248074ad613839accf