### PR TITLE
Allow decimal property inputs and update connection visuals

### DIFF
--- a/icons/equipment.svg
+++ b/icons/equipment.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
-  <circle cx="26" cy="20" r="8" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
-  <rect x="46" y="12" width="20" height="16" fill="#fff" stroke="#333" stroke-width="2"/>
+  <circle cx="26" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
+  <rect x="46" y="12" width="20" height="16" fill="none" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/load.svg
+++ b/icons/load.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <circle cx="40" cy="20" r="18" fill="#fff" stroke="#333" stroke-width="2"/>
+  <circle cx="40" cy="20" r="18" fill="none" stroke="#333" stroke-width="2"/>
   <polyline points="40 8 32 20 44 20 36 32" fill="none" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/panel.svg
+++ b/icons/panel.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="10" fill="#fff" stroke="#333" stroke-width="2"/>
+  <rect x="1" y="1" width="78" height="38" rx="10" fill="none" stroke="#333" stroke-width="2"/>
   <line x1="26" y1="10" x2="26" y2="30" stroke="#333" stroke-width="2"/>
   <line x1="40" y1="10" x2="40" y2="30" stroke="#333" stroke-width="2"/>
   <line x1="54" y1="10" x2="54" y2="30" stroke="#333" stroke-width="2"/>

--- a/icons/placeholder.svg
+++ b/icons/placeholder.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <rect x="1" y="1" width="78" height="38" rx="2" fill="none" stroke="#333" stroke-width="2"/>
   <line x1="10" y1="10" x2="70" y2="30" stroke="#333" stroke-width="2"/>
   <line x1="70" y1="10" x2="10" y2="30" stroke="#333" stroke-width="2"/>
 </svg>

--- a/oneline.html
+++ b/oneline.html
@@ -186,8 +186,8 @@
               <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
                 <path d="M20 0 L0 0 0 20" fill="none" stroke="#ccc" stroke-width="0.5" />
               </pattern>
-              <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto" markerUnits="strokeWidth">
-                <path d="M0,0 L10,5 L0,10 Z" fill="context-stroke" />
+              <marker id="connection-x" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto" markerUnits="strokeWidth">
+                <path d="M0,0 L10,10 M0,10 L10,0" fill="none" stroke="context-stroke" stroke-width="2" />
               </marker>
             </defs>
             <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />

--- a/oneline.js
+++ b/oneline.js
@@ -1260,7 +1260,7 @@ function render() {
       const stroke = phaseColor || vRange?.color || cableColors[conn.cable?.cable_type] || conn.cable?.color || '#000';
       poly.setAttribute('stroke', stroke);
       poly.setAttribute('fill', 'none');
-      poly.setAttribute('marker-end', 'url(#arrow)');
+      poly.setAttribute('marker-end', 'url(#connection-x)');
       poly.setAttribute('stroke-width', '2');
       poly.style.pointerEvents = 'stroke';
       poly.style.cursor = 'move';
@@ -1807,6 +1807,7 @@ function selectComponent(compOrId) {
     } else {
       input = document.createElement('input');
       input.type = f.type || 'text';
+      if (f.type === 'number') input.step = 'any';
       input.value = curVal;
     }
     input.name = f.name;
@@ -1957,7 +1958,9 @@ function selectComponent(compOrId) {
     };
     fields.forEach(f => {
       const v = fd.get(f.name);
-      data[f.name] = f.type === 'checkbox' ? v === 'on' : (v || '');
+      if (f.type === 'checkbox') data[f.name] = v === 'on';
+      else if (f.type === 'number') data[f.name] = v ? parseFloat(v) : '';
+      else data[f.name] = v || '';
     });
     data.tccId = fd.get('tccId') || '';
     templates.push({ name, component: data });
@@ -1995,7 +1998,9 @@ function selectComponent(compOrId) {
     const fd = new FormData(form);
     fields.forEach(f => {
       const v = fd.get(f.name);
-      comp[f.name] = f.type === 'checkbox' ? v === 'on' : (v || '');
+      if (f.type === 'checkbox') comp[f.name] = v === 'on';
+      else if (f.type === 'number') comp[f.name] = v ? parseFloat(v) : '';
+      else comp[f.name] = v || '';
     });
     comp.tccId = fd.get('tccId') || '';
     pushHistory();


### PR DESCRIPTION
## Summary
- permit decimal values in component property fields
- draw connections with X markers instead of arrowheads
- remove background boxes from component icons for ANSI/IEC styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ce086bf08324bd452d0ca7367f78