### PR TITLE
Fix palette initialization and organize toolbar groups

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -231,6 +231,16 @@
   gap: var(--ol-spacing);
 }
 
+.toolbar-group + .toolbar-group {
+  border-left: 1px solid var(--ol-border-color);
+  padding-left: var(--ol-spacing);
+}
+
+.toolbar-group-label {
+  font-weight: 600;
+  margin-right: var(--ol-spacing);
+}
+
 .toolbar-group-right {
   margin-left: auto;
   display: flex;

--- a/oneline.html
+++ b/oneline.html
@@ -84,28 +84,38 @@
           </div>
         </div>
         <div class="toolbar">
-          <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
-          <button id="dimension-btn" class="icon-button" title="Dimension" aria-label="Dimension"><img src="icons/toolbar/dimension.svg" alt=""></button>
-          <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
-          <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
-          <button id="align-left-btn" class="icon-button" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
-          <button id="align-right-btn" class="icon-button" title="Align Right" aria-label="Align Right"><img src="icons/toolbar/align-right.svg" alt=""></button>
-          <button id="align-top-btn" class="icon-button" title="Align Top" aria-label="Align Top"><img src="icons/toolbar/align-top.svg" alt=""></button>
-          <button id="align-bottom-btn" class="icon-button" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
-          <button id="distribute-h-btn" class="icon-button" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
-          <button id="distribute-v-btn" class="icon-button" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
-          <div class="export-group">
-            <button id="export-btn" class="icon-button" title="Export" aria-label="Export" aria-haspopup="true" aria-expanded="false"><img src="icons/toolbar/export.svg" alt=""></button>
-            <ul id="export-menu" class="export-menu" role="menu">
-              <li data-format="pdf" role="menuitem">Export PDF</li>
-              <li data-format="dxf" role="menuitem">Export DXF</li>
-              <li data-format="dwg" role="menuitem">Export DWG</li>
-            </ul>
+          <div class="toolbar-group" aria-label="Edit">
+            <span class="toolbar-group-label">Edit</span>
+            <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="icons/toolbar/connect.svg" alt=""></button>
+            <button id="dimension-btn" class="icon-button" title="Dimension" aria-label="Dimension"><img src="icons/toolbar/dimension.svg" alt=""></button>
+            <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="icons/toolbar/undo.svg" alt=""></button>
+            <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="icons/toolbar/redo.svg" alt=""></button>
           </div>
-          <input type="file" id="import-input" accept=".json" class="hidden-input">
-          <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
-          <button id="validate-btn" class="icon-button" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
-          <div class="grid-controls toolbar-group">
+          <div class="toolbar-group" aria-label="Align">
+            <span class="toolbar-group-label">Align</span>
+            <button id="align-left-btn" class="icon-button" title="Align Left" aria-label="Align Left"><img src="icons/toolbar/align-left.svg" alt=""></button>
+            <button id="align-right-btn" class="icon-button" title="Align Right" aria-label="Align Right"><img src="icons/toolbar/align-right.svg" alt=""></button>
+            <button id="align-top-btn" class="icon-button" title="Align Top" aria-label="Align Top"><img src="icons/toolbar/align-top.svg" alt=""></button>
+            <button id="align-bottom-btn" class="icon-button" title="Align Bottom" aria-label="Align Bottom"><img src="icons/toolbar/align-bottom.svg" alt=""></button>
+            <button id="distribute-h-btn" class="icon-button" title="Distribute Horizontal" aria-label="Distribute Horizontal"><img src="icons/toolbar/distribute-h.svg" alt=""></button>
+            <button id="distribute-v-btn" class="icon-button" title="Distribute Vertical" aria-label="Distribute Vertical"><img src="icons/toolbar/distribute-v.svg" alt=""></button>
+          </div>
+          <div class="toolbar-group" aria-label="Files">
+            <span class="toolbar-group-label">Files</span>
+            <div class="export-group">
+              <button id="export-btn" class="icon-button" title="Export" aria-label="Export" aria-haspopup="true" aria-expanded="false"><img src="icons/toolbar/export.svg" alt=""></button>
+              <ul id="export-menu" class="export-menu" role="menu">
+                <li data-format="pdf" role="menuitem">Export PDF</li>
+                <li data-format="dxf" role="menuitem">Export DXF</li>
+                <li data-format="dwg" role="menuitem">Export DWG</li>
+              </ul>
+            </div>
+            <input type="file" id="import-input" accept=".json" class="hidden-input">
+            <button id="import-btn" class="icon-button" title="Import" aria-label="Import"><img src="icons/toolbar/import.svg" alt=""></button>
+            <button id="validate-btn" class="icon-button" title="Validate" aria-label="Validate"><img src="icons/toolbar/validate.svg" alt=""></button>
+          </div>
+          <div class="grid-controls toolbar-group" aria-label="Grid">
+            <span class="toolbar-group-label">Grid</span>
             <label class="icon-button" title="Toggle Grid" aria-label="Toggle Grid">
               <input type="checkbox" id="grid-toggle" class="hidden-input" checked>
               <img src="icons/toolbar/grid.svg" alt="">
@@ -115,7 +125,8 @@
               <input type="number" id="grid-size" value="20" min="1">
             </label>
           </div>
-          <div class="toolbar-group toolbar-group-right">
+          <div class="toolbar-group toolbar-group-right" aria-label="Scale">
+            <span class="toolbar-group-label">Scale</span>
             <label class="scale-label">1 px = <input type="number" id="scale-value" value="1" step="0.01" min="0" placeholder="Scale"> <input type="text" id="scale-unit" value="in" size="3" aria-label="Scale unit"></label>
             <label class="slack-label">Slack % <input type="number" id="slack-pct" value="0" step="0.1" min="0" placeholder="Slack %"></label>
           </div>

--- a/oneline.js
+++ b/oneline.js
@@ -209,11 +209,14 @@ async function loadComponentLibrary() {
     else banner.classList.add('hidden');
   }
   document.querySelectorAll('#reload-library-btn, #library-reload-btn').forEach(btn => {
-    btn.onclick = async () => {
-      await loadComponentLibrary();
-      buildPalette();
+    btn.onclick = () => {
+      // allow reloading the library and rebuilding the palette
+      loadComponentLibrary();
     };
   });
+
+  // build the palette with the newly loaded library
+  buildPalette();
 
   if (skipped.length) {
     showToast(`Skipped components: ${skipped.join(', ')}`);
@@ -336,20 +339,22 @@ function buildPalette() {
     });
   });
   const paletteSearch = document.getElementById('palette-search');
