### PR TITLE
feat: Arc Flash Warning Label Generation on one-line diagram (Gap #49)

### DIFF
--- a/COMPETITOR_FEATURE_ANALYSIS.md
+++ b/COMPETITOR_FEATURE_ANALYSIS.md
@@ -20,7 +20,7 @@ A **2026-04-05 pass** focused specifically on the **one-line diagram editor UI**
 
 A **2026-04-06 pass** performed a focused deep dive on **one-line diagram connectivity features** and the **TCC (Time-Current Curve) engine**, benchmarked against ETAP 2024/2025, EasyPower 2025, SKM PTW 9, PowerWorld Simulator 23, and DIgSILENT PowerFactory 2024. This revealed **10 new gaps** (Gaps #48–#57) across two areas: (1) multi-sheet diagramming and diagram annotation capabilities missing from the one-line editor and (2) advanced TCC curve types, arc flash integration, ground fault protection, and reporting absent from the coordination study tool. See "One-Line Diagram & TCC Deep Dive (2026-04-06)" below.
 
-**Current status: 49 of 58 total identified gaps implemented. 3 deferred (BIM/CAD plugin, live pricing, digital twin). 6 open (Gaps #48–#50, #52, #55, #57).**
+**Current status: 50 of 58 total identified gaps implemented. 3 deferred (BIM/CAD plugin, live pricing, digital twin). 5 open (Gaps #48, #50, #52, #55, #57).**
 
 ---
 
@@ -136,11 +136,17 @@ Benchmarked against: **ETAP 2024/2025** (composite networks, protection zone ove
 
 ### Gap #49 – Arc Flash Warning Label Generation on One-Line
 
-| Missing Feature | Competitor(s) | Description |
+| Implemented Feature | Competitor(s) | Description |
 |---|---|---|
 | **NFPA 70E–compliant arc flash label overlay on diagram** | ETAP 2024/2025 (arc flash label printing from one-line), EasyPower 2025 (arc flash annotation blocks) | After running the arc flash study, ETAP and EasyPower generate NFPA 70E–compliant warning label text blocks directly on the one-line at each analyzed bus: incident energy (cal/cm²), PPE category, arc flash boundary (mm), working distance, and glove class. These can be printed as stand-alone label sheets for field installation on switchgear. CableTrayRoute already stores arc flash results per component (`arcFlash.incidentEnergy`, `arcFlash.boundary`, `arcFlash.ppeCategory`, `arcFlash.clearingTime`) and exposes them in datablocks and the study approval panel, but has no dedicated arc flash label layout mode that formats NFPA 70E–standard warning label geometry for printing. |
 
-**Status:** New gap identified 2026-04-06. Not yet implemented.
+**Status:** ✅ **Implemented 2026-04-07.** Two complementary deliverables:
+
+1. **Print Label Sheet** — `reports/arcFlashReport.mjs` exports `buildLabelSheetHtml(results, projectName)` which generates a complete print-ready HTML document with all NFPA 70E labels arranged in a 2-column × 6 in × 4 in grid (landscape, ½ in margins). `openLabelPrintWindow(results)` opens the sheet in a new browser window with a "Print All Labels" button. The "Print Labels" button in `oneline.html` Studies panel becomes enabled after each arc flash run and calls `openLabelPrintWindow(getStudies().arcFlash)`.
+
+2. **One-Line Diagram Overlay** — `renderArcFlashLabelOverlays(svg)` in `oneline.js` renders compact signal-color SVG badge overlays above each analyzed bus component: colored banner (orange WARNING / red DANGER per ANSI Z535), PPE category, and incident energy. Controlled by the "Show Label Overlays" checkbox in the Studies panel (`#toggle-arcflash-label-mode`); state held in `arcFlashLabelMode` flag, re-rendered on each `render()` call when active.
+
+Signal word thresholds per ANSI Z535: **DANGER** (≥ 40 cal/cm², `#d32f2f`) / **WARNING** (< 40 cal/cm², `#f57c00`). Label template at `reports/labels.mjs` (`generateArcFlashLabel()`); customisable via `reports/templates/arcflashLabel.svg`. Tests: `tests/arcFlashLabels.test.mjs` (17 assertions covering signal word selection, color mapping, voltage formatting, HTML structure, template token substitution). Docs: `docs/arc-flash-labels.md`.
 
 ---
 
@@ -897,7 +903,7 @@ All originally high- and medium-priority feasible items have been implemented:
 
 **Medium Priority — One-Line Diagram:**
 
-7. **Arc Flash Warning Label Generation** (Gap #49) — Directly supports NFPA 70E field labeling compliance. Recommended: add a "Generate Arc Flash Labels" action to `oneline.html` that renders NFPA 70E–format label blocks from `arcFlash.*` study result fields on each analyzed bus component.
+7. ~~**Arc Flash Warning Label Generation** (Gap #49)~~ — ✅ **Implemented 2026-04-07.** `reports/arcFlashReport.mjs` `buildLabelSheetHtml()` / `openLabelPrintWindow()` + "Print Labels" button in `oneline.html` Studies panel + `renderArcFlashLabelOverlays()` overlay badges in `oneline.js`. Tests: `tests/arcFlashLabels.test.mjs`. Docs: `docs/arc-flash-labels.md`.
 
 8. **Named Layer Management** (Gap #51) — ✅ Implemented 2026-04-06. See `docs/layer-management.md`.
 

--- a/docs/arc-flash-labels.md
+++ b/docs/arc-flash-labels.md
@@ -1,0 +1,138 @@
+# Arc Flash Warning Label Generation
+
+## Overview
+
+CableTrayRoute generates NFPA 70E–compliant arc flash warning labels directly from the one-line diagram after running an arc flash study. Labels can be:
+
+- **Printed as a label sheet** — a print-optimized page with all equipment labels arranged in a 2-column grid, ready to cut and apply to switchgear
+- **Viewed as overlay badges** on the one-line diagram — compact signal-color badges at each analyzed bus, showing PPE category and incident energy at a glance
+
+This feature satisfies **NFPA 70E 2021 §130.5(H)**, which requires electrical equipment to be field-labeled with arc flash hazard information before energized work is performed.
+
+---
+
+## Regulatory Background
+
+### NFPA 70E 2021 §130.5(H) — Equipment Labeling
+
+> "Electrical equipment such as switchboards, panelboards, industrial control panels, meter socket enclosures, and motor control centers that are in other than dwelling units and are likely to require examination, adjustment, servicing, or maintenance while energized shall be field-marked with a label containing all of the following information..."
+
+**Required label fields:**
+
+| Field | Source in CableTrayRoute |
+|---|---|
+| Nominal system voltage | `nominalVoltage` on bus component |
+| Arc flash boundary | Arc flash study `boundary` (mm) |
+| Incident energy at working distance | Arc flash study `incidentEnergy` (cal/cm²) |
+| Minimum arc rating of PPE | Derived from `ppeCategory` |
+| Working distance | Arc flash study `workingDistance` (mm) |
+| Upstream protective device | `upstreamDevice` from arc flash study |
+| Date of study | `studyDate` from arc flash study |
+
+### Signal Word Selection (ANSI Z535)
+
+| Incident Energy | Signal Word | Banner Color |
+|---|---|---|
+| < 40 cal/cm² | **WARNING** | Orange `#f57c00` |
+| ≥ 40 cal/cm² | **DANGER** | Red `#d32f2f` |
+
+---
+
+## Workflow
+
+### Step 1 – Run the Arc Flash Study
+
+1. Open the **One-Line Diagram** page (`oneline.html`)
+2. Open the **Studies** panel (toolbar button or keyboard shortcut)
+3. Click **Arc Flash** — this automatically runs Short Circuit first, then computes IEEE 1584-2018 incident energy for every bus component
+
+### Step 2 – Print Labels
+
+After the arc flash study completes, the **Print Labels** button becomes enabled in the Studies panel.
+
+1. Click **Print Labels**
+2. A new browser window opens containing all NFPA 70E labels in a 2-column grid
+3. Click **Print All Labels** in that window — the browser print dialog opens
+4. Select your label stock (landscape, ½ in margins), print, cut, and apply to switchgear
+
+**Label size:** 6 in × 4 in per label (matches standard industrial arc flash label stock)
+
+### Step 3 – Enable Diagram Overlay (Optional)
+
+Check **Show Label Overlays** in the Studies panel to toggle compact signal-color badge overlays on the one-line diagram at each analyzed bus. Each badge shows:
+
+- Signal color banner (orange = WARNING, red = DANGER)
+- Signal word
+- PPE category number
+- Incident energy in cal/cm²
+
+Overlays are for visual reference only and are not printed when exporting the diagram.
+
+---
+
+## Label Format
+
+Each label is a 6 in × 4 in SVG document. The default layout:
+
+```
+┌────────────────────────────────────────┐
+│ ▲  WARNING / DANGER (signal banner)    │
+│ !  ARC FLASH HAZARD                    │
+├────────────────────────────────────────┤
+│ Equipment Tag:        MCC-1            │
+│ Nominal Voltage:      480 V            │
+│ Incident Energy:      8.50 cal/cm² @ 18 in│
+│ Working Distance:     18 in (455 mm)   │
+│ Arc Flash Boundary:   5 ft (1524 mm)   │
+│ Limited Approach:     Not Applicable   │
+│ Restricted Approach:  11.8 in (300 mm) │
+│ Upstream Device:      CB-1A            │
+│ PPE Category: 2       Study: 2026-04-07│
+└────────────────────────────────────────┘
+```
+
+---
+
+## Individual SVG Downloads
+
+When the arc flash study runs, CableTrayRoute also automatically downloads one individual `.svg` label file per equipment piece (alongside the `arcflash.csv` and `arcflash.pdf` reports). These individual files can be opened in any SVG editor or sent to a label printer directly.
+
+File names are derived from the equipment tag (e.g., `MCC-1.svg`).
+
+---
+
+## Customising the Label Template
+
+The label layout is driven by the SVG template at `reports/templates/arcflashLabel.svg`. If that file exists, it takes priority over the built-in default template in `reports/labels.mjs`.
+
+To customise:
+1. Copy the default template SVG from `reports/labels.mjs` (the `template` string) into `reports/templates/arcflashLabel.svg`
+2. Edit dimensions, fonts, logo placement, or field layout as needed
+3. Keep all `{{key}}` placeholder tokens — they are replaced at generation time with study result values
+
+Available placeholder tokens:
+
+| Token | Value |
+|---|---|
+| `{{signalWord}}` | `WARNING` or `DANGER` |
+| `{{signalColor}}` | Hex color for the signal banner |
+| `{{equipmentTag}}` | Equipment identifier |
+| `{{voltage}}` | Formatted system voltage |
+| `{{incidentEnergy}}` | Incident energy with unit and working distance |
+| `{{workingDistance}}` | Verbose working distance (ft/in and mm) |
+| `{{arcFlashBoundary}}` | Arc flash boundary (ft/in and mm) |
+| `{{limitedApproach}}` | Limited approach boundary |
+| `{{restrictedApproach}}` | Restricted approach boundary |
+| `{{upstreamDevice}}` | Upstream protective device name |
+| `{{ppeCategory}}` | PPE category number |
+| `{{studyDate}}` | Date of arc flash study (YYYY-MM-DD) |
+
+---
+
+## Implementation Notes
+
+- **Module:** `reports/arcFlashReport.mjs` — `buildLabelSheetHtml()`, `openLabelPrintWindow()`
+- **Label renderer:** `reports/labels.mjs` — `generateArcFlashLabel(data)`
+- **Overlay renderer:** `oneline.js` — `renderArcFlashLabelOverlays(svg)`
+- **Tests:** `tests/arcFlashLabels.test.mjs` (17 assertions)
+- **Standard:** NFPA 70E 2021 §130.5(H), ANSI Z535 signal word hierarchy

--- a/oneline.html
+++ b/oneline.html
@@ -391,6 +391,8 @@
         <button id="run-loadflow-btn" type="button">Load Flow</button>
         <button id="run-shortcircuit-btn" type="button">Short Circuit</button>
         <button id="run-arcflash-btn" type="button">Arc Flash</button>
+        <button id="print-arcflash-labels-btn" type="button" class="btn" title="Open print sheet of all NFPA 70E arc flash labels" disabled>Print Labels</button>
+        <label class="d-block mt-1"><input type="checkbox" id="toggle-arcflash-label-mode"> Show Label Overlays</label>
         <button id="run-harmonics-btn" type="button">Harmonics</button>
         <button id="run-motorstart-btn" type="button">Motor Start</button>
         <button id="run-reliability-btn" type="button">Reliability</button>

--- a/oneline.js
+++ b/oneline.js
@@ -83,7 +83,7 @@ import { runArcFlash } from './analysis/arcFlash.mjs';
 import { runHarmonics } from './analysis/harmonics.js';
 import { runMotorStart } from './analysis/motorStart.js';
 import { runReliability } from './analysis/reliability.js';
-import { generateArcFlashReport } from './reports/arcFlashReport.mjs';
+import { generateArcFlashReport, openLabelPrintWindow } from './reports/arcFlashReport.mjs';
 import { exportAllReports } from './reports/exportAll.mjs';
 import { sizeConductor } from './sizing.js';
 import { runValidation } from './validation/rules.js';
@@ -1848,6 +1848,9 @@ let titleBlockFields = {};         // Gap #38
 let minimapVisible = false;        // Gap #39
 // Gap #46 – per-subtype datablock config: { [subtype]: string[] }
 let diagramDatablockConfig = {};
+// Gap #49 – Arc Flash Label Overlays on one-line diagram
+let arcFlashLabelMode = false;
+
 // Gap #51 – Named Layer Management
 let layers = [];             // layer definitions for the active sheet: [{id,name,visible,locked}]
 let layersHistory = [];      // parallel snapshot array to history[], each entry is deep copy of layers
@@ -1891,6 +1894,8 @@ if (studiesPanel && hasStoredStudiesWidth) {
 const runLFBtn = document.getElementById('run-loadflow-btn');
 const runSCBtn = document.getElementById('run-shortcircuit-btn');
 const runAFBtn = document.getElementById('run-arcflash-btn');
+const printAFLabelsBtn = document.getElementById('print-arcflash-labels-btn');
+const afLabelModeToggle = document.getElementById('toggle-arcflash-label-mode');
 const runHBtn = document.getElementById('run-harmonics-btn');
 const runMSBtn = document.getElementById('run-motorstart-btn');
 const runRelBtn = document.getElementById('run-reliability-btn');
@@ -2658,7 +2663,16 @@ if (runAFBtn) runAFBtn.addEventListener('click', async () => {
   studies.arcFlash = af;
   setStudies(studies);
   generateArcFlashReport(af);
+  if (printAFLabelsBtn) printAFLabelsBtn.disabled = false;
   renderStudyResults();
+  render();
+});
+if (printAFLabelsBtn) printAFLabelsBtn.addEventListener('click', () => {
+  const af = getStudies()?.arcFlash || {};
+  openLabelPrintWindow(af);
+});
+if (afLabelModeToggle) afLabelModeToggle.addEventListener('change', () => {
+  arcFlashLabelMode = afLabelModeToggle.checked;
   render();
 });
 if (runHBtn) runHBtn.addEventListener('click', () => {
@@ -6671,6 +6685,9 @@ function render() {
   // Gap #39 – Minimap
   renderMinimap();
 
+  // Gap #49 – Arc Flash label badge overlays
+  if (arcFlashLabelMode) renderArcFlashLabelOverlays(svg);
+
   if (lengthsChanged && !syncing) {
     syncing = true;
     syncSchedules(false);
@@ -6822,6 +6839,84 @@ function renderMinimap() {
     vpRect.classList.add('minimap-viewport');
     minimapSvg.appendChild(vpRect);
   }
+}
+
+// ----------------------------------------------------------------
+// Gap #49 – Arc Flash label badge overlays on one-line diagram
+// ----------------------------------------------------------------
+function renderArcFlashLabelOverlays(svg) {
+  svg.querySelectorAll('.af-label-badge').forEach(el => el.remove());
+  const afResults = cachedStudyResults?.arcFlash;
+  if (!afResults || typeof afResults !== 'object') return;
+
+  const BADGE_W = 90;
+  const BANNER_H = 18;
+  const BODY_H = 28;
+  const BADGE_H = BANNER_H + BODY_H;
+  const FONT = 'Helvetica, Arial, sans-serif';
+
+  components.forEach(comp => {
+    const af = afResults[comp.id];
+    if (!af || !Number.isFinite(af.incidentEnergy)) return;
+
+    const bounds = componentBounds(comp);
+    const cx = (bounds.left + bounds.right) / 2;
+    const cy = bounds.top;
+
+    const ie = af.incidentEnergy;
+    const isDanger = ie >= 40;
+    const bannerColor = isDanger ? '#d32f2f' : '#f57c00';
+    const signalWord = isDanger ? 'DANGER' : 'WARNING';
+    const ppeText = `PPE Cat: ${Number.isFinite(af.ppeCategory) ? af.ppeCategory : 'N/A'}`;
+    const ieText = `IE: ${ie.toFixed(2)} cal/cm²`;
+
+    const g = document.createElementNS(svgNS, 'g');
+    g.setAttribute('class', 'af-label-badge');
+    g.setAttribute('transform', `translate(${cx - BADGE_W / 2},${cy - BADGE_H - 4})`);
+    g.setAttribute('pointer-events', 'none');
+
+    // Outer border
+    const border = document.createElementNS(svgNS, 'rect');
+    border.setAttribute('x', 0); border.setAttribute('y', 0);
+    border.setAttribute('width', BADGE_W); border.setAttribute('height', BADGE_H);
+    border.setAttribute('fill', '#fff'); border.setAttribute('stroke', '#000');
+    border.setAttribute('stroke-width', '1');
+    g.appendChild(border);
+
+    // Colored signal banner
+    const banner = document.createElementNS(svgNS, 'rect');
+    banner.setAttribute('x', 0); banner.setAttribute('y', 0);
+    banner.setAttribute('width', BADGE_W); banner.setAttribute('height', BANNER_H);
+    banner.setAttribute('fill', bannerColor);
+    g.appendChild(banner);
+
+    // Signal word text
+    const sigText = document.createElementNS(svgNS, 'text');
+    sigText.setAttribute('x', BADGE_W / 2); sigText.setAttribute('y', BANNER_H - 4);
+    sigText.setAttribute('text-anchor', 'middle');
+    sigText.setAttribute('font-size', '11'); sigText.setAttribute('font-weight', 'bold');
+    sigText.setAttribute('fill', '#fff'); sigText.setAttribute('font-family', FONT);
+    sigText.textContent = signalWord;
+    g.appendChild(sigText);
+
+    // PPE Category line
+    const ppeLine = document.createElementNS(svgNS, 'text');
+    ppeLine.setAttribute('x', 4); ppeLine.setAttribute('y', BANNER_H + 11);
+    ppeLine.setAttribute('font-size', '9'); ppeLine.setAttribute('fill', '#000');
+    ppeLine.setAttribute('font-family', FONT);
+    ppeLine.textContent = ppeText;
+    g.appendChild(ppeLine);
+
+    // Incident energy line
+    const ieLine = document.createElementNS(svgNS, 'text');
+    ieLine.setAttribute('x', 4); ieLine.setAttribute('y', BANNER_H + 23);
+    ieLine.setAttribute('font-size', '9'); ieLine.setAttribute('fill', '#000');
+    ieLine.setAttribute('font-family', FONT);
+    ieLine.textContent = ieText;
+    g.appendChild(ieLine);
+
+    svg.appendChild(g);
+  });
 }
 
 // ----------------------------------------------------------------

--- a/reports/arcFlashReport.mjs
+++ b/reports/arcFlashReport.mjs
@@ -1,6 +1,22 @@
 import { downloadCSV, downloadPDF } from './reporting.mjs';
 import { generateArcFlashLabel } from './labels.mjs';
 
+const LABEL_SHEET_STYLE = `
+  body { margin: 0; padding: 16px; font-family: Helvetica, Arial, sans-serif; background: #f5f5f5; }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  .meta { font-size: 13px; color: #555; margin: 0 0 12px; }
+  .no-print { display: inline-block; margin-bottom: 16px; padding: 8px 20px; font-size: 14px; background: #1565c0; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+  .label-grid { display: grid; grid-template-columns: repeat(2, 6in); gap: 0.25in; }
+  .label-cell { break-inside: avoid; background: #fff; }
+  .label-cell svg { display: block; width: 6in; height: 4in; }
+  @media print {
+    body { background: #fff; padding: 0; }
+    h1, .meta, .no-print { display: none; }
+    .label-grid { grid-template-columns: repeat(2, 6in); gap: 0; }
+    @page { margin: 0.5in; size: landscape; }
+  }
+`;
+
 const MM_PER_INCH = 25.4;
 
 function round(value, decimals = 0) {
@@ -114,6 +130,58 @@ export function buildArcFlashLabelData(id, info = {}) {
     ppeCategory: formatPpeCategory(info.ppeCategory),
     workingDistance: workingDistanceVerbose
   };
+}
+
+/**
+ * Build a print-ready HTML document containing all NFPA 70E arc flash labels
+ * arranged in a 2-column grid suitable for printing on label stock (6"×4" per label).
+ * @param {Object<string, object>} results - Arc flash results keyed by component ID
+ * @param {string} [projectName] - Optional project name shown in the page heading
+ * @returns {string} Full HTML document string
+ */
+export function buildLabelSheetHtml(results = {}, projectName = '') {
+  const entries = safeEntries(results);
+  const date = new Date().toISOString().split('T')[0];
+  const heading = projectName ? `Arc Flash Warning Labels — ${projectName}` : 'Arc Flash Warning Labels';
+
+  const labelCells = entries.map(([id, info]) => {
+    const data = buildArcFlashLabelData(id, info);
+    const svg = generateArcFlashLabel(data);
+    return `<div class="label-cell">${svg}</div>`;
+  }).join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Arc Flash Labels</title>
+<style>${LABEL_SHEET_STYLE}</style>
+</head>
+<body>
+<h1>${heading}</h1>
+<p class="meta">Generated: ${date} &nbsp;|&nbsp; ${entries.length} label(s)</p>
+<button class="no-print" onclick="window.print()">Print All Labels</button>
+<div class="label-grid">
+${labelCells}
+</div>
+</body>
+</html>`;
+}
+
+/**
+ * Open a new browser window containing a print-ready NFPA 70E label sheet.
+ * @param {Object<string, object>} results - Arc flash results keyed by component ID
+ * @param {string} [projectName] - Optional project name for the page heading
+ * @returns {Window|null} The opened window, or null if blocked
+ */
+export function openLabelPrintWindow(results = {}, projectName = '') {
+  const html = buildLabelSheetHtml(results, projectName);
+  const win = window.open('', '_blank');
+  if (!win) return null;
+  win.document.open();
+  win.document.write(html);
+  win.document.close();
+  return win;
 }
 
 /**

--- a/tests/arcFlashLabels.test.mjs
+++ b/tests/arcFlashLabels.test.mjs
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for arc flash label generation (Gap #49).
+ *
+ * Tests cover:
+ *   - buildArcFlashLabelData  (reports/arcFlashReport.mjs)
+ *   - buildLabelSheetHtml     (reports/arcFlashReport.mjs)
+ *   - generateArcFlashLabel   (reports/labels.mjs)
+ *
+ * Run with: node tests/arcFlashLabels.test.mjs
+ */
+
+import assert from 'assert';
+import { buildArcFlashLabelData, buildLabelSheetHtml } from '../reports/arcFlashReport.mjs';
+import { generateArcFlashLabel } from '../reports/labels.mjs';
+
+function describe(name, fn) { console.log(name); fn(); }
+function it(name, fn) {
+  try { fn(); console.log('  \u2713', name); }
+  catch (err) { console.log('  \u2717', name); console.error(err); process.exitCode = 1; }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const warningInfo = {
+  incidentEnergy: 8.5,
+  ppeCategory: 2,
+  boundary: 1524,
+  workingDistance: 455,
+  nominalVoltage: 480,
+  limitedApproach: 1200,
+  restrictedApproach: 300,
+  upstreamDevice: 'CB-1A',
+  equipmentTag: 'MCC-1',
+  studyDate: '2026-04-07'
+};
+
+const dangerInfo = {
+  incidentEnergy: 52.3,
+  ppeCategory: 4,
+  boundary: 4500,
+  workingDistance: 610,
+  nominalVoltage: 13800,
+  limitedApproach: 3000,
+  restrictedApproach: 600,
+  upstreamDevice: 'GEN-BRKR',
+  equipmentTag: 'SWGR-HV',
+  studyDate: '2026-04-07'
+};
+
+// ── buildArcFlashLabelData ────────────────────────────────────────────────────
+
+describe('buildArcFlashLabelData', () => {
+  it('signal word is WARNING when incidentEnergy < 40 cal/cm²', () => {
+    const data = buildArcFlashLabelData('bus1', warningInfo);
+    assert.strictEqual(data.signalWord, 'WARNING');
+  });
+
+  it('signal word is DANGER when incidentEnergy >= 40 cal/cm²', () => {
+    const data = buildArcFlashLabelData('bus2', dangerInfo);
+    assert.strictEqual(data.signalWord, 'DANGER');
+  });
+
+  it('signal color is orange (#f57c00) for WARNING', () => {
+    const data = buildArcFlashLabelData('bus1', warningInfo);
+    assert.strictEqual(data.signalColor, '#f57c00');
+  });
+
+  it('signal color is red (#d32f2f) for DANGER', () => {
+    const data = buildArcFlashLabelData('bus2', dangerInfo);
+    assert.strictEqual(data.signalColor, '#d32f2f');
+  });
+
+  it('formats voltage in V for <1000 V systems', () => {
+    const data = buildArcFlashLabelData('bus1', warningInfo);
+    assert.ok(data.voltage.includes('480'), `Expected "480" in "${data.voltage}"`);
+    assert.ok(data.voltage.includes('V'), `Expected "V" unit in "${data.voltage}"`);
+  });
+
+  it('formats voltage in kV for >=1000 V systems', () => {
+    const data = buildArcFlashLabelData('bus2', dangerInfo);
+    assert.ok(data.voltage.includes('kV'), `Expected "kV" in "${data.voltage}"`);
+  });
+
+  it('equipment tag falls back to component id when not provided', () => {
+    const data = buildArcFlashLabelData('BUS-99', {});
+    assert.strictEqual(data.equipmentTag, 'BUS-99');
+  });
+
+  it('upstream device falls back to "Not Specified" when absent', () => {
+    const data = buildArcFlashLabelData('bus1', { incidentEnergy: 5 });
+    assert.strictEqual(data.upstreamDevice, 'Not Specified');
+  });
+
+  it('ppeCategory is formatted as a string number', () => {
+    const data = buildArcFlashLabelData('bus1', warningInfo);
+    assert.strictEqual(data.ppeCategory, '2');
+  });
+});
+
+// ── buildLabelSheetHtml ───────────────────────────────────────────────────────
+
+describe('buildLabelSheetHtml', () => {
+  it('returns an HTML document string', () => {
+    const html = buildLabelSheetHtml({ bus1: warningInfo, bus2: dangerInfo });
+    assert.ok(typeof html === 'string');
+    assert.ok(html.includes('<html') || html.includes('<!DOCTYPE html'));
+  });
+
+  it('contains a label cell for each result entry', () => {
+    const html = buildLabelSheetHtml({ bus1: warningInfo, bus2: dangerInfo });
+    const cellCount = (html.match(/<div class="label-cell">/g) || []).length;
+    assert.strictEqual(cellCount, 2, `Expected 2 label cells, got ${cellCount}`);
+  });
+
+  it('includes window.print() for the print button', () => {
+    const html = buildLabelSheetHtml({ bus1: warningInfo });
+    assert.ok(html.includes('window.print()'), 'Expected window.print() in HTML');
+  });
+
+  it('empty results produces zero label cells', () => {
+    const html = buildLabelSheetHtml({});
+    const cellCount = (html.match(/<div class="label-cell">/g) || []).length;
+    assert.strictEqual(cellCount, 0, 'Expected no label cells for empty results');
+  });
+
+  it('includes the project name in the heading when provided', () => {
+    const html = buildLabelSheetHtml({ bus1: warningInfo }, 'Test Plant');
+    assert.ok(html.includes('Test Plant'), 'Expected project name in HTML heading');
+  });
+
+  it('includes print CSS with @media print rule', () => {
+    const html = buildLabelSheetHtml({ bus1: warningInfo });
+    assert.ok(html.includes('@media print'), 'Expected @media print in style');
+  });
+});
+
+// ── generateArcFlashLabel ─────────────────────────────────────────────────────
+
+describe('generateArcFlashLabel', () => {
+  it('substitutes all {{key}} placeholders', () => {
+    const data = buildArcFlashLabelData('bus1', warningInfo);
+    const svg = generateArcFlashLabel(data);
+    assert.ok(typeof svg === 'string');
+    assert.ok(svg.includes(data.equipmentTag), 'Expected equipment tag in SVG');
+    assert.ok(svg.includes(data.signalWord), 'Expected signal word in SVG');
+  });
+
+  it('leaves no unreplaced {{...}} template tokens', () => {
+    const data = buildArcFlashLabelData('bus1', warningInfo);
+    const svg = generateArcFlashLabel(data);
+    const unresolved = svg.match(/\{\{[^}]+\}\}/g);
+    assert.ok(!unresolved, `Unresolved tokens found: ${JSON.stringify(unresolved)}`);
+  });
+});
+
+console.log('\nDone.');


### PR DESCRIPTION
Two deliverables closing NFPA 70E field-labeling compliance gap:

1. Print Label Sheet — reports/arcFlashReport.mjs exports
   buildLabelSheetHtml() and openLabelPrintWindow() which open a
   print-ready browser window with all NFPA 70E labels in a 2-column
   6"×4" grid. "Print Labels" button in oneline.html Studies panel
   becomes enabled after each arc flash run.

2. One-Line Overlay Badges — renderArcFlashLabelOverlays() in oneline.js
   draws compact signal-color SVG badges above each analyzed bus
   (orange WARNING / red DANGER per ANSI Z535 + PPE category +
   incident energy). Toggled via "Show Label Overlays" checkbox.

Tests: tests/arcFlashLabels.test.mjs (17 assertions)
Docs:  docs/arc-flash-labels.md (NFPA 70E §130.5(H) reference)
Status: 50/58 gaps now implemented (was 49/58)

https://claude.ai/code/session_014gzuC3Br4qMmV4qgV9t9uw