### PR TITLE
Improve oneline interactions and remove slack

### DIFF
--- a/oneline.css
+++ b/oneline.css
@@ -190,10 +190,6 @@
   opacity: 1;
 }
 
-.slack-label {
-  margin-left: var(--ol-spacing);
-}
-
 .hidden-input {
   display: none;
 }

--- a/oneline.html
+++ b/oneline.html
@@ -126,10 +126,6 @@
               <input type="number" id="grid-size" value="20" min="1">
             </label>
           </div>
-          <div class="toolbar-group toolbar-group-right" aria-label="Slack">
-            <span class="toolbar-group-label">Slack</span>
-            <label class="slack-label">Slack % <input type="number" id="slack-pct" value="0" step="0.1" min="0" placeholder="Slack %"></label>
-          </div>
         </div>
         <button id="palette-toggle" class="palette-toggle" aria-label="Toggle palette" aria-controls="palette" aria-expanded="false">☰</button>
         <details id="library-tools" class="library-tools">
@@ -206,6 +202,8 @@
               <li data-action="duplicate" data-context="component">Duplicate</li>
               <li data-action="rotate" data-context="component">Rotate</li>
               <li data-action="delete" data-context="component">Delete</li>
+              <li data-action="edit" data-context="connection">Edit Cable</li>
+              <li data-action="delete" data-context="connection">Delete Cable</li>
               <li data-action="paste" data-context="canvas">Paste</li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- Enable context menu and double-click editing for cables
- Orient connection arrows based on port direction
- Remove slack percentage fields and fix sample diagram loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1875da7fc8324bb6990ee96fe3881