### PR TITLE
Include extended fields in schedules

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -240,6 +240,10 @@ function ensurePanelFields(panel) {
     description: '',
     ref: '',
     voltage: '',
+    manufacturer: '',
+    model: '',
+    phases: '',
+    notes: '',
     mainRating: '',
     circuitCount: 42,
     ...panel

--- a/equipmentlist.js
+++ b/equipmentlist.js
@@ -10,20 +10,30 @@ if (typeof window !== 'undefined') {
     initCompactMode();
     initNavToggle();
 
-    const columns = [
-      { key: 'id', label: 'ID', type: 'text' },
-      { key: 'description', label: 'Description', type: 'text' },
-      { key: 'voltage', label: 'Voltage (V)', type: 'text' },
-      { key: 'category', label: 'Category', type: 'text' },
-      { key: 'subCategory', label: 'Sub-Category', type: 'text' },
-      { key: 'manufacturer', label: 'Manufacturer', type: 'text', className: 'manufacturer-input', filter: 'dropdown' },
-      { key: 'model', label: 'Model', type: 'text', className: 'model-input' },
-      { key: 'phases', label: 'Phases', type: 'text' },
-      { key: 'notes', label: 'Notes', type: 'text' },
-      { key: 'x', label: 'X', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
-      { key: 'y', label: 'Y', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
-      { key: 'z', label: 'Z', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' }
-    ];
+      const columns = [
+        { key: 'id', label: 'ID', type: 'text' },
+        { key: 'description', label: 'Description', type: 'text' },
+        { key: 'voltage', label: 'Voltage (V)', type: 'text' },
+        { key: 'category', label: 'Category', type: 'text' },
+        { key: 'subCategory', label: 'Sub-Category', type: 'text' },
+        { key: 'manufacturer', label: 'Manufacturer', type: 'text', className: 'manufacturer-input', filter: 'dropdown' },
+        { key: 'model', label: 'Model', type: 'text', className: 'model-input' },
+        { key: 'phases', label: 'Phases', type: 'text' },
+        { key: 'notes', label: 'Notes', type: 'text' },
+        { key: 'x', label: 'X', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
+        { key: 'y', label: 'Y', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' },
+        { key: 'z', label: 'Z', type: 'number', step: 'any', maxlength: 15, validate: 'numeric' }
+      ];
+
+      const existing = new Set(columns.map(c => c.key));
+      dataStore.getEquipment().forEach(eq => {
+        Object.keys(eq).forEach(k => {
+          if (!existing.has(k)) {
+            existing.add(k);
+            columns.push({ key: k, label: k.charAt(0).toUpperCase() + k.slice(1), type: 'text' });
+          }
+        });
+      });
 
     let table;
     table = TableUtils.createTable({

--- a/loadlist.js
+++ b/loadlist.js
@@ -143,29 +143,14 @@ if (typeof window !== 'undefined') {
       const n = Number(num);
       return Number.isFinite(n) && n !== 0 ? n.toFixed(2) : '';
     }
-  function gatherRow(tr) {
-    return {
-      id: tr.dataset.id || tr.querySelector('input[name="tag"]').value.trim(),
-      ref: tr.dataset.ref || '',
-      source: tr.querySelector('input[name="source"]').value.trim(),
-      tag: tr.querySelector('input[name="tag"]').value.trim(),
-      description: tr.querySelector('input[name="description"]').value.trim(),
-      manufacturer: tr.querySelector('input[name="manufacturer"]').value.trim(),
-      model: tr.querySelector('input[name="model"]').value.trim(),
-      quantity: tr.querySelector('input[name="quantity"]').value.trim(),
-      voltage: tr.querySelector('input[name="voltage"]').value.trim(),
-      loadType: tr.querySelector('input[name="loadType"]').value.trim(),
-      duty: tr.querySelector('select[name="duty"]').value.trim(),
-      kw: tr.querySelector('input[name="kw"]').value.trim(),
-      powerFactor: tr.querySelector('input[name="powerFactor"]').value.trim(),
-      loadFactor: tr.querySelector('input[name="loadFactor"]').value.trim(),
-      efficiency: tr.querySelector('input[name="efficiency"]').value.trim(),
-      demandFactor: tr.querySelector('input[name="demandFactor"]').value.trim(),
-      phases: tr.querySelector('input[name="phases"]').value.trim(),
-      circuit: tr.querySelector('input[name="circuit"]').value.trim(),
-      notes: tr.querySelector('textarea[name="notes"]').value.trim()
-    };
-  }
+    function gatherRow(tr) {
+      const load = { ref: tr.dataset.ref || '' };
+      tr.querySelectorAll('input[name],select[name],textarea[name]').forEach(el => {
+        load[el.name] = el.value.trim();
+      });
+      load.id = tr.dataset.id || load.tag || '';
+      return load;
+    }
 
   function saveRow(tr) {
     const idx = Number(tr.dataset.index);

--- a/oneline.js
+++ b/oneline.js
@@ -3006,6 +3006,7 @@ function syncSchedules(notify = true) {
       id: c.ref || c.id,
       ref: c.id,
       description: c.label,
+      voltage: c.voltage ?? '',
       manufacturer: c.manufacturer ?? '',
       model: c.model ?? '',
       voltage_class: c.voltage_class ?? '',
@@ -3014,7 +3015,6 @@ function syncSchedules(notify = true) {
       phases: connPhases,
       conductors: connConductors,
       notes: c.notes ?? '',
-      voltage: c.voltage ?? '',
       rating: c.rating ?? '',
       impedance_r: c.impedance?.r ?? '',
       impedance_x: c.impedance?.x ?? '',
@@ -3033,7 +3033,7 @@ function syncSchedules(notify = true) {
       z: c.z ?? ''
     };
     (propSchemas[c.subtype] || []).forEach(f => {
-      fields[f.name] = c[f.name] ?? fields[f.name] ?? '';
+      fields[f.name] = c[f.name] ?? f.default ?? fields[f.name] ?? '';
     });
     return fields;
   };

--- a/panelschedule.html
+++ b/panelschedule.html
@@ -54,11 +54,14 @@
         <p>Assign loads from the load list to panel breakers.</p>
       </header>
       <section class="card">
-        <div id="panel-info" class="mb-1">
-          <label>Voltage <input id="panel-voltage" type="text"></label>
-          <label>Main Breaker Rating (A) <input id="panel-main-rating" type="number" min="0"></label>
-          <label>Number of Circuits <input id="panel-circuit-count" type="number" min="1"></label>
-        </div>
+          <div id="panel-info" class="mb-1">
+            <label>Voltage <input id="panel-voltage" type="text"></label>
+            <label>Manufacturer <input id="panel-manufacturer" type="text"></label>
+            <label>Model <input id="panel-model" type="text"></label>
+            <label>Phases <input id="panel-phases" type="text"></label>
+            <label>Main Breaker Rating (A) <input id="panel-main-rating" type="number" min="0"></label>
+            <label>Number of Circuits <input id="panel-circuit-count" type="number" min="1"></label>
+          </div>
         <div id="panel-container"></div>
         <div id="panel-totals" class="mt-1"></div>
         <button id="export-panel-btn" class="btn" title="Export panel to Excel">Export to Excel</button>


### PR DESCRIPTION
## Summary
- Sync schedules to expose voltage, manufacturer, model, phases and schema defaults
- Persist panel manufacturer/model/phases with editable fields
- Auto-add extra equipment columns and gather dynamic load fields

## Testing
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf091aadc83249a6ec1c03e742b37