### PR TITLE
fix: adjust Revit import for ESM

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -14,13 +14,10 @@
  * @typedef {GenericRecord} Conduit
  */
 
-// Revit parser is authored as a CommonJS module. When importing from an ES module
-// environment we need to access the default export to retrieve the named
-// function. Using a default import keeps compatibility with both CJS and ESM
-// implementations so tests running under Node (which treats `.js` files as
-// CommonJS by default) can still access `parseRevit`.
-import revitModule from './src/importers/revit.js';
-const { parseRevit } = revitModule;
+// Revit parser is an ES module and exports the `parseRevit` helper
+// directly. Import it with a named import so it works consistently in
+// both the browser and Node test environments.
+import { parseRevit } from './src/importers/revit.mjs';
 
 // scenario management keys
 const SCENARIOS_KEY = 'ctr_scenarios_v1';

--- a/src/importers/revit.mjs
+++ b/src/importers/revit.mjs
@@ -10,7 +10,7 @@
  * @param {string|object} input - IFC STEP text or Revit JSON.
  * @returns {{trays:Array, conduits:Array}}
  */
-function parseRevit(input) {
+export function parseRevit(input) {
   if (typeof input === "string") {
     // Try JSON first – many exporters can emit JSON directly.
     try {
@@ -125,4 +125,3 @@ function parseIFC(text) {
   return { trays, conduits };
 }
 
-module.exports = { parseRevit };


### PR DESCRIPTION
## Summary
- convert Revit importer to ES module
- import `parseRevit` via named import for browser and Node compatibility

## Testing
- `npm test` *(fails: Failed to load conductor properties TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68beed4b96588324a18cb6b826abd74d