### PR TITLE
Fix overlapping grid control buttons

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -165,6 +165,15 @@
 .grid-controls label {
   display: flex;
   align-items: center;
+  width: auto;
+  height: auto;
+}
+
+.grid-controls label img {
+  width: 32px;
+  height: 32px;
+  margin-right: 0.25rem;
+  flex-shrink: 0;
 }
 
 .grid-controls input[type="number"] {


### PR DESCRIPTION
## Summary
- Prevent grid control buttons from overlapping on One-Line Diagram by allowing labels to auto-size and keeping icons fixed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf796165fc8324ad72bb2690505b09