### PR TITLE
Dynamically load file parsers in parseFile

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -286,14 +286,37 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const parseFile=(file,cb)=>{
         const reader=new FileReader();
-        reader.onload=e=>{
+        reader.onload=async e=>{
             try{
                 let rows=[];
-                if(file.name.toLowerCase().endsWith('.xlsx')||file.name.toLowerCase().endsWith('.xls')){
+                const isExcel=file.name.toLowerCase().endsWith('.xlsx')||file.name.toLowerCase().endsWith('.xls');
+                if(isExcel){
+                    if(!globalThis.XLSX){
+                        try{
+                            await import('./node_modules/xlsx/dist/xlsx.full.min.js');
+                        }catch(err){
+                            console.error('Failed to load XLSX library',err);
+                        }
+                        if(!globalThis.XLSX){
+                            showToast('Failed to load XLSX parser','error');
+                            return;
+                        }
+                    }
                     const wb=XLSX.read(e.target.result,{type:'binary'});
                     const ws=wb.Sheets[wb.SheetNames[0]];
                     rows=XLSX.utils.sheet_to_json(ws,{defval:''});
                 }else{
+                    if(!globalThis.Papa){
+                        try{
+                            await import('./node_modules/papaparse/papaparse.min.js');
+                        }catch(err){
+                            console.error('Failed to load PapaParse library',err);
+                        }
+                        if(!globalThis.Papa){
+                            showToast('Failed to load CSV parser','error');
+                            return;
+                        }
+                    }
                     rows=Papa.parse(e.target.result,{header:true,skipEmptyLines:true}).data;
                 }
                 rows=rows.map(r=>{const o={};Object.keys(r).forEach(k=>{o[k.trim().toLowerCase()]=r[k];});return o;});


### PR DESCRIPTION
## Summary
- ensure CSV and spreadsheet parsers are loaded on demand
- gracefully notify users when required parser libraries fail to load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf2422d8ac8324b62ecef179d0f2ed