### PR TITLE
Add curve profile controls to TCC device settings

### DIFF
--- a/analysis/tccUtils.js
+++ b/analysis/tccUtils.js
@@ -4,25 +4,141 @@ const DEFAULT_TOLERANCE = {
   timeUpper: 1.2
 };
 
+function firstDefined(...values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+function normalizeCurveProfiles(device = {}) {
+  const raw = device.curveProfiles;
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    return raw
+      .map(profile => {
+        if (!profile || typeof profile !== 'object') return null;
+        const id = profile.id ?? profile.key ?? profile.name;
+        if (!id) return null;
+        return {
+          id: String(id),
+          name: profile.name ?? profile.label ?? String(id),
+          curve: Array.isArray(profile.curve) ? profile.curve : [],
+          settings: profile.settings && typeof profile.settings === 'object' ? profile.settings : {},
+          tolerance: profile.tolerance && typeof profile.tolerance === 'object' ? profile.tolerance : undefined
+        };
+      })
+      .filter(Boolean);
+  }
+  if (typeof raw === 'object') {
+    return Object.entries(raw)
+      .map(([id, profile]) => {
+        if (!profile || typeof profile !== 'object') return null;
+        const resolvedId = profile.id ?? id;
+        return {
+          id: String(resolvedId),
+          name: profile.name ?? profile.label ?? String(resolvedId),
+          curve: Array.isArray(profile.curve) ? profile.curve : [],
+          settings: profile.settings && typeof profile.settings === 'object' ? profile.settings : {},
+          tolerance: profile.tolerance && typeof profile.tolerance === 'object' ? profile.tolerance : undefined
+        };
+      })
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function pickCurveProfile(device = {}, profileId) {
+  const profiles = normalizeCurveProfiles(device);
+  if (!profiles.length) {
+    return {
+      id: profileId ? String(profileId) : null,
+      name: null,
+      curve: device.curve || [],
+      settings: {},
+      tolerance: device.tolerance
+    };
+  }
+  if (profileId !== undefined && profileId !== null) {
+    const idStr = String(profileId);
+    const match = profiles.find(profile => profile.id === idStr)
+      || profiles.find(profile => profile.name === profileId);
+    if (match) {
+      const fallbackCurve = device.curve || [];
+      return {
+        ...match,
+        curve: match.curve && match.curve.length ? match.curve : fallbackCurve,
+        tolerance: match.tolerance ?? device.tolerance
+      };
+    }
+  }
+  const first = profiles[0];
+  return {
+    ...first,
+    curve: first.curve && first.curve.length ? first.curve : device.curve || [],
+    tolerance: first.tolerance ?? device.tolerance
+  };
+}
+
 export function scaleCurve(device = {}, overrides = {}) {
-  const base = device.settings || {};
-  const pickup = overrides.pickup ?? base.pickup ?? 1;
-  const time = overrides.time ?? base.time ?? base.delay ?? 1;
-  const instantaneous = overrides.instantaneous ?? base.instantaneous ?? 0;
-  const instDelay = overrides.instantaneousDelay ?? base.instantaneousDelay ?? 0.01;
-  const instMaxSetting = overrides.instantaneousMax
-    ?? base.instantaneousMax
-    ?? device.instantaneousMax
-    ?? null;
-  const baseTime = base.time ?? base.delay ?? 1;
-  const scaleI = base.pickup ? pickup / base.pickup : 1;
+  const baseSettings = device.settings || {};
+  const selectedProfileId = firstDefined(
+    overrides.curveProfile,
+    baseSettings.curveProfile,
+    device.curveProfile
+  );
+  const profile = pickCurveProfile(device, selectedProfileId);
+  const combinedBase = { ...baseSettings, ...profile.settings };
+
+  const pickup = firstDefined(
+    overrides.pickup,
+    overrides.longTimePickup,
+    combinedBase.pickup,
+    combinedBase.longTimePickup,
+    1
+  );
+  const time = firstDefined(
+    overrides.time,
+    overrides.delay,
+    overrides.longTimeDelay,
+    combinedBase.time,
+    combinedBase.delay,
+    combinedBase.longTimeDelay,
+    1
+  );
+  const shortTimePickup = firstDefined(overrides.shortTimePickup, combinedBase.shortTimePickup);
+  const shortTimeDelay = firstDefined(overrides.shortTimeDelay, combinedBase.shortTimeDelay);
+  const instantaneous = firstDefined(
+    overrides.instantaneous,
+    overrides.instantaneousPickup,
+    combinedBase.instantaneous,
+    combinedBase.instantaneousPickup,
+    0
+  );
+  const instDelay = firstDefined(
+    overrides.instantaneousDelay,
+    combinedBase.instantaneousDelay,
+    combinedBase.instantaneousDelaySetting,
+    0.01
+  );
+  const instMaxSetting = firstDefined(
+    overrides.instantaneousMax,
+    combinedBase.instantaneousMax,
+    device.instantaneousMax
+  );
+
+  const basePickup = firstDefined(combinedBase.pickup, combinedBase.longTimePickup, 1);
+  const baseTime = firstDefined(combinedBase.time, combinedBase.delay, combinedBase.longTimeDelay, 1);
+  const scaleI = basePickup ? pickup / basePickup : 1;
   const scaleT = baseTime ? time / baseTime : 1;
+
+  const toleranceSource = profile.tolerance || device.tolerance || DEFAULT_TOLERANCE;
   const tolerance = {
-    timeLower: Math.max(device.tolerance?.timeLower ?? DEFAULT_TOLERANCE.timeLower, 0.1),
-    timeUpper: Math.max(device.tolerance?.timeUpper ?? DEFAULT_TOLERANCE.timeUpper, 1.0)
+    timeLower: Math.max(toleranceSource.timeLower ?? DEFAULT_TOLERANCE.timeLower, 0.1),
+    timeUpper: Math.max(toleranceSource.timeUpper ?? DEFAULT_TOLERANCE.timeUpper, 1.0)
   };
 
-  const sorted = (device.curve || [])
+  const sorted = (profile.curve || device.curve || [])
     .map(p => ({ current: Number(p.current) || 0, time: Math.max(Number(p.time) || MIN_TIME, MIN_TIME) }))
     .filter(p => p.current > 0)
     .sort((a, b) => a.current - b.current);
@@ -78,9 +194,16 @@ export function scaleCurve(device = {}, overrides = {}) {
     maxCurve,
     envelope,
     settings: {
+      curveProfile: profile.id ?? null,
+      curveProfileLabel: profile.name ?? null,
       pickup,
       time,
+      longTimePickup: pickup,
+      longTimeDelay: time,
+      shortTimePickup,
+      shortTimeDelay,
       instantaneous,
+      instantaneousPickup: instantaneous,
       instantaneousDelay: instDelay,
       instantaneousMax: resolvedInstMax
     },

--- a/data/protectiveDevices.json
+++ b/data/protectiveDevices.json
@@ -111,28 +111,65 @@
     "name": "GE Multilin 750 Relay",
     "interruptRating": 30,
     "settings": {
-      "pickup": 150,
-      "time": 0.15,
-      "instantaneous": 600
+      "curveProfile": "IEC_VeryInverse",
+      "longTimePickup": 150,
+      "longTimeDelay": 0.15,
+      "shortTimePickup": 450,
+      "shortTimeDelay": 0.05,
+      "instantaneousPickup": 600
     },
     "settingOptions": {
-      "pickup": [75, 100, 125, 150, 175, 200],
-      "time": [0.1, 0.15, 0.2, 0.3],
-      "instantaneous": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
+      "curveProfile": [
+        { "value": "IEC_VeryInverse", "label": "IEC Very Inverse" },
+        { "value": "IEC_ExtremelyInverse", "label": "IEC Extremely Inverse" }
+      ],
+      "longTimePickup": [75, 100, 125, 150, 175, 200],
+      "longTimeDelay": [0.1, 0.15, 0.2, 0.3],
+      "shortTimePickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200],
+      "shortTimeDelay": [0.05, 0.1, 0.2, 0.3],
+      "instantaneousPickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
     },
-    "curve": [
+    "curveProfiles": [
       {
-        "current": 150,
-        "time": 50
+        "id": "IEC_VeryInverse",
+        "name": "IEC Very Inverse",
+        "curve": [
+          { "current": 150, "time": 40 },
+          { "current": 300, "time": 4 },
+          { "current": 600, "time": 0.6 },
+          { "current": 1200, "time": 0.12 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.15,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.05,
+          "instantaneousPickup": 600
+        }
       },
       {
-        "current": 600,
-        "time": 0.5
-      },
-      {
-        "current": 1200,
-        "time": 0.05
+        "id": "IEC_ExtremelyInverse",
+        "name": "IEC Extremely Inverse",
+        "curve": [
+          { "current": 150, "time": 30 },
+          { "current": 300, "time": 3 },
+          { "current": 600, "time": 0.4 },
+          { "current": 1200, "time": 0.08 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.2,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.08,
+          "instantaneousPickup": 600
+        }
       }
+    ],
+    "curve": [
+      { "current": 150, "time": 40 },
+      { "current": 300, "time": 4 },
+      { "current": 600, "time": 0.6 },
+      { "current": 1200, "time": 0.12 }
     ],
     "tolerance": {
       "timeLower": 0.75,

--- a/data/protectiveDevices.mjs
+++ b/data/protectiveDevices.mjs
@@ -111,28 +111,65 @@ export default [
     "name": "GE Multilin 750 Relay",
     "interruptRating": 30,
     "settings": {
-      "pickup": 150,
-      "time": 0.15,
-      "instantaneous": 600
+      "curveProfile": "IEC_VeryInverse",
+      "longTimePickup": 150,
+      "longTimeDelay": 0.15,
+      "shortTimePickup": 450,
+      "shortTimeDelay": 0.05,
+      "instantaneousPickup": 600
     },
     "settingOptions": {
-      "pickup": [75, 100, 125, 150, 175, 200],
-      "time": [0.1, 0.15, 0.2, 0.3],
-      "instantaneous": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
+      "curveProfile": [
+        { "value": "IEC_VeryInverse", "label": "IEC Very Inverse" },
+        { "value": "IEC_ExtremelyInverse", "label": "IEC Extremely Inverse" }
+      ],
+      "longTimePickup": [75, 100, 125, 150, 175, 200],
+      "longTimeDelay": [0.1, 0.15, 0.2, 0.3],
+      "shortTimePickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200],
+      "shortTimeDelay": [0.05, 0.1, 0.2, 0.3],
+      "instantaneousPickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
     },
-    "curve": [
+    "curveProfiles": [
       {
-        "current": 150,
-        "time": 50
+        "id": "IEC_VeryInverse",
+        "name": "IEC Very Inverse",
+        "curve": [
+          { "current": 150, "time": 40 },
+          { "current": 300, "time": 4 },
+          { "current": 600, "time": 0.6 },
+          { "current": 1200, "time": 0.12 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.15,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.05,
+          "instantaneousPickup": 600
+        }
       },
       {
-        "current": 600,
-        "time": 0.5
-      },
-      {
-        "current": 1200,
-        "time": 0.05
+        "id": "IEC_ExtremelyInverse",
+        "name": "IEC Extremely Inverse",
+        "curve": [
+          { "current": 150, "time": 30 },
+          { "current": 300, "time": 3 },
+          { "current": 600, "time": 0.4 },
+          { "current": 1200, "time": 0.08 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.2,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.08,
+          "instantaneousPickup": 600
+        }
       }
+    ],
+    "curve": [
+      { "current": 150, "time": 40 },
+      { "current": 300, "time": 4 },
+      { "current": 600, "time": 0.6 },
+      { "current": 1200, "time": 0.12 }
     ],
     "tolerance": {
       "timeLower": 0.75,

--- a/dist/data/protectiveDevices.json
+++ b/dist/data/protectiveDevices.json
@@ -111,28 +111,65 @@
     "name": "GE Multilin 750 Relay",
     "interruptRating": 30,
     "settings": {
-      "pickup": 150,
-      "time": 0.15,
-      "instantaneous": 600
+      "curveProfile": "IEC_VeryInverse",
+      "longTimePickup": 150,
+      "longTimeDelay": 0.15,
+      "shortTimePickup": 450,
+      "shortTimeDelay": 0.05,
+      "instantaneousPickup": 600
     },
     "settingOptions": {
-      "pickup": [75, 100, 125, 150, 175, 200],
-      "time": [0.1, 0.15, 0.2, 0.3],
-      "instantaneous": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
+      "curveProfile": [
+        { "value": "IEC_VeryInverse", "label": "IEC Very Inverse" },
+        { "value": "IEC_ExtremelyInverse", "label": "IEC Extremely Inverse" }
+      ],
+      "longTimePickup": [75, 100, 125, 150, 175, 200],
+      "longTimeDelay": [0.1, 0.15, 0.2, 0.3],
+      "shortTimePickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200],
+      "shortTimeDelay": [0.05, 0.1, 0.2, 0.3],
+      "instantaneousPickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
     },
-    "curve": [
+    "curveProfiles": [
       {
-        "current": 150,
-        "time": 50
+        "id": "IEC_VeryInverse",
+        "name": "IEC Very Inverse",
+        "curve": [
+          { "current": 150, "time": 40 },
+          { "current": 300, "time": 4 },
+          { "current": 600, "time": 0.6 },
+          { "current": 1200, "time": 0.12 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.15,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.05,
+          "instantaneousPickup": 600
+        }
       },
       {
-        "current": 600,
-        "time": 0.5
-      },
-      {
-        "current": 1200,
-        "time": 0.05
+        "id": "IEC_ExtremelyInverse",
+        "name": "IEC Extremely Inverse",
+        "curve": [
+          { "current": 150, "time": 30 },
+          { "current": 300, "time": 3 },
+          { "current": 600, "time": 0.4 },
+          { "current": 1200, "time": 0.08 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.2,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.08,
+          "instantaneousPickup": 600
+        }
       }
+    ],
+    "curve": [
+      { "current": 150, "time": 40 },
+      { "current": 300, "time": 4 },
+      { "current": 600, "time": 0.6 },
+      { "current": 1200, "time": 0.12 }
     ],
     "tolerance": {
       "timeLower": 0.75,

--- a/dist/data/protectiveDevices.mjs
+++ b/dist/data/protectiveDevices.mjs
@@ -111,28 +111,65 @@ export default [
     "name": "GE Multilin 750 Relay",
     "interruptRating": 30,
     "settings": {
-      "pickup": 150,
-      "time": 0.15,
-      "instantaneous": 600
+      "curveProfile": "IEC_VeryInverse",
+      "longTimePickup": 150,
+      "longTimeDelay": 0.15,
+      "shortTimePickup": 450,
+      "shortTimeDelay": 0.05,
+      "instantaneousPickup": 600
     },
     "settingOptions": {
-      "pickup": [75, 100, 125, 150, 175, 200],
-      "time": [0.1, 0.15, 0.2, 0.3],
-      "instantaneous": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
+      "curveProfile": [
+        { "value": "IEC_VeryInverse", "label": "IEC Very Inverse" },
+        { "value": "IEC_ExtremelyInverse", "label": "IEC Extremely Inverse" }
+      ],
+      "longTimePickup": [75, 100, 125, 150, 175, 200],
+      "longTimeDelay": [0.1, 0.15, 0.2, 0.3],
+      "shortTimePickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200],
+      "shortTimeDelay": [0.05, 0.1, 0.2, 0.3],
+      "instantaneousPickup": [300, 400, 500, 600, 700, 800, 900, 1000, 1200]
     },
-    "curve": [
+    "curveProfiles": [
       {
-        "current": 150,
-        "time": 50
+        "id": "IEC_VeryInverse",
+        "name": "IEC Very Inverse",
+        "curve": [
+          { "current": 150, "time": 40 },
+          { "current": 300, "time": 4 },
+          { "current": 600, "time": 0.6 },
+          { "current": 1200, "time": 0.12 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.15,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.05,
+          "instantaneousPickup": 600
+        }
       },
       {
-        "current": 600,
-        "time": 0.5
-      },
-      {
-        "current": 1200,
-        "time": 0.05
+        "id": "IEC_ExtremelyInverse",
+        "name": "IEC Extremely Inverse",
+        "curve": [
+          { "current": 150, "time": 30 },
+          { "current": 300, "time": 3 },
+          { "current": 600, "time": 0.4 },
+          { "current": 1200, "time": 0.08 }
+        ],
+        "settings": {
+          "longTimePickup": 150,
+          "longTimeDelay": 0.2,
+          "shortTimePickup": 450,
+          "shortTimeDelay": 0.08,
+          "instantaneousPickup": 600
+        }
       }
+    ],
+    "curve": [
+      { "current": 150, "time": 40 },
+      { "current": 300, "time": 4 },
+      { "current": 600, "time": 0.6 },
+      { "current": 1200, "time": 0.12 }
     ],
     "tolerance": {
       "timeLower": 0.75,


### PR DESCRIPTION
## Summary
- update the TCC device settings panel to support formatted labels, string-valued options, and default-aware override handling
- extend curve scaling to honor curve profile selections and new long/short time pickup settings
- add curve profile metadata to the GE Multilin 750 relay so profile options are available in the UI

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc4945835c83249b74fc3f1a8d2280