### PR TITLE
Load full cable schedule script

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
-  <script src="./dist/cableschedule.js" type="module" defer></script>
+  <script src="./cableschedule.js" type="module" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Use the full `cableschedule.js` instead of the simplified `dist` build so all columns render in the Cable Schedule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c21e7d97c08324a8e35cdc1581e9bf