### PR TITLE
Ensure sample one-line data is copied to build artifacts

### DIFF
--- a/dist/examples/sample_oneline.json
+++ b/dist/examples/sample_oneline.json
@@ -1,0 +1,49 @@
+{
+  "version": 2,
+  "scale": { "unitPerPx": 1, "unit": "in" },
+  "templates": [],
+  "sheets": [
+    {
+      "name": "Sample",
+      "components": [
+        {
+          "id": "n1",
+          "type": "bus",
+          "subtype": "Bus",
+          "x": 40,
+          "y": 60,
+          "label": "Bus 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": [ { "target": "n2" } ]
+        },
+        {
+          "id": "n2",
+          "type": "panel",
+          "subtype": "MLO",
+          "x": 220,
+          "y": 60,
+          "label": "Panel 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": [ { "target": "n3" } ]
+        },
+        {
+          "id": "n3",
+          "type": "load",
+          "subtype": "Load",
+          "x": 400,
+          "y": 60,
+          "label": "Load 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": []
+        }
+      ],
+      "connections": [
+        { "from": "n1", "to": "n2" },
+        { "from": "n2", "to": "n3" }
+      ]
+    }
+  ]
+}

--- a/docs/examples/sample_oneline.json
+++ b/docs/examples/sample_oneline.json
@@ -1,0 +1,49 @@
+{
+  "version": 2,
+  "scale": { "unitPerPx": 1, "unit": "in" },
+  "templates": [],
+  "sheets": [
+    {
+      "name": "Sample",
+      "components": [
+        {
+          "id": "n1",
+          "type": "bus",
+          "subtype": "Bus",
+          "x": 40,
+          "y": 60,
+          "label": "Bus 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": [ { "target": "n2" } ]
+        },
+        {
+          "id": "n2",
+          "type": "panel",
+          "subtype": "MLO",
+          "x": 220,
+          "y": 60,
+          "label": "Panel 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": [ { "target": "n3" } ]
+        },
+        {
+          "id": "n3",
+          "type": "load",
+          "subtype": "Load",
+          "x": 400,
+          "y": 60,
+          "label": "Load 1",
+          "rotation": 0,
+          "flipped": false,
+          "connections": []
+        }
+      ],
+      "connections": [
+        { "from": "n1", "to": "n2" },
+        { "from": "n2", "to": "n3" }
+      ]
+    }
+  ]
+}

--- a/scripts/copyAssets.js
+++ b/scripts/copyAssets.js
@@ -14,6 +14,7 @@ function copy(src, dest) {
 
 copy(path.join(root, 'icons'), path.join(dist, 'icons'));
 copy(path.join(root, 'data'), path.join(dist, 'data'));
+copy(path.join(root, 'examples', 'sample_oneline.json'), path.join(dist, 'examples', 'sample_oneline.json'));
 copy(path.join(root, 'icons'), path.join(docs, 'icons'));
 copy(path.join(root, 'reports', 'templates'), path.join(dist, 'templates'));
 copy(path.join(root, 'reports', 'templates'), path.join(docs, 'templates'));
@@ -23,6 +24,8 @@ copy(path.join(dist, 'vendor'), path.join(docs, 'dist', 'vendor'));
   fs.copyFileSync(src, path.join(dist, file));
   fs.copyFileSync(src, path.join(docs, file));
 });
+
+copy(path.join(root, 'examples', 'sample_oneline.json'), path.join(docs, 'examples', 'sample_oneline.json'));
 
 ['style.css'].forEach(file => {
   const src = path.join(root, file);


### PR DESCRIPTION
## Summary
- update the asset copy script to include the sample one-line JSON in the dist and docs outputs so the Load Sample button can retrieve it after a build
- add the copied sample file to the dist/docs artifacts to make it available in deployments

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df2bc317688324a72d577fe1daa09a