### PR TITLE
Add readiness beacons for E2E reliability

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -9,6 +9,16 @@ function markReady(flagName) {
   } catch {}
 }
 
+function ensureBeacon(id) {
+  let el = document.getElementById(id);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = id;
+    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    document.body.appendChild(el);
+  }
+}
+
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
   try { localStorage.clear(); sessionStorage.clear(); } catch {}
@@ -4023,6 +4033,7 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
     }
 
     markReady('data-optimal-ready');
+    ensureBeacon('optimal-ready-beacon');
 
     async function runSelfCheck(){
         const diag={};

--- a/e2e-helpers.js
+++ b/e2e-helpers.js
@@ -17,3 +17,14 @@ export function markReady(flagName) {
     document.documentElement.setAttribute(flagName, '1');
   }
 }
+
+export function ensureBeacon(id) {
+  if (typeof document === 'undefined') return;
+  let el = document.getElementById(id);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = id;
+    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    document.body.appendChild(el);
+  }
+}

--- a/oneline.js
+++ b/oneline.js
@@ -9,6 +9,16 @@ function markReady(flagName) {
   } catch {}
 }
 
+function ensureBeacon(id) {
+  let el = document.getElementById(id);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = id;
+    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    document.body.appendChild(el);
+  }
+}
+
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
   try { localStorage.clear(); sessionStorage.clear(); } catch {}
@@ -3474,6 +3484,7 @@ async function __oneline_init() {
 
   // Ready flag for Playwright
   markReady('data-oneline-ready');
+  ensureBeacon('oneline-ready-beacon');
 }
 
 if (document.readyState === 'loading') {

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -9,6 +9,16 @@ function markReady(flagName) {
   } catch {}
 }
 
+function ensureBeacon(id) {
+  let el = document.getElementById(id);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = id;
+    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    document.body.appendChild(el);
+  }
+}
+
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
   try { localStorage.clear(); sessionStorage.clear(); } catch {}
@@ -81,6 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // After any resume logic completes, ensure tray/conduit data is rebuilt
   if (typeof rebuildTrayData === 'function') rebuildTrayData();
   markReady('data-optimal-ready');
+  ensureBeacon('optimal-ready-beacon');
 });
 
 function addTrayRow(){

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -9,6 +9,16 @@ function markReady(flagName) {
   } catch {}
 }
 
+function ensureBeacon(id) {
+  let el = document.getElementById(id);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = id;
+    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    document.body.appendChild(el);
+  }
+}
+
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
   try { localStorage.clear(); sessionStorage.clear(); } catch {}
@@ -591,5 +601,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   markReady('data-raceway-ready');
+  ensureBeacon('raceway-ready-beacon');
 });
 


### PR DESCRIPTION
## Summary
- add `ensureBeacon` helper to create invisible DOM beacons for readiness checks
- call `ensureBeacon` after each `markReady` in oneline, raceway schedule, optimal route, and app modules
- export `ensureBeacon` in e2e helpers for reuse

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c03477ed5c8324acd210a890726485