### PR TITLE
refactor: load raceway schedule from source

### DIFF
--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -12,7 +12,7 @@
   <script type="module" src="site.js"></script>
   <script type="module" src="tableUtils.mjs" defer></script>
   <script type="module" src="ductbankTable.js"></script>
-  <script src="dist/racewayschedule.js" defer></script>
+  <script type="module" src="racewayschedule.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Load raceway schedule script directly from `racewayschedule.js` instead of the bundled dist version

## Testing
- `npm test`
- `npx playwright test playwright-tests/raceway-load-samples.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox)*
- `npm run build` *(fails: RollupError: Invalid value "iife" for option "output.format" - UMD and IIFE output formats are not supported for code-splitting builds.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf38f44bb88324ad8382e39fff76e1