### PR TITLE
Fix sample one-line loader to use base-aware asset path

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -7109,7 +7109,7 @@ async function importDiagram(data) {
 
 async function loadSampleDiagram() {
   try {
-    const res = await fetch('examples/sample_oneline.json');
+    const res = await fetch(asset('examples/sample_oneline.json'));
     if (!res.ok) throw new Error(res.statusText);
     const data = await res.json();
     await importDiagram(data);


### PR DESCRIPTION
## Summary
- load the sample one-line diagram using the base-aware asset helper so the request resolves correctly

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df31c2a038832491332ae6e8a469b4