### PR TITLE
Fix Load Sample button for One-Line diagram

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -3399,7 +3399,7 @@ async function importDiagram(data) {
 
 async function loadSampleDiagram() {
   try {
-    const res = await fetch('examples/sample_oneline.json');
+    const res = await fetch(new URL('examples/sample_oneline.json', baseUrl).href);
     if (!res.ok) throw new Error(res.statusText);
     const data = await res.json();
     await importDiagram(data);


### PR DESCRIPTION
## Summary
- ensure sample diagram JSON fetch uses document base URL so Load Sample works on the One-Line diagram page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf5069d7fc83248eb76bb187210ddb