### PR TITLE
Fix dirty tracker auto-save toggle behavior

### DIFF
--- a/dirtyTracker.js
+++ b/dirtyTracker.js
@@ -2,20 +2,24 @@ function createDirtyTracker(win = (typeof window !== 'undefined' ? window : unde
   if (!win) throw new Error('Window object required');
   let dirty = false;
   const message = 'Project is auto-saved; you can safely leave.';
+
+  const shouldPrompt = () => dirty && !Boolean(win.autoSaveEnabled);
   const handler = e => {
+    if (!shouldPrompt()) return;
     e.preventDefault();
     e.returnValue = message;
   };
   const update = () => {
-    if (dirty && !win.autoSaveEnabled) {
+    if (dirty) {
       win.addEventListener('beforeunload', handler);
     } else {
       win.removeEventListener('beforeunload', handler);
     }
   };
+
   return {
-    markDirty() { if (!dirty) { dirty = true; update(); } },
-    markClean() { if (dirty) { dirty = false; update(); } },
+    markDirty() { dirty = true; update(); },
+    markClean() { dirty = false; update(); },
     isDirty() { return dirty; }
   };
 }

--- a/tests/dirtyTracker.test.js
+++ b/tests/dirtyTracker.test.js
@@ -72,4 +72,20 @@ describe("dirty state tracker", () => {
     const e = win.fire();
     assert.strictEqual(e.defaultPrevented, false);
   });
+
+  it("toggle auto-save while dirty adjusts prompt", () => {
+    const win = makeWindow();
+    const tracker = createDirtyTracker(win);
+    tracker.markDirty();
+    let e = win.fire();
+    assert.strictEqual(e.defaultPrevented, true);
+
+    win.autoSaveEnabled = true;
+    e = win.fire();
+    assert.strictEqual(e.defaultPrevented, false);
+
+    win.autoSaveEnabled = false;
+    e = win.fire();
+    assert.strictEqual(e.defaultPrevented, true);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure the dirty tracker reuses the beforeunload handler but only prompts when auto-save is disabled at the time of navigation
- add a regression test that toggles auto-save on and off while the tracker is dirty

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb804736c083248737490fcb4df903