### PR TITLE
Ensure raceway sample data loads without network

### DIFF
--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -9,9 +9,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="node_modules/xlsx/dist/xlsx.full.min.js" defer></script>
   <script src="dirtyTracker.js" defer></script>
-  <script type="module" src="tableUtils.mjs"></script>
-  <script src="dist/racewayschedule.js" defer></script>
-  <script type="module" src="dataStore.mjs"></script>
+  <script type="module" src="src/racewayschedule.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -1,5 +1,12 @@
 import * as dataStore from './dataStore.mjs';
-import { normalizeDuctbankRow, normalizeConduitRow, normalizeTrayRow } from './racewaySampleData.mjs';
+import {
+  normalizeDuctbankRow,
+  normalizeConduitRow,
+  normalizeTrayRow,
+  sampleDuctbanks,
+  sampleTrays,
+  sampleConduits
+} from './racewaySampleData.mjs';
 
 checkPrereqs([{key:'cableSchedule',page:'cableschedule.html',label:'Cable Schedule'}]);
 
@@ -240,8 +247,16 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(!assertTablesReady()) return;
     console.time('raceway:loadSamples');
     try{
-      const res = await fetch('examples/sampleRaceways.json');
-      const { ductbanks = [], trays = [], conduits = [] } = await res.json();
+      let ductbanks=[],trays=[],conduits=[];
+      try{
+        const res=await fetch('examples/sampleRaceways.json');
+        ({ductbanks=[],trays=[],conduits=[]}=await res.json());
+      }catch(fetchErr){
+        console.warn('Sample raceways fetch failed, using built-in samples',fetchErr);
+        ductbanks=sampleDuctbanks;
+        trays=sampleTrays;
+        conduits=sampleConduits;
+      }
       const dbRows = ductbanks.map(normalizeDuctbankRow);
       const trayRows = trays.map(normalizeTrayRow);
       const conduitRowsRaw = conduits.map(normalizeConduitRow);


### PR DESCRIPTION
## Summary
- Fallback to built-in raceway samples if `examples/sampleRaceways.json` cannot be fetched
- Load raceway page scripts via `src/racewayschedule.js` module to include new fallback logic

## Testing
- `npm test`
- `npx playwright test --project=firefox --project=msedge` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bf05286fc083248f2d75631034d234