### PR TITLE
Rotate load icons upward and adjust selection highlight

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -66,10 +66,15 @@
       <section class="card">
         <div class="sheet-controls">
           <div class="scenario-controls">
-            <select id="scenario-select"></select>
-            <button id="scenario-duplicate-btn" type="button" class="btn">Duplicate</button>
-            <button id="scenario-diff-btn" type="button" class="btn">Diff</button>
-            <button id="revision-btn" type="button" class="btn">Revisions</button>
+            <div class="scenario-select-group">
+              <label for="scenario-select" class="scenario-label">Scenario</label>
+              <select id="scenario-select"></select>
+            </div>
+            <div class="scenario-action-group">
+              <button id="scenario-duplicate-btn" type="button" class="btn">Duplicate</button>
+              <button id="scenario-diff-btn" type="button" class="btn">Diff</button>
+              <button id="revision-btn" type="button" class="btn">Revisions</button>
+            </div>
           </div>
           <div id="sheet-tabs" class="sheet-tabs" role="tablist"></div>
           <div class="sheet-action-group">

--- a/style.css
+++ b/style.css
@@ -282,6 +282,35 @@
   gap: var(--ol-spacing);
   margin-bottom: var(--ol-spacing);
 }
+.sheet-controls > * {
+  display: flex;
+  align-items: center;
+  gap: var(--ol-spacing);
+}
+.sheet-controls > * + * {
+  border-left: 1px solid var(--ol-border-color);
+  padding-left: var(--ol-spacing);
+}
+.scenario-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--ol-spacing);
+}
+.scenario-select-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.scenario-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.scenario-action-group {
+  display: flex;
+  align-items: center;
+  gap: var(--ol-spacing);
+}
 
 .sheet-action-group {
   display: flex;
@@ -1197,6 +1226,16 @@ button:focus-visible, .primary-btn:focus-visible {
     width: 1.2em;
     height: 1.2em;
     margin-right: 0.25rem;
+    transform-origin: center;
+}
+#palette button:not(.icon-button) img[data-rotation="90"] {
+    transform: rotate(90deg);
+}
+#palette button:not(.icon-button) img[data-rotation="180"] {
+    transform: rotate(180deg);
+}
+#palette button:not(.icon-button) img[data-rotation="270"] {
+    transform: rotate(270deg);
 }
 body.compact-mode #palette button:not(.icon-button) img {
     width: 1em;
@@ -2006,6 +2045,35 @@ body.dark-mode .legalDisclaimer {
     stroke-width:2;
     stroke-linecap:round;
     pointer-events:none;
+}
+.drag-preview{
+    position:fixed;
+    top:-1000px;
+    left:-1000px;
+    pointer-events:none;
+    border:1px solid var(--primary-color);
+    border-radius:4px;
+    background:var(--ol-card-bg);
+    display:inline-flex;
+    align-items:center;
+    justify-content:center;
+    padding:4px;
+    box-sizing:border-box;
+}
+.drag-preview img{
+    width:100%;
+    height:100%;
+    object-fit:contain;
+    transform-origin:center;
+}
+.drag-preview[data-rotation="90"] img{
+    transform:rotate(90deg);
+}
+.drag-preview[data-rotation="180"] img{
+    transform:rotate(180deg);
+}
+.drag-preview[data-rotation="270"] img{
+    transform:rotate(270deg);
 }
 body.dark-mode .cable-lead{
     stroke:#bbb;


### PR DESCRIPTION
## Summary
- rotate load components to face upward by default and normalize existing components to the new orientation
- restore compact palette sizing while rotating icons directly so library buttons match placement orientation without borders
- align the on-canvas selection outline with component transforms so the dashed box follows rotation

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3f2ffe3388324b8872839a634270d