### PR TITLE
fix ampacity imports and add bundle check

### DIFF
--- a/.github/workflows/cableschedule-build.yml
+++ b/.github/workflows/cableschedule-build.yml
@@ -1,0 +1,33 @@
+name: cableschedule bundle check
+
+on:
+  push:
+    paths:
+      - 'cableschedule.js'
+      - 'sizing.js'
+      - 'src/voltageDrop.js'
+      - 'rollup.config.js'
+      - 'dist/cableschedule.js'
+  pull_request:
+    paths:
+      - 'cableschedule.js'
+      - 'sizing.js'
+      - 'src/voltageDrop.js'
+      - 'rollup.config.js'
+      - 'dist/cableschedule.js'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - name: Rebuild cableschedule bundle
+        run: npx rollup src/cableschedule.js --file dist/cableschedule.js --format es --inlineDynamicImports -p @rollup/plugin-terser
+      - name: Ensure bundle up to date
+        run: |
+          git status --short
+          test -z "$(git status --short)"

--- a/cableschedule.js
+++ b/cableschedule.js
@@ -44,7 +44,7 @@ window.E2E = E2E;
 import './site.js';
 import * as dataStore from './dataStore.mjs';
 import { sizeConductor } from './sizing.js';
-import ampacity from './ampacity.mjs?v=2';
+import ampacity from './ampacity.mjs';
 import { createTable, STORAGE_KEYS } from './tableUtils.mjs';
 const { sizeToArea } = ampacity;
 

--- a/sizing.js
+++ b/sizing.js
@@ -1,4 +1,4 @@
-import ampacity from './ampacity.mjs?v=2';
+import ampacity from './ampacity.mjs';
 import { calculateVoltageDrop } from './src/voltageDrop.js';
 import nec from './codes/necTables.js';
 import iec from './codes/iecTables.js';

--- a/src/voltageDrop.js
+++ b/src/voltageDrop.js
@@ -1,4 +1,4 @@
-import ampacity from "../ampacity.mjs?v=2";
+import ampacity from "../ampacity.mjs";
 
 export function calculateVoltageDrop(cable = {}, length = 0, phase = 3) {
   const { dcResistance } = ampacity;


### PR DESCRIPTION
## Summary
- fix ampacity imports without query strings to support bundling
- add GitHub Action to ensure `dist/cableschedule.js` is kept in sync

## Testing
- `npx rollup src/cableschedule.js --file dist/cableschedule.js --format es --inlineDynamicImports -p @rollup/plugin-terser`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c42eed9090832498aa6a34a526d8ef