### PR TITLE
Fix missing button warnings on cable schedule

### DIFF
--- a/dist/cableschedule.js
+++ b/dist/cableschedule.js
@@ -4,17 +4,17 @@
   document.addEventListener('DOMContentLoaded', init);
 
   function init() {
-    bind('#btnSave', onSave);
-    bind('#btnLoad', onLoad);
-    bind('#btnLoadSample', onLoadSample);
-    bind('#btnClearFilters', onClearFilters);
-    bind('#btnExportXlsx', onExportXlsx);
-    bind('#btnImportXlsx', onImportXlsx);
-    bind('#btnDeleteAll', onDeleteAll);
-    bind('#btnAddCable', onAddCable);
+    bind('#save-schedule-btn', onSave);
+    bind('#load-schedule-btn', onLoad);
+    bind('#load-sample-cables-btn', onLoadSample);
+    bind('#clear-filters-btn', onClearFilters);
+    bind('#export-xlsx-btn', onExportXlsx);
+    bind('#import-xlsx-btn', onImportXlsx);
+    bind('#delete-all-btn', onDeleteAll);
+    bind('#add-row-btn', onAddCable);
     if (!window.XLSX) {
-      disable('#btnExportXlsx');
-      disable('#btnImportXlsx');
+      disable('#export-xlsx-btn');
+      disable('#import-xlsx-btn');
     }
     render();
     window.__CableScheduleInitOK = true;


### PR DESCRIPTION
## Summary
- align Cable Schedule JS button selectors with HTML IDs
- avoid console warnings about missing elements when page loads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c40df4d0a08324b43f7b03f3f4d718