### PR TITLE
Refactor one-line editor scroll handling

### DIFF
--- a/oneline.html
+++ b/oneline.html
@@ -242,32 +242,34 @@
           </aside>
           <div class="splitter"></div>
           <div class="oneline-editor">
-            <svg id="diagram" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
-                <path d="M20 0 L0 0 0 20" fill="none" stroke="#ccc" stroke-width="0.5" />
-              </pattern>
-              <marker id="connection-x" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto" markerUnits="strokeWidth">
-                <path d="M0,0 L10,10 M0,10 L10,0" fill="none" stroke="context-stroke" stroke-width="2" />
-              </marker>
-            </defs>
-            <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
-          </svg>
-          <div id="voltage-legend" class="voltage-legend"></div>
-          <div id="prop-modal" class="prop-modal"><!-- populated dynamically --></div>
-          <div id="cable-modal" class="prop-modal"></div>
-          <div id="validation-modal" class="prop-modal"></div>
-          <div id="defaults-modal" class="prop-modal"></div>
-            <ul id="context-menu" class="context-menu">
-              <li data-action="edit" data-context="component">Edit Properties</li>
-              <li data-action="rename" data-context="component">Rename</li>
-              <li data-action="duplicate" data-context="component">Duplicate</li>
-              <li data-action="rotate" data-context="component">Rotate</li>
-              <li data-action="delete" data-context="component">Delete</li>
-              <li data-action="edit" data-context="connection">Edit Connection</li>
-              <li data-action="delete" data-context="connection">Delete Connection</li>
-              <li data-action="paste" data-context="canvas">Paste</li>
-            </ul>
+            <div class="oneline-canvas-scroll">
+              <svg id="diagram" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                  <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
+                    <path d="M20 0 L0 0 0 20" fill="none" stroke="#ccc" stroke-width="0.5" />
+                  </pattern>
+                  <marker id="connection-x" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto" markerUnits="strokeWidth">
+                    <path d="M0,0 L10,10 M0,10 L10,0" fill="none" stroke="context-stroke" stroke-width="2" />
+                  </marker>
+                </defs>
+                <rect id="grid-bg" width="100%" height="100%" fill="url(#grid)" />
+              </svg>
+              <div id="voltage-legend" class="voltage-legend"></div>
+              <div id="prop-modal" class="prop-modal"><!-- populated dynamically --></div>
+              <div id="cable-modal" class="prop-modal"></div>
+              <div id="validation-modal" class="prop-modal"></div>
+              <div id="defaults-modal" class="prop-modal"></div>
+              <ul id="context-menu" class="context-menu">
+                <li data-action="edit" data-context="component">Edit Properties</li>
+                <li data-action="rename" data-context="component">Rename</li>
+                <li data-action="duplicate" data-context="component">Duplicate</li>
+                <li data-action="rotate" data-context="component">Rotate</li>
+                <li data-action="delete" data-context="component">Delete</li>
+                <li data-action="edit" data-context="connection">Edit Connection</li>
+                <li data-action="delete" data-context="connection">Delete Connection</li>
+                <li data-action="paste" data-context="canvas">Paste</li>
+              </ul>
+            </div>
           </div>
         </div>
         </section>

