### PR TITLE
Ensure one-line workspace scrolls within viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -560,8 +560,10 @@ body.compact-mode .palette-section .section-buttons {
 
 body.oneline-page {
   min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 body.oneline-page .top-nav {
@@ -573,13 +575,16 @@ body.oneline-page .container {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  height: auto;
+  height: 100%;
+  overflow: hidden;
 }
 
 body.oneline-page .main-content {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  height: 100%;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- clamp the one-line page layout to the viewport height so the diagram uses its own scroll container
- keep the palette constrained with its own scrollbar instead of relying on the page scroll

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e670e8edb883249d464d93e64b2770