### PR TITLE
Remove scale controls from one-line diagram and fix canvas buttons

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -371,7 +371,7 @@ let hoverPort = null;
 let selectedConnection = null;
 let dimensionMode = false;
 let dimensionStart = null;
-let diagramScale = { unitPerPx: 1, unit: 'in' };
+let diagramScale = getItem('diagramScale', { unitPerPx: 1, unit: 'in' });
 let cableSlackPct = Number(getItem('cableSlackPct', 0));
 let slackPctInput = null;
 let gridSize = Number(getItem('gridSize', 20));
@@ -1478,6 +1478,7 @@ function save(notify = true) {
   components = sheets[activeSheet].components;
   connections = sheets[activeSheet].connections;
   setOneLine({ activeSheet, sheets: sheetData });
+  setItem('diagramScale', diagramScale);
   const issues = validateDiagram();
   if (issues.length === 0) {
     syncSchedules(notify);
@@ -3364,6 +3365,7 @@ async function importDiagram(data) {
   }
   data = migrateDiagram(data);
   diagramScale = data.scale || { unitPerPx: 1, unit: 'in' };
+  setItem('diagramScale', diagramScale);
   templates = data.templates || [];
   saveTemplates();
   renderTemplates();


### PR DESCRIPTION
## Summary
- drop the scale UI from the one-line diagram toolbar
- clean up related CSS and keep slack control only
- move canvas event wiring into init to restore toolbar button functionality
- persist diagram scale across reloads to maintain imported scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7861fe748324a3f64575801debcf