### PR TITLE
fix duplicate svg declaration

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -2459,7 +2459,8 @@ async function init() {
     }
   });
 
-  const svg = document.getElementById('diagram');
+  // Reuse the diagram element fetched earlier in this function.
+  // Avoid redeclaring the `svg` constant to prevent "Identifier has already been declared" errors.
   const menu = document.getElementById('context-menu');
     svg.addEventListener('mousedown', e => {
       if (connectMode && e.target.classList.contains('port')) {


### PR DESCRIPTION
## Summary
- avoid redeclaring `svg` inside one-line diagram initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7a2f352c8324be97651e41f90f9f