### PR TITLE
Enhance custom component builder tools

### DIFF
--- a/custom-components.html
+++ b/custom-components.html
@@ -24,7 +24,6 @@
       <a href="./conduitfill.html">Conduit Fill</a>
       <a href="./optimalRoute.html">Optimal Route</a>
       <a href="./oneline.html">One-Line</a>
-      <a href="./custom-components.html" class="active" aria-current="page">Custom Components</a>
     </div>
   </nav>
   <div class="container">
@@ -100,6 +99,23 @@
                 <button type="button" class="icon-tool-btn" data-tool="circle" aria-pressed="false">Circle</button>
                 <button type="button" class="icon-tool-btn" data-tool="arc" aria-pressed="false">Arc</button>
                 <button type="button" class="icon-tool-btn" data-tool="text" aria-pressed="false">Text</button>
+              </div>
+              <div class="text-style-controls" aria-label="Text options">
+                <label for="icon-text-font">Font
+                  <select id="icon-text-font">
+                    <option value="Arial, sans-serif">Arial</option>
+                    <option value="'Times New Roman', serif">Times New Roman</option>
+                    <option value="'Courier New', monospace">Courier New</option>
+                    <option value="'Segoe UI', sans-serif">Segoe UI</option>
+                    <option value="'Inter', sans-serif">Inter</option>
+                  </select>
+                </label>
+                <label for="icon-text-size">Size
+                  <input id="icon-text-size" type="number" min="6" max="120" value="18">
+                </label>
+                <label for="icon-text-color">Color
+                  <input id="icon-text-color" type="color" value="#1f2933">
+                </label>
               </div>
               <div class="icon-canvas-wrapper">
                 <svg id="icon-canvas" viewBox="0 0 120 120" tabindex="0" aria-label="Custom component icon canvas"></svg>

--- a/oneline.html
+++ b/oneline.html
@@ -29,7 +29,6 @@
       <a href="./conduitfill.html">Conduit Fill</a>
       <a href="./optimalRoute.html">Optimal Route</a>
       <a href="./oneline.html" class="active" aria-current="page">One-Line</a>
-      <a href="./custom-components.html" title="Create custom palette components">Custom Components</a>
       <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">⚙</button>
     </div>
   </nav>
@@ -215,6 +214,9 @@
                     <summary><img src="./icons/oneline.svg" alt="" class="summary-icon"> Templates</summary>
                       <div id="template-buttons" class="section-buttons"></div>
                     </details>
+                </div>
+                <div class="create-component-footer">
+                  <a href="./custom-components.html" class="btn create-component-btn" title="Design a new custom component">Create Component</a>
                 </div>
             </div>
           </aside>

--- a/oneline.js
+++ b/oneline.js
@@ -474,7 +474,12 @@ const manufacturerModels = {
 function loadStoredCustomComponents() {
   const stored = getItem(customComponentStorageKey, [], customComponentScenarioKey);
   if (!Array.isArray(stored)) return [];
-  return stored.filter(item => item && typeof item === 'object');
+  return stored
+    .filter(item => item && typeof item === 'object')
+    .map(item => ({
+      ...item,
+      defaultRotation: normalizeRotation(item?.defaultRotation ?? 0)
+    }));
 }
 
 function resolveIconSource(iconPath, fallbackSymbol) {

--- a/style.css
+++ b/style.css
@@ -96,6 +96,19 @@
   margin-bottom: var(--ol-spacing);
 }
 
+.create-component-footer {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ol-border-color);
+}
+
+.create-component-footer .create-component-btn {
+  display: inline-flex;
+  width: 100%;
+  justify-content: center;
+  text-align: center;
+}
+
 .palette-card h3 {
   display: none;
 }
@@ -3264,6 +3277,32 @@ body.dark-mode .workflow-card-title {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+}
+
+.text-style-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: 0.75rem;
+    align-items: end;
+}
+
+.text-style-controls label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.85rem;
+    color: var(--text-muted, #6c757d);
+    gap: 0.25rem;
+}
+
+.text-style-controls select,
+.text-style-controls input[type="number"],
+.text-style-controls input[type="color"] {
+    width: 100%;
+}
+
+.text-style-controls input[type="color"] {
+    padding: 0.1rem;
+    height: 2.5rem;
 }
 
 .icon-tool-btn {


### PR DESCRIPTION
## Summary
- add font, size, and color controls for icon text and wire the builder logic to honor those settings
- support shift-constrained square rectangles, a ctrl/cmd+Z undo shortcut, and persist a zero-degree default rotation for custom components
- remove the custom component nav link and surface a Create Component button at the bottom of the one-line palette

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5344a2104832484d739ec46a3a1bf