### PR TITLE
fix: load sample cables without fetch

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -327,8 +327,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('load-sample-cables-btn').addEventListener('click', async () => {
     try {
-      const res = await fetch('examples/sampleCables.json');
-      const sampleCables = await res.json();
+      const mod = await import('./examples/sampleCables.json', { assert: { type: 'json' } });
+      const sampleCables = mod.default;
       table.setData(sampleCables); // immediately display the sample rows
       tableData = sampleCables;
       table.save();


### PR DESCRIPTION
## Summary
- load cable schedule sample data via module import instead of fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c211b3fe448324ac448c6278d61e09