### PR TITLE
fix: enable e2e resume suppression on cable schedule

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -47,6 +47,9 @@ import ampacity from './ampacity.mjs?v=2';
 import { createTable, STORAGE_KEYS } from './tableUtils.mjs';
 const { sizeToArea } = ampacity;
 
+suppressResumeIfE2E();
+document.addEventListener('DOMContentLoaded', forceShowResumeIfE2E);
+
 // Initialize Cable Schedule page logic
 // This file mirrors the inline script previously embedded in
 // cableschedule.html.  It now lives in its own module so that the Rollup
@@ -75,7 +78,6 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
   console.log('Cable Schedule DOMContentLoaded event fired');
-  forceShowResumeIfE2E();
   const projectId = window.currentProjectId || 'default';
   dataStore.loadProject(projectId);
   console.log('Loaded project', projectId);


### PR DESCRIPTION
## Summary
- prevent automatic resume logic from interfering with Cable Schedule in E2E mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c219d5518c832496c9c3770929a15d