### PR TITLE
Show palette section labels and placeholders when empty

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -101,16 +101,14 @@
 }
 
 .palette-section summary {
-  padding: 0;
   cursor: pointer;
   list-style: none;
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  font-size: 0;
-  color: transparent;
+  gap: var(--ol-spacing);
+  padding: var(--ol-spacing);
+  color: inherit;
+  font-size: 1rem;
 }
 
 .palette-section[open] > summary {
@@ -123,6 +121,7 @@
   height: 24px;
   background-size: contain;
   background-repeat: no-repeat;
+  flex-shrink: 0;
 }
 
 #panel-section > summary::before { background-image: url('icons/panel.svg'); }
@@ -135,6 +134,11 @@
   flex-wrap: wrap;
   gap: var(--ol-spacing);
   padding: var(--ol-spacing);
+}
+
+.palette-section .no-components {
+  font-style: italic;
+  color: #666;
 }
 
 .summary-icon {

--- a/oneline.js
+++ b/oneline.js
@@ -247,8 +247,20 @@ function buildPalette() {
   });
   document.querySelectorAll('#component-buttons details').forEach(det => {
     const key = `palette-${det.id}-open`;
+    const container = det.querySelector('.section-buttons');
+    const hasButtons = container && container.children.length > 0;
+    if (!hasButtons && container) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'no-components';
+      placeholder.textContent = 'No components available';
+      container.appendChild(placeholder);
+    }
     const stored = localStorage.getItem(key);
-    if (stored !== null) det.open = stored === 'true';
+    if (stored !== null) {
+      det.open = stored === 'true';
+    } else if (!hasButtons) {
+      det.open = true;
+    }
     det.addEventListener('toggle', () => {
       localStorage.setItem(key, det.open);
     });
@@ -723,6 +735,13 @@ function renderTemplates() {
   const container = document.getElementById('template-buttons');
   if (!container) return;
   container.innerHTML = '';
+  if (!templates.length) {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'no-components';
+    placeholder.textContent = 'No components available';
+    container.appendChild(placeholder);
+    return;
+  }
   templates.forEach(t => {
     const btn = document.createElement('button');
     btn.textContent = t.name;


### PR DESCRIPTION
## Summary
- Ensure palette sections without buttons open by default and show a 'No components available' placeholder
- Keep component category labels visible by styling summary elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdcf7350a88324aadc78ac5c2f2a07