### PR TITLE
Fix one-line double click selection and add middle mouse panning

### DIFF
--- a/style.css
+++ b/style.css
@@ -455,6 +455,12 @@ body.compact-mode .palette-section .section-buttons {
   height: 100%;
 }
 
+.oneline-editor.panning,
+.oneline-editor.panning #diagram {
+  cursor: grabbing;
+  cursor: -webkit-grabbing;
+}
+
 #grid-bg {
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- preserve component context across renders so double-click reliably opens the properties modal
- add middle-mouse panning with a grabbing cursor to move around the one-line canvas

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d46cb1cab483249908c3e6d89c3230