### PR TITLE
Fix Handlebars CDN reference in oneline.html

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="oneline.css">
-  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/handlebars@latest/dist/handlebars.esm.js" crossorigin>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/handlebars@4.7.7/dist/handlebars.esm.js" crossorigin></script>
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="oneline.js" defer></script>
   <script type="module" src="scenarios.js" defer></script>


### PR DESCRIPTION
## Summary
- load Handlebars from a specific 4.7.7 CDN path using a module script instead of modulepreload

## Testing
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bde6d88f088324ba1605f82dc36de7