### PR TITLE
Remove radial reliability warnings

### DIFF
--- a/analysis/reliability.js
+++ b/analysis/reliability.js
@@ -1,5 +1,4 @@
 import { getOneLine, getStudies, setStudies } from '../dataStore.mjs';
-import { resolveComponentLabel } from '../utils/componentLabels.js';
 let d3;
 if (typeof document !== 'undefined') {
   d3 = await import('https://cdn.jsdelivr.net/npm/d3@7/+esm');
@@ -28,8 +27,6 @@ export function runReliability(components = []) {
   // Filter out non-operational components like dimensions or annotations
   const ops = components.filter(c => !isVisualComponent(c));
   const eligible = ops.filter(c => !isConnectorComponent(c));
-  const connectorIds = new Set(ops.filter(isConnectorComponent).map(c => c.id));
-  const compMap = new Map(ops.map(c => [c.id, c]));
   // Compute component availability and expected downtime per year
   const componentStats = {};
   const availMap = {};
@@ -47,88 +44,13 @@ export function runReliability(components = []) {
 
   const expectedOutage = Object.values(componentStats).reduce((sum, s) => sum + s.downtime, 0);
 
-  // Build undirected adjacency map
-  const adj = new Map();
-  ops.forEach(c => adj.set(c.id, new Set()));
-  ops.forEach(c => {
-    (c.connections || []).forEach(conn => {
-      if (compMap.has(conn.target)) {
-        adj.get(c.id).add(conn.target);
-        adj.get(conn.target).add(c.id);
-      }
-    });
-  });
-
-  function computeIslands(exclude = []) {
-    const excludeSet = new Set(exclude);
-    const nodes = ops.map(c => c.id).filter(id => !excludeSet.has(id));
-    const visited = new Set();
-    const islands = [];
-    nodes.forEach(start => {
-      if (visited.has(start)) return;
-      const stack = [start];
-      const group = [];
-      while (stack.length) {
-        const node = stack.pop();
-        if (visited.has(node) || excludeSet.has(node)) continue;
-        visited.add(node);
-        group.push(node);
-        adj.get(node)?.forEach(next => {
-          if (!visited.has(next) && !excludeSet.has(next)) stack.push(next);
-        });
-      }
-      if (group.length) islands.push(group);
-    });
-    return islands;
-  }
-
-  function isConnected(exclude = []) {
-    return computeIslands(exclude).length <= 1;
-  }
-
-  const labelFor = id => {
-    const comp = compMap.get(id);
-    return resolveComponentLabel(comp, id);
-  };
-
-  const n1Failures = [];
-  const n1FailureDetails = {};
-  eligible.forEach(c => {
-    const islands = computeIslands([c.id]);
-    if (islands.length <= 1) return;
-    n1Failures.push(c.id);
-    const sorted = islands.slice().sort((a, b) => b.length - a.length);
-    const impactedIslands = sorted.slice(1);
-    const impactedIds = impactedIslands.flat().filter(id => !connectorIds.has(id));
-    n1FailureDetails[c.id] = {
-      islands,
-      impactedIds,
-      impactedLabels: impactedIds.map(labelFor),
-      impactedCount: impactedIds.length
-    };
-  });
-
-  const n2Failures = [];
-  for (let i = 0; i < eligible.length; i++) {
-    for (let j = i + 1; j < eligible.length; j++) {
-      if (!isConnected([eligible[i].id, eligible[j].id])) {
-        n2Failures.push([eligible[i].id, eligible[j].id]);
-      }
-    }
-  }
-
   // Minimal cut set probabilities up to N-2
   const baseProd = Object.values(availMap).reduce((p, v) => p * v.p, 1) || 1;
-  const n1Impacts = n1Failures.map(id => ({
-    components: [id],
-    probability: availMap[id] ? availMap[id].q * (baseProd / availMap[id].p) : 0
-  }));
-  const n2Impacts = n2Failures.map(([a, b]) => ({
-    components: [a, b],
-    probability: (availMap[a] && availMap[b])
-      ? availMap[a].q * availMap[b].q * (baseProd / (availMap[a].p * availMap[b].p))
-      : 0
-  }));
+  const n1Failures = [];
+  const n2Failures = [];
+  const n1Impacts = [];
+  const n2Impacts = [];
+  const n1FailureDetails = {};
   const unavailability = n1Impacts.reduce((s, i) => s + i.probability, 0)
     + n2Impacts.reduce((s, i) => s + i.probability, 0);
   const systemAvailability = 1 - unavailability;

--- a/tests/analysis.test.js
+++ b/tests/analysis.test.js
@@ -116,25 +116,23 @@ function caseToDiagram(data) {
       assert.strictEqual(label, 'REF-1');
     });
 
-    it('uses enhanced labels in reliability outputs and validation issues', () => {
+    it('does not emit radial reliability failures', () => {
       const source = { id: 'source', type: 'bus', connections: [{ target: 'breaker' }] };
       const breaker = { id: 'breaker', type: 'breaker', tag: 'BRK-1', connections: [{ target: 'source' }, { target: 'load' }] };
       const load = { id: 'load', type: 'bus', props: { tag: 'LD-1' }, connections: [{ target: 'breaker' }] };
       const components = [source, breaker, load];
 
       const reliability = runReliability(components);
-      assert.deepStrictEqual(reliability.n1Failures, ['breaker']);
-      assert.deepStrictEqual(reliability.n1FailureDetails.breaker.impactedLabels, ['LD-1']);
+      assert.deepStrictEqual(reliability.n1Failures, []);
+      assert.deepStrictEqual(reliability.n1FailureDetails, {});
 
       const issues = runValidation(components, {
         reliability: {
-          n1Failures: ['breaker'],
-          n1FailureDetails: { breaker: { impactedIds: ['load'] } }
+          n1Failures: reliability.n1Failures,
+          n1FailureDetails: reliability.n1FailureDetails
         }
       });
-      assert.strictEqual(issues.length, 1);
-      assert.ok(issues[0].message.includes('BRK-1 single point of failure'));
-      assert.ok(issues[0].message.includes('LD-1'));
+      assert.strictEqual(issues.length, 0);
     });
   });
 })();


### PR DESCRIPTION
## Summary
- stop the reliability study from producing radial single-point-of-failure results
- remove validation messages that surfaced reliability single-point-of-failure warnings
- update reliability tests to reflect the new behaviour

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7250f3f88324b5181b9c2d7e9585