### PR TITLE
Use CDN Handlebars and preload script

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="oneline.css">
+  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/handlebars@latest/dist/handlebars.esm.js" crossorigin>
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="oneline.js" defer></script>
   <script type="module" src="scenarios.js" defer></script>

--- a/reports/exportAll.mjs
+++ b/reports/exportAll.mjs
@@ -35,7 +35,7 @@ export async function setReportTemplate(tpl) {
   }
   if (typeof tpl === 'string') {
     try {
-      const Handlebars = (await import('handlebars')).default;
+      const Handlebars = (await import('https://cdn.jsdelivr.net/npm/handlebars@latest/dist/handlebars.esm.js')).default;
       const compiled = Handlebars.compile(tpl);
       pdfTemplate = ctx => compiled(ctx);
     } catch {


### PR DESCRIPTION
## Summary
- Load Handlebars from jsDelivr CDN in exportAll report generation
- Preload Handlebars module in oneline page to reduce latency

## Testing
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda28470883248956067972608601