### PR TITLE
Align Auto-Size transformer kVA selection with NEMA series

### DIFF
--- a/analysis/autoSize.mjs
+++ b/analysis/autoSize.mjs
@@ -112,12 +112,16 @@ export const MOTOR_FLC_1PH = [
 ];
 
 // ---------------------------------------------------------------------------
-// Standard transformer kVA ratings
+// Standard transformer kVA ratings (U.S. NEMA typical preferred ratings)
+//
+// NEMA dry-type distribution transformer product ranges are typically published
+// in distinct single-phase and three-phase kVA steps. We use phase-specific
+// series so recommendations align with common U.S. catalog offerings.
 // ---------------------------------------------------------------------------
-export const STANDARD_XFMR_KVA = [
-  5, 7.5, 10, 15, 25, 37.5, 50, 75, 100, 167, 225, 300, 500,
-  750, 1000, 1500, 2000, 2500
-];
+export const STANDARD_XFMR_KVA = {
+  '1ph': [15, 25, 37.5, 50, 75, 100, 167, 250, 333, 500],
+  '3ph': [15, 30, 45, 75, 112.5, 150, 225, 300, 500, 750, 1000, 1500, 2000, 2500],
+};
 
 // ---------------------------------------------------------------------------
 // Conductor cost data — indicative $/ft per conductor
