### PR TITLE
Improve TCC setting controls and reliability messaging

### DIFF
--- a/analysis/motorStart.js
+++ b/analysis/motorStart.js
@@ -117,12 +117,18 @@ function renderMotorStartChart(svgEl, data) {
   svg.selectAll('*').remove();
 
   if (!data.length) {
-    svg.append('text')
-      .attr('x', width / 2)
-      .attr('y', height / 2)
-      .attr('text-anchor', 'middle')
-      .attr('fill', '#666')
-      .text('No motors with starting data found in the active project.');
+    const messages = [
+      'No motors with starting data found in the active project.',
+      'Add a motor starting curve by editing a motor on the One-Line and entering the inrush multiple, Thevenin impedance, inertia, and load torque curve points on the Motor Start tab.'
+    ];
+    messages.forEach((msg, index) => {
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2 + index * 20)
+        .attr('text-anchor', 'middle')
+        .attr('fill', index === 0 ? '#666' : '#444')
+        .text(msg);
+    });
     return;
   }
 

--- a/data/protectiveDevices.json
+++ b/data/protectiveDevices.json
@@ -10,6 +10,11 @@
       "time": 0.2,
       "instantaneous": 800
     },
+    "settingOptions": {
+      "pickup": [80, 100, 125, 160],
+      "time": [0.1, 0.2, 0.3, 0.4],
+      "instantaneous": [800, 960, 1120, 1280, 1440, 1600]
+    },
     "curve": [
       {
         "current": 160,
@@ -39,6 +44,11 @@
       "pickup": 125,
       "time": 0.25,
       "instantaneous": 600
+    },
+    "settingOptions": {
+      "pickup": [63, 80, 100, 125],
+      "time": [0.2, 0.25, 0.3, 0.4],
+      "instantaneous": [500, 600, 700, 800, 900, 1000]
     },
     "curve": [
       {
@@ -70,6 +80,11 @@
       "time": 0.3,
       "instantaneous": 500
     },
+    "settingOptions": {
+      "pickup": [50, 63, 80, 100],
+      "time": [0.2, 0.3, 0.4, 0.5],
+      "instantaneous": [400, 500, 600, 700, 800, 900]
+    },
     "curve": [
       {
         "current": 100,
@@ -99,6 +114,11 @@
       "pickup": 150,
       "time": 0.15,
       "instantaneous": 600
+    },
+    "settingOptions": {
+      "pickup": [75, 100, 125, 150, 175, 200],
+      "time": [0.1, 0.15, 0.2, 0.3],
+      "instantaneous": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
     },
     "curve": [
       {
@@ -130,6 +150,11 @@
       "time": 0.2,
       "instantaneous": 500
     },
+    "settingOptions": {
+      "pickup": [50, 63, 80, 100],
+      "time": [0.15, 0.2, 0.25, 0.3],
+      "instantaneous": [400, 500, 600, 700, 800, 900]
+    },
     "curve": [
       {
         "current": 100,
@@ -159,6 +184,11 @@
       "pickup": 225,
       "time": 0.3,
       "instantaneous": 1125
+    },
+    "settingOptions": {
+      "pickup": [125, 160, 200, 225],
+      "time": [0.2, 0.3, 0.4, 0.5],
+      "instantaneous": [1125, 1350, 1575, 1800, 2025, 2250]
     },
     "curve": [
       {

--- a/data/protectiveDevices.mjs
+++ b/data/protectiveDevices.mjs
@@ -10,6 +10,11 @@ export default [
       "time": 0.2,
       "instantaneous": 800
     },
+    "settingOptions": {
+      "pickup": [80, 100, 125, 160],
+      "time": [0.1, 0.2, 0.3, 0.4],
+      "instantaneous": [800, 960, 1120, 1280, 1440, 1600]
+    },
     "curve": [
       {
         "current": 160,
@@ -39,6 +44,11 @@ export default [
       "pickup": 125,
       "time": 0.25,
       "instantaneous": 600
+    },
+    "settingOptions": {
+      "pickup": [63, 80, 100, 125],
+      "time": [0.2, 0.25, 0.3, 0.4],
+      "instantaneous": [500, 600, 700, 800, 900, 1000]
     },
     "curve": [
       {
@@ -70,6 +80,11 @@ export default [
       "time": 0.3,
       "instantaneous": 500
     },
+    "settingOptions": {
+      "pickup": [50, 63, 80, 100],
+      "time": [0.2, 0.3, 0.4, 0.5],
+      "instantaneous": [400, 500, 600, 700, 800, 900]
+    },
     "curve": [
       {
         "current": 100,
@@ -99,6 +114,11 @@ export default [
       "pickup": 150,
       "time": 0.15,
       "instantaneous": 600
+    },
+    "settingOptions": {
+      "pickup": [75, 100, 125, 150, 175, 200],
+      "time": [0.1, 0.15, 0.2, 0.3],
+      "instantaneous": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
     },
     "curve": [
       {
@@ -130,6 +150,11 @@ export default [
       "time": 0.2,
       "instantaneous": 500
     },
+    "settingOptions": {
+      "pickup": [50, 63, 80, 100],
+      "time": [0.15, 0.2, 0.25, 0.3],
+      "instantaneous": [400, 500, 600, 700, 800, 900]
+    },
     "curve": [
       {
         "current": 100,
@@ -159,6 +184,11 @@ export default [
       "pickup": 225,
       "time": 0.3,
       "instantaneous": 1125
+    },
+    "settingOptions": {
+      "pickup": [125, 160, 200, 225],
+      "time": [0.2, 0.3, 0.4, 0.5],
+      "instantaneous": [1125, 1350, 1575, 1800, 2025, 2250]
     },
     "curve": [
       {


### PR DESCRIPTION
## Summary
- add device-defined setting options to the TCC controls and format persisted values consistently
- document available motor starting inputs when no curves are plotted
- expand single point of failure validation messages to mention the device and missing redundancy hint

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbebdf92e88324820edd6bf55b3276