### PR TITLE
emit import ready events after tray and cable imports

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -19,6 +19,14 @@ function ensureBeacon(id) {
   }
 }
 
+function emitAsync(name) {
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => {
+      document.dispatchEvent(new Event(name));
+    }),
+  );
+}
+
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
   try { localStorage.clear(); sessionStorage.clear(); } catch {}
@@ -2212,8 +2220,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
             updateTrayDisplay();
             updateTableCounts();
             saveSession();
-            if (typeof document !== 'undefined' && document.dispatchEvent) {
-                document.dispatchEvent(new Event('imports-ready'));
+            if (elements.manualTrayTableContainer?.querySelector('tbody tr')) {
+                emitAsync('imports-ready-trays');
             }
         });
         elements.importTraysFile.value='';
@@ -2272,8 +2280,8 @@ const openDuctbankRoute = (dbId, conduitId) => {
             updateCableListDisplay();
             updateTableCounts();
             saveSession();
-            if (typeof document !== 'undefined' && document.dispatchEvent) {
-                document.dispatchEvent(new Event('imports-ready'));
+            if (elements.cableListContainer?.querySelector('tbody tr')) {
+                emitAsync('imports-ready-cables');
             }
         });
         elements.importCablesFile.value='';

--- a/playwright-tests/workflow.spec.js
+++ b/playwright-tests/workflow.spec.js
@@ -61,10 +61,16 @@ test.describe("CableTrayRoute workflow", () => {
     await handleResume(page, false);
     const trayFile = path.join(root, "examples", "tray_schedule.csv");
     const cableFile = path.join(root, "examples", "cable_schedule.csv");
+    const traysReady = page.evaluate(
+      () => new Promise(r => document.addEventListener('imports-ready-trays', r, { once: true })),
+    );
     await page.setInputFiles("#import-trays-file", trayFile);
-    await page.waitForSelector("#manual-tray-table-container tbody tr", { state: 'attached' });
+    await traysReady;
+    const cablesReady = page.evaluate(
+      () => new Promise(r => document.addEventListener('imports-ready-cables', r, { once: true })),
+    );
     await page.setInputFiles("#import-cables-file", cableFile);
-    await page.waitForSelector("#cable-list-container tbody tr", { state: 'attached' });
+    await cablesReady;
     await page.click("#calculate-route-btn");
     await expect(page.locator("#results-section")).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- fire `imports-ready-trays` event after tray file import
- fire `imports-ready-cables` event after cable file import
- update workflow e2e tests to wait for new events

## Testing
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Chromium distribution 'msedge' is not found; Download failed 403 for firefox/msedge)*

------
https://chatgpt.com/codex/tasks/task_e_68c03be66448832485aa8d8b16be2f98