### PR TITLE
Fix one-line layout height

### DIFF
--- a/style.css
+++ b/style.css
@@ -558,10 +558,16 @@ body.compact-mode .palette-section .section-buttons {
   align-items: start;
 }
 
+html {
+  height: 100%;
+}
+
 body.oneline-page {
   min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 body.oneline-page .top-nav {
@@ -581,6 +587,8 @@ body.oneline-page .main-content {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  padding: 1rem;
+  gap: 1rem;
 }
 
 body.oneline-page .oneline-card {
@@ -589,6 +597,7 @@ body.oneline-page .oneline-card {
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
+  margin: 0;
 }
 
 body.oneline-page .oneline-card .sheet-controls,


### PR DESCRIPTION
## Summary
- ensure the one-line page body fills the viewport and hides global scroll
- adjust the main content padding and card margin so internal panels scroll instead of the page

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e68d21df748324bdecf18493bd5aa7