### PR TITLE
Improve one-line diagram interactions

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -102,6 +102,9 @@
     "ports": [{ "x": 0, "y": 20 }, { "x": 80, "y": 20 }],
     "schema": [
       { "name": "voltage", "label": "Voltage", "type": "number" },
+      { "name": "primary_voltage", "label": "Primary Voltage", "type": "number" },
+      { "name": "secondary_voltage", "label": "Secondary Voltage", "type": "number" },
+      { "name": "xr_ratio", "label": "X/R Ratio", "type": "number" },
       { "name": "rating", "label": "Rating", "type": "select", "options": ["45kVA", "75kVA", "112.5kVA", "150kVA", "225kVA", "300kVA"] },
       { "name": "breaker_frame", "label": "Breaker Frame", "type": "select", "options": ["250A", "400A", "600A", "800A", "1200A"] },
       { "name": "conductor_type", "label": "Conductor Type", "type": "select", "options": ["THHN", "XHHW", "RHW"] },


### PR DESCRIPTION
## Summary
- Fix routing so connection arrows orient vertically when targeting top or bottom ports
- Allow double-clicking components or cable labels to open edit dialogs
- Position context menu near the component that was right-clicked
- Add primary/secondary voltage and X/R ratio fields to transformer component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a6f284a483248c0220a4a33f0453