### PR TITLE
feat: add ready beacons for tested pages

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -10,9 +10,9 @@
   <link rel="stylesheet" href="./style.css">
   <link rel="stylesheet" href="./oneline.css">
   <script src="https://cdn.jsdelivr.net/npm/handlebars@4.7.8/dist/handlebars.min.js"></script>
-  <script type="module" src="./dataStore.mjs" defer></script>
+  <script type="module" src="./dataStore.mjs?v={{COMMIT_SHA}}" defer></script>
   <script type="module" src="./oneline.js?v={{COMMIT_SHA}}" defer></script>
-  <script type="module" src="./scenarios.js" defer></script>
+  <script type="module" src="./scenarios.js?v={{COMMIT_SHA}}" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/oneline.js
+++ b/oneline.js
@@ -6,11 +6,12 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // Visible enough for Playwright, invisible to users
+    // Visible to Playwright, invisible to users
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // exact same data-* attribute as tests wait for
+  // carry the SAME data-* attribute tests wait for
+  el.setAttribute(attrName, '1');
 }
 
 function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
@@ -3488,7 +3489,6 @@ async function __oneline_init() {
   }
 
   // Ready flag for Playwright
-  document.documentElement.setAttribute('data-oneline-ready', '1');
   ensureReadyBeacon('data-oneline-ready', 'oneline-ready-beacon');
 }
 

--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -11,8 +11,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" defer></script>
     <script src="dirtyTracker.js" defer></script>
-    <script type="module" src="site.js"></script>
-    <script type="module" src="tableUtils.mjs" defer></script>
+    <script type="module" src="site.js?v={{COMMIT_SHA}}"></script>
+    <script type="module" src="tableUtils.mjs?v={{COMMIT_SHA}}" defer></script>
     <script type="module" src="e2e-helpers.js?v={{COMMIT_SHA}}"></script>
     <script type="module" src="app.mjs?v={{COMMIT_SHA}}"></script>
     <script type="module" src="./optimalRoute.js?v={{COMMIT_SHA}}" defer></script>

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -6,11 +6,12 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // Visible enough for Playwright, invisible to users
+    // Visible to Playwright, invisible to users
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // exact same data-* attribute as tests wait for
+  // carry the SAME data-* attribute tests wait for
+  el.setAttribute(attrName, '1');
 }
 
 
@@ -97,7 +98,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // After any resume logic completes, ensure tray/conduit data is rebuilt
   if (typeof rebuildTrayData === 'function') rebuildTrayData();
-  document.documentElement.setAttribute('data-optimal-ready', '1');
   ensureReadyBeacon('data-optimal-ready', 'optimal-ready-beacon');
 });
 

--- a/racewayschedule.html
+++ b/racewayschedule.html
@@ -9,8 +9,8 @@
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
   <script src="dirtyTracker.js" defer></script>
-  <script type="module" src="site.js"></script>
-  <script type="module" src="tableUtils.mjs" defer></script>
+  <script type="module" src="site.js?v={{COMMIT_SHA}}"></script>
+  <script type="module" src="tableUtils.mjs?v={{COMMIT_SHA}}" defer></script>
   <script type="module" src="e2e-helpers.js?v={{COMMIT_SHA}}"></script>
   <script type="module" src="ductbankTable.js?v={{COMMIT_SHA}}"></script>
   <script type="module" src="./racewayschedule.js?v={{COMMIT_SHA}}" defer></script>

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -6,11 +6,12 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // Visible enough for Playwright, invisible to users
+    // Visible to Playwright, invisible to users
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // exact same data-* attribute as tests wait for
+  // carry the SAME data-* attribute tests wait for
+  el.setAttribute(attrName, '1');
 }
 
 
@@ -646,7 +647,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
-  document.documentElement.setAttribute('data-raceway-ready', '1');
   ensureReadyBeacon('data-raceway-ready', 'raceway-ready-beacon');
 });
 


### PR DESCRIPTION
## Summary
- signal page readiness using helper beacons instead of <html> attributes
- cache-bust module scripts on e2e pages with `?v={{COMMIT_SHA}}`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0867d76d083249bbe775fd8fc4674