### PR TITLE
Ensure results section visible after routing

### DIFF
--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -224,6 +224,8 @@ function calculateRoutes(){
         countEl.textContent = `Conduits added: ${conduitCount}`;
       }
       if (typeof document !== 'undefined') {
+        const rs = document.getElementById('results-section');
+        if (rs) rs.classList.remove('hidden', 'invisible', 'is-hidden');
         emitAsync('route-updated');
       }
     }


### PR DESCRIPTION
## Summary
- Remove hiding classes from results section when routing finishes so results become visible

## Testing
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/firefox-1490/firefox/firefox)*

------
https://chatgpt.com/codex/tasks/task_e_68c03aeadfe88324a31fcda4dec35dd6