### PR TITLE
Use CDN for xlsx and papaparse scripts

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -8,8 +8,8 @@
     <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" defer></script>
-    <script src="node_modules/xlsx/dist/xlsx.full.min.js" defer></script>
-    <script src="node_modules/papaparse/papaparse.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" defer></script>
     <script src="dirtyTracker.js" defer></script>
     <script type="module" src="site.js"></script>
     <script type="module" src="tableUtils.mjs" defer></script>

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -7,7 +7,7 @@
   <title>Raceway Schedule</title>
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
-  <script src="node_modules/xlsx/dist/xlsx.full.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script src="dirtyTracker.js" defer></script>
   <script type="module" src="site.js"></script>
   <script type="module" src="tableUtils.mjs" defer></script>


### PR DESCRIPTION
## Summary
- Fix racewayschedule and optimalRoute pages to load xlsx library from CDN instead of unreachable node_modules path
- Swap optimal route page's papaparse dependency to a CDN source as well

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4075d36c83249862e18097ef707a