### PR TITLE
fix: handle CommonJS import for Revit parser

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -14,7 +14,13 @@
  * @typedef {GenericRecord} Conduit
  */
 
-import { parseRevit } from './src/importers/revit.js';
+// Revit parser is authored as a CommonJS module. When importing from an ES module
+// environment we need to access the default export to retrieve the named
+// function. Using a default import keeps compatibility with both CJS and ESM
+// implementations so tests running under Node (which treats `.js` files as
+// CommonJS by default) can still access `parseRevit`.
+import revitModule from './src/importers/revit.js';
+const { parseRevit } = revitModule;
 
 // scenario management keys
 const SCENARIOS_KEY = 'ctr_scenarios_v1';


### PR DESCRIPTION
## Summary
- ensure `parseRevit` can be imported when Node treats `revit.js` as CommonJS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bee3a7cd848324baaa7d5bea45f23b