### PR TITLE
fix cable schedule missing table

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -41,6 +41,7 @@ function forceShowResumeIfE2E() {
 
 window.E2E = E2E;
 
+import './site.js';
 import * as dataStore from './dataStore.mjs';
 import { sizeConductor } from './sizing.js';
 import ampacity from './ampacity.mjs?v=2';


### PR DESCRIPTION
## Summary
- ensure cable schedule page imports shared site utilities so init functions are available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c1086b64832482cf0cd286ea9fb6