### PR TITLE
Improve one-line transformer voltage propagation and modal UX

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -189,8 +189,9 @@ function solvePhase(buses, baseMVA) {
       const ySh = conn.shunt?.from ? toPerUnitY(conn.shunt.from, bus.baseKV || 1, baseMVA) : toComplex(0, 0);
       const Iij = add(mul(sub(ViPrime, Vj), y), mul(ViPrime, ySh));
       const Sij = mul(Vi, conj(Iij));
-      const P = Sij.re * baseMVA;
-      const Q = Sij.im * baseMVA;
+      const scale = baseMVA * 1000; // convert per-unit results to kW/kvar
+      const P = Sij.re * scale;
+      const Q = Sij.im * scale;
       flows.push({ from: bus.id, to: buses[j].id, P, Q });
       const key = [bus.id, buses[j].id].sort().join('-');
       lossMap[key] = lossMap[key] || { P: 0, Q: 0 };

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -18,6 +18,263 @@ function parallel(a, b) {
   return div(mult(a, b), add(a, b));
 }
 
+function toImpedance(value) {
+  if (!value || typeof value !== 'object') return { r: 0, x: 0 };
+  const r = Number(value.r);
+  const x = Number(value.x);
+  return {
+    r: Number.isFinite(r) ? r : 0,
+    x: Number.isFinite(x) ? x : 0
+  };
+}
+
+function parseNumeric(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const match = value.replace(/[,\s]+/g, ' ').match(/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/);
+    if (!match) return null;
+    const num = Number.parseFloat(match[0]);
+    return Number.isFinite(num) ? num : null;
+  }
+  return null;
+}
+
+function toKV(value) {
+  const num = parseNumeric(value);
+  if (num === null) return null;
+  return num > 100 ? num / 1000 : num;
+}
+
+function pickValue(comp, key) {
+  if (!key) return undefined;
+  if (comp && Object.prototype.hasOwnProperty.call(comp, key)) return comp[key];
+  if (comp?.props && typeof comp.props === 'object' && Object.prototype.hasOwnProperty.call(comp.props, key)) {
+    return comp.props[key];
+  }
+  return undefined;
+}
+
+const fallbackTypes = new Set(['motor_load', 'static_load', 'load', 'panel', 'equipment', 'bus', 'cable', 'mcc']);
+const upstreamCandidateTypes = new Set([
+  'transformer',
+  'panel',
+  'equipment',
+  'bus',
+  'utility_source',
+  'generator',
+  'pv_inverter',
+  'mcc',
+  'feeder'
+]);
+
+const transformerVoltageKeyMap = {
+  two_winding: ['volts_primary', 'volts_secondary'],
+  auto_transformer: ['volts_primary', 'volts_secondary'],
+  grounding_transformer: ['volts_primary', 'volts_secondary'],
+  three_winding: ['volts_hv', 'volts_lv', 'volts_tv']
+};
+
+const transformerKvaKeyMap = {
+  two_winding: ['kva', 'kva'],
+  auto_transformer: ['kva', 'kva'],
+  grounding_transformer: ['kva', 'kva'],
+  three_winding: ['kva_hv', 'kva_lv', 'kva_tv']
+};
+
+const transformerPercentKeyMap = {
+  two_winding: ['percent_z', 'percent_z'],
+  auto_transformer: ['percent_z', 'percent_z'],
+  grounding_transformer: ['percent_z', 'percent_z'],
+  three_winding: ['z_hv_lv_percent', 'z_hv_lv_percent', 'z_hv_tv_percent']
+};
+
+function normalizePortIndex(port) {
+  const idx = Number(port);
+  return Number.isFinite(idx) ? idx : 0;
+}
+
+function isSourceComponent(comp) {
+  return ['utility_source', 'generator', 'pv_inverter'].includes(comp?.type);
+}
+
+function getNumericFromKeys(comp, keys) {
+  if (!Array.isArray(keys)) return null;
+  const seen = new Set();
+  for (const key of keys) {
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    const val = pickValue(comp, key);
+    const num = parseNumeric(val);
+    if (num !== null) return num;
+  }
+  return null;
+}
+
+function getTransformerVoltageForPort(xfmr, portIndex) {
+  const subtypeKeys = transformerVoltageKeyMap[xfmr?.subtype] || [];
+  const fallbackKeys = portIndex === 0
+    ? ['volts_primary', 'voltage_primary', 'primary_voltage', 'volts_hv', 'voltage']
+    : portIndex === 1
+      ? ['volts_secondary', 'voltage_secondary', 'secondary_voltage', 'volts_lv', 'voltage']
+      : ['volts_tv', 'volts_tertiary', 'tertiary_voltage', 'volts_lv', 'voltage'];
+  return getNumericFromKeys(xfmr, [subtypeKeys[portIndex], ...fallbackKeys]);
+}
+
+function getTransformerKvaForPort(xfmr, portIndex) {
+  const subtypeKeys = transformerKvaKeyMap[xfmr?.subtype] || [];
+  return getNumericFromKeys(xfmr, [subtypeKeys[portIndex], 'kva']);
+}
+
+function getTransformerPercentForPort(xfmr, portIndex) {
+  const subtypeKeys = transformerPercentKeyMap[xfmr?.subtype] || [];
+  const fallbacks = ['percent_z'];
+  if (xfmr?.subtype === 'three_winding' && portIndex === 2) fallbacks.unshift('z_lv_tv_percent');
+  return getNumericFromKeys(xfmr, [subtypeKeys[portIndex], ...fallbacks]);
+}
+
+function getTransformerImpedance(xfmr, portIndex) {
+  if (!xfmr || xfmr.type !== 'transformer') return { r: 0, x: 0 };
+  const percent = getTransformerPercentForPort(xfmr, portIndex);
+  const kva = getTransformerKvaForPort(xfmr, portIndex);
+  const voltage = getTransformerVoltageForPort(xfmr, portIndex);
+  const kv = toKV(voltage || pickValue(xfmr, 'voltage'));
+  if (!percent || !kva || !kv) return { r: 0, x: 0 };
+  const baseMVA = kva / 1000;
+  if (!baseMVA) return { r: 0, x: 0 };
+  const baseZ = (kv * kv) / baseMVA;
+  const zMag = baseZ * (percent / 100);
+  const xr = parseNumeric(pickValue(xfmr, 'xr_ratio'));
+  if (xr && Math.abs(xr) > 0.01) {
+    const r = zMag / Math.sqrt(1 + xr * xr);
+    return { r, x: r * xr };
+  }
+  const r = zMag * 0.1;
+  const x = Math.sqrt(Math.max(zMag * zMag - r * r, 0)) || zMag;
+  return { r, x };
+}
+
+function getSourceImpedance(comp) {
+  const mva = parseNumeric(pickValue(comp, 'thevenin_mva') ?? pickValue(comp, 'mva'));
+  const kv = toKV(pickValue(comp, 'voltage') ?? pickValue(comp, 'volts') ?? pickValue(comp, 'baseKV'));
+  if (!mva || !kv) return { r: 0, x: 0 };
+  const zMag = (kv * kv) / mva;
+  const xr = parseNumeric(pickValue(comp, 'xr_ratio'));
+  if (xr && Math.abs(xr) > 0.01) {
+    const r = zMag / Math.sqrt(1 + xr * xr);
+    return { r, x: r * xr };
+  }
+  const r = zMag * 0.1;
+  const x = Math.sqrt(Math.max(zMag * zMag - r * r, 0)) || zMag;
+  return { r, x };
+}
+
+function findParentInfo(comp, comps, compMap, visited) {
+  if (!comp?.id) return null;
+  const direct = comps.find(candidate =>
+    candidate?.id !== comp.id && (candidate.connections || []).some(conn => conn?.target === comp.id)
+  );
+  if (direct) {
+    const connection = (direct.connections || []).find(conn => conn?.target === comp.id) || null;
+    return { component: direct, connection, reversed: false };
+  }
+  if (!fallbackTypes.has(comp.type)) return null;
+  for (const conn of comp.connections || []) {
+    const target = compMap.get(conn?.target);
+    if (!target || visited.has(target.id)) continue;
+    if (!upstreamCandidateTypes.has(target.type) && target.type !== 'transformer') continue;
+    return { component: target, connection: conn, reversed: true };
+  }
+  return null;
+}
+
+function combineParallel(base, addition) {
+  if (!addition || (Math.abs(addition.r) < 1e-9 && Math.abs(addition.x) < 1e-9)) return base;
+  if (!base || (Math.abs(base.r) < 1e-9 && Math.abs(base.x) < 1e-9)) return addition;
+  return parallel(base, addition);
+}
+
+function computeImpedance(comp, comps, compMap, cache, visited = new Set()) {
+  if (!comp?.id) return { r: 0, x: 0 };
+  if (cache.has(comp.id)) return cache.get(comp.id);
+  if (visited.has(comp.id)) return { r: 0, x: 0 };
+  visited.add(comp.id);
+  let total = toImpedance(comp.impedance);
+  if (isSourceComponent(comp)) {
+    total = add(total, getSourceImpedance(comp));
+  }
+  const parent = findParentInfo(comp, comps, compMap, visited);
+  if (parent?.component) {
+    const { component: upstream, connection, reversed } = parent;
+    if (connection) {
+      total = add(total, toImpedance(connection.impedance));
+      if (upstream.type === 'transformer') {
+        const portIndex = normalizePortIndex(reversed ? connection?.targetPort : connection?.sourcePort);
+        total = add(total, getTransformerImpedance(upstream, portIndex));
+      }
+    }
+    total = add(total, computeImpedance(upstream, comps, compMap, cache, visited));
+  }
+  visited.delete(comp.id);
+  cache.set(comp.id, total);
+  return total;
+}
+
+function computePrefaultKV(comp, comps, compMap, cache, visited = new Set()) {
+  if (!comp?.id) return 1;
+  if (cache.has(comp.id)) return cache.get(comp.id);
+  if (visited.has(comp.id)) return 1;
+  visited.add(comp.id);
+  const direct = toKV(pickValue(comp, 'prefault_voltage'));
+  if (direct) {
+    cache.set(comp.id, direct);
+    visited.delete(comp.id);
+    return direct;
+  }
+  const baseKV = parseNumeric(pickValue(comp, 'baseKV'));
+  if (baseKV && baseKV > 0) {
+    cache.set(comp.id, baseKV);
+    visited.delete(comp.id);
+    return baseKV;
+  }
+  const voltageCandidates = [
+    pickValue(comp, 'voltage'),
+    pickValue(comp, 'volts'),
+    pickValue(comp, 'voltage_class'),
+    pickValue(comp, 'kV'),
+    pickValue(comp, 'kv'),
+    pickValue(comp, 'kv_ll')
+  ];
+  for (const candidate of voltageCandidates) {
+    const kv = toKV(candidate);
+    if (kv) {
+      cache.set(comp.id, kv);
+      visited.delete(comp.id);
+      return kv;
+    }
+  }
+  if (comp.type === 'transformer') {
+    const kv = toKV(getTransformerVoltageForPort(comp, 0) ?? getTransformerVoltageForPort(comp, 1));
+    if (kv) {
+      cache.set(comp.id, kv);
+      visited.delete(comp.id);
+      return kv;
+    }
+  }
+  const parent = findParentInfo(comp, comps, compMap, visited);
+  if (parent?.component) {
+    const upstreamKV = computePrefaultKV(parent.component, comps, compMap, cache, visited);
+    cache.set(comp.id, upstreamKV);
+    visited.delete(comp.id);
+    return upstreamKV;
+  }
+  visited.delete(comp.id);
+  cache.set(comp.id, 1);
+  return 1;
+}
+
 /**
  * Symmetrical component short‑circuit engine with basic ANSI C37 and
  * IEC 60909 support. Each component is treated as a bus with sequence
@@ -45,26 +302,42 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
   }
   let buses = comps.filter(c => c.subtype === 'Bus');
   if (buses.length === 0) buses = comps;
+  const compMap = new Map(comps.map(c => [c.id, c]));
+  const impedanceCache = new Map();
+  const voltageCache = new Map();
   const results = {};
 
-  buses.forEach(comp => {
-    const base = comp.impedance || { r: 0, x: 0 };
-    let z1 = comp.z1 || base;
-    let z2 = comp.z2 || z1;
-    let z0 = comp.z0 || z1;
-    (comp.sources || []).forEach(src => {
-      const s1 = src.z1 || src.impedance || { r: 0, x: 0 };
-      const s2 = src.z2 || s1;
-      const s0 = src.z0 || s1;
-      z1 = parallel(z1, s1);
-      z2 = parallel(z2, s2);
-      z0 = parallel(z0, s0);
-    });
+  const ensureNonZero = z => {
+    if (!z) return { r: 0.0001, x: 0.0001 };
+    const r = Number(z.r) || 0;
+    const x = Number(z.x) || 0;
+    if (Math.abs(r) < 1e-9 && Math.abs(x) < 1e-9) {
+      return { r: 0.0001, x: 0.0001 };
+    }
+    return { r, x };
+  };
 
-    const Vll = comp.prefault_voltage || comp.baseKV || comp.kV || 1;
-    const method = (comp.method || opts.method || (Vll > 1 ? 'IEC' : 'ANSI')).toUpperCase();
+  buses.forEach(comp => {
+    const baseZ = computeImpedance(comp, comps, compMap, impedanceCache);
+    let z1 = comp.z1 ? toImpedance(comp.z1) : baseZ;
+    z1 = ensureNonZero(z1);
+    let z2 = comp.z2 ? toImpedance(comp.z2) : z1;
+    let z0 = comp.z0 ? toImpedance(comp.z0) : z1;
+
+    const sourceList = Array.isArray(comp.sources) ? comp.sources : [];
+    if (sourceList.length) {
+      z1 = ensureNonZero(sourceList.reduce((acc, src) => combineParallel(acc, toImpedance(src.z1 || src.impedance || src)), z1));
+      z2 = ensureNonZero(sourceList.reduce((acc, src) => combineParallel(acc, toImpedance(src.z2 || src.impedance || src)), z2));
+      z0 = ensureNonZero(sourceList.reduce((acc, src) => combineParallel(acc, toImpedance(src.z0 || src.impedance || src)), z0));
+    } else {
+      z2 = ensureNonZero(z2);
+      z0 = ensureNonZero(z0);
+    }
+
+    const prefaultKV = computePrefaultKV(comp, comps, compMap, voltageCache) || 1;
+    const method = (comp.method || opts.method || (prefaultKV > 1 ? 'IEC' : 'ANSI')).toUpperCase();
     const vFactor = method === 'IEC' ? (comp.v_factor || 1.1) : (comp.v_factor || 1.05);
-    const V = (Vll * vFactor) / Math.sqrt(3); // phase voltage in kV
+    const V = (prefaultKV * vFactor) / Math.sqrt(3); // phase voltage in kV
 
     const I3 = V / mag(z1);
     const ILG = (3 * V) / mag(add(add(z1, z2), z0));
@@ -77,7 +350,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
 
     results[comp.id] = {
       method,
-      prefaultKV: Number(Vll),
+      prefaultKV: Number(prefaultKV.toFixed(3)),
       threePhaseKA: Number(I3.toFixed(2)),
       asymKA: Number(asym.toFixed(2)),
       lineToGroundKA: Number(ILG.toFixed(2)),

--- a/docs/style.css
+++ b/docs/style.css
@@ -520,6 +520,130 @@ body.compact-mode .palette-section .section-buttons {
   max-width: 800px;
 }
 
+.prop-modal-panel {
+  background: var(--ol-card-bg);
+  padding: var(--ol-spacing);
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  box-shadow: var(--ol-shadow);
+  max-height: 90%;
+  max-width: 960px;
+  width: min(90vw, 960px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ol-spacing);
+}
+
+.prop-modal-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ol-spacing);
+  overflow: auto;
+}
+
+.prop-modal-column {
+  flex: 1 1 260px;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.prop-modal-heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.prop-category-list,
+.prop-component-list {
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  background: var(--ol-card-bg);
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.prop-category-list {
+  max-height: 10rem;
+  overflow-y: auto;
+}
+
+.prop-component-list {
+  flex: 1 1 0;
+  max-height: 20rem;
+  overflow-y: auto;
+}
+
+.prop-category-option,
+.prop-component-option {
+  border: 1px solid transparent;
+  border-radius: var(--ol-radius);
+  padding: 0.45rem 0.75rem;
+  text-align: left;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.prop-category-option:hover,
+.prop-category-option:focus,
+.prop-component-option:hover,
+.prop-component-option:focus {
+  background: var(--ol-hover-bg);
+  outline: none;
+}
+
+.prop-category-option.is-active,
+.prop-component-option.is-active {
+  background: var(--primary-color);
+  color: var(--secondary-color);
+  border-color: var(--primary-color);
+}
+
+.prop-property-container {
+  border: 1px solid var(--ol-border-color);
+  border-radius: var(--ol-radius);
+  background: var(--ol-card-bg);
+  padding: var(--ol-spacing);
+  flex: 1 1 320px;
+  min-height: 12rem;
+  max-height: 60vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ol-spacing);
+}
+
+.prop-modal .prop-detail-form {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  box-shadow: none;
+  max-height: none;
+  max-width: none;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ol-spacing);
+}
+
+.prop-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.prop-property-empty {
+  margin: 0;
+  color: var(--text-muted, #666);
+}
+
 .prefix-table {
   width: 100%;
   border-collapse: collapse;
@@ -1641,6 +1765,10 @@ body.modal-open {
 }
 
 .view-component-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
     border: 1px solid transparent;
     border-radius: var(--ol-radius);
     padding: 0.45rem 0.75rem;
@@ -1650,6 +1778,29 @@ body.modal-open {
     font: inherit;
     cursor: pointer;
     transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.view-component-option.has-selection {
+    border-color: var(--primary-color);
+}
+
+.view-component-label {
+    flex: 1 1 auto;
+}
+
+.view-component-indicator {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+    background: var(--secondary-color);
+}
+
+.view-component-option.is-active .view-component-indicator {
+    color: var(--primary-color);
+    background: var(--secondary-color);
 }
 
 .view-component-option:hover,

--- a/style.css
+++ b/style.css
@@ -555,6 +555,7 @@ body.compact-mode .palette-section .section-buttons {
   font-weight: 600;
 }
 
+.prop-category-list,
 .prop-component-list {
   border: 1px solid var(--ol-border-color);
   border-radius: var(--ol-radius);
@@ -563,10 +564,20 @@ body.compact-mode .palette-section .section-buttons {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.prop-category-list {
+  max-height: 10rem;
+  overflow-y: auto;
+}
+
+.prop-component-list {
+  flex: 1 1 0;
   max-height: 20rem;
   overflow-y: auto;
 }
 
+.prop-category-option,
 .prop-component-option {
   border: 1px solid transparent;
   border-radius: var(--ol-radius);
@@ -579,12 +590,15 @@ body.compact-mode .palette-section .section-buttons {
   transition: background-color 0.2s, border-color 0.2s, color 0.2s;
 }
 
+.prop-category-option:hover,
+.prop-category-option:focus,
 .prop-component-option:hover,
 .prop-component-option:focus {
   background: var(--ol-hover-bg);
   outline: none;
 }
 
+.prop-category-option.is-active,
 .prop-component-option.is-active {
   background: var(--primary-color);
   color: var(--secondary-color);
@@ -1751,6 +1765,10 @@ body.modal-open {
 }
 
 .view-component-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
     border: 1px solid transparent;
     border-radius: var(--ol-radius);
     padding: 0.45rem 0.75rem;
@@ -1760,6 +1778,29 @@ body.modal-open {
     font: inherit;
     cursor: pointer;
     transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.view-component-option.has-selection {
+    border-color: var(--primary-color);
+}
+
+.view-component-label {
+    flex: 1 1 auto;
+}
+
+.view-component-indicator {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+    background: var(--secondary-color);
+}
+
+.view-component-option.is-active .view-component-indicator {
+    color: var(--primary-color);
+    background: var(--secondary-color);
 }
 
 .view-component-option:hover,


### PR DESCRIPTION
## Summary
- propagate transformer secondary voltages to downstream components on the one-line diagram
- surface filter indicators in the views modal and split the device properties modal into category and device panes
- correct load-flow line flow scaling and include `kV` metadata in short-circuit prefault voltage detection

## Testing
- npm test -- shortcircuit/shortCircuit.test.js
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd313480c8324adbeaa3f33a69837