### PR TITLE
Align tray and cable template headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ When batch mode is selected, you can now use the **Add Cable to List** button to
 add a cable using the current values from the Cable Specifications and Route
 Points fields. After filling in the details, click **Add Cable to List** and the
 cable will appear in the table for batch routing. Each row in the table allows
-you to edit not only the cable tag, but also the diameter and the start/end
+you to edit not only the cable tag, but also the cable OD and the start/end
 coordinates for that cable.
 
 ## New Feature: In-App Help Modal
@@ -105,19 +105,19 @@ diagram with the cables placed according to their properties.
 A tray CSV used for import must include the following headers:
 
 ```
-tray_id,start_x,start_y,start_z,end_x,end_y,end_z,width,height,current_fill,allowed_cable_group
+tray_id,start_x,start_y,start_z,end_x,end_y,end_z,inside_width,tray_depth,tray_type,current_fill,allowed_cable_group,shape
 ```
 
-All coordinates are in **feet**. Width and height are in **inches** and `current_fill` is the occupied area in square inches. A sample file is available at `examples/trays_template.csv`.
+All coordinates are in **feet**. Inside width and tray depth are in **inches** and `current_fill` is the occupied area in square inches. A sample file is available at `examples/trays_template.csv`.
 
 ### Cable CSV Format
 Cables can be imported with these column headers:
 
 ```
-tag,start_tag,end_tag,cable_type,conductors,conductor_size,diameter,weight,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
+tag,from_tag,to_tag,cable_type,conductors,conductor_size,cable_od,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
 ```
 
-Start and end coordinates use **feet**. Diameter is in **inches** and weight is in **lbs/ft**. See `examples/cables_template.csv` for a template.
+Start and end coordinates use **feet**. Cable OD is in **inches**. See `examples/cables_template.csv` for a template.
 
 Exported routing results are written to `route_data.xlsx`. Load this file in `cabletrayfill.html` to view tray utilization.
 
@@ -126,7 +126,7 @@ Exported routing results are written to `route_data.xlsx`. Load this file in `ca
 `racewayschedule.html` centralizes raceway data in three editable tables.
 
 - **Ductbank Schedule** – list each ductbank by `Tag`, `From`, and `To`. Expand a row to add its conduits (`Conduit ID`, `Type`, `Trade Size`, `From`, `To`).
-- **Tray Schedule** – record tray segments with start and end coordinates plus `Width`, `Height`, and optional `Capacity`.
+ - **Tray Schedule** – record tray segments with start and end coordinates plus `Inside Width`, `Tray Depth`, and `Tray Type`.
 - **Conduit Schedule** – catalog stand-alone conduits with start/end coordinates, `Type`, `Trade Size`, and `Capacity`.
 
 Use the buttons above each table to **Save** to browser storage, **Load** saved data, and **Import/Export XLSX** files. Templates are available in the `examples` folder (`ductbank_schedule_ductbanks.csv`, `ductbank_schedule_conduits.csv`, `tray_schedule.csv`, and `conduit_schedule.csv`). Save these CSV files as `.xlsx` with matching sheet names before importing.

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,7 +56,7 @@ Two files represent the different sheets:
 
 ## Cable Trays (`tray_schedule.csv`)
 
-Columns (in order): `tray_id`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`, `width`, `height`, `capacity`
+Columns (in order): `tray_id`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`, `inside_width`, `tray_depth`, `tray_type`
 
 ## Stand-alone Conduits (`conduit_schedule.csv`)
 
@@ -64,8 +64,8 @@ Columns (in order): `conduit_id`, `type`, `trade_size`, `start_x`, `start_y`, `s
 
 ## Tray Import Template (`trays_template.csv`)
 
-Columns (in order): `tray_id`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`, `width`, `height`, `current_fill`, `allowed_cable_group`
+Columns (in order): `tray_id`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`, `inside_width`, `tray_depth`, `tray_type`, `current_fill`, `allowed_cable_group`, `shape`
 
 ## Cable Import Template (`cables_template.csv`)
 
-Columns (in order): `tag`, `start_tag`, `end_tag`, `cable_type`, `conductors`, `conductor_size`, `diameter`, `weight`, `allowed_cable_group`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`
+Columns (in order): `tag`, `from_tag`, `to_tag`, `cable_type`, `conductors`, `conductor_size`, `cable_od`, `allowed_cable_group`, `start_x`, `start_y`, `start_z`, `end_x`, `end_y`, `end_z`

--- a/examples/cables_template.csv
+++ b/examples/cables_template.csv
@@ -1,3 +1,3 @@
-tag,start_tag,end_tag,cable_type,conductors,conductor_size,diameter,weight,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
-CABLE-1,START1,END1,Power,3,500 kcmil,1.5,2.0,HV,0,0,0,40,0,0
-CABLE-2,START2,END2,Control,2,#12 AWG,0.5,0.1,LV,0,0,10,40,0,10
+tag,from_tag,to_tag,cable_type,conductors,conductor_size,cable_od,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
+CABLE-1,START1,END1,Power,3,500 kcmil,1.5,HV,0,0,0,40,0,0
+CABLE-2,START2,END2,Control,2,#12 AWG,0.5,LV,0,0,10,40,0,10

--- a/examples/trays_template.csv
+++ b/examples/trays_template.csv
@@ -1,3 +1,3 @@
-tray_id,start_x,start_y,start_z,end_x,end_y,end_z,width,height,current_fill,allowed_cable_group
-T1,0,0,10,40,0,10,16,4,0,HV
-T2,40,0,10,80,0,10,16,4,0,LV
+tray_id,start_x,start_y,start_z,end_x,end_y,end_z,inside_width,tray_depth,tray_type,current_fill,allowed_cable_group,shape
+T1,0,0,10,40,0,10,16,4,Ladder (50 % fill),0,HV,STR
+T2,40,0,10,80,0,10,16,4,Solid Bottom (40 % fill),0,LV,STR


### PR DESCRIPTION
## Summary
- support `inside_width`, `tray_depth`, and `tray_type` in tray imports and exports
- accept `from_tag`, `to_tag`, and `cable_od` for cable templates while dropping `weight`
- update example CSVs and docs to reference the new headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf14d96f3c8324b717dbd298bafaff