### PR TITLE
Improve one-line diagram component ports and property modal

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -48,7 +48,11 @@
           "primary": "solid",
           "secondary": "solid"
         }
-      }
+      },
+      "ports": [
+        { "x": 0, "y": 20 },
+        { "x": 80, "y": 20 }
+      ]
     },
     {
       "type": "transformer",
@@ -66,7 +70,12 @@
         "z_hv_tv_percent": 10.0,
         "z_lv_tv_percent": 12.0,
         "vector_group": "YNd1d11"
-      }
+      },
+      "ports": [
+        { "x": 0, "y": 20 },
+        { "x": 80, "y": 10 },
+        { "x": 80, "y": 30 }
+      ]
     },
     {
       "type": "transformer",
@@ -80,7 +89,11 @@
         "percent_z": 8.0,
         "xr_ratio": 10,
         "vector_group": "YNa0d1"
-      }
+      },
+      "ports": [
+        { "x": 0, "y": 20 },
+        { "x": 80, "y": 20 }
+      ]
     },
     {
       "type": "transformer",
@@ -94,7 +107,11 @@
         "percent_z": 6.0,
         "xr_ratio": 10,
         "vector_group": "Zn0"
-      }
+      },
+      "ports": [
+        { "x": 0, "y": 20 },
+        { "x": 80, "y": 20 }
+      ]
     },
     {
       "type": "breaker",

--- a/oneline.css
+++ b/oneline.css
@@ -375,6 +375,23 @@
   box-shadow: var(--ol-shadow);
   max-height: 90%;
   overflow: auto;
+  width: 80vw;
+  max-width: 800px;
+}
+
+.prop-modal form fieldset {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--ol-spacing);
+}
+
+.prop-modal form fieldset label {
+  display: flex;
+  flex-direction: column;
+}
+
+.prop-modal form fieldset legend {
+  grid-column: 1 / -1;
 }
 
 .prop-modal .modal-header {


### PR DESCRIPTION
## Summary
- ensure component library entries get default ports, including three-winding transformer
- replace voltage halo with colored overlays
- constrain property modal width and show fields in two columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1bef85f708324bd6939300d2bcf61