### PR TITLE
feat: add ready beacons for e2e selectors

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -1,27 +1,15 @@
 // ---- Inline E2E helpers (no external import) ----
 const E2E = new URLSearchParams(location.search).has('e2e');
 
-function markReady(flagName) {
-  try {
-    document.documentElement.setAttribute(flagName, '1');
-    // also expose to window for debugging
-    window[flagName.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = true;
-  } catch {}
-}
-
 function ensureReadyBeacon(attrName, id) {
   let el = document.getElementById(id);
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // carry the SAME data attribute the tests look for
-    el.setAttribute(attrName, '1');
-    // make it "visible" to Playwright but unobtrusive
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
-  } else {
-    el.setAttribute(attrName, '1');
   }
+  el.setAttribute(attrName, '1'); // carry the SAME data-* attr the tests wait for
 }
 
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
@@ -3456,6 +3444,8 @@ if (typeof window !== 'undefined') {
 async function __oneline_init() {
   suppressResumeIfE2E();
 
+  buildPalette();
+
   // Load libraries
   try { await loadComponentLibrary(); } catch (e) { console.error('loadComponentLibrary failed:', e); }
   try { await loadManufacturerLibrary(); } catch (e) { console.error('loadManufacturerLibrary failed:', e); }
@@ -3487,7 +3477,7 @@ async function __oneline_init() {
   }
 
   // Ready flag for Playwright
-  markReady('data-oneline-ready');
+  document.documentElement.setAttribute('data-oneline-ready', '1');
   ensureReadyBeacon('data-oneline-ready', 'oneline-ready-beacon');
 }
 

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -1,27 +1,15 @@
 // ---- Inline E2E helpers (no external import) ----
 const E2E = new URLSearchParams(location.search).has('e2e');
 
-function markReady(flagName) {
-  try {
-    document.documentElement.setAttribute(flagName, '1');
-    // also expose to window for debugging
-    window[flagName.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = true;
-  } catch {}
-}
-
 function ensureReadyBeacon(attrName, id) {
   let el = document.getElementById(id);
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // carry the SAME data attribute the tests look for
-    el.setAttribute(attrName, '1');
-    // make it "visible" to Playwright but unobtrusive
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
-  } else {
-    el.setAttribute(attrName, '1');
   }
+  el.setAttribute(attrName, '1'); // carry the SAME data-* attr the tests wait for
 }
 
 
@@ -98,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // After any resume logic completes, ensure tray/conduit data is rebuilt
   if (typeof rebuildTrayData === 'function') rebuildTrayData();
-  markReady('data-optimal-ready');
+  document.documentElement.setAttribute('data-optimal-ready', '1');
   ensureReadyBeacon('data-optimal-ready', 'optimal-ready-beacon');
 });
 

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -1,27 +1,15 @@
 // ---- Inline E2E helpers (no external import) ----
 const E2E = new URLSearchParams(location.search).has('e2e');
 
-function markReady(flagName) {
-  try {
-    document.documentElement.setAttribute(flagName, '1');
-    // also expose to window for debugging
-    window[flagName.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = true;
-  } catch {}
-}
-
 function ensureReadyBeacon(attrName, id) {
   let el = document.getElementById(id);
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // carry the SAME data attribute the tests look for
-    el.setAttribute(attrName, '1');
-    // make it "visible" to Playwright but unobtrusive
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
-  } else {
-    el.setAttribute(attrName, '1');
   }
+  el.setAttribute(attrName, '1'); // carry the SAME data-* attr the tests wait for
 }
 
 
@@ -615,7 +603,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (hasInitialRows) emitAsync('samples-loaded');
   });
 
-  markReady('data-raceway-ready');
+  document.documentElement.setAttribute('data-raceway-ready', '1');
   ensureReadyBeacon('data-raceway-ready', 'raceway-ready-beacon');
 });
 


### PR DESCRIPTION
## Summary
- add ensureReadyBeacon helper to key pages and mark ready state only after UI setup
- build one-line palette before loading libraries for reliable e2e checks

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c04993f734832489d08d1d7a5f2927