### PR TITLE
Fix inactive library tools on one-line page

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -123,7 +123,7 @@
         <button id="palette-toggle" class="palette-toggle" aria-label="Toggle palette" aria-controls="palette" aria-expanded="false">☰</button>
         <details id="library-tools" class="library-tools">
           <summary>Library Tools</summary>
-          <button id="reload-library-btn" type="button" class="btn">Reload library</button>
+          <button id="library-reload-btn" type="button" class="btn">Reload library</button>
           <button id="template-export-btn" type="button" class="btn">Export Templates</button>
           <input type="file" id="template-import-input" accept=".json" class="hidden-input">
           <button id="template-import-btn" type="button" class="btn">Import Templates</button>

--- a/oneline.js
+++ b/oneline.js
@@ -204,16 +204,16 @@ async function loadComponentLibrary() {
     componentTypes[c.category].push(c.subtype);
   });
   const banner = document.getElementById('component-library-banner');
-  const reloadBtn = document.getElementById('reload-library-btn');
   if (banner) {
     if (libraryFailed) banner.classList.remove('hidden');
     else banner.classList.add('hidden');
   }
-  if (reloadBtn)
-    reloadBtn.onclick = async () => {
+  document.querySelectorAll('#reload-library-btn, #library-reload-btn').forEach(btn => {
+    btn.onclick = async () => {
       await loadComponentLibrary();
       buildPalette();
     };
+  });
 
   if (skipped.length) {
     showToast(`Skipped components: ${skipped.join(', ')}`);


### PR DESCRIPTION
## Summary
- Assign unique ID to one-line library reload button
- Wire reload handler to both banner and library tools buttons

## Testing
- `npm test` *(fails: Failed to load conductor properties TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bef23640c883249ce47f923646051a