### PR TITLE
Toast missing component icons with docs link

### DIFF
--- a/docs/componentLibrary.html
+++ b/docs/componentLibrary.html
@@ -49,6 +49,8 @@
       <li><code>schema</code> – array of property descriptors with <code>name</code>, <code>label</code>, and <code>type</code>.</li>
     </ul>
     <p>Add new components by appending objects to the JSON array and providing corresponding icons. The application reloads the file at startup, so no JavaScript changes are required.</p>
+    <h2 id="icons">Icons</h2>
+    <p>Place custom SVG files under <code>icons/components/</code> and reference them in <code>componentLibrary.json</code>. Missing icons fall back to <code>icons/placeholder.svg</code>.</p>
   </main>
 </div>
   <footer class="site-footer">

--- a/docs/componentLibrary.md
+++ b/docs/componentLibrary.md
@@ -25,3 +25,7 @@ The one-line editor loads component definitions from `componentLibrary.json`. Ea
 - `schema` – optional property descriptors with `name`, `label`, and `type`.
 
 Add new objects to the JSON array and provide matching icons to extend the palette without modifying JavaScript code.
+
+## Icons
+
+Place custom SVG files under `icons/components/` and reference them in `componentLibrary.json`. Missing icons fall back to `icons/placeholder.svg`.

--- a/oneline.js
+++ b/oneline.js
@@ -159,6 +159,11 @@ async function loadComponentLibrary() {
   }
   if (missingIcons.length) {
     console.warn('Using placeholder icons for: ' + missingIcons.join(', '));
+    showToast(
+      `Placeholder icons for: ${missingIcons.join(', ')}`,
+      'Fix icons',
+      'docs/componentLibrary.html#icons'
+    );
   }
 }
 
@@ -2862,10 +2867,17 @@ function getCategory(c) {
   return c.type || subtypeCategory[c.subtype];
 }
 
-function showToast(msg) {
+function showToast(msg, linkText, linkHref) {
   const t = document.getElementById('toast');
   if (!t) return;
   t.textContent = msg;
+  if (linkText && linkHref) {
+    const a = document.createElement('a');
+    a.href = linkHref;
+    a.textContent = linkText;
+    a.target = '_blank';
+    t.append(' ', a);
+  }
   t.classList.add('show');
   setTimeout(() => t.classList.remove('show'), 3000);
 }


### PR DESCRIPTION
## Summary
- notify when components fall back to placeholder icons and link to docs
- document how to supply custom SVG component icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdd0f7e17c832481ccb39c2e4360f1