### PR TITLE
Fix GitHub Pages assets for component library

### DIFF
--- a/scripts/copyAssets.js
+++ b/scripts/copyAssets.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const root = path.resolve(__dirname, '..');
 const dist = path.join(root, 'dist');
+const docs = path.join(root, 'docs');
 
 function copy(src, dest) {
   fs.rmSync(dest, { recursive: true, force: true });
@@ -11,6 +12,9 @@ function copy(src, dest) {
 
 copy(path.join(root, 'icons'), path.join(dist, 'icons'));
 copy(path.join(root, 'data'), path.join(dist, 'data'));
+copy(path.join(root, 'icons'), path.join(docs, 'icons'));
 ['componentLibrary.json', 'manufacturerLibrary.json'].forEach(file => {
-  fs.copyFileSync(path.join(root, file), path.join(dist, file));
+  const src = path.join(root, file);
+  fs.copyFileSync(src, path.join(dist, file));
+  fs.copyFileSync(src, path.join(docs, file));
 });


### PR DESCRIPTION
## Summary
- copy component library JSON and icons into `docs/` during build so GitHub Pages serves assets alongside `oneline.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf82afa59083248839115efc733c2a