### PR TITLE
Improve one-line palette scrolling

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -169,7 +169,8 @@
               <template id="palette-button-template">
                 <button draggable="true" data-subtype="" title="Drag to canvas or click to add"></button>
               </template>
-                <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
+              <input type="text" id="palette-search" placeholder="Search" aria-label="Filter components">
+              <div class="palette-scroll">
                 <div class="palette-card card">
                   <h3>Sources</h3>
                   <details id="sources-section" class="palette-section">
@@ -230,12 +231,13 @@
                   <h3>Templates</h3>
                   <details id="template-section" class="palette-section">
                     <summary><img src="./icons/oneline.svg" alt="" class="summary-icon"> Templates</summary>
-                      <div id="template-buttons" class="section-buttons"></div>
-                    </details>
+                    <div id="template-buttons" class="section-buttons"></div>
+                  </details>
                 </div>
                 <div class="create-component-footer">
                   <a href="./custom-components.html" class="btn create-component-btn" title="Design a new custom component">Create Component</a>
                 </div>
+              </div>
             </div>
           </aside>
           <div class="splitter"></div>

--- a/oneline.js
+++ b/oneline.js
@@ -6263,7 +6263,12 @@ async function init() {
 
   const editorEl = document.querySelector('.oneline-editor');
   const paletteRoot = document.getElementById('palette');
-  attachLocalWheelScroll(paletteRoot);
+  const paletteScroll = paletteRoot?.querySelector('.palette-scroll');
+  if (paletteScroll instanceof HTMLElement) {
+    attachLocalWheelScroll(paletteScroll);
+  } else {
+    attachLocalWheelScroll(paletteRoot);
+  }
   attachLocalWheelScroll(editorEl);
   const legendEl = document.getElementById('voltage-legend');
   if (editorEl) {

--- a/style.css
+++ b/style.css
@@ -606,10 +606,11 @@ body.oneline-page .workspace {
 body.oneline-page .palette {
   height: 100%;
   max-height: none;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  scrollbar-gutter: stable both-edges;
+  overflow: hidden;
+  padding-right: 0;
 }
 
 body.oneline-page .oneline-editor {
@@ -625,6 +626,11 @@ body.oneline-page .oneline-editor #diagram {
 }
 
 body.oneline-page #component-buttons {
+  flex: 1;
+  min-height: 0;
+}
+
+body.oneline-page .palette-scroll {
   flex: 1;
   min-height: 0;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- wrap the one-line palette content in a scrollable container so the sidebar scrolls independently
- update palette styling and wheel-lock wiring to target the new scroll host

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e677e36a608324b11067eed3067955