### PR TITLE
Emit sticky events after sample and import loads

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -2194,6 +2194,9 @@ const openDuctbankRoute = (dbId, conduitId) => {
         updateTableCounts();
         addSortHandlers(elements.manualTrayTableContainer, state.manualTrays, renderManualTrayTable, traySort);
         filterTable(elements.manualTrayTableContainer, elements.traySearch.value);
+        if (elements.manualTrayTableContainer?.querySelector('tbody tr')) {
+            emitSticky('imports-ready-trays','importsReadyTrays');
+        }
     };
 
     const exportManualTraysCSV = () => {
@@ -2681,6 +2684,9 @@ const renderBatchResults = (results) => {
         updateTableCounts();
         addSortHandlers(elements.cableListContainer, state.cableList, updateCableListDisplay, cableSort);
         filterTable(elements.cableListContainer, elements.cableSearch.value);
+        if (elements.cableListContainer?.querySelector('tbody tr')) {
+            emitSticky('imports-ready-cables','importsReadyCables');
+        }
     };
 
     const loadSampleCables = () => {

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -255,7 +255,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if(importProjInput){
     importProjInput.addEventListener('change',()=>{
       requestAnimationFrame(()=>{
-        ensureDuctbankRows();
+        document.querySelectorAll('#ductbankTable tbody tr').forEach(tr=>tr.classList.add('ductbank-row'));
         emitSticky('samples-loaded','samplesLoaded');
       });
       whenPresent('#ductbankTable tbody tr.ductbank-row', () => emitSticky('samples-loaded','samplesLoaded'));
@@ -453,7 +453,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       );
       const conduitCount=dbConduits.length+standalone.length;
       console.log(`Loaded samples: ductbanks=${dbRows.length}, trays=${trayRows.length}, conduits=${conduitCount}`);
-      ensureDuctbankRows();
+      document.querySelectorAll('#ductbankTable tbody tr').forEach(tr=>tr.classList.add('ductbank-row'));
       emitSticky('samples-loaded','samplesLoaded');
       showToast(`Loaded samples: ${dbRows.length} ductbanks, ${conduitCount} conduits, ${trayRows.length} trays.`,'success');
     }catch(err){


### PR DESCRIPTION
## Summary
- Ensure ductbank rows are tagged before signalling `samples-loaded` after sample or project JSON imports
- Fire sticky `imports-ready-trays` and `imports-ready-cables` events once imported tables render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09bd9750483249ac057010459aa0f