### PR TITLE
fix: resolve jspdf esm module

### DIFF
--- a/reports/reporting.mjs
+++ b/reports/reporting.mjs
@@ -1,4 +1,4 @@
-const { jsPDF } = window.jspdf || await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js');
+const { jsPDF } = window.jspdf || await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/+esm');
 
 /**
  * Convert array of objects to CSV string.


### PR DESCRIPTION
## Summary
- fix jsPDF import to use jsdelivr ESM build, avoiding @babel/runtime resolution error in the browser

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee54119ec8324847c398eae929def