### PR TITLE
fix: import table utils in cable schedule

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -44,6 +44,7 @@ window.E2E = E2E;
 import * as dataStore from './dataStore.mjs';
 import { sizeConductor } from './sizing.js';
 import ampacity from './ampacity.mjs?v=2';
+import { createTable, STORAGE_KEYS } from './tableUtils.mjs';
 const { sizeToArea } = ampacity;
 
 // Initialize Cable Schedule page logic
@@ -54,7 +55,6 @@ const { sizeToArea } = ampacity;
 
 window.addEventListener('DOMContentLoaded', () => {
   forceShowResumeIfE2E();
-  const TableUtils = window.TableUtils;
   const projectId = window.currentProjectId || 'default';
   dataStore.loadProject(projectId);
   initSettings();
@@ -246,9 +246,9 @@ window.addEventListener('DOMContentLoaded', () => {
     return allValid;
   }
 
-  const table = TableUtils.createTable({
+  const table = createTable({
     tableId:'cableScheduleTable',
-    storageKey:TableUtils.STORAGE_KEYS.cableSchedule,
+    storageKey:STORAGE_KEYS.cableSchedule,
     addRowBtnId:'add-row-btn',
     saveBtnId:'save-schedule-btn',
     loadBtnId:'load-schedule-btn',

--- a/tableUtils.mjs
+++ b/tableUtils.mjs
@@ -1089,3 +1089,11 @@ window.TableUtils = {
   showRacewayModal: TableManager.prototype.showRacewayModal,
   STORAGE_KEYS
 };
+
+export {
+  createTable,
+  saveToStorage,
+  loadFromStorage,
+  applyValidation,
+  STORAGE_KEYS
+};


### PR DESCRIPTION
## Summary
- import TableUtils helpers directly in cable schedule module
- export table utilities for module-based imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2141d6ac48324845f8beb8e9f7b97