### PR TITLE
Fix Cable Schedule sample data loading

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -444,16 +444,24 @@
     // Feed explorer (shows ALL data without touching table)
     explorer.load(sample, props);
 
-    // Try to populate any existing schedule table NON-destructively
-    const table = findExistingTable();
-    if (table && Array.isArray(sample)) {
-      const appended = populateExistingTable(table, sample);
-      console.info(`[CableDataViewer] appended ${appended} row(s) to existing table.`);
-    } else if (table && sample && Array.isArray(sample.rows)) {
-      const appended = populateExistingTable(table, sample.rows);
-      console.info(`[CableDataViewer] appended ${appended} row(s) from sample.rows.`);
-    } else {
-      console.info("[CableDataViewer] No compatible table found or sample format not array. Table untouched.");
+    function populateTable() {
+      const table = findExistingTable();
+      if (table && Array.isArray(sample)) {
+        const appended = populateExistingTable(table, sample);
+        console.info(`[CableDataViewer] appended ${appended} row(s) to existing table.`);
+        return appended;
+      } else if (table && sample && Array.isArray(sample.rows)) {
+        const appended = populateExistingTable(table, sample.rows);
+        console.info(`[CableDataViewer] appended ${appended} row(s) from sample.rows.`);
+        return appended;
+      } else {
+        console.info("[CableDataViewer] No compatible table found or sample format not array. Table untouched.");
+        return 0;
+      }
+    }
+
+    if (!populateTable()) {
+      window.addEventListener('cableschedule-ready', populateTable, { once: true });
     }
 
     // Open the explorer automatically on first load so you can see everything

--- a/cableschedule.js
+++ b/cableschedule.js
@@ -397,8 +397,8 @@ window.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('load-sample-cables-btn').addEventListener('click', async () => {
     console.log('load-sample-cables-btn clicked');
     try {
-      const mod = await import('./examples/sampleCables.json', { assert: { type: 'json' } });
-      const sampleCables = mod.default;
+      const res = await fetch('./examples/sampleCables.json', { cache: 'no-store' });
+      const sampleCables = await res.json();
       table.setData(sampleCables); // immediately display the sample rows
       tableData = sampleCables;
       table.save();
@@ -423,5 +423,6 @@ window.addEventListener('DOMContentLoaded', async () => {
     return table.getData();
   }
   window.getCableSchedule = getCableSchedule;
+  window.dispatchEvent(new Event('cableschedule-ready'));
   window.__CableScheduleInitOK = true;
 });


### PR DESCRIPTION
## Summary
- Use `fetch` to load sample cable data for broader browser support
- Dispatch `cableschedule-ready` event once schedule table initializes
- Data Explorer repopulates the schedule table when the table is ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c314f0aa248324a32d8fcc7b1ff8b0