@@ -274,8 +278,9 @@ export function smallConductorMaxOcpd(size, material = 'copper') {
  * @param {number} requiredKva
  * @returns {number|null}
  */
-export function nextStandardXfmrKva(requiredKva) {
-  return STANDARD_XFMR_KVA.find(kva => kva >= requiredKva) ?? null;
+export function nextStandardXfmrKva(requiredKva, phase = '3ph') {
+  const series = STANDARD_XFMR_KVA[phase] || STANDARD_XFMR_KVA['3ph'];
+  return series.find(kva => kva >= requiredKva) ?? null;
 }
 
 /**
@@ -733,7 +738,7 @@ export function sizeTransformer(params) {
   if (loadKva <= 0) throw new Error('Load kVA must be positive');
   if (primaryVoltage <= 0 || secondaryVoltage <= 0) throw new Error('Voltages must be positive');
 
-  const xfmrKva = nextStandardXfmrKva(loadKva);
+  const xfmrKva = nextStandardXfmrKva(loadKva, phase);
   const sqrtPhase = phase === '3ph' ? Math.sqrt(3) : 1;
 
   const primaryRatedAmps = (xfmrKva * 1000) / (sqrtPhase * primaryVoltage);
@@ -767,7 +772,7 @@ export function sizeTransformer(params) {
     secondaryConductorSize: secondaryConductor ? secondaryConductor.size : null,
     secondaryConductorAmpacity: secondaryConductor ? secondaryConductor.ampacity : null,
     nec: {
-      xfmrSizing: 'Next standard kVA ≥ required load kVA',
+      xfmrSizing: 'Next NEMA standard kVA (phase-specific) ≥ required load kVA',
       primaryRule: `NEC 450.3(B), Table 450.3(B) — ${primaryOcpdFactor === 1.25 ? '125%' : '167%'} of primary rated current`,
       secondaryRule: 'NEC 450.3(B), Table 450.3(B) — 125% of secondary rated current',
       conductorRule: 'NEC 310.15(B)(16) — secondary conductor at 125% rated current',

--- a/autosize.html
+++ b/autosize.html
@@ -403,8 +403,8 @@
       applies NEC 430.22 (conductor) and NEC 430.52 (breaker) rules automatically.</p>
       <h3>Transformer</h3>
       <p>Enter required kVA, primary voltage, and secondary voltage. The tool selects the
-      next standard transformer kVA and sizes primary and secondary overcurrent protection
-      per NEC 450.3(B), Table 450.3(B).</p>
+      next NEMA-aligned standard transformer kVA (phase-specific U.S. preferred ratings)
+      and sizes primary and secondary overcurrent protection per NEC 450.3(B), Table 450.3(B).</p>
     </div>
   </div>
 

--- a/tests/autoSize.test.mjs
+++ b/tests/autoSize.test.mjs
@@ -95,16 +95,20 @@ describe('smallConductorMaxOcpd — NEC 240.4(D)', () => {
 // nextStandardXfmrKva
 // ---------------------------------------------------------------------------
 describe('nextStandardXfmrKva', () => {
-  it('rounds up 80 kVA to 100', () => {
-    assert.strictEqual(nextStandardXfmrKva(80), 100);
+  it('rounds up 80 kVA to 112.5 for 3-phase NEMA series', () => {
+    assert.strictEqual(nextStandardXfmrKva(80, '3ph'), 112.5);
   });
 
   it('returns 500 for exactly 500', () => {
-    assert.strictEqual(nextStandardXfmrKva(500), 500);
+    assert.strictEqual(nextStandardXfmrKva(500, '3ph'), 500);
   });
 
-  it('rounds up from 1 to 5', () => {
-    assert.strictEqual(nextStandardXfmrKva(1), 5);
+  it('rounds up 80 kVA to 100 for 1-phase NEMA series', () => {
+    assert.strictEqual(nextStandardXfmrKva(80, '1ph'), 100);
+  });
+
+  it('rounds up from 1 to 15 (minimum standard NEMA size)', () => {
+    assert.strictEqual(nextStandardXfmrKva(1), 15);
   });
 });
 
@@ -310,14 +314,14 @@ describe('sizeTransformer — NEC 450.3(B)', () => {
   });
 
   it('uses 167% factor for primary current ≤ 9A', () => {
-    // 5 kVA, 480V primary, 3-phase → primary = 5000/(√3×480) = 6.01A ≤ 9A → 167%
+    // 15 kVA (minimum 3-phase standard), 12470V primary → primary current ≤ 9A → 167%
     const r = sizeTransformer({
       loadKva: 3,
-      primaryVoltage: 480,
+      primaryVoltage: 12470,
       secondaryVoltage: 208,
       phase: '3ph'
     });
-    assert.strictEqual(r.xfmrKva, 5);
+    assert.strictEqual(r.xfmrKva, 15);
     assert.ok(r.primaryRatedAmps <= 9, `Expected primary ≤ 9A, got ${r.primaryRatedAmps}`);
     assert.strictEqual(r.primaryOcpdFactor, '167%');
   });


### PR DESCRIPTION
### Motivation
- Transformer kVA recommendations were using a single mixed list that did not match typical U.S. NEMA product series, causing non-typical recommendations on the Auto-Size page.
- The goal is to make recommended transformer kVA selections align with common NEMA single-phase and three-phase catalog steps so users see realistic, market-aligned sizes.

### Description
- Replaced the flat `STANDARD_XFMR_KVA` array with a phase-specific object (`'1ph'` / `'3ph'`) containing U.S. NEMA-preferred kVA series and updated the comment to explain the change in `analysis/autoSize.mjs`.
- Changed `nextStandardXfmrKva` to accept an optional `phase` parameter and select from the appropriate series, and updated calls to pass `phase` (notably in `sizeTransformer`).
- Clarified the Auto-Size help text in `autosize.html` to state that transformer recommendations are NEMA-aligned and phase-specific.
- Updated unit tests in `tests/autoSize.test.mjs` to assert the new phase-specific behavior and adjusted the low-primary-current (167%) test to use the new minimum 3-phase standard.

### Testing
- Ran the Auto-Size unit tests with `node tests/autoSize.test.mjs`, and they passed.
- Built the app with `npm run build`, and the build completed successfully.
- Launched the full test suite with `npm test`; it produced extensive passing output before the CI environment hung and the run was terminated, and a targeted re-run of `node tests/autoSize.test.mjs` succeeded afterward.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd520e15688324ad38c4ae22ae7d89)