### PR TITLE
Add ready beacon helper comments

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -6,10 +6,11 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
+    // Visible enough for Playwright, invisible to users
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // carry the SAME data-* attr the tests wait for
+  el.setAttribute(attrName, '1'); // exact same data-* attribute as tests wait for
 }
 
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -6,10 +6,11 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
+    // Visible enough for Playwright, invisible to users
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // carry the SAME data-* attr the tests wait for
+  el.setAttribute(attrName, '1'); // exact same data-* attribute as tests wait for
 }
 
 

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -6,10 +6,11 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
+    // Visible enough for Playwright, invisible to users
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // carry the SAME data-* attr the tests wait for
+  el.setAttribute(attrName, '1'); // exact same data-* attribute as tests wait for
 }
 
 


### PR DESCRIPTION
## Summary
- clarify ready beacon helper so Playwright can see page readiness
- ensure oneline, racewayschedule, and optimalRoute scripts signal readiness via visible beacons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0534604088324bd45f033cd43d885