### PR TITLE
Use bundled cable schedule script

### DIFF
--- a/cableschedule.html
+++ b/cableschedule.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" defer></script>
-  <script src="cableschedule.js" type="module" defer></script>
+  <script src="dist/cableschedule.js" defer></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Point Cable Schedule page to bundled `dist/cableschedule.js` instead of module script
- Confirm the built script exists in the repository for GitHub Pages

## Testing
- `npm run build` *(fails: RollupError: Invalid value "iife" for option "output.format" - UMD and IIFE output formats are not supported for code-splitting builds)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c42e087f14832482903516f935ac47