### PR TITLE
chore: stabilize playwright e2e

### DIFF
--- a/playwright-tests/oneline.spec.js
+++ b/playwright-tests/oneline.spec.js
@@ -7,8 +7,9 @@ function pageUrl(file) {
 }
 
 test('drag first library item onto canvas', async ({ page }) => {
-  await page.goto(pageUrl('oneline.html'));
-  const firstBtn = page.locator('#component-buttons button').first();
+  await page.goto(pageUrl('oneline.html?e2e=1'));
+  await page.waitForSelector('[data-oneline-ready="1"]');
+  const firstBtn = page.locator('[data-testid="palette-button"]').first();
   await firstBtn.waitFor({ state: 'visible' });
   const before = await page.locator('g.component').count();
   await firstBtn.dragTo(page.locator('#diagram'));

--- a/playwright-tests/raceway-load-samples.spec.ts
+++ b/playwright-tests/raceway-load-samples.spec.ts
@@ -16,9 +16,13 @@ test('raceway load samples populates all tables', async ({ page }) => {
       return originalFetch(input, init);
     };
   }, sampleJson);
-  await page.goto(pageUrl('racewayschedule.html'));
+  await page.goto(pageUrl('racewayschedule.html?e2e=1'));
+  await page.waitForSelector('[data-raceway-ready="1"]');
   await page.waitForSelector('#raceway-load-samples');
   await page.click('#raceway-load-samples');
+  await page.evaluate(
+    () => new Promise(r => document.addEventListener('samples-loaded', r, { once: true })),
+  );
   await page.waitForSelector('#ductbankTable tbody tr.ductbank-row', { state: 'attached' });
   await page.waitForSelector('#trayTable tbody tr', { state: 'attached' });
   await page.waitForSelector('#conduitTable tbody tr', { state: 'attached' });

--- a/playwright-tests/raceway-samples.spec.ts
+++ b/playwright-tests/raceway-samples.spec.ts
@@ -23,12 +23,16 @@ test('raceway samples roundtrip and route', async ({ page }) => {
       return originalFetch(input, init);
     };
   }, { racewayJson, cableJson });
-  await page.goto(pageUrl('cableschedule.html'));
+  await page.goto(pageUrl('cableschedule.html?e2e=1'));
   await page.click('#load-sample-cables-btn');
 
-  await page.goto(pageUrl('racewayschedule.html'));
+  await page.goto(pageUrl('racewayschedule.html?e2e=1'));
+  await page.waitForSelector('[data-raceway-ready="1"]');
   await page.waitForSelector('#raceway-load-samples');
   await page.click('#raceway-load-samples');
+  await page.evaluate(
+    () => new Promise(r => document.addEventListener('samples-loaded', r, { once: true })),
+  );
   await page.waitForSelector('#ductbankTable tbody tr.ductbank-row', { state: 'attached' });
   await page.waitForSelector('#trayTable tbody tr', { state: 'attached' });
   await page.waitForSelector('#conduitTable tbody tr', { state: 'attached' });
@@ -60,7 +64,7 @@ test('raceway samples roundtrip and route', async ({ page }) => {
   expect(await page.locator('#trayTable tbody tr').count()).toBe(trayCount);
   expect(await page.locator('#conduitTable tbody tr').count()).toBeGreaterThanOrEqual(conduitCount);
 
-  await page.goto(pageUrl('optimalRoute.html'));
+  await page.goto(pageUrl('optimalRoute.html?e2e=1'));
   await page.click('#resume-no-btn');
   await page.click('#settings-btn');
   await page.click('#import-project-btn');

--- a/playwright-tests/workflow.spec.js
+++ b/playwright-tests/workflow.spec.js
@@ -18,7 +18,7 @@ test.describe("CableTrayRoute workflow", () => {
   test("create DB-01 with three conduits appears in Optimal Route", async ({
     page,
   }) => {
-    await page.goto(pageUrl("ductbankroute.html"));
+    await page.goto(pageUrl("ductbankroute.html?e2e=1"));
     await page.fill("#ductbankTag", "DB-01");
     for (let i = 0; i < 3; i++) {
       await page.click("#addConduit");
@@ -47,13 +47,17 @@ test.describe("CableTrayRoute workflow", () => {
       localStorage.setItem('base:traySchedule', '[]');
       localStorage.setItem('base:cableSchedule', '[]');
     }, dbData);
-    await page.goto(pageUrl('optimalRoute.html'));
+    await page.goto(pageUrl('optimalRoute.html?e2e=1'));
+    const routeUpdated = page.evaluate(
+      () => new Promise(r => document.addEventListener('route-updated', r, { once: true })),
+    );
     await handleResume(page, true);
+    await routeUpdated;
     await expect(page.locator("#conduit-count")).toContainText("3");
   });
 
   test("import sample CSV/XLSX and route cables", async ({ page }) => {
-    await page.goto(pageUrl("optimalRoute.html"));
+    await page.goto(pageUrl("optimalRoute.html?e2e=1"));
     await handleResume(page, false);
     const trayFile = path.join(root, "examples", "tray_schedule.csv");
     const cableFile = path.join(root, "examples", "cable_schedule.csv");
@@ -94,7 +98,7 @@ test.describe("CableTrayRoute workflow", () => {
         return originalFetch(input, init);
       };
     }, { trayJson, cableJson });
-    await page.goto(pageUrl("optimalRoute.html"));
+    await page.goto(pageUrl("optimalRoute.html?e2e=1"));
     await handleResume(page, false);
     await page.click("#load-sample-trays-btn");
     await page.waitForSelector("#manual-tray-table-container tbody tr", { state: 'attached' });
@@ -112,7 +116,7 @@ test.describe("CableTrayRoute workflow", () => {
   });
 
   test("dirty-state prompts appear when navigating away", async ({ page }) => {
-    await page.goto(pageUrl("ductbankroute.html"));
+    await page.goto(pageUrl("ductbankroute.html?e2e=1"));
     await page.fill("#ductbankTag", "TEMP");
     const prevented = await page.evaluate(() => {
       const event = new Event("beforeunload", { cancelable: true });


### PR DESCRIPTION
## Summary
- run oneline and raceway pages in e2e mode
- wait for ready flags and events before interacting
- ensure optimal route conduit count waits for route updates

## Testing
- `npm test`
- `npx playwright test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox)*

------
https://chatgpt.com/codex/tasks/task_e_68c02865ec008324a28d8d24edc723b7