### PR TITLE
Ensure oneline boot block always marks ready and add cache busting

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="./oneline.css">
   <script src="https://cdn.jsdelivr.net/npm/handlebars@4.7.8/dist/handlebars.min.js"></script>
   <script type="module" src="./dataStore.mjs" defer></script>
-  <script type="module" src="./oneline.js?v=__COMMIT_SHA__" defer></script>
+  <script type="module" src="./oneline.js?v={{COMMIT_SHA}}" defer></script>
   <script type="module" src="./scenarios.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace oneline.js boot sequence with robust init that handles drag-and-drop and always sets `data-oneline-ready`
- add cache-busting commit SHA query parameter to oneline.js script tag

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository InRelease not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c02fab65dc83249d8be9401149a67e