### PR TITLE
Add motor start inputs and improve empty state message

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -628,6 +628,11 @@
         "gap": 32,
         "working_distance": 455,
         "electrode_config": "VCB",
+        "inrushMultiple": 6,
+        "thevenin_r": 0.02,
+        "thevenin_x": 0.08,
+        "inertia": 0.5,
+        "load_torque_curve": "0:0 100:100",
         "load": {
           "kw": 117.789,
           "kvar": 63.576

--- a/dist/componentLibrary.json
+++ b/dist/componentLibrary.json
@@ -628,6 +628,11 @@
         "gap": 32,
         "working_distance": 455,
         "electrode_config": "VCB",
+        "inrushMultiple": 6,
+        "thevenin_r": 0.02,
+        "thevenin_x": 0.08,
+        "inertia": 0.5,
+        "load_torque_curve": "0:0 100:100",
         "load": {
           "kw": 117.789,
           "kvar": 63.576

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -628,6 +628,11 @@
         "gap": 32,
         "working_distance": 455,
         "electrode_config": "VCB",
+        "inrushMultiple": 6,
+        "thevenin_r": 0.02,
+        "thevenin_x": 0.08,
+        "inertia": 0.5,
+        "load_torque_curve": "0:0 100:100",
         "load": {
           "kw": 117.789,
           "kvar": 63.576


### PR DESCRIPTION
## Summary
- wrap the empty-state message on the motor starting chart so the guidance text stays readable
- add default motor starting parameters to the motor component metadata and surface editable inputs in the one-line properties modal

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de900043748324a07d8652e71456f9