### PR TITLE
Load cable schedule module directly

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
-  <script src="dist/cableschedule.js" type="module" defer></script>
+  <script src="cableschedule.js" type="module" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Reference the source module in `cableschedule.html` so the page uses the latest cable schedule logic and displays all expected columns.

## Testing
- `npm test`
- `npm run build` *(fails: Invalid value "iife" for option "output.format" - UMD and IIFE output formats are not supported for code-splitting builds)*

------
https://chatgpt.com/codex/tasks/task_e_68c417a05fd08324845452a33818d7af