### PR TITLE
Use UMD Handlebars build on oneline page

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="oneline.css">
-  <script src="https://cdn.jsdelivr.net/npm/handlebars@4.7.8/dist/cjs/handlebars.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/handlebars@4.7.8/dist/handlebars.min.js"></script>
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="oneline.js" defer></script>
   <script type="module" src="scenarios.js" defer></script>


### PR DESCRIPTION
## Summary
- load Handlebars from UMD build instead of CommonJS to avoid jsdelivr-header error

## Testing
- `node -e "const {chromium}=require('playwright');(async()=>{const browser=await chromium.launch();const page=await browser.newPage();const errors=[];page.on('console',m=>{if(m.type()==='error') errors.push(m.text());});await page.goto('file://'+process.cwd()+'/oneline.html');await page.waitForLoadState('load');console.log('Console errors:', errors);await browser.close();})();"` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npx playwright install chromium` *(fails: server returned code 403 body 'Forbidden')*
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68beccecc2b88324b5cec2cb6bc8a99c