### PR TITLE
fix: restore row addition on cable schedule

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
+  <script type="module" src="tableUtils.mjs" defer></script>
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="cableschedule.js" defer></script>
 </head>


### PR DESCRIPTION
## Summary
- ensure TableUtils is loaded on Cable Schedule page so Add Cable button works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c207b08bac832483bf08861618f47d