### PR TITLE
Add cable components to one-line editor

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -170,6 +170,13 @@
                   </details>
                 </div>
                 <div class="palette-card card">
+                  <h3>Cable</h3>
+                  <details id="cable-section" class="palette-section">
+                    <summary><img src="./icons/oneline.svg" alt="" class="summary-icon"> Cable</summary>
+                    <div id="cable-buttons" class="section-buttons"></div>
+                  </details>
+                </div>
+                <div class="palette-card card">
                   <h3>Templates</h3>
                   <details id="template-section" class="palette-section">
                     <summary><img src="./icons/oneline.svg" alt="" class="summary-icon"> Templates</summary>
@@ -201,8 +208,8 @@
               <li data-action="duplicate" data-context="component">Duplicate</li>
               <li data-action="rotate" data-context="component">Rotate</li>
               <li data-action="delete" data-context="component">Delete</li>
-              <li data-action="edit" data-context="connection">Edit Cable</li>
-              <li data-action="delete" data-context="connection">Delete Cable</li>
+              <li data-action="edit" data-context="connection">Edit Connection</li>
+              <li data-action="delete" data-context="connection">Delete Connection</li>
               <li data-action="paste" data-context="canvas">Paste</li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- add a cable category and metadata so cables appear in the palette as placeable components
- route connection styling and editing through the associated cable component, including a cable-specific properties modal
- derive cable schedule data from cable components while still honoring legacy connection-based entries

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1acadd7dc8324af99d4eff4d49296