### PR TITLE
Load site helpers on cable schedule page

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
+  <script type="module" src="site.js" defer></script>
   <script type="module" src="tableUtils.mjs" defer></script>
   <script type="module" src="dataStore.mjs" defer></script>
   <script type="module" src="cableschedule.js" defer></script>


### PR DESCRIPTION
## Summary
- Load `site.js` on the cable schedule page so UI helpers and event handlers initialize

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c20975b7248324ab432105cb385373