### PR TITLE
fix: use bundled cable schedule script

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
-  <script src="./cableschedule.js" type="module" defer></script>
+  <script src="dist/cableschedule.js" type="module" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- load the bundled `dist/cableschedule.js` in `cableschedule.html` so GitHub Pages uses the deployed script

## Testing
- `npm run build` *(fails: Invalid value "iife" for option "output.format")*
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Chromium distribution 'msedge' is not found)*
- custom node script to load `dist/cableschedule.js` and verify `window.__CableScheduleInitOK` and blank row rendering

------
https://chatgpt.com/codex/tasks/task_e_68c348bea9dc83249ef6c58d6e83101c