### PR TITLE
Create component view modal for one-line attributes

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -133,9 +133,8 @@
           </div>
           <div class="toolbar-group" aria-label="View options">
             <span class="toolbar-group-label">View</span>
-            <div class="view-group">
-              <button id="view-menu-btn" type="button" class="btn" aria-haspopup="true" aria-expanded="false">Views</button>
-              <ul id="view-menu" class="export-menu view-menu" role="menu" aria-label="Device attribute visibility"></ul>
+              <div class="view-group">
+                <button id="view-menu-btn" type="button" class="btn" aria-haspopup="dialog" aria-expanded="false">Views</button>
             </div>
           </div>
           <div class="toolbar-group" aria-label="Find devices">

--- a/style.css
+++ b/style.css
@@ -1579,11 +1579,108 @@ body.modal-open {
     position: relative;
 }
 
+.modal-content[data-variant="wide"] {
+    max-width: 720px;
+}
+
 .modal-body {
     margin-top: var(--spacing-base);
     display: flex;
     flex-direction: column;
     gap: var(--spacing-base);
+}
+
+.view-modal-body {
+    gap: calc(var(--spacing-base) * 2);
+}
+
+.view-modal-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-base);
+}
+
+.view-modal-column {
+    flex: 1 1 240px;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.view-modal-heading {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.view-component-list,
+.view-property-list {
+    border: 1px solid var(--ol-border-color);
+    border-radius: var(--ol-radius);
+    background: var(--ol-card-bg);
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-height: 16rem;
+    overflow-y: auto;
+}
+
+.view-component-option {
+    border: 1px solid transparent;
+    border-radius: var(--ol-radius);
+    padding: 0.45rem 0.75rem;
+    text-align: left;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.view-component-option:hover,
+.view-component-option:focus {
+    background: var(--ol-hover-bg);
+    outline: none;
+}
+
+.view-component-option.is-active {
+    background: var(--primary-color);
+    color: var(--secondary-color);
+    border-color: var(--primary-color);
+}
+
+.view-property-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.5rem;
+    border-radius: var(--ol-radius);
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.view-property-option:hover,
+.view-property-option:focus-within {
+    background: var(--ol-hover-bg);
+}
+
+.view-property-option.is-selected {
+    background: var(--ol-hover-bg);
+    color: var(--primary-color);
+}
+
+.view-property-option input[type="checkbox"] {
+    margin: 0;
+}
+
+.view-property-label {
+    flex: 1;
+}
+
+.view-modal-empty {
+    margin: 0;
+    color: var(--text-muted, #666);
 }
 
 .modal-description {


### PR DESCRIPTION
## Summary
- replace the one-line view dropdown with a modal that separates component and property selection
- build per-component attribute groupings and persist the last selected component for quicker edits
- add styling for the dual-list modal layout used by the component view picker

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52e4037148324b41d9e9009746a86