### PR TITLE
Harden component library loader and fix relative paths

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -19,17 +19,17 @@
   <nav class="top-nav">
     <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">☰</button>
     <div id="nav-links" class="nav-links">
-      <a href="index.html">Home</a>
-      <a href="equipmentlist.html">Equipment List</a>
-      <a href="loadlist.html">Load List</a>
-      <a href="cableschedule.html">Cable Schedule</a>
-      <a href="panelschedule.html">Panel Schedule</a>
-      <a href="racewayschedule.html">Raceway Schedule</a>
-      <a href="ductbankroute.html">Ductbank</a>
-      <a href="cabletrayfill.html">Tray Fill</a>
-      <a href="conduitfill.html">Conduit Fill</a>
-      <a href="optimalRoute.html">Optimal Route</a>
-      <a href="oneline.html" class="active" aria-current="page">One-Line</a>
+      <a href="./index.html">Home</a>
+      <a href="./equipmentlist.html">Equipment List</a>
+      <a href="./loadlist.html">Load List</a>
+      <a href="./cableschedule.html">Cable Schedule</a>
+      <a href="./panelschedule.html">Panel Schedule</a>
+      <a href="./racewayschedule.html">Raceway Schedule</a>
+      <a href="./ductbankroute.html">Ductbank</a>
+      <a href="./cabletrayfill.html">Tray Fill</a>
+      <a href="./conduitfill.html">Conduit Fill</a>
+      <a href="./optimalRoute.html">Optimal Route</a>
+      <a href="./oneline.html" class="active" aria-current="page">One-Line</a>
       <button id="studies-panel-btn" type="button" class="btn" title="Open studies panel">Studies</button>
       <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
@@ -248,6 +248,6 @@
       localStorage.setItem('onelineTourSeen', 'true');
     }
   </script>
-  <script type="module" src="projectManager.js"></script>
+  <script type="module" src="./projectManager.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure all asset URLs in oneline.html resolve under /CableTrayRoute/
- robustify loadComponentLibrary with base-relative fetches, normalization, and tolerant icon checks
- await library loading at startup and wire reload buttons to re-fetch

## Testing
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Chromium distribution 'msedge' is not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf96cc95f8832489b7327855257522