### PR TITLE
Improve one-line editor interactions

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -58,7 +58,8 @@
 }
 
 .icon-button:hover,
-.icon-button:focus {
+.icon-button:focus,
+.icon-button.active {
   background: var(--ol-hover-bg);
   border-radius: 4px;
 }
@@ -411,6 +412,7 @@ g.component.scenario-diff > * {
   box-shadow: var(--ol-shadow);
   font-family: var(--ol-font);
   display: none;
+  cursor: move;
 }
 
 .voltage-legend .legend-item {
@@ -459,13 +461,14 @@ g.component.scenario-diff > * {
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 1000;
 }
 
 .tour-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: var(--ol-card-bg);
   padding: 1rem;
   border-radius: var(--ol-radius);
@@ -478,6 +481,12 @@ g.component.scenario-diff > * {
   position: relative;
   z-index: 1001;
   box-shadow: 0 0 0 4px orange;
+}
+
+.bus-handle {
+  fill: #fff;
+  stroke: #000;
+  cursor: ew-resize;
 }
 
 .overlay-label {


### PR DESCRIPTION
## Summary
- Ensure tour modal sits above the canvas so Next button is always clickable
- Allow voltage legend to be dragged away from the corner
- Fix connect tool so ports appear when toggled
- Add resize handle so bus components can be stretched

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17671f2a08324b42023e74b1d47d1