### PR TITLE
Fix bus scaling and component interactions

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -383,7 +383,6 @@
   fill: #666;
   stroke: #fff;
   stroke-width: 1;
-  pointer-events: none;
 }
 
 
@@ -433,15 +432,7 @@ g.component.scenario-diff > * {
   display: inline-block;
 }
 
-.dimension {
-  stroke: #000;
-}
-
-.dim-label {
-  font-size: 10px;
-  fill: #000;
-  pointer-events: none;
-}
+/* dimension tool removed */
 
 @keyframes fadeIn {
   from { opacity: 0; }

--- a/oneline.html
+++ b/oneline.html
@@ -89,7 +89,6 @@
           <div class="toolbar-group" aria-label="Edit">
             <span class="toolbar-group-label">Edit</span>
             <button id="connect-btn" class="icon-button" title="Connect" aria-label="Connect"><img src="./icons/toolbar/connect.svg" alt=""></button>
-            <button id="dimension-btn" class="icon-button" title="Dimension" aria-label="Dimension"><img src="./icons/toolbar/dimension.svg" alt=""></button>
             <button id="undo-btn" class="icon-button" title="Undo" aria-label="Undo"><img src="./icons/toolbar/undo.svg" alt=""></button>
             <button id="redo-btn" class="icon-button" title="Redo" aria-label="Redo"><img src="./icons/toolbar/redo.svg" alt=""></button>
           </div>


### PR DESCRIPTION
## Summary
- scale bus icons when resized
- load property schemas so component properties can be edited
- enable port selection for connecting components
- remove obsolete dimension tool

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17d677900832486ba4bb81149d8cb