### PR TITLE
feat: support emitAsync for node and browser

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -44,7 +44,7 @@ function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#r
 
 window.E2E = E2E;
 
-import { emitAsync } from './utils/safeEvents.js';
+import { emitAsync } from './utils/safeEvents.mjs';
 import { getItem, setItem, removeItem, getTrays, getCables, getDuctbanks, getConduits, exportProject, importProject, setCables } from './dataStore.mjs';
 import { buildSegmentRows, buildSummaryRows, buildBOM } from './resultsExport.mjs';
 import './site.js';

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -38,7 +38,7 @@ function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#r
 
 window.E2E = E2E;
 
-import { emitAsync } from './utils/safeEvents.js';
+import { emitAsync } from './utils/safeEvents.mjs';
 suppressResumeIfE2E();
 
 checkPrereqs([

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -38,7 +38,7 @@ function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#r
 
 window.E2E = E2E;
 
-import { emitAsync } from './utils/safeEvents.js';
+import { emitAsync } from './utils/safeEvents.mjs';
 import * as dataStore from './dataStore.mjs';
 import {
   normalizeDuctbankRow,

--- a/utils/safeEvents.js
+++ b/utils/safeEvents.js
@@ -1,5 +1,4 @@
-export function emitAsync(name) {
-  // Fire after DOM updates; no-op in Node if no document exists.
+function emitAsync(name) {
   const fire = () => {
     try {
       if (typeof document !== 'undefined' && document?.dispatchEvent) {
@@ -8,13 +7,18 @@ export function emitAsync(name) {
     } catch {}
   };
   if (typeof requestAnimationFrame === 'function') {
+    // In Node this is usually undefined; falls back to setTimeout.
     requestAnimationFrame(() => requestAnimationFrame(fire));
   } else {
     setTimeout(fire, 0);
   }
 }
 
-// Defensive global for legacy call-sites
-if (typeof globalThis.emitAsync !== 'function') {
-  globalThis.emitAsync = emitAsync;
+// export for Node
+module.exports = { emitAsync };
+
+// and a global fallback so legacy browser code calling globalThis.emitAsync still works
+if (typeof globalThis === 'object' && typeof globalThis.emitAsync !== 'function') {
+  try { globalThis.emitAsync = emitAsync; } catch {}
 }
+

--- a/utils/safeEvents.mjs
+++ b/utils/safeEvents.mjs
@@ -1,0 +1,18 @@
+export function emitAsync(name) {
+  const fire = () => {
+    try {
+      if (typeof document !== 'undefined' && document?.dispatchEvent) {
+        document.dispatchEvent(new Event(name));
+      }
+    } catch {}
+  };
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => requestAnimationFrame(fire));
+  } else {
+    setTimeout(fire, 0);
+  }
+}
+
+// also expose globally (defensive)
+if (typeof globalThis.emitAsync !== 'function') globalThis.emitAsync = emitAsync;
+


### PR DESCRIPTION
## Summary
- add CommonJS `emitAsync` helper and retain global fallback
- provide ESM variant for browser modules
- update modules to import `.mjs` helper

## Testing
- `node test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c058d48a1c8324870b5882f9ab218a