### PR TITLE
Fix Playwright workflow tests and stub sample raceway fetch

### DIFF
--- a/playwright-tests/raceway-load-samples.spec.ts
+++ b/playwright-tests/raceway-load-samples.spec.ts
@@ -1,9 +1,15 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
+import fs from 'fs';
 const root = path.join(__dirname, '..');
 const pageUrl = (file: string) => 'file://' + path.join(root, file);
 
 test('raceway load samples populates all tables', async ({ page }) => {
+  const samplePath = path.join(root, 'examples', 'sampleRaceways.json');
+  const sampleJson = fs.readFileSync(samplePath, 'utf-8');
+  await page.route('**/examples/sampleRaceways.json', route => {
+    route.fulfill({ body: sampleJson, contentType: 'application/json' });
+  });
   await page.goto(pageUrl('racewayschedule.html'));
   await page.click('#raceway-load-samples');
   await page.waitForSelector('#ductbank-table tbody tr.ductbank-row');

--- a/playwright-tests/raceway-samples.spec.ts
+++ b/playwright-tests/raceway-samples.spec.ts
@@ -1,15 +1,23 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
+import fs from 'fs';
 const root = path.join(__dirname, '..');
 const pageUrl = (file: string) => 'file://' + path.join(root, file);
 
 test('raceway samples roundtrip and route', async ({ page }) => {
+  const samplePath = path.join(root, 'examples', 'sampleRaceways.json');
+  const sampleJson = fs.readFileSync(samplePath, 'utf-8');
+  await page.route('**/examples/sampleRaceways.json', route => {
+    route.fulfill({ body: sampleJson, contentType: 'application/json' });
+  });
   await page.goto(pageUrl('cableschedule.html'));
   await page.click('#load-sample-cables-btn');
 
   await page.goto(pageUrl('racewayschedule.html'));
   await page.click('#raceway-load-samples');
-
+  await page.waitForSelector('#ductbankTable tbody tr.ductbank-row');
+  await page.waitForSelector('#trayTable tbody tr');
+  await page.waitForSelector('#conduitTable tbody tr');
   const dbCount = await page.locator('#ductbankTable tbody tr.ductbank-row').count();
   const trayCount = await page.locator('#trayTable tbody tr').count();
   const conduitCount = await page.locator('#conduitTable tbody tr').count();
@@ -36,6 +44,7 @@ test('raceway samples roundtrip and route', async ({ page }) => {
   await expect(page.locator('#conduitTable tbody tr')).toHaveCount(conduitCount);
 
   await page.goto(pageUrl('optimalRoute.html'));
+  await page.click('#resume-no-btn');
   await page.click('#settings-btn');
   await page.click('#import-project-btn');
   await page.setInputFiles('#import-project-input', filePath);


### PR DESCRIPTION
## Summary
- intercept sample raceway JSON so tables populate in tests
- wait for imports and handle resume prompts in workflow tests
- verify dirty-state prompt via beforeunload event

## Testing
- `npx playwright test --project=firefox --project=msedge` *(fails: browsers not installed)*
- `npx playwright install firefox msedge` *(fails: server returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68befa2a76148324a36c35c60f05a704