### PR TITLE
Respect NEC 240.4(D) small‑conductor OCPD limits in Auto‑Size feeder sizing

### DIFF
--- a/analysis/autoSize.mjs
+++ b/analysis/autoSize.mjs
@@ -248,6 +248,27 @@ export function nextStandardOcpd(requiredAmps) {
 }
 
 /**
+ * NEC 240.4(D) small-conductor maximum OCPD limits.
+ *
+ * Returns null when no special small-conductor cap applies for the size/material.
+ *
+ * @param {string} size
+ * @param {'copper'|'aluminum'} material
+ * @returns {number|null}
+ */
+export function smallConductorMaxOcpd(size, material = 'copper') {
+  if (material === 'copper') {
+    if (size === '#14 AWG') return 15;
+    if (size === '#12 AWG') return 20;
+    if (size === '#10 AWG') return 30;
+    return null;
+  }
+  if (size === '#12 AWG') return 15;
+  if (size === '#10 AWG') return 25;
+  return null;
+}
+
+/**
  * Find the next standard transformer kVA at or above the required kVA.
  *
  * @param {number} requiredKva
@@ -272,10 +293,11 @@ export function nextStandardXfmrKva(requiredKva) {
  * @param {number}  [options.ambientTempC=30]        Ambient temperature in °C
  * @param {number}  [options.bundledConductors=1]    Number of current-carrying conductors in raceway
  * @param {'conduit'|'tray_spaced'|'tray_touching'} [options.installationType='conduit']
+ * @param {number|null} [options.requiredOcpd]   Minimum OCPD rating that must be allowed by NEC 240.4(D)
  * @returns {{size: string, ampacity: number, deratingFactor: number, trayFactor: number}|null}
  */
 export function selectConductorSize(requiredAmps, material = 'copper', tempRating = 75, options = {}) {
-  const { ambientTempC = 30, bundledConductors = 1, installationType = 'conduit' } = options;
+  const { ambientTempC = 30, bundledConductors = 1, installationType = 'conduit', requiredOcpd = null } = options;
 
   const tempFactor = ambientTempFactor(ambientTempC, tempRating);
   const bundleFactor = bundlingFactor(bundledConductors);
@@ -293,7 +315,10 @@ export function selectConductorSize(requiredAmps, material = 'copper', tempRatin
 
   const entry = NEC_AMPACITY_TABLE.find(row => {
     const amp = row[col];
-    return amp !== null && amp >= adjustedRequired;
+    if (amp === null || amp < adjustedRequired) return false;
+    if (requiredOcpd === null) return true;
+    const maxSmallOcpd = smallConductorMaxOcpd(row.size, material);
+    return maxSmallOcpd === null || requiredOcpd <= maxSmallOcpd;
   });
   if (!entry) return null;
   return { size: entry.size, ampacity: entry[col], deratingFactor: combinedFactor, trayFactor };
@@ -523,7 +548,13 @@ export function sizeFeeder(params) {
   if (loadAmps <= 0) throw new Error('Load current must be positive');
 
   const requiredAmps = continuous ? loadAmps * 1.25 : loadAmps;
-  const conductor = selectConductorSize(requiredAmps, material, tempRating, { ambientTempC, bundledConductors, installationType });
+  const ocpd = nextStandardOcpd(requiredAmps);
+  const conductor = selectConductorSize(requiredAmps, material, tempRating, {
+    ambientTempC,
+    bundledConductors,
+    installationType,
+    requiredOcpd: ocpd,
+  });
   if (!conductor) {
     // Find the minimum parallel set count that satisfies the load (NEC 310.10(H))
     let parallelSuggestion = null;
@@ -547,7 +578,6 @@ export function sizeFeeder(params) {
     };
   }
 
-  const ocpd = nextStandardOcpd(conductor.ampacity);
   const derating = conductor.deratingFactor;
 
   return {
@@ -570,7 +600,8 @@ export function sizeFeeder(params) {
       ambientRule: ambientTempC !== 30 ? `NEC 310.15(B)(1)(a) — ambient ${ambientTempC}°C correction factor ${ambientTempFactor(ambientTempC, tempRating).toFixed(2)}` : null,
       bundlingRule: bundledConductors > 3 ? `NEC 310.15(C)(1) — ${bundledConductors} conductors bundling factor ${bundlingFactor(bundledConductors).toFixed(2)}` : null,
       trayRule: installationType === 'tray_touching' ? 'NEC 392.80(A)(1)(b) — cable tray, cables touching: 0.65× derating factor' : null,
-      ocpdRule: 'NEC 240.4(B) — next standard size above conductor ampacity',
+      ocpdRule: 'NEC 240.4(B) / 240.6(A) — standard OCPD at or above required load ampacity',
+      smallConductorRule: 'NEC 240.4(D) — #14 Cu max 15A, #12 Cu max 20A, #10 Cu max 30A; #12 Al max 15A, #10 Al max 25A',
     }
   };
 }

--- a/autosize.html
+++ b/autosize.html
@@ -131,7 +131,9 @@
           bundling, and cable tray correction factors per NEC 310.15(B)(1)(a), 310.15(C)(1),
           and 392.80(A) are applied based on the Installation Conditions you enter below.</p>
           <p>OCPD rating is the next standard rating from NEC 240.6(A) at or above
-          the conductor's ampacity (NEC 240.4(B)).</p>
+          required load ampacity (NEC 240.4(B)). For small conductors, NEC 240.4(D)
+          limits maximum OCPD to #14 Cu = 15A, #12 Cu = 20A, #10 Cu = 30A,
+          #12 Al = 15A, and #10 Al = 25A.</p>
         </details>
 
         <form id="feeder-form" novalidate>

--- a/tests/autoSize.test.mjs
+++ b/tests/autoSize.test.mjs
@@ -7,6 +7,7 @@
 import assert from 'assert';
 import {
   nextStandardOcpd,
+  smallConductorMaxOcpd,
   nextStandardXfmrKva,
   selectConductorSize,
   motorFLC3Ph,
@@ -70,6 +71,23 @@ describe('nextStandardOcpd — NEC 240.6(A)', () => {
 
   it('returns null above 6000A', () => {
     assert.strictEqual(nextStandardOcpd(6001), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// smallConductorMaxOcpd
+// ---------------------------------------------------------------------------
+describe('smallConductorMaxOcpd — NEC 240.4(D)', () => {
+  it('returns 20A max for #12 AWG copper', () => {
+    assert.strictEqual(smallConductorMaxOcpd('#12 AWG', 'copper'), 20);
+  });
+
+  it('returns 25A max for #10 AWG aluminum', () => {
+    assert.strictEqual(smallConductorMaxOcpd('#10 AWG', 'aluminum'), 25);
+  });
+
+  it('returns null for larger conductors', () => {
+    assert.strictEqual(smallConductorMaxOcpd('#8 AWG', 'copper'), null);
   });
 });
 
@@ -180,12 +198,12 @@ describe('sizeFeeder — NEC 210.20 / 215.3 / 240.4', () => {
   it('sizes a 60A continuous load correctly', () => {
     // Required = 60 × 1.25 = 75A → conductor must handle 75A
     // 75°C Cu: #4 AWG = 85A ≥ 75A ✓
-    // OCPD: next standard ≥ 85A → 90A
+    // OCPD: next standard ≥ required load ampacity 75A → 80A
     const r = sizeFeeder({ loadAmps: 60, continuous: true });
     assert.strictEqual(r.requiredAmps, 75);
     assert.strictEqual(r.conductorSize, '#4 AWG');
     assert.strictEqual(r.conductorAmpacity, 85);
-    assert.strictEqual(r.ocpdRating, 90);
+    assert.strictEqual(r.ocpdRating, 80);
   });
 
   it('sizes a 100A non-continuous load correctly', () => {
@@ -209,6 +227,12 @@ describe('sizeFeeder — NEC 210.20 / 215.3 / 240.4', () => {
   it('includes NEC references', () => {
     const r = sizeFeeder({ loadAmps: 30, continuous: true });
     assert.ok(r.nec && r.nec.continuousRule);
+  });
+
+  it('applies NEC 240.4(D) and avoids #12 copper on a 25A feeder', () => {
+    const r = sizeFeeder({ loadAmps: 25, continuous: false, material: 'copper' });
+    assert.strictEqual(r.ocpdRating, 25);
+    assert.strictEqual(r.conductorSize, '#10 AWG');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Make the Auto‑Size feeder calculations obey NEC small‑conductor OCPD caps (NEC 240.4(D)) so the tool does not select a conductor that would be prohibited from being protected by the required breaker size.

### Description
- Add `smallConductorMaxOcpd()` to `analysis/autoSize.mjs` to encode NEC 240.4(D) caps for #14/#12/#10 Cu and #12/#10 Al. 
- Teach `selectConductorSize()` to accept a `requiredOcpd` option and filter out conductor table entries that the small‑conductor caps would forbid for the required OCPD. 
- Change `sizeFeeder()` to compute the required OCPD from the required load ampacity (using `nextStandardOcpd`) and pass that into `selectConductorSize()` so conductor selection respects small‑conductor limits; also expose the small‑conductor rule text in the NEC reference output. 
- Update `autosize.html` method text to document the NEC 240.4(D) small‑conductor maximum OCPD limits and expand `tests/autoSize.test.mjs` with unit tests for `smallConductorMaxOcpd()` and a feeder case demonstrating the small‑conductor behavior, plus adjust an expected OCPD assertion that reflects selecting OCPD from required load ampacity.

### Testing
- Ran the full test suite with `npm test` and all automated tests passed including the updated `tests/autoSize.test.mjs`. 
- Built the distribution with `npm run build`, which completed successfully (produces unrelated Rollup warnings about unresolved exports in other modules). 
- Attempted to capture a preview screenshot via a Playwright script, but the environment lacks the `playwright` package so an automated screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd50383354832496c13e660f4d31dc)