### PR TITLE
Handle component library loading failures with UI feedback

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -54,6 +54,10 @@
     <button id="prefix-settings-btn" class="btn" title="Edit label prefixes">Label Prefixes</button>
     <button id="update-defaults-btn" class="btn" title="Update default settings">Update Defaults</button>
   </div>
+  <div id="component-library-banner" class="message error hidden">
+    Component library failed to load
+    <button id="reload-library-btn" class="btn">Reload Library</button>
+  </div>
   <div class="container">
     <main id="main-content" class="main-content">
       <header class="page-header">


### PR DESCRIPTION
## Summary
- Surface HTTP status and error messages when loading `componentLibrary.json` fails
- Display banner with reload button when component library loads with ≤1 type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdcec491d883249e800bf853975c01