### PR TITLE
Replace dxf-writer dependency with local DXF implementation

### DIFF
--- a/bimExport.mjs
+++ b/bimExport.mjs
@@ -5,7 +5,7 @@
  * shared with other BIM environments.
  */
 
-import { Drawing } from 'dxf-writer';
+import { Drawing } from './exporters/simpleDxf.js';
 
 export function exportRevitJSON(panels = [], cables = []) {
   const blob = new Blob([JSON.stringify({ panels, cables }, null, 2)], {

--- a/exporters/dxf.js
+++ b/exporters/dxf.js
@@ -1,4 +1,4 @@
-import { Drawing } from 'dxf-writer';
+import { Drawing } from './simpleDxf.js';
 
 function buildDXF(components = []) {
   const d = new Drawing();

--- a/exporters/simpleDxf.js
+++ b/exporters/simpleDxf.js
@@ -1,0 +1,19 @@
+export class Drawing {
+  constructor() {
+    this.entities = [];
+  }
+
+  drawText(x, y, height, value, rotation = 0) {
+    this.entities.push(`0\nTEXT\n8\n0\n10\n${x}\n20\n${y}\n30\n0\n40\n${height}\n1\n${value}\n50\n${rotation}`);
+  }
+
+  drawLine3d(x1, y1, z1, x2, y2, z2) {
+    this.entities.push(`0\nLINE\n8\n0\n10\n${x1}\n20\n${y1}\n30\n${z1}\n11\n${x2}\n21\n${y2}\n31\n${z2}`);
+  }
+
+  toDxfString() {
+    const header = `0\nSECTION\n2\nHEADER\n9\n$ACADVER\n1\nAC1027\n0\nENDSEC`;
+    const entities = `0\nSECTION\n2\nENTITIES\n${this.entities.join('\n')}\n0\nENDSEC`;
+    return `${header}\n${entities}\n0\nEOF`;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "svg2pdf.js": "^2.0.1",
     "handlebars": "^4.7.8",
     "pdfkit": "^0.13.0",
-    "dxf-writer": "^1.0.0",
     "express": "^4.19.2"
   }
 }


### PR DESCRIPTION
## Summary
- replace dxf-writer import with internal simple DXF drawing class
- update BIM and DXF exporters to use the internal module
- remove external dxf-writer dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bee0488bec83248f1025e99cbe322f