### PR TITLE
feat: signal optimal route readiness and update events

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -15,6 +15,7 @@
     <script type="module" src="tableUtils.mjs" defer></script>
     <script type="module" src="e2e-helpers.js?v={{COMMIT_SHA}}"></script>
     <script type="module" src="app.mjs?v={{COMMIT_SHA}}"></script>
+    <script type="module" src="./optimalRoute.js?v={{COMMIT_SHA}}"></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -22,6 +22,7 @@ function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#r
 }
 
 window.E2E = E2E;
+suppressResumeIfE2E();
 
 checkPrereqs([
   {key:'cableSchedule',page:'cableschedule.html',label:'Cable Schedule'},
@@ -79,6 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // After any resume logic completes, ensure tray/conduit data is rebuilt
   if (typeof rebuildTrayData === 'function') rebuildTrayData();
+  markReady('data-optimal-ready');
 });
 
 function addTrayRow(){
@@ -196,6 +198,12 @@ function calculateRoutes(){
   routingWorker.onmessage = (e) => {
     if (e.data.type === 'done') {
       drawNetwork(e.data.finalTrays || [], e.data.allRoutes || [], e.data.utilization || {});
+      const countEl = document.getElementById('conduit-count');
+      if (countEl && Array.isArray(e.data.finalTrays)) {
+        const conduitCount = e.data.finalTrays.filter(t => t.raceway_type === 'conduit').length;
+        countEl.textContent = `Conduits added: ${conduitCount}`;
+      }
+      document.dispatchEvent(new Event('route-updated'));
     }
   };
   routingWorker.postMessage({ type:'start', trays: trayData, options: getRoutingOptions(), cables: cableData });


### PR DESCRIPTION
## Summary
- inline helper calls for E2E now executed on optimal route page startup
- mark the page ready with `data-optimal-ready` and dispatch `route-updated` after routing
- load `optimalRoute.js` with cache-busting commit hash

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c03202c05c83249887fc62186c0cbb