### PR TITLE
Ensure ductbank rows attach to table body and wire sample/import controls

### DIFF
--- a/ductbankTable.js
+++ b/ductbankTable.js
@@ -146,9 +146,10 @@ import { getDuctbanks as readStoredDuctbanks, setDuctbanks, setItem, getItem } f
     const specs = globalThis.CONDUIT_SPECS || {};
     ductbankTbody.innerHTML='';
     ductbanks.forEach((db,i)=>{
-      const row=ductbankTbody.insertRow();
-      row.className='ductbank-row';
+      const row=document.createElement('tr');
+      row.classList.add('ductbank-row');
       row.dataset.tag = db.tag;
+      ductbankTbody.appendChild(row);
       const tgl=row.insertCell();
       setWidth(tgl,0);
       const tglBtn=document.createElement('button');
@@ -265,8 +266,9 @@ import { getDuctbanks as readStoredDuctbanks, setDuctbanks, setItem, getItem } f
       act.appendChild(iconBtn('\u29C9','duplicateBtn','Duplicate Ductbank',()=>{duplicateDuctbank(i);}));
       act.appendChild(iconBtn('\u2716','removeBtn','Delete Ductbank',()=>{deleteDuctbank(i);}));
 
-      const cRow=ductbankTbody.insertRow();
-      cRow.className='conduit-container';
+      const cRow=document.createElement('tr');
+      cRow.classList.add('conduit-container');
+      ductbankTbody.appendChild(cRow);
       cRow.style.display=db.expanded?'':'none';
       const cCell=cRow.insertCell();
       cCell.colSpan=12;

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -430,7 +430,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
   window.getRacewaySchedule=getRacewaySchedule;
   persistAllConduits();
-  document.getElementById('raceway-load-samples')?.addEventListener('click', onRacewayLoadSamples, { once:false });
+  const loadSamplesBtn=document.getElementById('raceway-load-samples');
+  console.assert(loadSamplesBtn,'#raceway-load-samples button missing');
+  loadSamplesBtn?.addEventListener('click', onRacewayLoadSamples, { once:false });
 
   const normalize=s=>(s||'').trim().toUpperCase();
 

--- a/site.js
+++ b/site.js
@@ -758,6 +758,7 @@ function initProjectIO(){
   }
   const importBtn=document.getElementById('import-project-btn');
   const fileInput=document.getElementById('import-project-input');
+  console.assert(importBtn&&fileInput,'Project import controls missing');
   if(exportBtn){
     exportBtn.addEventListener('click',()=>{
       try{


### PR DESCRIPTION
## Summary
- Ensure ductbank rows are appended to the `#ductbankTable` tbody and marked with `ductbank-row`
- Assert presence of sample loader and project import controls before wiring their handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04e1e102c8324b7e3630169e7244c