### PR TITLE
Initialize tray data and conduit count at startup

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -3888,12 +3888,12 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
     const cableKey = globalThis.TableUtils?.STORAGE_KEYS?.cableSchedule || 'cableSchedule';
     const hasSaved = hadSession || getItem(trayKey) || getItem(cableKey);
 
-    const finalizeLoad = () => {
+    const finalizeLoad = async () => {
         renderManualTrayTable();
         updateCableListDisplay();
+        await loadDuctbankData();
         rebuildTrayData();
         updateTrayDisplay();
-        loadDuctbankData();
     };
 
     if (hasSaved) {
@@ -3914,7 +3914,7 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
             yesBtn.addEventListener('click', async () => {
                 close();
                 await loadSchedulesIntoSession();
-                finalizeLoad();
+                await finalizeLoad();
             }, { once: true });
             noBtn.addEventListener('click', async () => {
                 close();
@@ -3923,22 +3923,14 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
                 saveSession();
                 removeItem(trayKey);
                 removeItem(cableKey);
-                renderManualTrayTable();
-                updateCableListDisplay();
-                rebuildTrayData();
-                updateTrayDisplay();
-                await loadDuctbankData();
+                await finalizeLoad();
             }, { once: true });
         } else {
             await loadSchedulesIntoSession();
-            finalizeLoad();
+            await finalizeLoad();
         }
     } else {
-        renderManualTrayTable();
-        updateCableListDisplay();
-        rebuildTrayData();
-        updateTrayDisplay();
-        loadDuctbankData();
+        await finalizeLoad();
     }
 
     async function runSelfCheck(){

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -11,7 +11,7 @@
     <script src="node_modules/xlsx/dist/xlsx.full.min.js" defer></script>
     <script src="node_modules/papaparse/papaparse.min.js" defer></script>
     <script src="dirtyTracker.js" defer></script>
-    <script src="site.js" defer></script>
+    <script type="module" src="site.js"></script>
     <script type="module" src="tableUtils.mjs" defer></script>
     <script src="dist/optimalRoute.js" defer></script>
     <script type="module" src="dataStore.mjs"></script>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="node_modules/xlsx/dist/xlsx.full.min.js" defer></script>
   <script src="dirtyTracker.js" defer></script>
-  <script src="site.js" defer></script>
+  <script type="module" src="site.js"></script>
   <script type="module" src="tableUtils.mjs" defer></script>
   <script src="dist/racewayschedule.js" defer></script>
 </head>


### PR DESCRIPTION
## Summary
- Load site.js as an ES module so shared utilities initialize correctly
- Wait for ductbank data and rebuild tray information during startup
- Ensure conduit totals are reflected in the #conduit-count display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a76aee083248e72665151c76c63