### PR TITLE
Fix oneline palette scroll behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -605,11 +605,12 @@ body.oneline-page .workspace {
 
 body.oneline-page .palette {
   height: 100%;
-  max-height: none;
+  max-height: 100%;
   display: flex;
   flex-direction: column;
   min-height: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding-right: 0;
 }
 
@@ -642,6 +643,7 @@ body.oneline-page #component-buttons {
 body.oneline-page .palette-scroll {
   flex: 1;
   min-height: 0;
+  height: 100%;
   overflow-y: auto;
   padding-right: 0.25rem;
   scrollbar-gutter: stable both-edges;


### PR DESCRIPTION
## Summary
- limit the oneline palette column to the workspace height while restoring vertical overflow management
- ensure the palette scroll container spans the full column to show its scrollbar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68a3933b083248adafdee5e8b416e