### PR TITLE
Enhance one-line editor interactions and custom component builder

### DIFF
--- a/custom-components.html
+++ b/custom-components.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Build custom one-line diagram components.">
+  <title>Custom Components</title>
+  <link rel="icon" href="./icons/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <nav class="top-nav">
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">☰</button>
+    <div id="nav-links" class="nav-links">
+      <a href="./index.html">Home</a>
+      <a href="./equipmentlist.html">Equipment List</a>
+      <a href="./loadlist.html">Load List</a>
+      <a href="./cableschedule.html">Cable Schedule</a>
+      <a href="./panelschedule.html">Panel Schedule</a>
+      <a href="./racewayschedule.html">Raceway Schedule</a>
+      <a href="./ductbankroute.html">Ductbank</a>
+      <a href="./cabletrayfill.html">Tray Fill</a>
+      <a href="./conduitfill.html">Conduit Fill</a>
+      <a href="./optimalRoute.html">Optimal Route</a>
+      <a href="./oneline.html">One-Line</a>
+      <a href="./custom-components.html" class="active" aria-current="page">Custom Components</a>
+    </div>
+  </nav>
+  <div class="container">
+    <main id="main-content" class="main-content">
+      <header class="page-header">
+        <h1>Custom Components</h1>
+        <p>Create reusable palette entries that load directly into the One-Line diagram.</p>
+      </header>
+      <section class="card component-builder-card">
+        <h2>Create or Edit Component</h2>
+        <p class="muted">Saved components are stored in this browser and appear under the appropriate palette category.</p>
+        <form id="component-form" class="component-form" novalidate>
+          <input type="hidden" id="component-index" value="">
+          <div class="form-grid">
+            <label for="component-label">Display label
+              <input id="component-label" name="label" type="text" maxlength="80" required placeholder="e.g., Custom Switchgear">
+            </label>
+            <label for="component-subtype">Subtype (unique id)
+              <input id="component-subtype" name="subtype" type="text" maxlength="80" required placeholder="e.g., custom_switchgear">
+            </label>
+            <label for="component-type">Type
+              <input id="component-type" name="type" type="text" maxlength="80" required placeholder="e.g., panel">
+            </label>
+            <label for="component-category">Palette category
+              <select id="component-category" name="category" required>
+                <option value="equipment">Equipment</option>
+                <option value="sources">Sources</option>
+                <option value="protection">Protection</option>
+                <option value="load">Load</option>
+                <option value="bus">Bus</option>
+                <option value="cable">Cable</option>
+                <option value="links">Links</option>
+                <option value="annotations">Annotations</option>
+              </select>
+            </label>
+            <label for="component-width">Width (px)
+              <input id="component-width" name="width" type="number" min="20" max="600" value="80" required>
+            </label>
+            <label for="component-height">Height (px)
+              <input id="component-height" name="height" type="number" min="20" max="400" value="40" required>
+            </label>
+          </div>
+          <fieldset class="ports-fieldset">
+            <legend>Connection Ports</legend>
+            <p class="muted">Set how many connection points should appear on each edge. Ports are spaced evenly.</p>
+            <div class="port-grid">
+              <label for="port-top">Top
+                <input id="port-top" name="portTop" type="number" min="0" max="12" value="0">
+              </label>
+              <label for="port-right">Right
+                <input id="port-right" name="portRight" type="number" min="0" max="12" value="1">
+              </label>
+              <label for="port-bottom">Bottom
+                <input id="port-bottom" name="portBottom" type="number" min="0" max="12" value="0">
+              </label>
+              <label for="port-left">Left
+                <input id="port-left" name="portLeft" type="number" min="0" max="12" value="1">
+              </label>
+            </div>
+          </fieldset>
+          <fieldset class="properties-fieldset">
+            <legend>Default Properties</legend>
+            <p class="muted">Add optional default properties that appear in the edit dialog.</p>
+            <div id="property-list" class="property-list"></div>
+            <button type="button" id="add-property-btn" class="btn">Add Property</button>
+          </fieldset>
+          <div class="icon-fieldset">
+            <div class="icon-upload">
+              <label for="component-icon">Icon (SVG or PNG)
+                <input id="component-icon" type="file" accept="image/svg+xml,image/png">
+              </label>
+              <button type="button" id="clear-icon-btn" class="btn secondary-btn">Clear Icon</button>
+            </div>
+            <div id="icon-preview" class="icon-preview" aria-live="polite"></div>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="btn primary-btn">Save Component</button>
+            <button type="button" id="reset-form-btn" class="btn">Reset</button>
+          </div>
+        </form>
+      </section>
+      <section class="card component-list-card">
+        <div class="component-list-header">
+          <h2>Saved Components</h2>
+          <div class="component-list-actions">
+            <button type="button" id="export-components-btn" class="btn">Export</button>
+            <input type="file" id="import-components-input" accept="application/json" class="hidden-input">
+            <button type="button" id="import-components-btn" class="btn">Import</button>
+          </div>
+        </div>
+        <p class="muted">Custom components apply to this browser. Export and share the JSON file to reuse elsewhere.</p>
+        <p id="no-components-message" class="empty-state">No custom components yet. Save one above to get started.</p>
+        <div class="table-wrapper">
+          <table id="custom-components-table" class="component-table">
+            <thead>
+              <tr>
+                <th scope="col">Label</th>
+                <th scope="col">Subtype</th>
+                <th scope="col">Category</th>
+                <th scope="col">Type</th>
+                <th scope="col">Ports</th>
+                <th scope="col" class="actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div id="custom-toast" class="toast" role="status" aria-live="polite"></div>
+  <script type="module" src="./custom-components.js"></script>
+</body>
+</html>

