### PR TITLE
Adjust DC panel polarity handling

### DIFF
--- a/style.css
+++ b/style.css
@@ -2894,6 +2894,14 @@ body.dark-mode .panel-device {
     box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.15);
 }
 
+.panel-device--dc-positive .panel-device-handle {
+    background: #c62828;
+}
+
+.panel-device--dc-negative .panel-device-handle {
+    background: #000;
+}
+
 .panel-device--fuse .panel-device-handle {
     width: 0.75rem;
     height: 0.75rem;
@@ -3084,6 +3092,14 @@ body.dark-mode .panel-slot-add-btn {
     letter-spacing: 0.05em;
     text-transform: uppercase;
     opacity: 0.75;
+}
+
+.panel-slot-phase--positive {
+    color: #c62828;
+}
+
+.panel-slot-phase--negative {
+    color: #000;
 }
 
 .panel-slot-control {


### PR DESCRIPTION
## Summary
- keep DC circuit pairs on the same polarity and expose polarity classes for styling in the schedule grid
- color DC breaker icons by polarity and store the polarity on rendered devices
- restrict DC branch breaker choices to 1- and 2-pole options across the toolbox, quick add buttons, and configuration

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d173a4fae88324b35b761ee0e41e0b