### PR TITLE
Add study settings controls and better one-line interactions

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -92,9 +92,17 @@ function arcingCurrent(Ibf, V, gap, cfg, enclosure) {
  * { incidentEnergy, boundary, ppeCategory, clearingTime } where energy is
  * in cal/cm^2 and boundary in millimeters.
  */
-export async function runArcFlash() {
+export async function runArcFlash(options = {}) {
   const devices = await loadDevices();
-  const sc = runShortCircuit();
+  let scOptions = {};
+  if (options && typeof options === 'object') {
+    if (options.shortCircuit && typeof options.shortCircuit === 'object') {
+      scOptions = options.shortCircuit;
+    } else if (Object.prototype.hasOwnProperty.call(options, 'method')) {
+      scOptions = options;
+    }
+  }
+  const sc = runShortCircuit(scOptions);
   const { sheets } = getOneLine();
   const comps = (Array.isArray(sheets[0]?.components)
     ? sheets.flatMap(s => s.components)

--- a/oneline.html
+++ b/oneline.html
@@ -273,10 +273,32 @@
       <button id="run-shortcircuit-btn" type="button">Short Circuit</button>
         <button id="run-arcflash-btn" type="button">Arc Flash</button>
         <button id="run-harmonics-btn" type="button">Harmonics</button>
-        <button id="run-motorstart-btn" type="button">Motor Start</button>
-        <button id="run-reliability-btn" type="button">Reliability</button>
+      <button id="run-motorstart-btn" type="button">Motor Start</button>
+      <button id="run-reliability-btn" type="button">Reliability</button>
+      <button id="study-settings-btn" type="button" class="btn" aria-expanded="false">Settings</button>
         <label class="d-block mt-1"><input type="checkbox" id="toggle-overlays" checked> Show Result Overlays</label>
       </div>
+      <form id="study-settings-menu" class="study-settings hidden" aria-label="Study settings">
+        <fieldset>
+          <legend>Load Flow</legend>
+          <label for="study-loadflow-basemva">Base MVA
+            <input type="number" id="study-loadflow-basemva" min="1" step="1">
+          </label>
+          <label class="inline-control">
+            <input type="checkbox" id="study-loadflow-balanced">
+            <span>Balanced solution</span>
+          </label>
+        </fieldset>
+        <fieldset>
+          <legend>Short Circuit</legend>
+          <label for="study-shortcircuit-method">Method
+            <select id="study-shortcircuit-method">
+              <option value="IEC">IEC 60909</option>
+              <option value="ANSI">ANSI</option>
+            </select>
+          </label>
+        </fieldset>
+      </form>
       <pre id="study-results" class="study-results"></pre>
       <div id="loadflow-results" class="study-results"></div>
     </aside>

--- a/style.css
+++ b/style.css
@@ -3460,6 +3460,41 @@ body.dark-mode .workflow-card-title {
     display: none;
 }
 
+.study-settings {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    background: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--ol-radius);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.study-settings.hidden {
+    display: none;
+}
+
+.study-settings fieldset {
+    border: 1px solid var(--border-color);
+    border-radius: var(--ol-radius);
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.study-settings label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.study-settings .inline-control {
+    justify-content: flex-start;
+}
+
 .study-results {
     white-space: pre-wrap;
     background: var(--bg-color);


### PR DESCRIPTION
## Summary
- add a study settings menu so users can choose load flow and short circuit defaults and persist them
- improve the one-line viewport math to support panning alongside zooming and keep overlays in sync
- automatically insert bus nodes when connecting impedance devices and plumb study settings into analyses

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01d1d9fb883249d4442daf383e9a5