### PR TITLE
Revert changes from PR #965 affecting the one-line diagram

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -12,103 +12,6 @@ function isUsableComponent(comp) {
   return comp && !IGNORED_TYPES.has(comp.type);
 }
 
-const BASE_KV_KEYS = ['baseKV', 'base_kv', 'base_kV', 'basekv', 'kv', 'kV'];
-const VOLTAGE_KEYS = [
-  'voltage',
-  'volts',
-  'nominal_voltage',
-  'nominalVolts',
-  'prefault_voltage',
-  'line_voltage',
-  'line_to_line_voltage',
-  'lineToLineVoltage',
-  'll_voltage',
-  'ln_voltage',
-  'voltage_ll',
-  'voltage_ln'
-];
-const EXTRA_VALUE_SOURCES = ['props', 'parameters', 'settings', 'config', 'metadata', 'rating'];
-const KNOWN_KV_INTEGERS = new Set([11, 12, 13, 14, 15, 16, 20, 22, 23, 24, 25, 27, 33, 34, 35]);
-
-function findField(source, key) {
-  if (!source || typeof source !== 'object') return undefined;
-  if (source[key] !== undefined) return source[key];
-  const camel = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-  if (source[camel] !== undefined) return source[camel];
-  const pascal = camel.charAt(0).toUpperCase() + camel.slice(1);
-  if (source[pascal] !== undefined) return source[pascal];
-  const lower = key.toLowerCase();
-  const matchKey = Object.keys(source).find(prop => prop.toLowerCase() === lower);
-  return matchKey ? source[matchKey] : undefined;
-}
-
-function extractNumeric(source, keys) {
-  if (!source) return null;
-  for (const key of keys) {
-    const raw = findField(source, key);
-    if (raw === undefined || raw === null) continue;
-    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
-    if (typeof raw === 'string') {
-      const match = raw.match(/-?\d+(?:\.\d+)?/);
-      if (!match) continue;
-      const parsed = Number.parseFloat(match[0]);
-      if (Number.isFinite(parsed)) return parsed;
-    }
-  }
-  return null;
-}
-
-function normalizeKvValue(value) {
-  if (!Number.isFinite(value) || value <= 0) return null;
-  if (value >= 100) return value / 1000;
-  return value;
-}
-
-function normalizeVoltageValue(value) {
-  if (!Number.isFinite(value) || value <= 0) return null;
-  if (value >= 100) return value / 1000;
-  if (value > 10 && Number.isInteger(value)) return KNOWN_KV_INTEGERS.has(value) ? value : value / 1000;
-  if (value > 10) return value;
-  return value;
-}
-
-function resolveBaseKV(comp) {
-  const sources = [comp];
-  EXTRA_VALUE_SOURCES.forEach(key => {
-    const src = comp && comp[key];
-    if (src) sources.push(src);
-  });
-  for (const src of sources) {
-    const raw = extractNumeric(src, BASE_KV_KEYS);
-    const normalized = normalizeKvValue(raw);
-    if (normalized) return normalized;
-  }
-  for (const src of sources) {
-    const raw = extractNumeric(src, VOLTAGE_KEYS);
-    const normalized = normalizeVoltageValue(raw);
-    if (normalized) return normalized;
-  }
-  if (Array.isArray(comp?.connections)) {
-    for (const conn of comp.connections) {
-      if (!conn) continue;
-      const connSources = [conn];
-      EXTRA_VALUE_SOURCES.forEach(key => {
-        const src = conn && conn[key];
-        if (src) connSources.push(src);
-      });
-      for (const src of connSources) {
-        const rawKv = extractNumeric(src, BASE_KV_KEYS);
-        const normalizedKv = normalizeKvValue(rawKv);
-        if (normalizedKv) return normalizedKv;
-        const rawVolt = extractNumeric(src, VOLTAGE_KEYS);
-        const normalizedVolt = normalizeVoltageValue(rawVolt);
-        if (normalizedVolt) return normalizedVolt;
-      }
-    }
-  }
-  return 1;
-}
-
 /** Basic complex number helpers used by the load-flow solver */
 function toComplex(re = 0, im = 0) {
   return { re, im };
@@ -480,14 +383,12 @@ export function runLoadFlow(modelOrOpts = {}, maybeOpts = {}) {
       const loadPQ = extractPhasePQ(c.load, phase, balanced);
       const genPQ = extractPhasePQ(c.generation, phase, balanced);
       const shunt = balanced ? c.shunt : resolvePhaseRecord(c.shunt, phase);
-      const baseKV = resolveBaseKV(c);
-      c.baseKV = baseKV;
       return {
         id: c.id,
         type: c.busType || (idx === 0 ? 'slack' : 'PQ'),
-        Vm: Number.isFinite(c.Vm) ? c.Vm : 1,
-        Va: Number.isFinite(c.Va) ? c.Va : 0,
-        baseKV,
+        Vm: c.Vm,
+        Va: c.Va,
+        baseKV: c.baseKV || 1,
         Pd: loadPQ.kw,
         Qd: loadPQ.kvar,
         Pg: genPQ.kw,

--- a/oneline.js
+++ b/oneline.js
@@ -1191,7 +1191,6 @@ function renderStudyResults() {
   if (!studyResultsEl) return;
   const res = getStudies();
   studyResultsEl.textContent = Object.keys(res).length ? JSON.stringify(res, null, 2) : 'No results';
-  renderLoadFlowResults(res.loadFlow);
 }
 
 function highlightSPF(ids = []) {
@@ -1290,22 +1289,16 @@ function applyDiagramZoom({ adjustScroll = false, previousZoom, focusPoint } = {
   const zoom = diagramZoom || DEFAULT_DIAGRAM_ZOOM;
   const { minX, minY, width, height } = diagramViewport;
   if (width && height) {
-    const pixelWidth = width * zoom;
-    const pixelHeight = height * zoom;
     svg.setAttribute('viewBox', `${minX} ${minY} ${width} ${height}`);
-    svg.setAttribute('width', String(pixelWidth));
-    svg.setAttribute('height', String(pixelHeight));
-    svg.style.width = `${pixelWidth}px`;
-    svg.style.height = `${pixelHeight}px`;
-    svg.style.minWidth = `${pixelWidth}px`;
-    svg.style.minHeight = `${pixelHeight}px`;
+    svg.style.width = `${width * zoom}px`;
+    svg.style.height = `${height * zoom}px`;
   }
   const gridBg = document.getElementById('grid-bg');
   if (gridBg) {
     gridBg.setAttribute('x', String(minX));
     gridBg.setAttribute('y', String(minY));
-    gridBg.setAttribute('width', String(width + gridSize));
-    gridBg.setAttribute('height', String(height + gridSize));
+    gridBg.setAttribute('width', String(width));
+    gridBg.setAttribute('height', String(height));
   }
   if (!adjustScroll) return;
   const editor = svg.parentElement;
@@ -1505,48 +1498,24 @@ if (runLFBtn) runLFBtn.addEventListener('click', () => {
     }
   });
   setOneLine({ activeSheet, sheets });
-  const currentStudies = getStudies();
-  let clonedResult;
-  if (typeof structuredClone === 'function') {
-    clonedResult = structuredClone(res);
-  } else {
-    try {
-      clonedResult = JSON.parse(JSON.stringify(res));
-    } catch {
-      const cloneRecursive = value => {
-        if (Array.isArray(value)) return value.map(cloneRecursive);
-        if (value && typeof value === 'object') {
-          const out = {};
-          Object.keys(value).forEach(key => {
-            out[key] = cloneRecursive(value[key]);
-          });
-          return out;
-        }
-        return value;
-      };
-      clonedResult = cloneRecursive(res);
-    }
-  }
-  const studies = { ...currentStudies, loadFlow: clonedResult };
+  const studies = getStudies();
+  studies.loadFlow = res;
   setStudies(studies);
   syncSchedules(false);
   renderStudyResults();
+  renderLoadFlowResults(res);
   render();
 });
 
 function renderLoadFlowResults(res) {
   if (!loadFlowResultsEl) return;
-  if (!res) {
-    loadFlowResultsEl.innerHTML = '<p>No load flow results.</p>';
-    return;
-  }
-  const buses = Array.isArray(res?.buses) ? res.buses : (Array.isArray(res) ? res : []);
+  const buses = res.buses || res;
   let html = '<h3>Bus Voltages</h3><table><tr><th>Bus</th><th>Phase</th><th>Vm</th><th>Va</th></tr>';
   buses.forEach(b => {
     html += `<tr><td>${b.id}</td><td>${b.phase || ''}</td><td>${b.Vm.toFixed(4)}</td><td>${b.Va.toFixed(2)}</td></tr>`;
   });
   html += '</table>';
-  if (Array.isArray(res.lines) && res.lines.length) {
+  if (res.lines) {
     html += '<h3>Line Flows (kW/kvar)</h3><table><tr><th>From</th><th>To</th><th>Phase</th><th>P</th><th>Q</th><th>I (A)</th></tr>';
     res.lines.forEach(l => {
       const amps = typeof l.amps === 'number'

--- a/style.css
+++ b/style.css
@@ -620,9 +620,8 @@ body.oneline-page .oneline-editor #diagram {
 .oneline-editor #diagram {
   border: 1px solid var(--ol-border-color);
   border-radius: var(--ol-radius);
-  display: block;
-  min-width: 100%;
-  min-height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 .oneline-editor.panning,


### PR DESCRIPTION
## Summary
- revert PR #965 to restore the prior one-line diagram behavior
- restore the previous load flow solver and styling that existed before the regression

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4212649208324b39ae4252e705fd9