### PR TITLE
feat: add bus section to palette

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -126,6 +126,7 @@
 
 #panel-section > summary::before { background-image: url('icons/panel.svg'); }
 #equipment-section > summary::before { background-image: url('icons/equipment.svg'); }
+#bus-section > summary::before { background-image: url('icons/Bus.svg'); }
 #load-section > summary::before { background-image: url('icons/load.svg'); }
 #template-section > summary::before { background-image: url('icons/oneline.svg'); }
 

--- a/oneline.html
+++ b/oneline.html
@@ -151,6 +151,13 @@
                   </details>
                 </div>
                 <div class="palette-card card">
+                  <h3>Bus</h3>
+                  <details id="bus-section" class="palette-section">
+                    <summary><img src="icons/Bus.svg" alt="" class="summary-icon"> Bus</summary>
+                    <div id="bus-buttons" class="section-buttons"></div>
+                  </details>
+                </div>
+                <div class="palette-card card">
                   <h3>Load</h3>
                   <details id="load-section" class="palette-section">
                     <summary><img src="icons/load.svg" alt="" class="summary-icon"> Load</summary>

--- a/oneline.js
+++ b/oneline.js
@@ -214,7 +214,8 @@ function buildPalette() {
   const sectionContainers = {
     panel: document.getElementById('panel-buttons'),
     equipment: document.getElementById('equipment-buttons'),
-    load: document.getElementById('load-buttons')
+    load: document.getElementById('load-buttons'),
+    bus: document.getElementById('bus-buttons')
   };
   Object.values(sectionContainers).forEach(c => {
     if (c) c.innerHTML = '';


### PR DESCRIPTION
## Summary
- extend buildPalette with bus section
- add Bus card to oneline palette
- style bus section consistently with others

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdd06b418c8324a39186f2cd79c53f