### PR TITLE
Stop auto-resuming E2E pages

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -20,26 +20,15 @@ function ensureBeacon(id) {
 }
 
 
-function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 
 window.E2E = E2E;

--- a/cableschedule.js
+++ b/cableschedule.js
@@ -9,26 +9,15 @@ function markReady(flagName) {
   } catch {}
 }
 
-function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 
 window.E2E = E2E;

--- a/dist/ductbankroute.js
+++ b/dist/ductbankroute.js
@@ -1,26 +1,15 @@
 // ---- Inline E2E helpers (no external import) ----
 const E2E = new URLSearchParams(location.search).has('e2e');
 function markReady(flagName) { try { document.documentElement.setAttribute(flagName, '1'); window[flagName.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = true; } catch {} }
-function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 window.E2E = E2E;
 suppressResumeIfE2E();

--- a/ductbankroute.js
+++ b/ductbankroute.js
@@ -9,26 +9,15 @@ function markReady(flagName) {
   } catch {}
 }
 
-function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 
 window.E2E = E2E;

--- a/e2e-helpers.js
+++ b/e2e-helpers.js
@@ -1,25 +1,14 @@
 export const E2E = new URLSearchParams(location.search).get('e2e') === '1';
 
-export function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+export function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 
 export function markReady(flagName) {

--- a/oneline.js
+++ b/oneline.js
@@ -14,26 +14,15 @@ function ensureReadyBeacon(attrName, id) {
   el.setAttribute(attrName, '1');
 }
 
-function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 
 window.E2E = E2E;

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -15,26 +15,15 @@ function ensureReadyBeacon(attrName, id) {
 }
 
 
-function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 
 window.E2E = E2E;

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -15,26 +15,15 @@ function ensureReadyBeacon(attrName, id) {
 }
 
 
-function suppressResumeIfE2E({ resumeYesId = '#resume-yes-btn', resumeNoId = '#resume-no-btn' } = {}) {
+function suppressResumeIfE2E() {
   if (!E2E) return;
-
-  // Do NOT clear storage by default; it breaks cross-page flows.
-  // Only clear when explicitly requested via ?e2e_reset=1
+  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
   const shouldClear = qs.has('e2e_reset');
-
   if (shouldClear) {
     try { localStorage.clear(); sessionStorage.clear(); } catch {}
   }
-
-  // Still auto-dismiss the resume modal if it appears
-  queueMicrotask(() => {
-    const noBtn = document.querySelector(resumeNoId);
-    const yesBtn = document.querySelector(resumeYesId);
-    const isVisible = el => !!el && el.offsetParent !== null;
-    if (isVisible(noBtn)) noBtn.click();
-    else if (isVisible(yesBtn)) yesBtn.click();
-  });
+  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 
 window.E2E = E2E;


### PR DESCRIPTION
## Summary
- simplify `suppressResumeIfE2E` to only clear storage on `?e2e_reset` and leave resume modal alone
- apply new helper across all page scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c08783aef083249148758324b58335