--- a/custom-components.js
+++ b/custom-components.js
@@ -1,0 +1,597 @@
+import { getItem as getStoredItem, setItem as setStoredItem } from './dataStore.mjs';
+
+const STORAGE_KEY = 'customComponents';
+const STORAGE_SCENARIO = '__ctr_custom_components__';
+const MAX_PROPERTIES = 20;
+
+const form = document.getElementById('component-form');
+const formIndexInput = document.getElementById('component-index');
+const labelInput = document.getElementById('component-label');
+const subtypeInput = document.getElementById('component-subtype');
+const typeInput = document.getElementById('component-type');
+const categorySelect = document.getElementById('component-category');
+const widthInput = document.getElementById('component-width');
+const heightInput = document.getElementById('component-height');
+const portTopInput = document.getElementById('port-top');
+const portRightInput = document.getElementById('port-right');
+const portBottomInput = document.getElementById('port-bottom');
+const portLeftInput = document.getElementById('port-left');
+const propertyList = document.getElementById('property-list');
+const addPropertyBtn = document.getElementById('add-property-btn');
+const iconInput = document.getElementById('component-icon');
+const clearIconBtn = document.getElementById('clear-icon-btn');
+const iconPreview = document.getElementById('icon-preview');
+const resetFormBtn = document.getElementById('reset-form-btn');
+const exportBtn = document.getElementById('export-components-btn');
+const importBtn = document.getElementById('import-components-btn');
+const importInput = document.getElementById('import-components-input');
+const tableBody = document.querySelector('#custom-components-table tbody');
+const emptyMessage = document.getElementById('no-components-message');
+const submitBtn = form?.querySelector('button[type="submit"]');
+
+const navToggle = document.getElementById('nav-toggle');
+const navLinks = document.getElementById('nav-links');
+
+let components = loadComponents();
+let editingIndex = null;
+let currentIconData = null;
+let toastTimer = null;
+
+if (navToggle && navLinks) {
+  navToggle.addEventListener('click', () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+    navLinks.classList.toggle('open', !expanded);
+  });
+}
+
+function showToast(message, kind = 'info') {
+  const toast = document.getElementById('custom-toast');
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.remove('toast-error', 'toast-success');
+  if (kind === 'error') {
+    toast.classList.add('toast-error');
+  } else if (kind === 'success') {
+    toast.classList.add('toast-success');
+  }
+  toast.classList.add('show');
+  if (toastTimer) window.clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => {
+    toast.classList.remove('show', 'toast-error', 'toast-success');
+    toastTimer = null;
+  }, 3000);
+}
+
+function loadComponents() {
+  const data = getStoredItem(STORAGE_KEY, [], STORAGE_SCENARIO);
+  if (!Array.isArray(data)) return [];
+  return data;
+}
+
+function persist() {
+  try {
+    setStoredItem(STORAGE_KEY, components, STORAGE_SCENARIO);
+    components = loadComponents();
+  } catch (err) {
+    console.error('Failed to store custom components', err);
+    showToast('Unable to save components. Storage may be full.', 'error');
+    return false;
+  }
+  return true;
+}
+
+function buildPorts(counts, width, height) {
+  const ports = [];
+  const addPorts = (count, side) => {
+    const total = Math.max(0, Math.floor(Number(count) || 0));
+    if (!total) return;
+    for (let idx = 1; idx <= total; idx += 1) {
+      if (side === 'top') {
+        const spacing = width / (total + 1);
+        ports.push({ x: spacing * idx, y: 0 });
+      } else if (side === 'right') {
+        const spacing = height / (total + 1);
+        ports.push({ x: width, y: spacing * idx });
+      } else if (side === 'bottom') {
+        const spacing = width / (total + 1);
+        ports.push({ x: spacing * idx, y: height });
+      } else if (side === 'left') {
+        const spacing = height / (total + 1);
+        ports.push({ x: 0, y: spacing * idx });
+      }
+    }
+  };
+  addPorts(counts.top, 'top');
+  addPorts(counts.right, 'right');
+  addPorts(counts.bottom, 'bottom');
+  addPorts(counts.left, 'left');
+  return ports;
+}
+
+function sanitizeNumber(input, fallback) {
+  const value = Number(input);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function clearPropertyRows() {
+  propertyList.innerHTML = '';
+}
+
+function addPropertyRow(data = {}) {
+  if (propertyList.children.length >= MAX_PROPERTIES) {
+    showToast(`Limit ${MAX_PROPERTIES} properties per component.`, 'error');
+    return;
+  }
+  const row = document.createElement('div');
+  row.className = 'property-row';
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'prop-name';
+  nameInput.placeholder = 'Property key';
+  nameInput.value = data.name || '';
+  nameInput.maxLength = 80;
+
+  const typeSelect = document.createElement('select');
+  typeSelect.className = 'prop-type';
+  ['text', 'number', 'checkbox'].forEach(optionValue => {
+    const opt = document.createElement('option');
+    opt.value = optionValue;
+    opt.textContent = optionValue === 'checkbox' ? 'Yes/No' : optionValue.charAt(0).toUpperCase() + optionValue.slice(1);
+    if ((data.type || 'text') === optionValue) opt.selected = true;
+    typeSelect.appendChild(opt);
+  });
+
+  const valueContainer = document.createElement('div');
+  valueContainer.className = 'prop-value-container';
+
+  const buildValueInput = (type, value) => {
+    let input;
+    if (type === 'checkbox') {
+      input = document.createElement('input');
+      input.type = 'checkbox';
+      input.className = 'prop-value';
+      input.checked = Boolean(value);
+    } else {
+      input = document.createElement('input');
+      input.type = type === 'number' ? 'number' : 'text';
+      input.className = 'prop-value';
+      if (value !== undefined && value !== null && value !== '') {
+        input.value = type === 'number' ? Number(value) : value;
+      }
+    }
+    return input;
+  };
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'btn property-remove-btn';
+  removeBtn.setAttribute('aria-label', 'Remove property');
+  removeBtn.textContent = '✕';
+  removeBtn.addEventListener('click', () => {
+    row.remove();
+  });
+
+  const renderValueInput = () => {
+    const currentType = typeSelect.value;
+    const existing = valueContainer.querySelector('.prop-value');
+    const currentValue = currentType === 'checkbox'
+      ? existing?.checked
+      : existing?.value ?? data.value;
+    valueContainer.innerHTML = '';
+    const input = buildValueInput(currentType, currentValue);
+    valueContainer.appendChild(input);
+  };
+
+  typeSelect.addEventListener('change', renderValueInput);
+
+  row.appendChild(nameInput);
+  row.appendChild(typeSelect);
+  renderValueInput();
+  row.appendChild(valueContainer);
+  row.appendChild(removeBtn);
+  propertyList.appendChild(row);
+}
+
+function collectProperties() {
+  const entries = [];
+  const rows = propertyList.querySelectorAll('.property-row');
+  rows.forEach(row => {
+    const name = row.querySelector('.prop-name')?.value.trim();
+    if (!name) return;
+    const type = row.querySelector('.prop-type')?.value || 'text';
+    const valueEl = row.querySelector('.prop-value');
+    let value;
+    if (type === 'checkbox') {
+      value = valueEl?.checked || false;
+    } else if (type === 'number') {
+      const raw = valueEl?.value ?? '';
+      if (raw === '') {
+        value = '';
+      } else {
+        const num = Number(raw);
+        if (!Number.isFinite(num)) {
+          throw new Error(`Property "${name}" must be a number.`);
+        }
+        value = num;
+      }
+    } else {
+      value = valueEl?.value ?? '';
+    }
+    entries.push({ name, type, value });
+  });
+  return entries;
+}
+
+function propertiesToObject(properties) {
+  const obj = {};
+  properties.forEach(({ name, type, value }) => {
+    if (type === 'checkbox') {
+      obj[name] = Boolean(value);
+    } else if (type === 'number') {
+      obj[name] = value === '' ? '' : Number(value);
+    } else {
+      obj[name] = value ?? '';
+    }
+  });
+  return obj;
+}
+
+function resetIcon() {
+  currentIconData = null;
+  if (iconPreview) {
+    iconPreview.innerHTML = '<span class="icon-placeholder">No icon selected</span>';
+  }
+  if (iconInput) {
+    iconInput.value = '';
+  }
+}
+
+function resetForm() {
+  form.reset();
+  formIndexInput.value = '';
+  editingIndex = null;
+  if (submitBtn) submitBtn.textContent = 'Save Component';
+  clearPropertyRows();
+  addPropertyRow();
+  resetIcon();
+}
+
+function updateIconPreview(src) {
+  if (!iconPreview) return;
+  iconPreview.innerHTML = '';
+  if (!src) {
+    iconPreview.innerHTML = '<span class="icon-placeholder">No icon selected</span>';
+    return;
+  }
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = '';
+  iconPreview.appendChild(img);
+}
+
+function updateTable() {
+  tableBody.innerHTML = '';
+  if (!components.length) {
+    emptyMessage?.classList.remove('hidden');
+    return;
+  }
+  emptyMessage?.classList.add('hidden');
+  components.forEach((comp, idx) => {
+    const row = document.createElement('tr');
+
+    const labelCell = document.createElement('td');
+    labelCell.textContent = comp.label || comp.subtype;
+
+    const subtypeCell = document.createElement('td');
+    subtypeCell.textContent = comp.subtype;
+
+    const categoryCell = document.createElement('td');
+    categoryCell.textContent = comp.category;
+
+    const typeCell = document.createElement('td');
+    typeCell.textContent = comp.type;
+
+    const portsCell = document.createElement('td');
+    const counts = comp.portCounts || { top: 0, right: 0, bottom: 0, left: 0 };
+    portsCell.textContent = `T${counts.top || 0} · R${counts.right || 0} · B${counts.bottom || 0} · L${counts.left || 0}`;
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'btn';
+    editBtn.textContent = 'Edit';
+    editBtn.addEventListener('click', () => loadComponentForEdit(idx));
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'btn secondary-btn';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.addEventListener('click', () => deleteComponent(idx));
+
+    actionsCell.appendChild(editBtn);
+    actionsCell.appendChild(deleteBtn);
+
+    row.appendChild(labelCell);
+    row.appendChild(subtypeCell);
+    row.appendChild(categoryCell);
+    row.appendChild(typeCell);
+    row.appendChild(portsCell);
+    row.appendChild(actionsCell);
+
+    tableBody.appendChild(row);
+  });
+}
+
+function loadComponentForEdit(index) {
+  const comp = components[index];
+  if (!comp) return;
+  editingIndex = index;
+  formIndexInput.value = String(index);
+  labelInput.value = comp.label || '';
+  subtypeInput.value = comp.subtype || '';
+  typeInput.value = comp.type || '';
+  categorySelect.value = comp.category || 'equipment';
+  widthInput.value = comp.width || 80;
+  heightInput.value = comp.height || 40;
+  const counts = comp.portCounts || inferPortCounts(comp.ports || [], comp.width, comp.height);
+  portTopInput.value = counts.top || 0;
+  portRightInput.value = counts.right || 0;
+  portBottomInput.value = counts.bottom || 0;
+  portLeftInput.value = counts.left || 0;
+  clearPropertyRows();
+  (comp.properties || []).forEach(entry => addPropertyRow(entry));
+  if (!comp.properties || comp.properties.length === 0) addPropertyRow();
+  currentIconData = comp.icon || null;
+  updateIconPreview(currentIconData);
+  if (submitBtn) submitBtn.textContent = 'Update Component';
+  form.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function inferPortCounts(ports = [], width = 80, height = 40) {
+  const counts = { top: 0, right: 0, bottom: 0, left: 0 };
+  const w = Number(width) || 80;
+  const h = Number(height) || 40;
+  const epsilon = 0.5;
+  ports.forEach(port => {
+    if (!port || typeof port.x !== 'number' || typeof port.y !== 'number') return;
+    if (Math.abs(port.y) <= epsilon) counts.top += 1;
+    else if (Math.abs(port.x - w) <= epsilon) counts.right += 1;
+    else if (Math.abs(port.y - h) <= epsilon) counts.bottom += 1;
+    else if (Math.abs(port.x) <= epsilon) counts.left += 1;
+  });
+  return counts;
+}
+
+function deleteComponent(index) {
+  const comp = components[index];
+  if (!comp) return;
+  const ok = window.confirm(`Delete ${comp.label || comp.subtype}?`);
+  if (!ok) return;
+  components.splice(index, 1);
+  if (!persist()) return;
+  showToast('Component deleted.', 'success');
+  if (editingIndex === index) {
+    resetForm();
+  }
+  updateTable();
+}
+
+function handleFormSubmit(event) {
+  event.preventDefault();
+  try {
+    const label = labelInput.value.trim();
+    const subtype = subtypeInput.value.trim();
+    const type = typeInput.value.trim();
+    const category = categorySelect.value.trim() || 'equipment';
+    const width = sanitizeNumber(widthInput.value, 80);
+    const height = sanitizeNumber(heightInput.value, 40);
+    const counts = {
+      top: Math.max(0, Math.floor(sanitizeNumber(portTopInput.value, 0))),
+      right: Math.max(0, Math.floor(sanitizeNumber(portRightInput.value, 0))),
+      bottom: Math.max(0, Math.floor(sanitizeNumber(portBottomInput.value, 0))),
+      left: Math.max(0, Math.floor(sanitizeNumber(portLeftInput.value, 0)))
+    };
+    const totalPorts = counts.top + counts.right + counts.bottom + counts.left;
+    if (!label || !subtype || !type) {
+      showToast('Label, subtype, and type are required.', 'error');
+      return;
+    }
+    if (totalPorts === 0) {
+      showToast('Add at least one connection port.', 'error');
+      return;
+    }
+    const properties = collectProperties();
+    const props = propertiesToObject(properties);
+    const ports = buildPorts(counts, width, height);
+    const data = {
+      label,
+      subtype,
+      type,
+      category,
+      width,
+      height,
+      ports,
+      portCounts: counts,
+      props,
+      properties,
+      icon: currentIconData || null
+    };
+    const duplicateIndex = components.findIndex((c, idx) => c.subtype === subtype && idx !== editingIndex);
+    if (duplicateIndex !== -1) {
+      showToast('Subtype must be unique.', 'error');
+      return;
+    }
+    if (editingIndex !== null && editingIndex >= 0) {
+      components[editingIndex] = data;
+    } else {
+      components.push(data);
+    }
+    if (!persist()) return;
+    showToast('Component saved.', 'success');
+    resetForm();
+    updateTable();
+  } catch (err) {
+    console.error(err);
+    showToast(err.message || 'Unable to save component.', 'error');
+  }
+}
+
+function handleIconChange(event) {
+  const file = event.target.files?.[0];
+  if (!file) {
+    resetIcon();
+    return;
+  }
+  if (!/image\/(svg\+xml|png)/.test(file.type)) {
+    showToast('Icon must be an SVG or PNG file.', 'error');
+    iconInput.value = '';
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = () => {
+    currentIconData = reader.result;
+    updateIconPreview(currentIconData);
+  };
+  reader.onerror = () => {
+    showToast('Failed to read icon file.', 'error');
+    resetIcon();
+  };
+  reader.readAsDataURL(file);
+}
+
+function handleExport() {
+  if (!components.length) {
+    showToast('No custom components to export.', 'error');
+    return;
+  }
+  const blob = new Blob([JSON.stringify(components, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'customComponents.json';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  showToast('Export started.', 'success');
+}
+
+function normalizeImportedComponent(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const subtype = String(raw.subtype || '').trim();
+  const type = String(raw.type || raw.category || '').trim() || 'equipment';
+  if (!subtype) return null;
+  const label = String(raw.label || subtype);
+  const category = String(raw.category || '').trim() || type;
+  const width = sanitizeNumber(raw.width, 80);
+  const height = sanitizeNumber(raw.height, 40);
+  const counts = raw.portCounts || inferPortCounts(raw.ports || [], width, height);
+  const props = raw.props && typeof raw.props === 'object' ? raw.props : {};
+  const properties = Array.isArray(raw.properties)
+    ? raw.properties
+        .map(p => ({
+          name: String(p.name || '').trim(),
+          type: p.type === 'number' || p.type === 'checkbox' ? p.type : 'text',
+          value: p.value
+        }))
+        .filter(p => p.name)
+    : Object.keys(props).map(key => ({
+        name: key,
+        type: typeof props[key] === 'number' ? 'number' : typeof props[key] === 'boolean' ? 'checkbox' : 'text',
+        value: props[key]
+      }));
+  const normalizedProperties = properties.map(entry => {
+    if (entry.type === 'number') {
+      const num = Number(entry.value);
+      return { name: entry.name, type: 'number', value: Number.isFinite(num) ? num : '' };
+    }
+    if (entry.type === 'checkbox') {
+      return { name: entry.name, type: 'checkbox', value: Boolean(entry.value) };
+    }
+    return { name: entry.name, type: 'text', value: entry.value == null ? '' : String(entry.value) };
+  });
+  const ports = buildPorts(counts, width, height);
+  return {
+    label,
+    subtype,
+    type,
+    category,
+    width,
+    height,
+    ports,
+    portCounts: counts,
+    props: propertiesToObject(normalizedProperties),
+    properties: normalizedProperties,
+    icon: raw.icon || null
+  };
+}
+
+function handleImportChange(event) {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result);
+      const list = Array.isArray(data) ? data : [];
+      if (!list.length) {
+        showToast('No components found in file.', 'error');
+        return;
+      }
+      let added = 0;
+      list.forEach(raw => {
+        const normalized = normalizeImportedComponent(raw);
+        if (!normalized) return;
+        const idx = components.findIndex(c => c.subtype === normalized.subtype);
+        if (idx >= 0) components[idx] = normalized;
+        else components.push(normalized);
+        added += 1;
+      });
+      if (!added) {
+        showToast('No valid components imported.', 'error');
+        return;
+      }
+      if (!persist()) return;
+      showToast(`Imported ${added} component${added === 1 ? '' : 's'}.`, 'success');
+      updateTable();
+    } catch (err) {
+      console.error('Import failed', err);
+      showToast('Invalid JSON file.', 'error');
+    } finally {
+      importInput.value = '';
+    }
+  };
+  reader.onerror = () => {
+    showToast('Failed to read import file.', 'error');
+    importInput.value = '';
+  };
+  reader.readAsText(file);
+}
+
+function setupListeners() {
+  form.addEventListener('submit', handleFormSubmit);
+  addPropertyBtn.addEventListener('click', () => addPropertyRow());
+  resetFormBtn.addEventListener('click', resetForm);
+  iconInput.addEventListener('change', handleIconChange);
+  clearIconBtn.addEventListener('click', resetIcon);
+  exportBtn.addEventListener('click', handleExport);
+  importBtn.addEventListener('click', () => importInput.click());
+  importInput.addEventListener('change', handleImportChange);
+  const storageSuffix = `:${STORAGE_KEY}`;
+  window.addEventListener('storage', e => {
+    if (!e.key) return;
+    if (e.key === STORAGE_KEY || e.key.endsWith(storageSuffix)) {
+      components = loadComponents();
+      updateTable();
+    }
+  });
+}
+
+resetForm();
+updateTable();
+setupListeners();
+

--- a/oneline.html
+++ b/oneline.html
@@ -29,7 +29,7 @@
       <a href="./conduitfill.html">Conduit Fill</a>
       <a href="./optimalRoute.html">Optimal Route</a>
       <a href="./oneline.html" class="active" aria-current="page">One-Line</a>
-      <button id="studies-panel-btn" type="button" class="btn" title="Open studies panel">Studies</button>
+      <a href="./custom-components.html" title="Create custom palette components">Custom Components</a>
       <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
   </nav>
@@ -86,6 +86,7 @@
             <button id="diagram-import-btn" type="button" class="icon-button" title="Import Diagram" aria-label="Import Diagram"><img src="./icons/toolbar/import.svg" alt=""></button>
             <button id="sample-diagram-btn" type="button" class="btn" title="Load sample diagram">Load Sample</button>
             <button id="diagram-share-btn" type="button" class="btn" title="Share diagram">Share</button>
+            <button id="studies-panel-btn" type="button" class="btn" title="Open studies panel">Studies</button>
             <button id="tour-btn" type="button" class="btn" title="Start tour">Tour</button>
           </div>
         </div>
@@ -136,6 +137,13 @@
               <button id="view-menu-btn" type="button" class="btn" aria-haspopup="true" aria-expanded="false">Views</button>
               <ul id="view-menu" class="export-menu view-menu" role="menu" aria-label="Device attribute visibility"></ul>
             </div>
+          </div>
+          <div class="toolbar-group" aria-label="Find devices">
+            <span class="toolbar-group-label">Find</span>
+            <form id="find-device-form" class="find-device" role="search">
+              <input type="search" id="find-device-input" name="device" placeholder="Device tag" aria-label="Device tag" autocomplete="off">
+              <button type="submit" class="btn">Go</button>
+            </form>
           </div>
         </div>
         <button id="palette-toggle" class="palette-toggle" aria-label="Toggle palette" aria-controls="palette" aria-expanded="false">☰</button>
@@ -268,15 +276,6 @@
     <ul id="lint-list"></ul>
   </aside>
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
-  <script type="module">
-    import * as tour from './tour.js';
-    const btn = document.getElementById('tour-btn');
-    btn.addEventListener('click', () => tour.start());
-    if (!localStorage.getItem('onelineTourSeen')) {
-      tour.start();
-      localStorage.setItem('onelineTourSeen', 'true');
-    }
-  </script>
   <script type="module" src="./dist/projectManager.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -72,6 +72,10 @@
   box-shadow: var(--ol-shadow);
 }
 
+.muted {
+  color: var(--text-muted, #6c757d);
+}
+
 .palette {
   display: flex;
   flex-direction: column;
@@ -318,6 +322,25 @@ body.compact-mode .palette-section .section-buttons {
   gap: var(--ol-spacing);
 }
 
+.find-device {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.find-device input[type="search"] {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  width: 10rem;
+  background: var(--secondary-color);
+  color: var(--text-color);
+}
+
+.find-device .btn {
+  white-space: nowrap;
+}
+
 .sheet-controls {
   display: flex;
   align-items: center;
@@ -417,6 +440,7 @@ body.compact-mode .palette-section .section-buttons {
   width: 5px;
   cursor: col-resize;
   background: var(--ol-border-color);
+  z-index: 2;
 }
 
 .palette-toggle {
@@ -579,6 +603,11 @@ g.component.scenario-diff > * {
   to { opacity: 1; }
 }
 
+@keyframes findPulse {
+  from { opacity: 1; }
+  to { opacity: 0.35; }
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .prop-modal.show {
     animation: fadeIn 0.3s ease-out;
@@ -593,6 +622,29 @@ g.component.scenario-diff > * {
   height: 100%;
   background: rgba(0, 0, 0, 0.6);
   z-index: 1000;
+}
+
+.tour-modal.anchored {
+  transform: none;
+}
+
+.tour-modal .tour-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.tour-modal .tour-actions button {
+  min-width: 4rem;
+}
+
+.find-highlight {
+  stroke: #ff9800;
+  stroke-width: 3;
+  fill: none;
+  pointer-events: none;
+  animation: findPulse 0.9s ease-in-out infinite alternate;
 }
 
 .tour-modal {
@@ -2992,6 +3044,203 @@ body.dark-mode .workflow-card-title {
     padding: 0.5rem;
     margin-top: 0.5rem;
     font-size: 0.85rem;
+}
+
+.component-builder-card,
+.component-list-card {
+    margin-bottom: var(--ol-spacing);
+}
+
+.component-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.component-form .form-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.component-form label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-weight: 500;
+}
+
+.component-form input,
+.component-form select,
+.component-form textarea {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--ol-border-color);
+    border-radius: var(--ol-radius);
+    font: inherit;
+    background: var(--secondary-color);
+    color: var(--text-color);
+}
+
+.ports-fieldset,
+.properties-fieldset,
+.icon-fieldset {
+    border: 1px solid var(--ol-border-color);
+    border-radius: var(--ol-radius);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.ports-fieldset legend,
+.properties-fieldset legend {
+    font-weight: 600;
+    padding: 0 0.5rem;
+}
+
+.port-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.property-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.property-row {
+    display: grid;
+    grid-template-columns: minmax(140px, 1fr) 140px minmax(140px, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.property-row .prop-value-container {
+    display: flex;
+    align-items: center;
+}
+
+.property-row .prop-value-container input,
+.property-row .prop-value-container select {
+    width: 100%;
+}
+
+.property-row input,
+.property-row select {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid var(--ol-border-color);
+    border-radius: var(--ol-radius);
+    font: inherit;
+    background: var(--secondary-color);
+    color: var(--text-color);
+}
+
+.property-row input[type="checkbox"].prop-value {
+    width: auto;
+    padding: 0;
+}
+
+.property-remove-btn {
+    padding: 0.25rem 0.5rem;
+    line-height: 1;
+}
+
+.icon-upload {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.icon-preview {
+    min-height: 64px;
+    min-width: 120px;
+    max-width: 180px;
+    border: 1px dashed var(--ol-border-color);
+    border-radius: var(--ol-radius);
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--secondary-color);
+}
+
+.icon-preview img {
+    max-width: 100%;
+    max-height: 80px;
+}
+
+.icon-placeholder {
+    color: var(--text-muted, #6c757d);
+    font-size: 0.9rem;
+}
+
+.component-form .form-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.component-list-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ol-spacing);
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.component-list-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+.component-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.component-table th,
+.component-table td {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--ol-border-color);
+    text-align: left;
+}
+
+.component-table th {
+    background: var(--ol-hover-bg);
+    font-weight: 600;
+}
+
+.component-table .actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.empty-state {
+    margin: 0 0 1rem;
+    font-style: italic;
+}
+
+@media (max-width: 800px) {
+    .component-form .form-grid {
+        grid-template-columns: 1fr;
+    }
+    .property-row {
+        grid-template-columns: 1fr;
+    }
+    .component-table .actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 }
 
 .lint-header {


### PR DESCRIPTION
## Summary
- make double-click reliably open the property dialog, add a device-tag search, resizeable palette, and an anchored tour flow while moving the Studies action into the sheet header
- merge stored custom components into the palette and add a dedicated custom component builder page backed by the shared data store
- extend one-line styles for the search UI, tour overlays, palette splitter, and custom component layouts

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4544f2e3883248e70d8adcb48f11c