### PR TITLE
Use beacons for E2E readiness flags

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -1,26 +1,27 @@
 // ---- Inline E2E helpers (no external import) ----
 const E2E = new URLSearchParams(location.search).has('e2e');
 
+function e2eOpenDetails() {
+  // Ensure controls nested in <details> are visible in E2E
+  document.querySelectorAll('details').forEach(d => { d.open = true; });
+}
 function ensureReadyBeacon(attrName, id) {
   let el = document.getElementById(id);
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // visible to Playwright (non-zero rect), visually negligible
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // exact data-* Playwright waits for
+  el.setAttribute(attrName, '1');
 }
-
 function setReadyWhen(selector, attrName, id, timeoutMs = 25000) {
   const start = performance.now();
   const poll = () => {
-    // element must exist and be visible
     const el = document.querySelector(selector);
     const visible = !!el && !!(el.offsetParent || el.getClientRects().length);
     if (visible) return ensureReadyBeacon(attrName, id);
-    if (performance.now() - start > timeoutMs) return; // give up silently
+    if (performance.now() - start > timeoutMs) return;
     setTimeout(poll, 50);
   };
   if (document.readyState === 'loading') {
@@ -3507,12 +3508,7 @@ async function __oneline_init() {
     });
   }
 
-  // Auto-open palette details in E2E so buttons are visible
-  if (window.E2E === true) {
-    document.querySelectorAll('#component-buttons details').forEach(det => det.open = true);
-  }
-
-  // Ready flag for Playwright
+  if (new URLSearchParams(location.search).has('e2e')) e2eOpenDetails();
   setReadyWhen('[data-testid="palette-button"]', 'data-oneline-ready', 'oneline-ready-beacon');
 }
 

--- a/optimalRoute.js
+++ b/optimalRoute.js
@@ -1,26 +1,27 @@
 // ---- Inline E2E helpers (no external import) ----
 const E2E = new URLSearchParams(location.search).has('e2e');
 
+function e2eOpenDetails() {
+  // Ensure controls nested in <details> are visible in E2E
+  document.querySelectorAll('details').forEach(d => { d.open = true; });
+}
 function ensureReadyBeacon(attrName, id) {
   let el = document.getElementById(id);
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // visible to Playwright (non-zero rect), visually negligible
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // exact data-* Playwright waits for
+  el.setAttribute(attrName, '1');
 }
-
 function setReadyWhen(selector, attrName, id, timeoutMs = 25000) {
   const start = performance.now();
   const poll = () => {
-    // element must exist and be visible
     const el = document.querySelector(selector);
     const visible = !!el && !!(el.offsetParent || el.getClientRects().length);
     if (visible) return ensureReadyBeacon(attrName, id);
-    if (performance.now() - start > timeoutMs) return; // give up silently
+    if (performance.now() - start > timeoutMs) return;
     setTimeout(poll, 50);
   };
   if (document.readyState === 'loading') {
@@ -153,6 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  if (new URLSearchParams(location.search).has('e2e')) e2eOpenDetails();
   setReadyWhen('#settings-btn', 'data-optimal-ready', 'optimal-ready-beacon');
 
   // After any resume logic completes, ensure tray/conduit data is rebuilt

--- a/racewayschedule.js
+++ b/racewayschedule.js
@@ -1,26 +1,27 @@
 // ---- Inline E2E helpers (no external import) ----
 const E2E = new URLSearchParams(location.search).has('e2e');
 
+function e2eOpenDetails() {
+  // Ensure controls nested in <details> are visible in E2E
+  document.querySelectorAll('details').forEach(d => { d.open = true; });
+}
 function ensureReadyBeacon(attrName, id) {
   let el = document.getElementById(id);
   if (!el) {
     el = document.createElement('div');
     el.id = id;
-    // visible to Playwright (non-zero rect), visually negligible
     el.style.cssText = 'position:fixed;left:0;bottom:0;width:1px;height:1px;opacity:0.01;z-index:2147483647;';
     document.body.appendChild(el);
   }
-  el.setAttribute(attrName, '1'); // exact data-* Playwright waits for
+  el.setAttribute(attrName, '1');
 }
-
 function setReadyWhen(selector, attrName, id, timeoutMs = 25000) {
   const start = performance.now();
   const poll = () => {
-    // element must exist and be visible
     const el = document.querySelector(selector);
     const visible = !!el && !!(el.offsetParent || el.getClientRects().length);
     if (visible) return ensureReadyBeacon(attrName, id);
-    if (performance.now() - start > timeoutMs) return; // give up silently
+    if (performance.now() - start > timeoutMs) return;
     setTimeout(poll, 50);
   };
   if (document.readyState === 'loading') {
@@ -709,6 +710,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
+  if (new URLSearchParams(location.search).has('e2e')) e2eOpenDetails();
   setReadyWhen('#raceway-load-samples', 'data-raceway-ready', 'raceway-ready-beacon');
 });
 


### PR DESCRIPTION
## Summary
- add shared helper to open `<details>` controls and expose ready beacons
- gate oneline, raceway schedule, and optimal route readiness on visible selectors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a4106ce08324be03a85b6239de9f