### PR TITLE
Add on-page console readout for Cable Schedule debugging

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -95,6 +95,7 @@
         <a href="loadlist.html">Load List</a>
         <a href="panelschedule.html">Next</a>
       </nav>
+      <pre id="console-log" class="console-log" aria-live="polite"></pre>
     </main>
   </div>
   <div id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="help-title">

--- a/cableschedule.js
+++ b/cableschedule.js
@@ -54,6 +54,26 @@ const { sizeToArea } = ampacity;
 // behaviour needed to populate the schedule table.
 
 window.addEventListener('DOMContentLoaded', () => {
+  const logContainer = document.getElementById('console-log');
+  if (logContainer) {
+    ['log', 'warn', 'error'].forEach(level => {
+      const orig = console[level];
+      console[level] = (...args) => {
+        orig.apply(console, args);
+        const msg = args.map(a => {
+          try {
+            return typeof a === 'object' ? JSON.stringify(a) : String(a);
+          } catch {
+            return String(a);
+          }
+        }).join(' ');
+        const line = document.createElement('div');
+        line.textContent = `[${level}] ${msg}`;
+        logContainer.appendChild(line);
+        logContainer.scrollTop = logContainer.scrollHeight;
+      };
+    });
+  }
   console.log('Cable Schedule DOMContentLoaded event fired');
   forceShowResumeIfE2E();
   const projectId = window.currentProjectId || 'default';

--- a/style.css
+++ b/style.css
@@ -2022,3 +2022,15 @@ body.dark-mode .workflow-card-title {
     background: var(--primary-color);
     color: #fff;
 }
+
+/* Debug console output */
+.console-log {
+    background: #000;
+    color: #0f0;
+    padding: 0.5rem;
+    max-height: 200px;
+    overflow-y: auto;
+    font-family: monospace;
+    font-size: 0.8rem;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- Show console messages on Cable Schedule page to help diagnose schedule issues
- Style new debug log area for readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c21871cd308324a9acf102626f9902