### PR TITLE
Improve one-line scroll handling

### DIFF
--- a/style.css
+++ b/style.css
@@ -616,6 +616,8 @@ body.oneline-page .oneline-editor {
   flex: 1;
   min-height: 0;
   height: 100%;
+  overflow: auto;
+  scrollbar-gutter: stable both-edges;
 }
 
 body.oneline-page .oneline-editor #diagram {


### PR DESCRIPTION
## Summary
- add utilities to detect scrollable ancestors and wire the palette and diagram to them
- ensure the oneline editor container scrolls by default so wheel events stay within the canvas

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e65f223754832480b1f20ac5c6c0c6