### PR TITLE
Add sample one-line diagram loader

### DIFF
--- a/examples/sample_oneline.json
+++ b/examples/sample_oneline.json
@@ -1,0 +1,49 @@
+{
+  "version": 2,
+  "scale": { "unitPerPx": 1, "unit": "in" },
+  "templates": [],
+  "sheets": [
+    {
+      "name": "Sample",
+      "components": [
+        {
+          "id": "n1",
+          "type": "bus",
+          "subtype": "Bus",
+          "x": 40,
+          "y": 60,
+          "label": "Bus 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": [ { "target": "n2" } ]
+        },
+        {
+          "id": "n2",
+          "type": "panel",
+          "subtype": "MLO",
+          "x": 220,
+          "y": 60,
+          "label": "Panel 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": [ { "target": "n3" } ]
+        },
+        {
+          "id": "n3",
+          "type": "load",
+          "subtype": "Load",
+          "x": 400,
+          "y": 60,
+          "label": "Load 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": []
+        }
+      ],
+      "connections": [
+        { "from": "n1", "to": "n2" },
+        { "from": "n2", "to": "n3" }
+      ]
+    }
+  ]
+}

--- a/oneline.html
+++ b/oneline.html
@@ -79,6 +79,7 @@
             <button id="diagram-export-btn" type="button" class="icon-button" title="Export Diagram" aria-label="Export Diagram"><img src="icons/toolbar/export.svg" alt=""></button>
             <input type="file" id="diagram-import-input" accept=".json" class="hidden-input">
             <button id="diagram-import-btn" type="button" class="icon-button" title="Import Diagram" aria-label="Import Diagram"><img src="icons/toolbar/import.svg" alt=""></button>
+            <button id="sample-diagram-btn" type="button" class="btn" title="Load sample diagram">Load Sample</button>
             <button id="diagram-share-btn" type="button" class="btn" title="Share diagram">Share</button>
             <button id="tour-btn" type="button" class="btn" title="Start tour">Tour</button>
           </div>

--- a/oneline.js
+++ b/oneline.js
@@ -2397,6 +2397,8 @@ async function init() {
   if (diagramImportInput) diagramImportInput.addEventListener('change', handleImport);
   const shareBtn = document.getElementById('diagram-share-btn');
   if (shareBtn) shareBtn.addEventListener('click', shareDiagram);
+  const sampleBtn = document.getElementById('sample-diagram-btn');
+  if (sampleBtn) sampleBtn.addEventListener('click', loadSampleDiagram);
   document.getElementById('add-sheet-btn').addEventListener('click', addSheet);
   document.getElementById('rename-sheet-btn').addEventListener('click', renameSheet);
   document.getElementById('delete-sheet-btn').addEventListener('click', deleteSheet);
@@ -3392,6 +3394,18 @@ async function importDiagram(data) {
     loadSheet(0);
     renderSheetTabs();
     save();
+  }
+}
+
+async function loadSampleDiagram() {
+  try {
+    const res = await fetch('examples/sample_oneline.json');
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    await importDiagram(data);
+  } catch (err) {
+    console.error('Failed to load sample diagram', err);
+    showToast('Failed to load sample diagram');
   }
 }
 


### PR DESCRIPTION
## Summary
- Add button to load a sample one-line diagram
- Fetch and import example diagram into the editor
- Include example diagram data with bus, panel, and load components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf4e4735dc83249c42947c6f033184