### PR TITLE
Improve one-line panning and load flow base voltage normalization

### DIFF
--- a/style.css
+++ b/style.css
@@ -620,8 +620,9 @@ body.oneline-page .oneline-editor #diagram {
 .oneline-editor #diagram {
   border: 1px solid var(--ol-border-color);
   border-radius: var(--ol-radius);
-  width: 100%;
-  height: 100%;
+  display: block;
+  min-width: 100%;
+  min-height: 100%;
 }
 
 .oneline-editor.panning,


### PR DESCRIPTION
## Summary
- allow the one-line diagram SVG to expand with zooming so the editor can scroll in all directions
- surface load flow results more reliably by cloning study data and rendering the latest run
- normalize bus base voltage detection for load flow models to avoid improbable per-unit values

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e41a750fec8324932fd966f5a8b463