### PR TITLE
fix: stabilize playwright tests

### DIFF
--- a/playwright-tests/raceway-load-samples.spec.ts
+++ b/playwright-tests/raceway-load-samples.spec.ts
@@ -19,9 +19,9 @@ test('raceway load samples populates all tables', async ({ page }) => {
   await page.goto(pageUrl('racewayschedule.html'));
   await page.waitForSelector('#raceway-load-samples');
   await page.click('#raceway-load-samples');
-  await page.waitForSelector('#ductbankTable tbody tr.ductbank-row');
-  await page.waitForSelector('#trayTable tbody tr');
-  await page.waitForSelector('#conduitTable tbody tr');
+  await page.waitForSelector('#ductbankTable tbody tr.ductbank-row', { state: 'attached' });
+  await page.waitForSelector('#trayTable tbody tr', { state: 'attached' });
+  await page.waitForSelector('#conduitTable tbody tr', { state: 'attached' });
   const dbCount = await page.locator('#ductbankTable tbody tr.ductbank-row').count();
   const trayCount = await page.locator('#trayTable tbody tr').count();
   const conduitCount = await page.locator('#conduitTable tbody tr').count();

--- a/playwright-tests/raceway-samples.spec.ts
+++ b/playwright-tests/raceway-samples.spec.ts
@@ -29,9 +29,9 @@ test('raceway samples roundtrip and route', async ({ page }) => {
   await page.goto(pageUrl('racewayschedule.html'));
   await page.waitForSelector('#raceway-load-samples');
   await page.click('#raceway-load-samples');
-  await page.waitForSelector('#ductbankTable tbody tr.ductbank-row');
-  await page.waitForSelector('#trayTable tbody tr');
-  await page.waitForSelector('#conduitTable tbody tr');
+  await page.waitForSelector('#ductbankTable tbody tr.ductbank-row', { state: 'attached' });
+  await page.waitForSelector('#trayTable tbody tr', { state: 'attached' });
+  await page.waitForSelector('#conduitTable tbody tr', { state: 'attached' });
   const dbCount = await page.locator('#ductbankTable tbody tr.ductbank-row').count();
   const trayCount = await page.locator('#trayTable tbody tr').count();
   const conduitCount = await page.locator('#conduitTable tbody tr').count();
@@ -52,6 +52,9 @@ test('raceway samples roundtrip and route', async ({ page }) => {
   await page.click('#settings-btn');
   await page.click('#import-project-btn');
   await page.setInputFiles('#import-project-input', filePath);
+  await page.waitForSelector('#ductbankTable tbody tr.ductbank-row', { state: 'attached' });
+  await page.waitForSelector('#trayTable tbody tr', { state: 'attached' });
+  await page.waitForSelector('#conduitTable tbody tr', { state: 'attached' });
 
   expect(await page.locator('#ductbankTable tbody tr.ductbank-row').count()).toBe(dbCount);
   expect(await page.locator('#trayTable tbody tr').count()).toBe(trayCount);

--- a/playwright-tests/workflow.spec.js
+++ b/playwright-tests/workflow.spec.js
@@ -26,18 +26,23 @@ test.describe("CableTrayRoute workflow", () => {
     await expect(page.locator("#conduitTable tbody tr")).toHaveCount(3);
     const dbData = await page.evaluate(() => {
       const tag = document.getElementById('ductbankTag').value;
+      const db = {
+        tag,
+        start_x: 0, start_y: 0, start_z: 0,
+        end_x: 0, end_y: 0, end_z: 0,
+      };
       const conduits = Array.from(document.querySelectorAll('#conduitTable tbody tr')).map((tr, i) => ({
         ductbankTag: tag,
         conduit_id: i + 1,
         type: '',
         trade_size: '',
         start_x: 0, start_y: 0, start_z: 0,
-        end_x: 0, end_y: 0, end_z: 0
+        end_x: 0, end_y: 0, end_z: 0,
       }));
-      return { tag, conduits };
+      return { db, conduits };
     });
-    await page.addInitScript(({ tag, conduits }) => {
-      localStorage.setItem('base:ductbankSchedule', JSON.stringify([{ tag }]));
+    await page.addInitScript(({ db, conduits }) => {
+      localStorage.setItem('base:ductbankSchedule', JSON.stringify([db]));
       localStorage.setItem('base:conduitSchedule', JSON.stringify(conduits));
       localStorage.setItem('base:traySchedule', '[]');
       localStorage.setItem('base:cableSchedule', '[]');
@@ -53,9 +58,9 @@ test.describe("CableTrayRoute workflow", () => {
     const trayFile = path.join(root, "examples", "tray_schedule.csv");
     const cableFile = path.join(root, "examples", "cable_schedule.csv");
     await page.setInputFiles("#import-trays-file", trayFile);
-    await page.waitForSelector("#manual-tray-table-container tbody tr");
+    await page.waitForSelector("#manual-tray-table-container tbody tr", { state: 'attached' });
     await page.setInputFiles("#import-cables-file", cableFile);
-    await page.waitForSelector("#cable-list-container tbody tr");
+    await page.waitForSelector("#cable-list-container tbody tr", { state: 'attached' });
     await page.click("#calculate-route-btn");
     await expect(page.locator("#results-section")).toBeVisible();
   });
@@ -92,9 +97,9 @@ test.describe("CableTrayRoute workflow", () => {
     await page.goto(pageUrl("optimalRoute.html"));
     await handleResume(page, false);
     await page.click("#load-sample-trays-btn");
-    await page.waitForSelector("#manual-tray-table-container tbody tr");
+    await page.waitForSelector("#manual-tray-table-container tbody tr", { state: 'attached' });
     await page.click("#load-sample-cables-btn");
-    await page.waitForSelector("#cable-list-container tbody tr");
+    await page.waitForSelector("#cable-list-container tbody tr", { state: 'attached' });
     await page.click("#calculate-route-btn");
     await expect(page.locator("#results-section")).toBeVisible();
     const firstRow = page.locator("#cable-list-container tbody tr").first();

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="node_modules/xlsx/dist/xlsx.full.min.js" defer></script>
   <script src="dirtyTracker.js" defer></script>
-  <script type="module" src="src/racewayschedule.js"></script>
+  <script src="dist/racewayschedule.js" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- load dist build of racewayschedule for cross-browser support
- ensure playwright waits for table rows before asserting counts
- add ductbank geometry in workflow test for accurate conduit reporting

## Testing
- `npx playwright test --project=firefox --project=msedge` *(fails: Chromium distribution 'msedge' is not found)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_68bf0c6f8fc0832489b7ba041409c6bf