### PR TITLE
Ensure oneline boot block runs after DOM ready

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="./oneline.css">
   <script src="https://cdn.jsdelivr.net/npm/handlebars@4.7.8/dist/handlebars.min.js"></script>
   <script type="module" src="./dataStore.mjs" defer></script>
-  <script type="module" src="./oneline.js" defer></script>
+  <script type="module" src="./oneline.js?v={{COMMIT_SHA}}" defer></script>
   <script type="module" src="./scenarios.js" defer></script>
 </head>
 <body>

--- a/oneline.js
+++ b/oneline.js
@@ -3401,7 +3401,7 @@ if (typeof window !== 'undefined') {
   window.loadManufacturerLibrary = loadManufacturerLibrary;
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
+async function __oneline_init() {
   setupLibraryTools();
   try {
     await loadComponentLibrary();
@@ -3425,4 +3425,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   } catch (err) {
     console.error('Initialization failed', err);
   }
-});
+}
+// (insert the __oneline_init block above, exactly)
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', __oneline_init);
+} else {
+  __oneline_init();
+}


### PR DESCRIPTION
## Summary
- ensure oneline boot sequence always runs even if DOMContentLoaded already fired
- cache-bust oneline.js with commit SHA in script tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9d18cf0483249725c7abd3e8fe01