### PR TITLE
Handle protective device library load failures

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -487,9 +487,9 @@ if (runSCBtn) runSCBtn.addEventListener('click', () => {
   renderStudyResults();
   render();
 });
-if (runAFBtn) runAFBtn.addEventListener('click', () => {
+if (runAFBtn) runAFBtn.addEventListener('click', async () => {
   const sc = runShortCircuit();
-  const af = runArcFlash();
+  const af = await runArcFlash();
   const { sheets } = getOneLine();
   const diagram = sheets.flatMap(s => s.components);
   diagram.forEach(c => {

--- a/studies/arcFlash.js
+++ b/studies/arcFlash.js
@@ -9,8 +9,8 @@ import { generateArcFlashReport } from '../reports/arcFlashReport.mjs';
  * Results are persisted and a PDF/CSV report with labels is generated.
  * @returns {Object}
  */
-export function runArcFlashStudy() {
-  const res = runArcFlash();
+export async function runArcFlashStudy() {
+  const res = await runArcFlash();
   const studies = getStudies();
   studies.arcFlash = res;
   setStudies(studies);
@@ -22,9 +22,9 @@ if (typeof document !== 'undefined') {
   const form = document.getElementById('arcflash-form');
   const out = document.getElementById('arcflash-output');
   if (form && out) {
-    form.addEventListener('submit', ev => {
+    form.addEventListener('submit', async ev => {
       ev.preventDefault();
-      const res = runArcFlashStudy();
+      const res = await runArcFlashStudy();
       out.textContent = JSON.stringify(res, null, 2);
     });
   }

--- a/tests/analysis.test.js
+++ b/tests/analysis.test.js
@@ -7,8 +7,13 @@ function describe(name, fn) {
 
 function it(name, fn) {
   try {
-    fn();
-    console.log('  \u2713', name);
+    const res = fn();
+    if (res && typeof res.then === 'function') {
+      res.then(() => console.log('  \u2713', name))
+        .catch(err => { console.log('  \u2717', name); console.error(err); process.exitCode = 1; });
+    } else {
+      console.log('  \u2713', name);
+    }
   } catch (err) {
     console.log('  \u2717', name);
     console.error(err);
@@ -86,10 +91,10 @@ function caseToDiagram(data) {
       });
     });
 
-    it('matches arc-flash example', () => {
+    it('matches arc-flash example', async () => {
       setItem('tccSettings', afBench.tccSettings);
       setOneLine({ activeSheet: 0, sheets: afBench.oneLine });
-      const res = runArcFlash();
+      const res = await runArcFlash();
       Object.entries(afBench.expected).forEach(([id, exp]) => {
         const bus = res[id];
         assert(bus, `Missing bus ${id}`);

--- a/tests/arcflash/arcFlashExample.test.js
+++ b/tests/arcflash/arcFlashExample.test.js
@@ -2,8 +2,19 @@ const assert = require('assert');
 
 function describe(name, fn) { console.log(name); fn(); }
 function it(name, fn) {
-  try { fn(); console.log('  \u2713', name); }
-  catch (err) { console.log('  \u2717', name); console.error(err); process.exitCode = 1; }
+  try {
+    const res = fn();
+    if (res && typeof res.then === 'function') {
+      res.then(() => console.log('  \u2713', name))
+        .catch(err => { console.log('  \u2717', name); console.error(err); process.exitCode = 1; });
+    } else {
+      console.log('  \u2713', name);
+    }
+  } catch (err) {
+    console.log('  \u2717', name);
+    console.error(err);
+    process.exitCode = 1;
+  }
 }
 
 const store = {};
@@ -18,7 +29,7 @@ global.localStorage = {
   const { runArcFlash } = await import('../../analysis/arcFlash.js');
 
   describe('arc flash analysis', () => {
-    it('uses protective device clearing time', () => {
+    it('uses protective device clearing time', async () => {
       setItem('tccSettings', { devices: ['abb_tmax_160'], settings: { abb_tmax_160: { pickup: 160, delay: 0.2, instantaneous: 800 } } });
       setOneLine({ activeSheet: 0, sheets: [{ name: 'S1', components: [
         { id: 'BUS1', kV: 0.48, z1: { r: 0, x: 0.05 }, z2: { r: 0, x: 0.05 }, z0: { r: 0, x: 0.05 },
@@ -26,7 +37,7 @@ global.localStorage = {
           enclosure: 'Box', gap: 32, working_distance: 455, electrode_config: 'VCB', tccId: 'abb_tmax_160',
           enclosure_height: 508, enclosure_width: 508, enclosure_depth: 508 }
       ] }] });
-      const res = runArcFlash();
+      const res = await runArcFlash();
       const af = res.BUS1;
       assert(Math.abs(af.incidentEnergy - 1.25) < 0.05);
       assert(Math.abs(af.boundary - 463.6) < 1.5);


### PR DESCRIPTION
## Summary
- load protective device library via dynamic import with error handling
- surface user-visible banner or toast when the library fails to load
- propagate async arc-flash study calls and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdd4c7fe148324a2ff631791f00905