### PR TITLE
Fix optimal route init timing

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -151,7 +151,7 @@ const SHAPE_COLORS = {
     'SPIRAL': '#17becf'
 };
 
-document.addEventListener('DOMContentLoaded', async () => {
+async function initializeApp() {
     initSettings();
     initDarkMode();
     if (typeof initCompactMode === 'function') {
@@ -4138,4 +4138,12 @@ Plotly.newPlot(document.getElementById('plot'), data, layout, {responsive: true}
     if(new URLSearchParams(location.search).get('selfcheck')==='1'){
         runSelfCheck();
     }
-});
+}
+
+const startApp = () => initializeApp().catch(err => console.error('App initialization failed', err));
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startApp, { once: true });
+} else {
+    startApp();
+}


### PR DESCRIPTION
## Summary
- ensure the optimal route UI initializes even when the DOM is already loaded so manual tray/cable actions and the settings menu respond again

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2c68d275c8324aed98dc8ceaf8910