### PR TITLE
Fix oneline export behaviors and restore saved diagrams

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -520,8 +520,9 @@ export function loadProject(projectId, scenario = getCurrentScenarioNameState())
   if (!projectId) return false;
   try {
     const rawPayload = readSavedProject(projectId);
+    if (!rawPayload) return false;
     const payload = rawPayload || {};
-    const migrated = rawPayload ? wasSavedProjectMigrated(projectId) : false;
+    const migrated = wasSavedProjectMigrated(projectId);
     const equipment = payload.equipment;
     const panels = payload.panels;
     const loads = payload.loads;
@@ -541,7 +542,7 @@ export function loadProject(projectId, scenario = getCurrentScenarioNameState())
       setOneLine(oneLine || { activeSheet: 0, sheets: [] }, scenario);
     }
     if (migrated) saveProject(projectId, scenario);
-    return !!rawPayload;
+    return true;
   } catch (e) {
     console.error('Failed to load project', e);
     return false;

--- a/docs/style.css
+++ b/docs/style.css
@@ -235,6 +235,7 @@
   padding: 0.25rem 0;
   box-shadow: var(--ol-shadow);
   display: none;
+  z-index: 10;
 }
 
 .export-menu li {
@@ -402,6 +403,24 @@
   overflow: auto;
   width: 80vw;
   max-width: 800px;
+}
+
+.prefix-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--ol-spacing);
+}
+
+.prefix-table th,
+.prefix-table td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--ol-border-color);
+}
+
+.prefix-table input[type="text"] {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .prop-modal form fieldset {

--- a/exporters/pdf.js
+++ b/exporters/pdf.js
@@ -3,7 +3,11 @@ const { jsPDF } = window.jspdf || await import('https://cdn.jsdelivr.net/npm/jsp
 // non-existent file and caused a 404 in the browser. The `+esm` suffix
 // ensures the module entry in the package is used, which serves
 // `dist/svg2pdf.es.min.js` for version 2.5.0.
-const svg2pdf = (await import('https://cdn.jsdelivr.net/npm/svg2pdf.js@2.5.0/+esm')).default;
+const svg2pdfModule = await import('https://cdn.jsdelivr.net/npm/svg2pdf.js@2.5.0/+esm');
+const svg2pdf = svg2pdfModule?.default || svg2pdfModule?.svg2pdf;
+if (typeof svg2pdf !== 'function') {
+  throw new Error('svg2pdf module failed to load');
+}
 
 /**
  * Export the current set of sheets to a PDF document.

--- a/site.js
+++ b/site.js
@@ -23,6 +23,22 @@ let cachedProjectFileHandle=null;
 let autoSaveSchedulerInstance=null;
 let dirtyTrackerInstance=null;
 
+function currentProjectFromHash(){
+  if(typeof location==='undefined') return '';
+  const hash=location.hash;
+  if(!hash||hash==='#'||hash.startsWith('#project=')) return '';
+  try{
+    return decodeURIComponent(hash.slice(1)).trim();
+  }catch{
+    return '';
+  }
+}
+
+if(typeof window!=='undefined'){
+  const initialProject=currentProjectFromHash()||(window.currentProjectId||'');
+  window.currentProjectId=initialProject||'default';
+}
+
 function getDirtyTracker(){
   if(dirtyTrackerInstance) return dirtyTrackerInstance;
   const win=typeof window!=='undefined'?window:globalThis;
@@ -412,6 +428,11 @@ async function loadProjectFromHash(){
 }
 
 function applyProjectHash(){
+  if(typeof window!=='undefined'){
+    const current=currentProjectFromHash();
+    window.currentProjectId=current||'default';
+  }
+  if(typeof document==='undefined'||typeof location==='undefined') return;
   const hash=location.hash;
   if(!hash) return;
   document.querySelectorAll('a[href$=".html"]').forEach(a=>{

--- a/style.css
+++ b/style.css
@@ -235,6 +235,7 @@
   padding: 0.25rem 0;
   box-shadow: var(--ol-shadow);
   display: none;
+  z-index: 10;
 }
 
 .export-menu li {
@@ -402,6 +403,24 @@
   overflow: auto;
   width: 80vw;
   max-width: 800px;
+}
+
+.prefix-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--ol-spacing);
+}
+
+.prefix-table th,
+.prefix-table td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--ol-border-color);
+}
+
+.prefix-table input[type="text"] {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .prop-modal form fieldset {


### PR DESCRIPTION
## Summary
- ensure the toolbar export menu layers above the canvas and add table styles for the new label prefix editor
- stop clearing one-line data when no saved project exists and derive the current project id from the URL hash before initializing the editor
- replace the prefix prompt loop with a modal table editor, clarify the GitHub token prompt for sharing, and harden the PDF exporter against missing svg2pdf exports

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d30ca103908324920e25737c9755fd