### PR TITLE
Load ductbank script before raceway schedule bundle

### DIFF
--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -11,6 +11,7 @@
   <script src="dirtyTracker.js" defer></script>
   <script type="module" src="site.js"></script>
   <script type="module" src="tableUtils.mjs" defer></script>
+  <script src="ductbankTable.js" defer></script>
   <script src="dist/racewayschedule.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Ensure ductbank table helpers load by adding `ductbankTable.js` before the raceway schedule bundle

## Testing
- `npm test`
- `npx playwright install chromium` *(fails: 403 Forbidden when attempting to download browser)*

------
https://chatgpt.com/codex/tasks/task_e_68bf294a34cc83248b7caa889c23f206