-  paletteSearch.addEventListener('input', () => {
-    const term = paletteSearch.value.trim().toLowerCase();
-    palette.querySelectorAll('button').forEach(btn => {
-      const sub = (btn.dataset.subtype || '').toLowerCase();
-      const label = (btn.dataset.label || componentMeta[btn.dataset.subtype]?.label || '').toLowerCase();
-      btn.style.display = !term || sub.includes(term) || label.includes(term) ? '' : 'none';
+  if (paletteSearch) {
+    paletteSearch.addEventListener('input', () => {
+      const term = paletteSearch.value.trim().toLowerCase();
+      palette.querySelectorAll('button').forEach(btn => {
+        const sub = (btn.dataset.subtype || '').toLowerCase();
+        const label = (btn.dataset.label || componentMeta[btn.dataset.subtype]?.label || '').toLowerCase();
+        btn.style.display = !term || sub.includes(term) || label.includes(term) ? '' : 'none';
+      });
     });
-  });
-  paletteSearch.addEventListener('keydown', e => {
-    if (e.key === 'Escape') {
-      paletteSearch.value = '';
-      paletteSearch.dispatchEvent(new Event('input'));
-    }
-  });
+    paletteSearch.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        paletteSearch.value = '';
+        paletteSearch.dispatchEvent(new Event('input'));
+      }
+    });
+  }
 }
 
 const svgNS = 'http://www.w3.org/2000/svg';
@@ -2308,23 +2313,33 @@ async function init() {
   const exportReportsBtn = document.getElementById('export-reports-btn');
   if (exportReportsBtn) exportReportsBtn.addEventListener('click', () => exportAllReports());
 
-    buildPalette();
-    loadTemplates();
+  buildPalette();
+  loadTemplates();
   renderTemplates();
-  document.getElementById('template-export-btn').addEventListener('click', exportTemplates);
-  document.getElementById('template-import-btn').addEventListener('click', () => document.getElementById('template-import-input').click());
-  document.getElementById('template-import-input').addEventListener('change', importTemplates);
-  document.getElementById('connect-btn').addEventListener('click', () => {
-    connectMode = true;
-    connectSource = null;
-  });
+  const templateExportBtn = document.getElementById('template-export-btn');
+  if (templateExportBtn) templateExportBtn.addEventListener('click', exportTemplates);
+  const templateImportBtn = document.getElementById('template-import-btn');
+  const templateImportInput = document.getElementById('template-import-input');
+  if (templateImportBtn && templateImportInput) {
+    templateImportBtn.addEventListener('click', () => templateImportInput.click());
+    templateImportInput.addEventListener('change', importTemplates);
+  }
+  const connectBtn = document.getElementById('connect-btn');
+  if (connectBtn) {
+    connectBtn.addEventListener('click', () => {
+      connectMode = true;
+      connectSource = null;
+    });
+  }
   const dimensionBtn = document.getElementById('dimension-btn');
-  dimensionBtn.addEventListener('click', () => {
-    dimensionMode = !dimensionMode;
-    dimensionStart = null;
-    connectMode = false;
-    dimensionBtn.classList.toggle('active', dimensionMode);
-  });
+  if (dimensionBtn) {
+    dimensionBtn.addEventListener('click', () => {
+      dimensionMode = !dimensionMode;
+      dimensionStart = null;
+      connectMode = false;
+      dimensionBtn.classList.toggle('active', dimensionMode);
+    });
+  }
   document.getElementById('undo-btn').addEventListener('click', undo);
   document.getElementById('redo-btn').addEventListener('click', redo);
   document.getElementById('align-left-btn').addEventListener('click', () => alignSelection('left'));


### PR DESCRIPTION
## Summary
- Ensure component library reload builds palette and palette search handles missing fields
- Wire up template import/export buttons and connect/dimension controls safely
- Group toolbar actions into labeled sections with separators for clarity

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bf43c9ba248324999796ffaadc4f25