### PR TITLE
Improve one-line component placement and canvas viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -590,7 +590,7 @@ body.oneline-page .palette {
   height: 100%;
   max-height: none;
   min-height: 0;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 body.oneline-page .oneline-editor {
@@ -601,6 +601,13 @@ body.oneline-page .oneline-editor {
 
 body.oneline-page .oneline-editor #diagram {
   height: 100%;
+}
+
+body.oneline-page #component-buttons {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
 .splitter {


### PR DESCRIPTION
## Summary
- place new one-line components relative to the current viewport instead of the legacy fixed origin
- hold the one-line canvas to a large static viewport and center the initial view for each sheet
- make the device library panel manage its own vertical scrolling without affecting the rest of the layout

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e532863d648324a7a58e30d6da2097