### PR TITLE
Adjust one-line viewport defaults and improve palette scrollbar

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -1034,9 +1034,9 @@ let diagramScale = getItem('diagramScale', { unitPerPx: 1, unit: 'in' });
 const DEFAULT_DIAGRAM_ZOOM = 1;
 const MIN_DIAGRAM_ZOOM = 0.25;
 const MAX_DIAGRAM_ZOOM = 4;
-const DEFAULT_VIEWPORT_WIDTH = 1200;
-const DEFAULT_VIEWPORT_HEIGHT = 675;
-const STATIC_VIEWPORT_SCALE = 6;
+const DEFAULT_VIEWPORT_WIDTH = 960;
+const DEFAULT_VIEWPORT_HEIGHT = 540;
+const STATIC_VIEWPORT_SCALE = 4;
 const STATIC_VIEWPORT_BOUNDS = {
   minX: -DEFAULT_VIEWPORT_WIDTH * STATIC_VIEWPORT_SCALE / 2,
   minY: -DEFAULT_VIEWPORT_HEIGHT * STATIC_VIEWPORT_SCALE / 2,
@@ -1367,16 +1367,18 @@ function adjustZoom(factor, opts = {}) {
 
 function panDiagram(direction, container) {
   if (!(container instanceof HTMLElement)) return;
-  const stepX = Math.max(80, Math.round(container.clientWidth * 0.3));
-  const stepY = Math.max(80, Math.round(container.clientHeight * 0.3));
+  const scrollHost = getScrollableContainer(container) || container;
+  if (!(scrollHost instanceof HTMLElement)) return;
+  const stepX = Math.max(80, Math.round(scrollHost.clientWidth * 0.3));
+  const stepY = Math.max(80, Math.round(scrollHost.clientHeight * 0.3));
   if (direction === 'left') {
-    container.scrollLeft -= stepX;
+    scrollHost.scrollLeft -= stepX;
   } else if (direction === 'right') {
-    container.scrollLeft += stepX;
+    scrollHost.scrollLeft += stepX;
   } else if (direction === 'up') {
-    container.scrollTop -= stepY;
+    scrollHost.scrollTop -= stepY;
   } else if (direction === 'down') {
-    container.scrollTop += stepY;
+    scrollHost.scrollTop += stepY;
   } else {
     return;
   }

--- a/style.css
+++ b/style.css
@@ -609,6 +609,7 @@ body.oneline-page .palette {
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-gutter: stable both-edges;
 }
 
 body.oneline-page .oneline-editor {
@@ -626,6 +627,7 @@ body.oneline-page #component-buttons {
   min-height: 0;
   overflow-y: auto;
   padding-right: 0.25rem;
+  scrollbar-gutter: stable both-edges;
 }
 
 .splitter {


### PR DESCRIPTION
## Summary
- shrink the default one-line viewport bounds so diagrams open with a tighter canvas
- make toolbar-based and keyboard panning use the scroll host so vertical movement works reliably
- reserve gutter space for the palette scrollbar so it stays visible next to the device library

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e57cd666d48324a29de3442ff6f03f