### PR TITLE
Reveal results before emitting route updates

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -425,8 +425,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 elements.messages.innerHTML += '<div class="message warning">No valid conduits were loaded. Verify geometry fields or conduit identifiers.</div>';
             }
         }
-        if (typeof document !== 'undefined' && document.dispatchEvent) {
-            document.dispatchEvent(new Event('route-updated'));
+        if (typeof document !== 'undefined') {
+            const rs = document.getElementById('results-section');
+            if (rs) rs.classList.remove('hidden', 'invisible', 'is-hidden');
+            emitAsync('route-updated');
         }
     };
 


### PR DESCRIPTION
## Summary
- Reveal `#results-section` when routes are computed
- Emit `route-updated` after showing the results section

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / network unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0447ab4a08324b604ccdc6d7f2332