### PR TITLE
Delay oneline ready flag until palette exists

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -387,7 +387,6 @@ function buildPalette() {
       localStorage.setItem(key, det.open);
     });
   });
-  document.documentElement.setAttribute('data-oneline-ready', '1');
   const paletteSearch = document.getElementById('palette-search');
   if (paletteSearch) {
     paletteSearch.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- ensure `data-oneline-ready` is only set after the palette is built and auto-opened
- move ready beacon and flag to end of oneline initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0459eac408324aedc99d593fdc24c