### PR TITLE
fix: use commonjs for revit importer

### DIFF
--- a/src/importers/revit.js
+++ b/src/importers/revit.js
@@ -10,7 +10,7 @@
  * @param {string|object} input - IFC STEP text or Revit JSON.
  * @returns {{trays:Array, conduits:Array}}
  */
-export function parseRevit(input) {
+function parseRevit(input) {
   if (typeof input === "string") {
     // Try JSON first – many exporters can emit JSON directly.
     try {
@@ -125,4 +125,4 @@ function parseIFC(text) {
   return { trays, conduits };
 }
 
-export default { parseRevit };
+module.exports = { parseRevit };


### PR DESCRIPTION
## Summary
- convert Revit importer to CommonJS so Node can load without syntax errors

## Testing
- `node test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beeab7629c832493d5791c5c36dc9d