### PR TITLE
Fix TableUtils reference for cable schedule

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -54,6 +54,7 @@ const { sizeToArea } = ampacity;
 
 window.addEventListener('DOMContentLoaded', () => {
   forceShowResumeIfE2E();
+  const TableUtils = window.TableUtils;
   const projectId = window.currentProjectId || 'default';
   dataStore.loadProject(projectId);
   initSettings();


### PR DESCRIPTION
## Summary
- Ensure Cable Schedule page accesses TableUtils via the global window object so buttons can add rows.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c20ea4a8c88324a54efda935f3e02e