### PR TITLE
Clarify project naming and improve PDF export

### DIFF
--- a/projectStorage.js
+++ b/projectStorage.js
@@ -219,7 +219,7 @@ export function writeScenarioValue(key, value, scenario = currentScenarioName) {
     if (serialized.length > MAX_SCENARIO_ENTRY_SIZE) {
       writeScenarioRaw(target, key, serialized, { skipLocalStorage: true });
       if (target === currentScenarioName) {
-        setProjectKey(key, serialized);
+        setProjectKey(key, serialized, { skipLocalStorage: true });
       }
       if (!scenarioSizeWarnings.has(storageKey)) {
         scenarioSizeWarnings.add(storageKey);


### PR DESCRIPTION
## Summary
- Align project naming with saved project IDs, add rename support, and initialize new projects with empty saved records.
- Keep the settings UI and navigation hash in sync with the active project name and guard scenario storage from oversized entries to avoid quota errors.
- Inline equipment icons during PDF export so diagrams render correctly and update the compiled project manager bundle.
- Ensure oversized scenario entries remain memory-only by skipping project-level localStorage writes when they exceed the limit.

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3e6a4db3c8324a38fb50bcc72bd72