### PR TITLE
Add zoom controls and load flow current overlays

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -204,7 +204,12 @@ function solvePhase(buses, baseMVA) {
       const scale = baseMVA * 1000; // convert per-unit results to kW/kvar
       const P = Sij.re * scale;
       const Q = Sij.im * scale;
-      flows.push({ from: bus.id, to: buses[j].id, P, Q });
+      const Ipu = Math.hypot(Iij.re, Iij.im);
+      const baseKV = bus.baseKV || buses[j].baseKV || 1;
+      const baseCurrentKA = baseKV ? baseMVA / (Math.sqrt(3) * baseKV) : 0;
+      const currentKA = Ipu * baseCurrentKA;
+      const currentA = currentKA * 1000;
+      flows.push({ from: bus.id, to: buses[j].id, P, Q, Ipu, currentKA, amps: currentA });
       const key = [bus.id, buses[j].id].sort().join('-');
       lossMap[key] = lossMap[key] || { P: 0, Q: 0 };
       lossMap[key].P += P;

--- a/oneline.html
+++ b/oneline.html
@@ -131,6 +131,15 @@
               <input type="number" id="grid-size" value="20" min="1">
             </label>
           </div>
+          <div class="toolbar-group" aria-label="Zoom">
+            <span class="toolbar-group-label">Zoom</span>
+            <div class="zoom-controls">
+              <button id="zoom-out-btn" type="button" class="icon-button" title="Zoom out" aria-label="Zoom out">&minus;</button>
+              <span id="zoom-display" aria-live="polite">100%</span>
+              <button id="zoom-in-btn" type="button" class="icon-button" title="Zoom in" aria-label="Zoom in">+</button>
+              <button id="zoom-reset-btn" type="button" class="btn" title="Reset zoom">Reset</button>
+            </div>
+          </div>
           <div class="toolbar-group" aria-label="View options">
             <span class="toolbar-group-label">View</span>
               <div class="view-group">

--- a/style.css
+++ b/style.css
@@ -154,6 +154,9 @@
   flex-direction: column;
   gap: var(--ol-spacing);
   font-family: var(--ol-font);
+  overflow-y: auto;
+  max-height: calc(100vh - 12rem);
+  padding-right: 0.25rem;
 }
 
 #palette-search {
@@ -256,6 +259,12 @@
 
 body.compact-mode .palette-section .section-buttons {
   --palette-column-min: 5rem;
+}
+
+@media (max-width: 900px) {
+  .palette {
+    max-height: none;
+  }
 }
 
 .palette-section .no-components {
@@ -512,11 +521,24 @@ body.compact-mode .palette-section .section-buttons {
   margin-bottom: var(--ol-spacing);
 }
 
+.zoom-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#zoom-display {
+  min-width: 3rem;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
 .workspace {
   --palette-width: 250px;
   display: grid;
   grid-template-columns: var(--palette-width) 1fr;
   position: relative;
+  align-items: start;
 }
 
 .splitter {


### PR DESCRIPTION
## Summary
- allow the one-line component palette to scroll independently and add zoom controls to the toolbar
- persist zoom state, support Ctrl+wheel zooming, and ensure pointer events respect the current zoom
- compute and display load-flow branch currents in amps alongside existing power data on the diagram and in the report panel

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfddc317f883249ff9cfb08194a096