### PR TITLE
Fix oneline placement and palette scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -589,6 +589,8 @@ body.oneline-page .workspace {
 body.oneline-page .palette {
   height: 100%;
   max-height: none;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 body.oneline-page .oneline-editor {


### PR DESCRIPTION
## Summary
- align drag-and-drop placement with diagram coordinates so new components follow the cursor
- guard the upstream panel lookup against cycles when wiring transformers to loads
- allow the one-line palette column to scroll independently of the page

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e42541ad8c8324a3532ca12c4f5e22