### PR TITLE
Add test beacons and cache-busting query params

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -14,7 +14,9 @@ function ensureBeacon(id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    el.setAttribute('data-e2e-beacon', '1');
+    // Keep it visible to Playwright but unobtrusive
+    el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:99999;';
     document.body.appendChild(el);
   }
 }

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -15,7 +15,7 @@
     <script type="module" src="tableUtils.mjs" defer></script>
     <script type="module" src="e2e-helpers.js?v={{COMMIT_SHA}}"></script>
     <script type="module" src="app.mjs?v={{COMMIT_SHA}}"></script>
-    <script type="module" src="./optimalRoute.js?v={{COMMIT_SHA}}"></script>
+    <script type="module" src="./optimalRoute.js?v={{COMMIT_SHA}}" defer></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -14,7 +14,9 @@ function ensureBeacon(id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    el.setAttribute('data-e2e-beacon', '1');
+    // Keep it visible to Playwright but unobtrusive
+    el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:99999;';
     document.body.appendChild(el);
   }
 }

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -13,7 +13,7 @@
   <script type="module" src="tableUtils.mjs" defer></script>
   <script type="module" src="e2e-helpers.js?v={{COMMIT_SHA}}"></script>
   <script type="module" src="ductbankTable.js?v={{COMMIT_SHA}}"></script>
-  <script type="module" src="./racewayschedule.js?v={{COMMIT_SHA}}"></script>
+  <script type="module" src="./racewayschedule.js?v={{COMMIT_SHA}}" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -14,7 +14,9 @@ function ensureBeacon(id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    el.style.cssText = 'position:fixed;inset:auto auto 0 0;width:1px;height:1px;opacity:0;pointer-events:none;';
+    el.setAttribute('data-e2e-beacon', '1');
+    // Keep it visible to Playwright but unobtrusive
+    el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:99999;';
     document.body.appendChild(el);
   }
 }


### PR DESCRIPTION
## Summary
- expose visible beacons after markReady in oneline, raceway schedule, and optimal route scripts
- add defer + commit SHA cache busting to page scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c03953a3c08324b11c7aa5d2ffc3e8