### PR TITLE
Use module script for ductbank table

### DIFF
--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -11,7 +11,7 @@
   <script src="dirtyTracker.js" defer></script>
   <script type="module" src="site.js"></script>
   <script type="module" src="tableUtils.mjs" defer></script>
-  <script src="ductbankTable.js" defer></script>
+  <script type="module" src="ductbankTable.js"></script>
   <script src="dist/racewayschedule.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load `ductbankTable.js` as ES module and ensure it precedes `dist/racewayschedule.js`

## Testing
- `npx playwright test` *(fails: missing browsers; download 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3221ea308324ba16cd2a481b4cbd