--- a/oneline.js
+++ b/oneline.js
@@ -6093,8 +6093,8 @@ async function init() {
   const bindPan = (btn, direction) => {
     if (!btn) return;
     btn.addEventListener('click', () => {
-      if (!editorEl) return;
-      panDiagram(direction, editorEl);
+      if (!canvasScroll) return;
+      panDiagram(direction, canvasScroll);
     });
   };
   bindPan(panUpBtn, 'up');
@@ -6103,7 +6103,7 @@ async function init() {
   bindPan(panRightBtn, 'right');
 
   document.addEventListener('keydown', e => {
-    if (!editorEl) return;
+    if (!canvasScroll) return;
     if (e.defaultPrevented) return;
     if (e.altKey || e.ctrlKey || e.metaKey) return;
     const target = e.target instanceof HTMLElement ? e.target : null;
@@ -6115,16 +6115,16 @@ async function init() {
     }
     if (e.key === 'ArrowUp') {
       e.preventDefault();
-      panDiagram('up', editorEl);
+      panDiagram('up', canvasScroll);
     } else if (e.key === 'ArrowDown') {
       e.preventDefault();
-      panDiagram('down', editorEl);
+      panDiagram('down', canvasScroll);
     } else if (e.key === 'ArrowLeft') {
       e.preventDefault();
-      panDiagram('left', editorEl);
+      panDiagram('left', canvasScroll);
     } else if (e.key === 'ArrowRight') {
       e.preventDefault();
-      panDiagram('right', editorEl);
+      panDiagram('right', canvasScroll);
     }
   });
 
@@ -6262,6 +6262,7 @@ async function init() {
   });
 
   const editorEl = document.querySelector('.oneline-editor');
+  const canvasScroll = document.querySelector('.oneline-canvas-scroll') || editorEl;
   const paletteRoot = document.getElementById('palette');
   const paletteScroll = paletteRoot?.querySelector('.palette-scroll');
   if (paletteScroll instanceof HTMLElement) {
@@ -6269,10 +6270,10 @@ async function init() {
   } else {
     attachLocalWheelScroll(paletteRoot);
   }
-  attachLocalWheelScroll(editorEl);
+  attachLocalWheelScroll(canvasScroll);
   const legendEl = document.getElementById('voltage-legend');
-  if (editorEl) {
-    editorEl.addEventListener('wheel', e => {
+  if (canvasScroll) {
+    canvasScroll.addEventListener('wheel', e => {
       if (!e.ctrlKey) return;
       const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
       const focus = toDiagramCoords(e);
@@ -6297,9 +6298,9 @@ async function init() {
     e.preventDefault();
   });
   document.addEventListener('mousemove', e => {
-    if (!legendDrag || !legendEl || !editorEl) return;
-    const rect = editorEl.getBoundingClientRect();
-    const parent = legendEl.offsetParent instanceof HTMLElement ? legendEl.offsetParent : editorEl;
+    if (!legendDrag || !legendEl || !canvasScroll) return;
+    const rect = canvasScroll.getBoundingClientRect();
+    const parent = legendEl.offsetParent instanceof HTMLElement ? legendEl.offsetParent : canvasScroll;
     const boundsWidth = parent instanceof HTMLElement ? parent.clientWidth : rect.width;
     const boundsHeight = parent instanceof HTMLElement ? parent.clientHeight : rect.height;
     const rawLeft = e.clientX - rect.left - legendDrag.dx;
@@ -6328,9 +6329,9 @@ async function init() {
       marqueeSelectionMade = false;
       pointerDownComponentId = null;
       if (e.button === 1) {
-        if (editorEl) {
+        if (canvasScroll) {
           e.preventDefault();
-          startMiddlePan(e, editorEl);
+          startMiddlePan(e, canvasScroll);
         }
         return;
       }
@@ -6757,7 +6758,7 @@ async function init() {
     compItems.forEach(li => li.style.display = contextTarget && !contextTarget.connection ? 'block' : 'none');
     connItems.forEach(li => li.style.display = contextTarget && contextTarget.connection ? 'block' : 'none');
     canvasItems.forEach(li => li.style.display = contextTarget ? 'none' : 'block');
-    const rect = editorEl?.getBoundingClientRect();
+    const rect = canvasScroll?.getBoundingClientRect();
     if (rect) {
       menu.style.left = `${e.clientX - rect.left}px`;
       menu.style.top = `${e.clientY - rect.top}px`;

--- a/style.css
+++ b/style.css
@@ -617,11 +617,20 @@ body.oneline-page .oneline-editor {
   flex: 1;
   min-height: 0;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.oneline-canvas-scroll {
+  position: relative;
+  flex: 1;
+  min-height: 0;
   overflow: auto;
   scrollbar-gutter: stable both-edges;
 }
 
-body.oneline-page .oneline-editor #diagram {
+body.oneline-page .oneline-canvas-scroll #diagram {
   height: 100%;
 }
 
@@ -654,7 +663,7 @@ body.oneline-page .palette-scroll {
   margin-bottom: var(--ol-spacing);
 }
 
-.oneline-editor #diagram {
+.oneline-canvas-scroll #diagram {
   border: 1px solid var(--ol-border-color);
   border-radius: var(--ol-radius);
   width: 100%;
@@ -662,7 +671,10 @@ body.oneline-page .palette-scroll {
 }
 
 .oneline-editor.panning,
-.oneline-editor.panning #diagram {
+.oneline-editor.panning .oneline-canvas-scroll,
+.oneline-editor.panning .oneline-canvas-scroll #diagram,
+.oneline-canvas-scroll.panning,
+.oneline-canvas-scroll.panning #diagram {
   cursor: grabbing;
   cursor: -webkit-grabbing;
 }


### PR DESCRIPTION
## Summary
- wrap the diagram, voltage legend, and menus in a new `.oneline-canvas-scroll` container inside the editor
- move scroll styling to the new wrapper and update diagram and panning selectors
- update oneline.js to target the canvas scroll host for wheel zoom, panning, and legend dragging

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6804811888324ab615d48644e8039