### PR TITLE
Improve on-line diagram interactions and palette

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -167,6 +167,30 @@
     ]
   },
   {
+    "subtype": "Breaker",
+    "label": "Breaker",
+    "icon": "icons/components/Breaker.svg",
+    "category": "equipment",
+    "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
+    "schema": [
+      { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "rating", "label": "Rating", "type": "select", "options": ["100A", "225A", "400A", "600A"] },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
+    ]
+  },
+  {
+    "subtype": "Utility",
+    "label": "Utility Source",
+    "icon": "icons/components/Utility.svg",
+    "category": "equipment",
+    "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
+    "schema": [
+      { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "sc_rating", "label": "Short-Circuit Rating (kA)", "type": "number" },
+      { "name": "notes", "label": "Notes", "type": "textarea" }
+    ]
+  },
+  {
     "subtype": "Motor",
     "label": "Motor",
     "icon": "icons/components/Motor.svg",

--- a/icons/components/Breaker.svg
+++ b/icons/components/Breaker.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40">
+  <line x1="10" y1="20" x2="30" y2="20" stroke="black" />
+  <rect x="30" y="10" width="20" height="20" fill="none" stroke="black" />
+  <line x1="50" y1="20" x2="70" y2="20" stroke="black" />
+</svg>

--- a/icons/components/Utility.svg
+++ b/icons/components/Utility.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40">
+  <line x1="10" y1="20" x2="25" y2="20" stroke="black" />
+  <circle cx="40" cy="20" r="15" fill="none" stroke="black" />
+  <line x1="55" y1="20" x2="70" y2="20" stroke="black" />
+</svg>

--- a/oneline.css
+++ b/oneline.css
@@ -262,6 +262,16 @@
   align-items: center;
   gap: var(--ol-spacing);
 }
+.sheet-action-group .icon-button {
+  border: 1px solid var(--border-color);
+  background: var(--ol-card-bg);
+  color: var(--text-color);
+}
+
+.sheet-action-group .icon-button:hover,
+.sheet-action-group .icon-button:focus {
+  background: var(--ol-hover-bg);
+}
 
 .sheet-tabs {
   display: flex;
@@ -270,13 +280,15 @@
 
 .sheet-tab {
   padding: 0.25rem 0.5rem;
-  border: 1px solid var(--ol-border-color);
+  border: 1px solid var(--border-color);
   background: var(--ol-card-bg);
   cursor: pointer;
+  color: var(--text-color);
 }
 
 .sheet-tab.active {
-  background: var(--ol-hover-bg);
+  background: var(--primary-color);
+  color: var(--secondary-color);
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- Enable double-click to open component or cable properties directly
- Orient trailing arrows based on connection direction
- Add Breaker and Utility Source components and improve sheet tab contrast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c18da6faa483249cbf9f4a2a446d81