### PR TITLE
feat: centralize async event emission

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -19,13 +19,6 @@ function ensureBeacon(id) {
   }
 }
 
-function emitAsync(name) {
-  requestAnimationFrame(() =>
-    requestAnimationFrame(() => {
-      document.dispatchEvent(new Event(name));
-    }),
-  );
-}
 
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
@@ -41,6 +34,7 @@ function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#r
 
 window.E2E = E2E;
 
+import { emitAsync } from './utils/safeEvents.js';
 import { getItem, setItem, removeItem, getTrays, getCables, getDuctbanks, getConduits, exportProject, importProject, setCables } from './dataStore.mjs';
 import { buildSegmentRows, buildSummaryRows, buildBOM } from './resultsExport.mjs';
 import './site.js';

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -24,12 +24,6 @@ function ensureReadyBeacon(attrName, id) {
   }
 }
 
-function emitAsync(name) {
-  // Two RAFs to ensure DOM attached + layout done before the event
-  requestAnimationFrame(() => requestAnimationFrame(() => {
-    document.dispatchEvent(new Event(name));
-  }));
-}
 
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
@@ -44,6 +38,8 @@ function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#r
 }
 
 window.E2E = E2E;
+
+import { emitAsync } from './utils/safeEvents.js';
 suppressResumeIfE2E();
 
 checkPrereqs([

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -24,12 +24,6 @@ function ensureReadyBeacon(attrName, id) {
   }
 }
 
-function emitAsync(name) {
-  // Two RAFs to ensure DOM attached + layout done before the event
-  requestAnimationFrame(() => requestAnimationFrame(() => {
-    document.dispatchEvent(new Event(name));
-  }));
-}
 
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
   if (!E2E) return;
@@ -45,6 +39,7 @@ function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#r
 
 window.E2E = E2E;
 
+import { emitAsync } from './utils/safeEvents.js';
 import * as dataStore from './dataStore.mjs';
 import {
   normalizeDuctbankRow,

--- a/utils/safeEvents.js
+++ b/utils/safeEvents.js
@@ -1,0 +1,20 @@
+export function emitAsync(name) {
+  // Fire after DOM changes; harmless no-op in Node.
+  const fire = () => {
+    try {
+      if (typeof document !== 'undefined' && document?.dispatchEvent) {
+        document.dispatchEvent(new Event(name));
+      }
+    } catch {}
+  };
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => requestAnimationFrame(fire));
+  } else {
+    setTimeout(fire, 0); // Node/test fallback
+  }
+}
+
+// Defensive global for legacy call sites:
+if (typeof globalThis.emitAsync !== 'function') {
+  globalThis.emitAsync = emitAsync;
+}


### PR DESCRIPTION
## Summary
- add `utils/safeEvents.js` utility to safely emit DOM events
- replace inline `emitAsync` helpers with imports in app, raceway, and optimal route scripts

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c04835aa288324ba6b5a67764749de