### PR TITLE
Add custom icon drawing tools and improve one-line interactions

### DIFF
--- a/custom-components.html
+++ b/custom-components.html
@@ -92,11 +92,23 @@
             <button type="button" id="add-property-btn" class="btn">Add Property</button>
           </fieldset>
           <div class="icon-fieldset">
-            <div class="icon-upload">
-              <label for="component-icon">Icon (SVG or PNG)
-                <input id="component-icon" type="file" accept="image/svg+xml,image/png">
-              </label>
-              <button type="button" id="clear-icon-btn" class="btn secondary-btn">Clear Icon</button>
+            <div class="icon-builder">
+              <div id="icon-tool-buttons" class="icon-toolbar" role="toolbar" aria-label="Icon drawing tools">
+                <button type="button" class="icon-tool-btn active" data-tool="select" aria-pressed="true">Select</button>
+                <button type="button" class="icon-tool-btn" data-tool="line" aria-pressed="false">Line</button>
+                <button type="button" class="icon-tool-btn" data-tool="rectangle" aria-pressed="false">Rectangle</button>
+                <button type="button" class="icon-tool-btn" data-tool="circle" aria-pressed="false">Circle</button>
+                <button type="button" class="icon-tool-btn" data-tool="arc" aria-pressed="false">Arc</button>
+                <button type="button" class="icon-tool-btn" data-tool="text" aria-pressed="false">Text</button>
+              </div>
+              <div class="icon-canvas-wrapper">
+                <svg id="icon-canvas" viewBox="0 0 120 120" tabindex="0" aria-label="Custom component icon canvas"></svg>
+              </div>
+              <div class="icon-actions">
+                <button type="button" id="undo-icon-btn" class="btn secondary-btn">Undo</button>
+                <button type="button" id="clear-icon-btn" class="btn secondary-btn">Clear</button>
+              </div>
+              <p class="icon-hint muted">Draw directly on the canvas. Use Select to move shapes or press Delete to remove the selection.</p>
             </div>
             <div id="icon-preview" class="icon-preview" aria-live="polite"></div>
           </div>

--- a/oneline.html
+++ b/oneline.html
@@ -239,6 +239,7 @@
           <div id="defaults-modal" class="prop-modal"></div>
             <ul id="context-menu" class="context-menu">
               <li data-action="edit" data-context="component">Edit Properties</li>
+              <li data-action="rename" data-context="component">Rename</li>
               <li data-action="duplicate" data-context="component">Duplicate</li>
               <li data-action="rotate" data-context="component">Rotate</li>
               <li data-action="delete" data-context="component">Delete</li>

--- a/style.css
+++ b/style.css
@@ -415,6 +415,7 @@ body.compact-mode .palette-section .section-buttons {
 .oneline-editor {
   position: relative;
   min-height: 600px;
+  overflow: auto;
 }
 
 .toolbar {
@@ -3153,34 +3154,113 @@ body.dark-mode .workflow-card-title {
     line-height: 1;
 }
 
-.icon-upload {
+.icon-fieldset {
+    gap: 1.25rem;
+}
+
+.icon-builder {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.icon-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.icon-tool-btn {
+    padding: 0.35rem 0.75rem;
+    border: 1px solid var(--ol-border-color);
+    border-radius: var(--ol-radius);
+    background: var(--secondary-color);
+    color: var(--text-color);
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.icon-tool-btn.active,
+.icon-tool-btn:focus-visible {
+    outline: none;
+    border-color: var(--primary-color);
+    background: var(--primary-color);
+    color: var(--secondary-color);
+}
+
+.icon-canvas-wrapper {
+    width: 200px;
+    height: 200px;
+    border: 1px solid var(--ol-border-color);
+    border-radius: var(--ol-radius);
+    background: var(--secondary-color);
     display: flex;
     align-items: center;
-    gap: 1rem;
+    justify-content: center;
+    position: relative;
+}
+
+#icon-canvas {
+    width: 180px;
+    height: 180px;
+    border-radius: var(--ol-radius);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+    cursor: crosshair;
+}
+
+#icon-canvas:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.icon-actions {
+    display: flex;
+    gap: 0.5rem;
     flex-wrap: wrap;
+}
+
+.icon-hint {
+    margin: 0;
+    font-size: 0.85rem;
 }
 
 .icon-preview {
     min-height: 64px;
-    min-width: 120px;
-    max-width: 180px;
+    min-width: 140px;
+    max-width: 220px;
     border: 1px dashed var(--ol-border-color);
     border-radius: var(--ol-radius);
-    padding: 0.5rem;
+    padding: 0.75rem;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 0.5rem;
     background: var(--secondary-color);
+    text-align: center;
 }
 
 .icon-preview img {
     max-width: 100%;
-    max-height: 80px;
+    max-height: 96px;
 }
 
 .icon-placeholder {
     color: var(--text-muted, #6c757d);
     font-size: 0.9rem;
+}
+
+.icon-note {
+    font-size: 0.8rem;
+    color: var(--text-muted, #6c757d);
+    margin: 0;
+}
+
+.icon-canvas-bg {
+    fill: url(#icon-grid-pattern);
+}
+
+.icon-shape-selected {
+    filter: drop-shadow(0 0 4px rgba(0, 123, 255, 0.6));
 }
 
 .component-form .form-actions {


### PR DESCRIPTION
## Summary
- replace the custom component icon upload with an in-app drawing workspace that supports select, line, rectangle, circle, arc, text, undo, and delete interactions
- update the one-line canvas to pan reliably with the middle mouse button by targeting the appropriate scroll container and enabling overflow on the editor
- add a rename option to the one-line context menu so component labels can be updated directly from the diagram

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d47c7fa0188324bae4f12285f6be02