### PR TITLE
Use UMD Handlebars build in one-line page

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="oneline.css">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/handlebars@4.7.7/dist/handlebars.esm.js" crossorigin></script>
+  <script src="https://cdn.jsdelivr.net/npm/handlebars@4.7.8/dist/cjs/handlebars.min.js"></script>
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="oneline.js" defer></script>
   <script type="module" src="scenarios.js" defer></script>


### PR DESCRIPTION
## Summary
- load Handlebars from its UMD/CJS build so the global is available

## Testing
- `npm test` *(fails: ReferenceError window is not defined in reports/reporting.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68beca3d3fc4832496a3a88e9058eb9f