### PR TITLE
Refresh login layout to match site design

### DIFF
--- a/login.html
+++ b/login.html
@@ -3,30 +3,77 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Login</title>
+  <meta name="description" content="Secure access to CableTrayRoute for managing cable routing workflows.">
+  <title>CableTrayRoute Login</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <main class="container">
-    <h1>Login or Sign Up</h1>
-    <section class="card">
-      <form id="signup-form">
-        <h2>Sign Up</h2>
-        <input id="signup-user" placeholder="Username" required>
-        <input id="signup-pass" type="password" placeholder="Password" required>
-        <button type="submit">Sign Up</button>
-      </form>
-    </section>
-    <section class="card">
-      <form id="login-form">
-        <h2>Log In</h2>
-        <input id="login-user" placeholder="Username" required>
-        <input id="login-pass" type="password" placeholder="Password" required>
-        <button type="submit">Log In</button>
-      </form>
+<body class="auth-page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header class="auth-top-bar">
+    <a href="index.html" class="auth-brand">
+      <img src="icons/route.svg" alt="" class="auth-brand-icon" aria-hidden="true">
+      <span>CableTrayRoute</span>
+    </a>
+    <nav class="auth-top-links" aria-label="Primary">
+      <a href="help.html">Help</a>
+      <a href="docs/index.html">Docs</a>
+      <a href="README.md">Overview</a>
+    </nav>
+  </header>
+  <main id="main-content" class="auth-main">
+    <section class="auth-card" aria-labelledby="auth-title">
+      <header class="auth-header">
+        <h1 id="auth-title">Access CableTrayRoute</h1>
+        <p class="auth-subtitle">Sign in to continue your electrical design workflow or create an account to launch a new project.</p>
+      </header>
+      <div class="auth-panels">
+        <section class="auth-pane" aria-labelledby="signup-title">
+          <h2 id="signup-title">Create an account</h2>
+          <p class="auth-description">Set up credentials to keep cable schedules, tray fill analyses, and routing studies in sync across the suite.</p>
+          <form id="signup-form" class="auth-form">
+            <div class="auth-field">
+              <label for="signup-user">Username</label>
+              <input id="signup-user" name="signup-user" type="text" autocomplete="username" placeholder="Username" required>
+            </div>
+            <div class="auth-field">
+              <label for="signup-pass">Password</label>
+              <input id="signup-pass" name="signup-pass" type="password" autocomplete="new-password" placeholder="Password" required>
+            </div>
+            <button type="submit" class="primary-btn">Sign Up</button>
+          </form>
+        </section>
+        <section class="auth-pane" aria-labelledby="login-title">
+          <h2 id="login-title">Sign in</h2>
+          <p class="auth-description">Return to your saved workspaces and continue coordinating load lists, one-line diagrams, and routes.</p>
+          <form id="login-form" class="auth-form">
+            <div class="auth-field">
+              <label for="login-user">Username</label>
+              <input id="login-user" name="login-user" type="text" autocomplete="username" placeholder="Username" required>
+            </div>
+            <div class="auth-field">
+              <label for="login-pass">Password</label>
+              <input id="login-pass" name="login-pass" type="password" autocomplete="current-password" placeholder="Password" required>
+            </div>
+            <button type="submit" class="primary-btn">Log In</button>
+          </form>
+        </section>
+      </div>
+      <p class="auth-note">Need a refresher first? Review the <a href="docs/quickstart.html">Quick Start</a> guide or explore the <a href="help.html">help center</a>.</p>
     </section>
   </main>
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="icons/route.svg" alt="CableTrayRoute logo" class="footer-logo">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links" aria-label="Footer">
+      <a href="README.md">README</a>
+      <a href="docs/quickstart.html">Quick Start</a>
+      <a href="docs/index.html">Docs</a>
+      <a href="mailto:contact@example.com">Contact</a>
+    </nav>
+  </footer>
   <script type="module" src="auth.js"></script>
 </body>
 </html>
-

--- a/style.css
+++ b/style.css
@@ -789,6 +789,262 @@ body.compact-mode td {
     }
 }
 
