### PR TITLE
Fix prop modal availability on double click

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -82,6 +82,18 @@ import './site.js';
 
 let componentMeta = {};
 
+function ensurePropModal() {
+  let modal = document.getElementById('prop-modal');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'prop-modal';
+    modal.className = 'prop-modal';
+    const host = document.querySelector('.oneline-editor') || document.body;
+    host.appendChild(modal);
+  }
+  return modal;
+}
+
 const baseHref = document.querySelector('base')?.href || new URL('.', window.location.href).href;
 const asset = path => new URL(path, baseHref).href;
 
@@ -3070,7 +3082,7 @@ function selectComponent(compOrId) {
   selected = comp;
   selection = [comp];
   selectedConnection = null;
-  let modal = document.getElementById('prop-modal');
+  let modal = ensurePropModal();
   if (modal._outsideHandler) modal.removeEventListener('click', modal._outsideHandler);
   if (modal._keyHandler) document.removeEventListener('keydown', modal._keyHandler);
   modal.innerHTML = '';
@@ -3741,7 +3753,7 @@ function openCableProperties(comp) {
   selected = comp;
   selection = [comp];
   selectedConnection = null;
-  const modal = document.getElementById('prop-modal');
+  const modal = ensurePropModal();
   if (modal._outsideHandler) modal.removeEventListener('click', modal._outsideHandler);
   if (modal._keyHandler) document.removeEventListener('keydown', modal._keyHandler);
   modal.innerHTML = '';
@@ -4606,7 +4618,7 @@ async function init() {
       pushHistory();
       render();
       save();
-      const modal = document.getElementById('prop-modal');
+      const modal = ensurePropModal();
       if (modal) modal.classList.remove('show');
     } else if (action === 'duplicate' && contextTarget) {
       const copy = {
@@ -4698,7 +4710,7 @@ async function init() {
       pushHistory();
       render();
       save();
-      const modal = document.getElementById('prop-modal');
+      const modal = ensurePropModal();
       if (modal) modal.classList.remove('show');
     }
   });


### PR DESCRIPTION
## Summary
- add a guard that creates the property modal on demand before it is used
- reuse the guard when opening or closing component and cable property dialogs so double-click always works

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d460eb874c8324b9c278536955b5f6