### PR TITLE
Use visibility-based E2E readiness beacons

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -6,12 +6,28 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // Visible to Playwright, invisible to users
+    // visible to Playwright (non-zero rect), visually negligible
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  // carry the SAME data-* attribute tests wait for
-  el.setAttribute(attrName, '1');
+  el.setAttribute(attrName, '1'); // exact data-* Playwright waits for
+}
+
+function setReadyWhen(selector, attrName, id, timeoutMs = 25000) {
+  const start = performance.now();
+  const poll = () => {
+    // element must exist and be visible
+    const el = document.querySelector(selector);
+    const visible = !!el && !!(el.offsetParent || el.getClientRects().length);
+    if (visible) return ensureReadyBeacon(attrName, id);
+    if (performance.now() - start > timeoutMs) return; // give up silently
+    setTimeout(poll, 50);
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', poll, { once: true });
+  } else {
+    poll();
+  }
 }
 
 function suppressResumeIfE2E() {
@@ -3478,7 +3494,7 @@ async function __oneline_init() {
   }
 
   // Ready flag for Playwright
-  ensureReadyBeacon('data-oneline-ready', 'oneline-ready-beacon');
+  setReadyWhen('[data-testid="palette-button"]', 'data-oneline-ready', 'oneline-ready-beacon');
 }
 
 if (document.readyState === 'loading') {

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -6,12 +6,28 @@ function ensureReadyBeacon(attrName, id) {
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // Visible to Playwright, invisible to users
+    // visible to Playwright (non-zero rect), visually negligible
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  // carry the SAME data-* attribute tests wait for
-  el.setAttribute(attrName, '1');
+  el.setAttribute(attrName, '1'); // exact data-* Playwright waits for
+}
+
+function setReadyWhen(selector, attrName, id, timeoutMs = 25000) {
+  const start = performance.now();
+  const poll = () => {
+    // element must exist and be visible
+    const el = document.querySelector(selector);
+    const visible = !!el && !!(el.offsetParent || el.getClientRects().length);
+    if (visible) return ensureReadyBeacon(attrName, id);
+    if (performance.now() - start > timeoutMs) return; // give up silently
+    setTimeout(poll, 50);
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', poll, { once: true });
+  } else {
+    poll();
+  }
 }
 
 
@@ -668,6 +684,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
-  ensureReadyBeacon('data-raceway-ready', 'raceway-ready-beacon');
+  setReadyWhen('#raceway-load-samples', 'data-raceway-ready', 'raceway-ready-beacon');
 });
 


### PR DESCRIPTION
## Summary
- add ensureReadyBeacon/setReadyWhen helpers to page modules for Playwright beacons
- mark pages ready only after key UI elements are visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c097954ddc8324b762336979ea5442