+/* --- Auth Layout --- */
+body.auth-page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--secondary-color);
+    background-image: linear-gradient(160deg, rgba(13, 110, 253, 0.12), rgba(13, 110, 253, 0));
+}
+
+body.dark-mode.auth-page {
+    background-color: #212529;
+    background-image: linear-gradient(160deg, rgba(23, 162, 184, 0.25), rgba(33, 37, 41, 0.9));
+}
+
+.auth-top-bar {
+    background: rgba(255, 255, 255, 0.85);
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.5rem;
+    gap: 1rem;
+    backdrop-filter: blur(12px);
+}
+
+body.dark-mode .auth-top-bar {
+    background: rgba(52, 58, 64, 0.8);
+}
+
+.auth-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 1.1rem;
+    text-decoration: none;
+    color: var(--text-color);
+}
+
+.auth-brand-icon {
+    width: 28px;
+    height: 28px;
+}
+
+.auth-top-links {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.auth-top-links a {
+    color: var(--text-color);
+    font-weight: 500;
+    text-decoration: none;
+}
+
+.auth-top-links a:hover,
+.auth-top-links a:focus-visible {
+    text-decoration: underline;
+}
+
+.auth-main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1rem;
+}
+
+.auth-card {
+    width: min(960px, 100%);
+    padding: 2.5rem 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(13, 110, 253, 0.08);
+    border-radius: 16px;
+    box-shadow: 0 32px 60px -45px rgba(13, 110, 253, 0.7);
+    backdrop-filter: blur(10px);
+}
+
+body.dark-mode .auth-card {
+    background: rgba(33, 37, 41, 0.9);
+    border-color: rgba(23, 162, 184, 0.25);
+    box-shadow: 0 32px 60px -45px rgba(23, 162, 184, 0.45);
+}
+
+.auth-header {
+    text-align: center;
+    margin: 0 auto;
+    max-width: 620px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.auth-header h1 {
+    margin-bottom: 0;
+}
+
+.auth-subtitle {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: rgba(33, 37, 41, 0.75);
+}
+
+body.dark-mode .auth-subtitle {
+    color: rgba(248, 249, 250, 0.75);
+}
+
+.auth-panels {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.auth-pane {
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.85));
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    box-shadow: 0 24px 40px -30px rgba(13, 110, 253, 0.25);
+}
+
+body.dark-mode .auth-pane {
+    background: linear-gradient(160deg, rgba(33, 37, 41, 0.95), rgba(33, 37, 41, 0.85));
+    box-shadow: 0 24px 40px -30px rgba(23, 162, 184, 0.25);
+}
+
+.auth-pane h2 {
+    margin-bottom: 0.25rem;
+}
+
+.auth-description {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: rgba(33, 37, 41, 0.7);
+}
+
+body.dark-mode .auth-description {
+    color: rgba(248, 249, 250, 0.75);
+}
+
+.auth-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 0.5rem;
+}
+
+.auth-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.auth-form label {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--text-color);
+}
+
+.auth-form input {
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0.75rem 0.85rem;
+    font-size: 1rem;
+    background: rgba(255, 255, 255, 0.95);
+    color: var(--text-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.dark-mode .auth-form input {
+    background: rgba(33, 37, 41, 0.85);
+    border-color: rgba(23, 162, 184, 0.35);
+}
+
+.auth-form input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.25);
+}
+
+body.dark-mode .auth-form input:focus {
+    box-shadow: 0 0 0 3px rgba(23, 162, 184, 0.35);
+}
+
+.auth-form .primary-btn {
+    width: 100%;
+    margin-top: 0.5rem;
+    font-weight: 600;
+}
+
+.auth-note {
+    margin: 0;
+    font-size: 0.95rem;
+    text-align: center;
+    color: rgba(33, 37, 41, 0.7);
+}
+
+body.dark-mode .auth-note {
+    color: rgba(248, 249, 250, 0.75);
+}
+
+.auth-note a {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.auth-note a:hover,
+.auth-note a:focus-visible {
+    text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+    .auth-card {
+        padding: 2rem;
+    }
+}
+
+@media (max-width: 700px) {
+    .auth-top-bar {
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 1rem;
+    }
+    .auth-top-links {
+        width: 100%;
+        justify-content: space-between;
+    }
+    .auth-main {
+        padding: 2rem 1rem;
+    }
+    .auth-panels {
+        gap: 1.5rem;
+    }
+}
+
+@media (max-width: 500px) {
+    .auth-top-links {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+    .auth-card {
+        padding: 1.75rem 1.25rem;
+    }
+}
+
 .sidebar-toggle {
     display: none;
 }


### PR DESCRIPTION
## Summary
- rebuild the login page with site branding, accessible copy, and structured sign-up/login panels
- add dedicated auth-page styling for responsive layout, form controls, and dark mode support

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b093344083248770826d703a64d6