### PR TITLE
feat: add protective device module

### DIFF
--- a/analysis/arcFlash.js
+++ b/analysis/arcFlash.js
@@ -1,6 +1,6 @@
 import { runShortCircuit } from './shortCircuit.js';
 import { getOneLine, getItem } from '../dataStore.mjs';
-import devices from '../data/protectiveDevices.json' assert { type: 'json' };
+import devices from '../data/protectiveDevices.mjs';
 
 function interpolateTime(curve = [], currentA) {
   if (!curve.length) return 0.2;

--- a/data/protectiveDevices.mjs
+++ b/data/protectiveDevices.mjs
@@ -1,0 +1,80 @@
+export default [
+  {
+    "id": "abb_tmax_160",
+    "type": "breaker",
+    "vendor": "ABB",
+    "name": "ABB Tmax T3 160A",
+    "interruptRating": 65,
+    "settings": { "pickup": 160, "time": 0.2, "instantaneous": 800 },
+    "curve": [
+      { "current": 160, "time": 100 },
+      { "current": 800, "time": 0.2 },
+      { "current": 1600, "time": 0.05 }
+    ]
+  },
+  {
+    "id": "siemens_3va_125",
+    "type": "breaker",
+    "vendor": "Siemens",
+    "name": "Siemens 3VA 125A",
+    "interruptRating": 35,
+    "settings": { "pickup": 125, "time": 0.25, "instantaneous": 600 },
+    "curve": [
+      { "current": 125, "time": 100 },
+      { "current": 500, "time": 1 },
+      { "current": 1000, "time": 0.1 }
+    ]
+  },
+  {
+    "id": "schneider_nsx100",
+    "type": "breaker",
+    "vendor": "Schneider",
+    "name": "Schneider Compact NSX100",
+    "interruptRating": 50,
+    "settings": { "pickup": 100, "time": 0.3, "instantaneous": 500 },
+    "curve": [
+      { "current": 100, "time": 100 },
+      { "current": 400, "time": 1 },
+      { "current": 1000, "time": 0.1 }
+    ]
+  },
+  {
+    "id": "ge_multilin_750",
+    "type": "relay",
+    "vendor": "GE",
+    "name": "GE Multilin 750 Relay",
+    "interruptRating": 30,
+    "settings": { "pickup": 150, "time": 0.15, "instantaneous": 600 },
+    "curve": [
+      { "current": 150, "time": 50 },
+      { "current": 600, "time": 0.5 },
+      { "current": 1200, "time": 0.05 }
+    ]
+  },
+  {
+    "id": "eaton_seriesC_100",
+    "type": "breaker",
+    "vendor": "Eaton",
+    "name": "Eaton Series C 100A",
+    "interruptRating": 25,
+    "settings": { "pickup": 100, "time": 0.2, "instantaneous": 500 },
+    "curve": [
+      { "current": 100, "time": 80 },
+      { "current": 400, "time": 0.4 },
+      { "current": 800, "time": 0.05 }
+    ]
+  },
+  {
+    "id": "mitsubishi_ws_225",
+    "type": "breaker",
+    "vendor": "Mitsubishi",
+    "name": "Mitsubishi WS 225A",
+    "interruptRating": 42,
+    "settings": { "pickup": 225, "time": 0.3, "instantaneous": 1125 },
+    "curve": [
+      { "current": 225, "time": 100 },
+      { "current": 900, "time": 0.4 },
+      { "current": 1800, "time": 0.05 }
+    ]
+  }
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,16 @@
+const fs = require('fs');
+const path = require('path');
 const terser = require('@rollup/plugin-terser');
+
+// Auto-generate an ES module wrapper for JSON data so it can be imported in browsers
+const jsonPath = path.resolve(__dirname, 'data/protectiveDevices.json');
+const mjsPath = path.resolve(__dirname, 'data/protectiveDevices.mjs');
+try {
+  const json = fs.readFileSync(jsonPath, 'utf8');
+  fs.writeFileSync(mjsPath, `export default ${json};\n`);
+} catch (err) {
+  console.error('Failed to generate protectiveDevices.mjs', err);
+}
 
 const entries = {
   index: 'src/index.js',

--- a/studies/arcFlash.js
+++ b/studies/arcFlash.js
@@ -2,6 +2,8 @@ import { runArcFlash } from '../analysis/arcFlash.js';
 import { getStudies, setStudies } from '../dataStore.mjs';
 import { generateArcFlashReport } from '../reports/arcFlashReport.mjs';
 
+// JSON imports require a .mjs wrapper for broad browser compatibility.
+
 /**
  * Perform an IEEE 1584 arc‑flash study based on the current project data.
  * Results are persisted and a PDF/CSV report with labels is generated.


### PR DESCRIPTION
## Summary
- add `data/protectiveDevices.mjs` for browser-safe import of protective device data
- update arc flash analysis to import the module
- generate `.mjs` file from JSON in rollup build and document requirement in arc-flash study

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd3e661048324bc1ca8c686bdda34