### PR TITLE
Sync cable schedule with data store updates

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -315,6 +315,15 @@ window.addEventListener('DOMContentLoaded', () => {
   validateAllRows();
   vdLimitIn.addEventListener('input', applySizingHighlight);
 
+  // Update the table whenever cables are modified elsewhere (e.g. One-Line).
+  dataStore.on(dataStore.STORAGE_KEYS.cables, cables => {
+    table.setData(cables || []);
+    tableData = cables || [];
+    applySizingHighlight();
+    validateAllRows();
+    markSaved();
+  });
+
   document.getElementById('load-sample-cables-btn').addEventListener('click', async () => {
     try {
       const res = await fetch('examples/sampleCables.json');


### PR DESCRIPTION
## Summary
- Refresh cable schedule when the underlying data store changes
- Keep manual add cable button functional and mark schedule saved after external updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c20ccba9688324b4da6eb5254683b4