### PR TITLE
Refactor saved project storage to single blob

### DIFF
--- a/help.html
+++ b/help.html
@@ -64,8 +64,9 @@
     </section>
     <section>
       <h2>Saving Projects</h2>
-      <p>Click <strong>Export Project</strong> the first time you want to save. In supported browsers a file picker opens so you can choose a destination and grant CableTrayRoute permission to write to that file. This access only needs to be granted once per project.</p>
-      <p>After a file is linked, use the adjacent <strong>Save</strong> button to write your latest changes without another prompt. Browsers that do not support direct saves continue to download the JSON export instead.</p>
+      <p>Click <strong>Save Project</strong> to capture the entire workspace. CableTrayRoute now stores every schedule, diagram, and preference for a project inside a single browser entry, so loading a project restores the full state in one step.</p>
+      <p>Use <strong>Load Project</strong> to switch between saved projects. To clear the saved entries, open the ⚙ settings menu and choose <strong>Delete Saved Data</strong>.</p>
+      <p>For an external copy, use <strong>Export Project</strong>. The first export prompts for a destination file; later exports update that file automatically when the browser supports direct writes. Otherwise, the app continues to download a JSON file you can store manually.</p>
     </section>
     <section>
       <h2>Video Walkthroughs</h2>


### PR DESCRIPTION
## Summary
- consolidate saved project persistence into a single CTR_SAVED_PROJECTS_V1 record with lazy migration and error reporting
- update dataStore save/load logic to re-save migrated projects and surface success flags
- improve projectManager messaging for storage issues and refresh the help page to describe unified saves

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2fb24afe08324a4e44e08d2014710