### PR TITLE
Display conduit count after session load

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -3937,6 +3937,8 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
             yesBtn.addEventListener('click', async () => {
                 close();
                 await loadSchedulesIntoSession();
+                rebuildTrayData();
+                displayConduitCount(state.trayData.filter(t => t.raceway_type === 'conduit').length, true);
                 await finalizeLoad();
             }, { once: true });
             noBtn.addEventListener('click', async () => {
@@ -3950,6 +3952,8 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
             }, { once: true });
         } else {
             await loadSchedulesIntoSession();
+            rebuildTrayData();
+            displayConduitCount(state.trayData.filter(t => t.raceway_type === 'conduit').length, true);
             await finalizeLoad();
         }
     } else {


### PR DESCRIPTION
## Summary
- Rebuild tray data and show conduit count immediately after loading schedules
- Prevent conduit count element from being cleared during resume or fallback flows

## Testing
- `npm test`
- `npx playwright test --project=firefox` *(fails: download failure 403 for browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bf33b0f6148324b2859e331b9a3085