### PR TITLE
Render component icons with images and fallback placeholder

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -1228,25 +1228,19 @@ function render() {
     }
     const meta = componentMeta[c.subtype] || {};
     const iconHref = meta.icon || placeholderIcon;
-    if (iconHref === placeholderIcon) {
-      const img = document.createElementNS(svgNS, 'image');
-      img.setAttribute('x', c.x);
-      img.setAttribute('y', c.y);
-      img.setAttribute('width', w);
-      img.setAttribute('height', h);
-      img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref);
-      g.appendChild(img);
-    } else {
-      const svgEl = document.createElementNS(svgNS, 'svg');
-      svgEl.setAttribute('x', c.x);
-      svgEl.setAttribute('y', c.y);
-      svgEl.setAttribute('width', w);
-      svgEl.setAttribute('height', h);
-      const use = document.createElementNS(svgNS, 'use');
-      use.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref + '#icon');
-      svgEl.appendChild(use);
-      g.appendChild(svgEl);
+    const img = document.createElementNS(svgNS, 'image');
+    img.setAttribute('x', c.x);
+    img.setAttribute('y', c.y);
+    img.setAttribute('width', w);
+    img.setAttribute('height', h);
+    img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref);
+    if (iconHref !== placeholderIcon) {
+      img.addEventListener('error', () => {
+        console.warn(`Missing icon for subtype ${c.subtype}`);
+        img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', placeholderIcon);
+      }, { once: true });
     }
+    g.appendChild(img);
     const text = document.createElementNS(svgNS, 'text');
     text.setAttribute('x', c.x + w / 2);
     text.setAttribute('y', c.y + h + 15);


### PR DESCRIPTION
## Summary
- Simplify component rendering by replacing `<use>` icons with `<image>` elements
- Log missing component subtype when icon load fails and swap in placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc9f2e0d8832487d65c728c7ddf66