### PR TITLE
Improve oneline connectors and add text boxes

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -286,6 +286,16 @@
       }
     },
     {
+      "type": "annotation",
+      "subtype": "text_box",
+      "label": "Text Box",
+      "icon": "icons/components/TextBox.svg",
+      "props": {
+        "text": "Text"
+      },
+      "ports": []
+    },
+    {
       "type": "mcc",
       "label": "MCC",
       "icon": "icons/components/MCC.svg",

--- a/icons/Generator.svg
+++ b/icons/Generator.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <circle cx="40" cy="20" r="12" fill="none" stroke="#333" stroke-width="2"/>
   <path d="M28 20h24M40 8v24" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/Motor.svg
+++ b/icons/Motor.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <circle cx="40" cy="20" r="12" fill="#fff" stroke="#333" stroke-width="2"/>
   <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">M</text>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/PVArray.svg
+++ b/icons/PVArray.svg
@@ -1,8 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="15" y2="20" stroke="#333" stroke-width="2"/>
   <rect x="15" y="8" width="50" height="24" fill="none" stroke="#333" stroke-width="2"/>
   <line x1="30" y1="8" x2="30" y2="32" stroke="#333" stroke-width="1"/>
   <line x1="45" y1="8" x2="45" y2="32" stroke="#333" stroke-width="1"/>
   <line x1="15" y1="16" x2="65" y2="16" stroke="#333" stroke-width="1"/>
   <line x1="15" y1="24" x2="65" y2="24" stroke="#333" stroke-width="1"/>
+  <line x1="65" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/Switchgear.svg
+++ b/icons/Switchgear.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <rect x="20" y="10" width="40" height="20" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>
 

--- a/icons/TextBox.svg
+++ b/icons/TextBox.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="10" y="5" width="60" height="30" fill="none" stroke="#333" stroke-width="2"/>
+  <text x="40" y="25" font-size="20" text-anchor="middle" fill="#333">T</text>
+</svg>
+

--- a/icons/Transformer.svg
+++ b/icons/Transformer.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <circle cx="30" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
   <circle cx="50" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>
 

--- a/icons/UPS.svg
+++ b/icons/UPS.svg
@@ -1,7 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <rect x="20" y="10" width="40" height="20" fill="none" stroke="#333" stroke-width="2"/>
   <line x1="26" y1="20" x2="34" y2="20" stroke="#333" stroke-width="2"/>
   <line x1="30" y1="16" x2="30" y2="24" stroke="#333" stroke-width="2"/>
   <line x1="46" y1="20" x2="54" y2="20" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/components/Generator.svg
+++ b/icons/components/Generator.svg
@@ -1,5 +1,6 @@
 <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <circle cx="40" cy="20" r="12" fill="none" stroke="#333" stroke-width="2"/>
   <path d="M28 20h24M40 8v24" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/components/Motor.svg
+++ b/icons/components/Motor.svg
@@ -1,5 +1,6 @@
 <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <circle cx="40" cy="20" r="12" fill="#fff" stroke="#333" stroke-width="2"/>
   <text x="40" y="25" font-size="12" text-anchor="middle" fill="#333">M</text>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/components/PVArray.svg
+++ b/icons/components/PVArray.svg
@@ -1,8 +1,9 @@
 <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="15" y2="20" stroke="#333" stroke-width="2"/>
   <rect x="15" y="8" width="50" height="24" fill="none" stroke="#333" stroke-width="2"/>
   <line x1="30" y1="8" x2="30" y2="32" stroke="#333" stroke-width="1"/>
   <line x1="45" y1="8" x2="45" y2="32" stroke="#333" stroke-width="1"/>
   <line x1="15" y1="16" x2="65" y2="16" stroke="#333" stroke-width="1"/>
   <line x1="15" y1="24" x2="65" y2="24" stroke="#333" stroke-width="1"/>
+  <line x1="65" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/icons/components/Switchgear.svg
+++ b/icons/components/Switchgear.svg
@@ -1,5 +1,6 @@
 <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <rect x="20" y="10" width="40" height="20" fill="#e0e0e0" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>
 

--- a/icons/components/TextBox.svg
+++ b/icons/components/TextBox.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <rect x="10" y="5" width="60" height="30" fill="none" stroke="#333" stroke-width="2"/>
+  <text x="40" y="25" font-size="20" text-anchor="middle" fill="#333">T</text>
+</svg>
+

--- a/icons/components/Transformer.svg
+++ b/icons/components/Transformer.svg
@@ -1,6 +1,7 @@
 <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <circle cx="30" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
   <circle cx="50" cy="20" r="8" fill="none" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>
 

--- a/icons/components/UPS.svg
+++ b/icons/components/UPS.svg
@@ -1,7 +1,8 @@
 <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
-  <rect x="1" y="1" width="78" height="38" rx="2" fill="#fff" stroke="#333" stroke-width="2"/>
+  <line x1="0" y1="20" x2="20" y2="20" stroke="#333" stroke-width="2"/>
   <rect x="20" y="10" width="40" height="20" fill="none" stroke="#333" stroke-width="2"/>
   <line x1="26" y1="20" x2="34" y2="20" stroke="#333" stroke-width="2"/>
   <line x1="30" y1="16" x2="30" y2="24" stroke="#333" stroke-width="2"/>
   <line x1="46" y1="20" x2="54" y2="20" stroke="#333" stroke-width="2"/>
+  <line x1="60" y1="20" x2="80" y2="20" stroke="#333" stroke-width="2"/>
 </svg>

--- a/oneline.js
+++ b/oneline.js
@@ -1260,6 +1260,7 @@ function render() {
       const stroke = phaseColor || vRange?.color || cableColors[conn.cable?.cable_type] || conn.cable?.color || '#000';
       poly.setAttribute('stroke', stroke);
       poly.setAttribute('fill', 'none');
+      poly.setAttribute('marker-start', 'url(#connection-x)');
       poly.setAttribute('marker-end', 'url(#connection-x)');
       poly.setAttribute('stroke-width', '2');
       poly.style.pointerEvents = 'stroke';
@@ -1419,34 +1420,56 @@ function render() {
       g.appendChild(bg);
     }
     const meta = componentMeta[c.subtype] || {};
-    const iconHref = meta.icon || placeholderIcon;
-    const img = document.createElementNS(svgNS, 'image');
-    img.setAttribute('x', c.x);
-    img.setAttribute('y', c.y);
-    img.setAttribute('width', w);
-    img.setAttribute('height', h);
-    img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref);
-    if (isBusComponent(c)) img.setAttribute('preserveAspectRatio', 'none');
-    if (iconHref !== placeholderIcon) {
-      img.addEventListener('error', () => {
-        console.warn(`Missing icon for subtype ${c.subtype}`);
-        img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', placeholderIcon);
-      }, { once: true });
+    if (c.type === 'annotation') {
+      const rect = document.createElementNS(svgNS, 'rect');
+      rect.setAttribute('x', c.x);
+      rect.setAttribute('y', c.y);
+      rect.setAttribute('width', w);
+      rect.setAttribute('height', h);
+      rect.setAttribute('fill', '#fff');
+      rect.setAttribute('stroke', '#333');
+      g.appendChild(rect);
+      const txt = document.createElementNS(svgNS, 'text');
+      txt.setAttribute('x', c.x + w / 2);
+      txt.setAttribute('y', c.y + h / 2 + 5);
+      txt.setAttribute('text-anchor', 'middle');
+      txt.textContent = c.text || c.label || '';
+      txt.addEventListener('dblclick', e => {
+        e.stopPropagation();
+        selectComponent(c);
+      });
+      g.appendChild(txt);
+    } else {
+      const iconHref = meta.icon || placeholderIcon;
+      const img = document.createElementNS(svgNS, 'image');
+      img.setAttribute('x', c.x);
+      img.setAttribute('y', c.y);
+      img.setAttribute('width', w);
+      img.setAttribute('height', h);
+      img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconHref);
+      if (isBusComponent(c)) img.setAttribute('preserveAspectRatio', 'none');
+      if (iconHref !== placeholderIcon) {
+        img.addEventListener('error', () => {
+          console.warn(`Missing icon for subtype ${c.subtype}`);
+          img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', placeholderIcon);
+        }, { once: true });
+      }
+      img.addEventListener('dblclick', e => {
+        e.stopPropagation();
+        selectComponent(c);
+      });
+      g.appendChild(img);
+      const text = document.createElementNS(svgNS, 'text');
+      text.setAttribute('x', c.x + w / 2);
+      text.setAttribute('y', c.y + h + 15);
+      text.setAttribute('text-anchor', 'middle');
+      text.textContent = c.label || meta.label || c.subtype || c.type;
+      text.addEventListener('dblclick', e => {
+        e.stopPropagation();
+        selectComponent(c);
+      });
+      g.appendChild(text);
     }
-    img.addEventListener('dblclick', e => {
-      e.stopPropagation();
-      selectComponent(c);
-    });
-    g.appendChild(img);
-    const text = document.createElementNS(svgNS, 'text');
-    text.setAttribute('x', c.x + w / 2);
-    text.setAttribute('y', c.y + h + 15);
-    text.setAttribute('text-anchor', 'middle');
-    text.textContent = c.label || meta.label || c.subtype || c.type;
-    text.addEventListener('dblclick', e => {
-      e.stopPropagation();
-      selectComponent(c);
-    });
     if (selection.includes(c)) {
       const rect = document.createElementNS(svgNS, 'rect');
       rect.setAttribute('x', c.x - 2);
@@ -1459,7 +1482,6 @@ function render() {
       rect.style.pointerEvents = 'none';
       g.appendChild(rect);
     }
-    g.appendChild(text);
     svg.appendChild(g);
     if (isBusComponent(c) && selection.includes(c)) {
       const handleRight = document.createElementNS(svgNS, 'rect');


### PR DESCRIPTION
## Summary
- show X markers on both ends of oneline connections
- replace boxy component icons with lead wires
- support draggable text boxes on one-line diagrams

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d268be088324997ac81b37f5cf03