### PR TITLE
Ensure results visible after routing

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -421,7 +421,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
         if (typeof document !== 'undefined') {
             const rs = document.getElementById('results-section');
-            if (rs) rs.classList.remove('hidden', 'invisible', 'is-hidden');
+            if (rs) {
+                rs.classList.remove('hidden', 'invisible', 'is-hidden');
+                rs.removeAttribute('hidden');
+                rs.style.visibility = 'visible';
+                rs.style.display = '';
+            }
             if (typeof emitAsync === 'function') emitAsync('route-updated');
         }
     };

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -214,7 +214,12 @@ function calculateRoutes(){
       }
       if (typeof document !== 'undefined') {
         const rs = document.getElementById('results-section');
-        if (rs) rs.classList.remove('hidden', 'invisible', 'is-hidden');
+        if (rs) {
+          rs.classList.remove('hidden', 'invisible', 'is-hidden');
+          rs.removeAttribute('hidden');
+          rs.style.visibility = 'visible';
+          rs.style.display = '';
+        }
         requestAnimationFrame(() => emitAsync('route-updated'));
       }
     }


### PR DESCRIPTION
## Summary
- unhide `#results-section` after a successful route calculation before broadcasting `route-updated`
- apply visibility reset both in `app.mjs` and standalone `optimalRoute.js`

## Testing
- `npm test`
- `npm run e2e` *(fails: Chromium distribution 'msedge' is not found, suggested to run `npx playwright install msedge`; attempted install but downloads return 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c04c8ea0f48324b9015945f8d74c40