### PR TITLE
Fix load flow bus filtering using metadata-aware helper

### DIFF
--- a/tests/loadflow/ieeeCases.test.js
+++ b/tests/loadflow/ieeeCases.test.js
@@ -57,5 +57,39 @@ function caseToDiagram(data){
       const res = runLoadFlow({ baseMVA: case57.baseMVA });
       assert(Array.isArray(res.buses || res));
     });
+
+    it('keeps only bus components when subtype keys include metadata prefixes', () => {
+      setOneLine({
+        activeSheet: 0,
+        sheets: [{
+          name: 'meta',
+          components: [
+            {
+              id: 'bus-1',
+              type: 'bus',
+              subtype: 'bus_Bus',
+              busType: 'slack',
+              baseKV: 13.8,
+              Vm: 1,
+              Va: 0,
+              connections: [
+                { target: 'motor-1', impedance: { r: 0.01, x: 0.05 } }
+              ]
+            },
+            {
+              id: 'motor-1',
+              type: 'motor_load',
+              subtype: 'motor_load',
+              load: { kw: 75, kvar: 40 }
+            }
+          ]
+        }]
+      });
+      const res = runLoadFlow();
+      const buses = Array.isArray(res?.buses) ? res.buses : res;
+      assert(Array.isArray(buses));
+      assert.strictEqual(buses.length, 1);
+      assert.strictEqual(buses[0].id, 'bus-1');
+    });
   });
 })();


### PR DESCRIPTION
## Summary
- add a metadata-aware bus detection helper for the load flow solver
- filter one-line components through the new helper so only real buses are solved
- add a regression test covering bus subtypes with metadata-prefixed keys

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de6d4ae2f483249d3f0ee9f6856150