### PR TITLE
Add File System Access export support

### DIFF
--- a/help.html
+++ b/help.html
@@ -63,6 +63,11 @@
       </ul>
     </section>
     <section>
+      <h2>Saving Projects</h2>
+      <p>Click <strong>Export Project</strong> the first time you want to save. In supported browsers a file picker opens so you can choose a destination and grant CableTrayRoute permission to write to that file. This access only needs to be granted once per project.</p>
+      <p>After a file is linked, use the adjacent <strong>Save</strong> button to write your latest changes without another prompt. Browsers that do not support direct saves continue to download the JSON export instead.</p>
+    </section>
+    <section>
       <h2>Video Walkthroughs</h2>
       <ul>
         <li><a href="https://example.com/videos/tray-workflow" target="_blank" rel="noopener">Tray workflow overview</a></li>


### PR DESCRIPTION
## Summary
- add support for saving exports via the File System Access API with a reusable handle and quick-save button
- document the new save flow in the help page so users know about the one-time permission prompt

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2e42f40488324b80a0823598de8e7