### PR TITLE
Add oneline boot ready flag and cache-busting script tag

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="./oneline.css">
   <script src="https://cdn.jsdelivr.net/npm/handlebars@4.7.8/dist/handlebars.min.js"></script>
   <script type="module" src="./dataStore.mjs" defer></script>
-  <script type="module" src="./oneline.js?v={{COMMIT_SHA}}" defer></script>
+  <script type="module" src="./oneline.js?v=__COMMIT_SHA__" defer></script>
   <script type="module" src="./scenarios.js" defer></script>
 </head>
 <body>

--- a/oneline.js
+++ b/oneline.js
@@ -3419,15 +3419,17 @@ async function __oneline_init() {
   } catch (e) {
     console.error('loadProtectiveDevices() threw:', e);
   }
-  // buildPalette() is called inside loader; calling again is harmless
-  buildPalette();
   try {
+    // buildPalette() is called inside loader; calling again is harmless
+    buildPalette();
     await init();
   } catch (err) {
     console.error('Initialization failed', err);
+  } finally {
+    document.documentElement.setAttribute('data-oneline-ready', '1');
   }
 }
-// (insert the __oneline_init block above, exactly)
+
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', __oneline_init);
 } else {


### PR DESCRIPTION
## Summary
- initialize one-line UI after DOM ready and mark completion with `data-oneline-ready`
- load component, manufacturer, and protective device libraries before building palette
- include cache-busting query parameter in oneline module script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c01b09db80832486ea4ff095f22025