### PR TITLE
Improve one-line editor connections and protection palette

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["bus", "equipment", "load", "sources", "links", "annotations", "cable"],
+  "categories": ["bus", "equipment", "protection", "load", "sources", "links", "annotations", "cable"],
   "components": [
     {
       "type": "bus",

--- a/dist/componentLibrary.json
+++ b/dist/componentLibrary.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["bus", "equipment", "load", "sources", "links", "annotations", "cable"],
+  "categories": ["bus", "equipment", "protection", "load", "sources", "links", "annotations", "cable"],
   "components": [
     {
       "type": "bus",

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["bus", "equipment", "load", "sources", "links", "annotations", "cable"],
+  "categories": ["bus", "equipment", "protection", "load", "sources", "links", "annotations", "cable"],
   "components": [
     {
       "type": "bus",

--- a/oneline.html
+++ b/oneline.html
@@ -149,6 +149,13 @@
                   </details>
                 </div>
                 <div class="palette-card card">
+                  <h3>Protection</h3>
+                  <details id="protection-section" class="palette-section">
+                    <summary><img src="./icons/components/Breaker.svg" alt="" class="summary-icon"> Protection</summary>
+                    <div id="protection-buttons" class="section-buttons"></div>
+                  </details>
+                </div>
+                <div class="palette-card card">
                   <h3>Bus</h3>
                   <details id="bus-section" class="palette-section">
                     <summary><img src="./icons/Bus.svg" alt="" class="summary-icon"> Bus</summary>


### PR DESCRIPTION
## Summary
- add a protection category in the library and palette so breakers and similar devices are grouped together
- limit each port to a single connection, add cable lead stubs, and keep bus connections stable when resizing
- ensure property dialogs open on double click and skip connection validation for annotations

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2a0bd13d483249a19b504e3773712