### PR TITLE
refactor: dynamically load conductor properties

### DIFF
--- a/ampacity.js
+++ b/ampacity.js
@@ -1,4 +1,10 @@
-import conductorProps from './data/conductor_properties.json' assert { type: 'json' };
+const conductorProps = await (async () => {
+  try {
+    return await fetch('./data/conductor_properties.json').then(r => r.json());
+  } catch {
+    return (await import('./conductorProperties.mjs')).default;
+  }
+})();
 
 const AWG_AREA = {"22":642,"20":1020,"18":1624,"16":2583,"14":4107,"12":6530,"10":10380,"8":16510,"6":26240,"4":41740,"3":52620,"2":66360,"1":83690,"1/0":105600,"2/0":133100,"3/0":167800,"4/0":211600,"250":250000,"350":350000,"500":500000,"750":750000,"1000":1000000};
 const BASE_RESISTIVITY = { cu: 0.017241, al: 0.028264 };

--- a/cableschedule.html
+++ b/cableschedule.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script type="module" src="dataStore.mjs" defer></script>
-  <script src="dist/cableschedule.js" defer></script>
+  <script type="module" src="cableschedule.js" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/conductorProperties.mjs
+++ b/conductorProperties.mjs
@@ -1,0 +1,2 @@
+import data from './data/conductor_properties.json' assert { type: 'json' };
+export default data;


### PR DESCRIPTION
## Summary
- load conductor property JSON with fetch and fallback module
- mark cableschedule script as module so top-level await works
- add conductorProperties.mjs for bundlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bed40f8db88324ae4c94a64123a408