### PR TITLE
Improve oneline double-click and custom component tools

### DIFF
--- a/style.css
+++ b/style.css
@@ -3257,6 +3257,7 @@ body.dark-mode .workflow-card-title {
 
 .icon-canvas-bg {
     fill: url(#icon-grid-pattern);
+    opacity: 0.35;
 }
 
 .icon-shape-selected {


### PR DESCRIPTION
## Summary
- prevent micro-drags from cancelling one-line double-clicks by requiring a small move threshold before moving components
- allow icon shapes to be repositioned without switching tools, constrain line drawing with shift, and soften the custom component canvas grid
- tone down the icon canvas grid styling for easier viewing

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d48d4502d48324910a4950f7996ffc