### PR TITLE
Add unit toggle, arrangement image selector, and force-vector preview to Fault Bracing calculator

### DIFF
--- a/cableFaultBracing.html
+++ b/cableFaultBracing.html
@@ -19,6 +19,18 @@
   <link rel="dns-prefetch" href="https://fonts.gstatic.com">
   <meta name="color-scheme" content="light dark">
   <link rel="stylesheet" href="style.css" />
+  <style>
+    .units-toggle { display: inline-flex; gap: 0.5rem; border: 1px solid var(--border-color, #cbd5e1); border-radius: 999px; padding: 0.25rem; }
+    .unit-pill { border: 0; border-radius: 999px; padding: 0.4rem 0.9rem; cursor: pointer; background: transparent; color: inherit; font-weight: 600; }
+    .unit-pill[aria-pressed="true"] { background: color-mix(in srgb, var(--primary-color, #2563eb) 22%, white); }
+    .arrangement-gallery { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.75rem; margin-top: 0.25rem; }
+    .arrangement-card { border: 1px solid var(--border-color, #cbd5e1); border-radius: 10px; padding: 0.7rem; background: var(--secondary-color, #f8fafc); cursor: pointer; text-align: left; }
+    .arrangement-card.active { border-color: var(--primary-color, #2563eb); box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color, #2563eb) 18%, transparent); }
+    .arrangement-card svg { width: 100%; height: auto; }
+    .phase-label { font-size: 14px; font-weight: 700; }
+    .force-vectors { margin-top: 0.5rem; border: 1px solid var(--border-color, #cbd5e1); border-radius: 10px; padding: 0.75rem; background: var(--secondary-color, #f8fafc); }
+    .force-vectors svg { width: 100%; max-width: 500px; height: auto; display: block; }
+  </style>
   <script type="module" src="dirtyTracker.js"></script>
   <script type="module" src="dist/cableFaultBracing.js" defer></script>
 </head>
@@ -135,6 +147,14 @@ Three-phase:    F = √3×10⁻⁷ × i_peak² / d  [N/m]</pre>
       <!-- Fault system parameters -->
       <fieldset>
         <legend><strong>Fault System Parameters</strong></legend>
+        <div class="field-row">
+          <label>Calculator units</label>
+          <div class="units-toggle" role="group" aria-label="Calculator units toggle">
+            <button id="unitsImperial" type="button" class="unit-pill" aria-pressed="false">Imperial</button>
+            <button id="unitsMetric" type="button" class="unit-pill" aria-pressed="true">Metric</button>
+          </div>
+          <p class="field-hint">Switch spacing and cleat span entry labels between imperial and metric units.</p>
+        </div>
 
         <div class="field-row">
           <label for="faultCurrent">
@@ -179,11 +199,28 @@ Three-phase:    F = √3×10⁻⁷ × i_peak² / d  [N/m]</pre>
         </div>
 
         <div class="field-row" id="arrangementRow">
-          <label for="arrangement">Cable arrangement in raceway</label>
-          <select id="arrangement" aria-describedby="arrangementHint">
-            <option value="trefoil" selected>Trefoil (equilateral triangle)</option>
-            <option value="flat">Flat / single-layer</option>
-          </select>
+          <label>Cable arrangement in raceway</label>
+          <input type="hidden" id="arrangement" value="trefoil">
+          <div class="arrangement-gallery" id="arrangementGallery" role="radiogroup" aria-label="Cable arrangement selector">
+            <button class="arrangement-card active" id="arrangementTrefoil" type="button" data-arrangement="trefoil" role="radio" aria-checked="true">
+              <svg viewBox="0 0 180 120" aria-hidden="true">
+                <defs><marker id="arrowBlue" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
+                <circle cx="90" cy="28" r="16" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="57" cy="84" r="16" fill="#dcfce7" stroke="#15803d"></circle><circle cx="123" cy="84" r="16" fill="#fee2e2" stroke="#dc2626"></circle>
+                <text x="90" y="33" text-anchor="middle" class="phase-label">A</text><text x="57" y="89" text-anchor="middle" class="phase-label">B</text><text x="123" y="89" text-anchor="middle" class="phase-label">C</text>
+                <line x1="90" y1="28" x2="90" y2="7" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue)"></line><line x1="57" y1="84" x2="38" y2="99" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue)"></line><line x1="123" y1="84" x2="142" y2="99" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue)"></line>
+              </svg>
+              <span>Trefoil (outward force vectors)</span>
+            </button>
+            <button class="arrangement-card" id="arrangementFlat" type="button" data-arrangement="flat" role="radio" aria-checked="false">
+              <svg viewBox="0 0 180 120" aria-hidden="true">
+                <defs><marker id="arrowBlue2" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
+                <circle cx="42" cy="62" r="16" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="90" cy="62" r="16" fill="#dcfce7" stroke="#15803d"></circle><circle cx="138" cy="62" r="16" fill="#fee2e2" stroke="#dc2626"></circle>
+                <text x="42" y="67" text-anchor="middle" class="phase-label">A</text><text x="90" y="67" text-anchor="middle" class="phase-label">B</text><text x="138" y="67" text-anchor="middle" class="phase-label">C</text>
+                <line x1="42" y1="62" x2="18" y2="62" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue2)"></line><line x1="138" y1="62" x2="162" y2="62" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue2)"></line><line x1="90" y1="62" x2="90" y2="38" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue2)"></line>
+              </svg>
+              <span>Flat / single-layer</span>
+            </button>
+          </div>
           <p id="arrangementHint" class="field-hint">
             Both trefoil and flat arrangements produce the same peak force on
             the worst-case conductor for a balanced three-phase fault.
@@ -213,7 +250,7 @@ Three-phase:    F = √3×10⁻⁷ × i_peak² / d  [N/m]</pre>
 
         <div class="field-row" id="spacingDirectRow">
           <label for="spacing">
-            d — Centre-to-centre cable spacing (mm)
+            d — Centre-to-centre cable spacing (<span id="spacingUnitLabel">mm</span>)
           </label>
           <input type="number" id="spacing" min="1" max="2000" step="1"
                  value="50" aria-describedby="spacingHint" aria-required="true">
@@ -227,7 +264,7 @@ Three-phase:    F = √3×10⁻⁷ × i_peak² / d  [N/m]</pre>
 
         <div class="field-row hidden" id="spacingODRow">
           <label for="cableOD">
-            Cable outer diameter (mm)
+            Cable outer diameter (<span id="odUnitLabel">mm</span>)
           </label>
           <input type="number" id="cableOD" min="1" max="500" step="0.5"
                  value="40" aria-describedby="cableODHint">
@@ -247,7 +284,7 @@ Three-phase:    F = √3×10⁻⁷ × i_peak² / d  [N/m]</pre>
 
         <div class="field-row">
           <label for="cleatSpacing">
-            L — Cleat spacing / support interval (mm)
+            L — Cleat spacing / support interval (<span id="cleatUnitLabel">mm</span>)
             <button class="helpBtn" data-doc="docs/standards.html#cleat-spacing"
                     aria-label="Help — cleat spacing">?</button>
           </label>
@@ -305,6 +342,11 @@ Three-phase:    F = √3×10⁻⁷ × i_peak² / d  [N/m]</pre>
       </div>
 
       <div id="results" role="region" aria-live="polite" aria-label="Fault bracing results"></div>
+      <div class="force-vectors hidden" id="forceVectorsPanel">
+        <h2>Fault Force Vector Preview</h2>
+        <p class="field-hint" id="vectorLegend"></p>
+        <svg id="forceVectorSvg" viewBox="0 0 420 240" role="img" aria-label="Cable phase force vector diagram"></svg>
+      </div>
 
       <!-- Schedule mode section -->
       <section id="scheduleSection" hidden aria-label="Schedule evaluation">

--- a/cableFaultBracing.js
+++ b/cableFaultBracing.js
@@ -17,7 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const xrRatioInput       = document.getElementById('xrRatio');
   const systemTypeSel      = document.getElementById('systemType');
   const arrangementSel     = document.getElementById('arrangement');
+  const arrangementGallery = document.getElementById('arrangementGallery');
+  const arrangementCards   = Array.from(document.querySelectorAll('.arrangement-card'));
   const arrangementRow     = document.getElementById('arrangementRow');
+  const unitsImperialBtn   = document.getElementById('unitsImperial');
+  const unitsMetricBtn     = document.getElementById('unitsMetric');
   const spacingDirectRadio = document.getElementById('spacingDirect');
   const spacingFromODRadio = document.getElementById('spacingFromOD');
   const spacingDirectRow   = document.getElementById('spacingDirectRow');
@@ -35,6 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const resultsDiv         = document.getElementById('results');
   const scheduleSection    = document.getElementById('scheduleSection');
   const scheduleResultsDiv = document.getElementById('scheduleResults');
+  const forceVectorsPanel  = document.getElementById('forceVectorsPanel');
+  const forceVectorSvg     = document.getElementById('forceVectorSvg');
+  const vectorLegend       = document.getElementById('vectorLegend');
 
   // Build a lookup map from cable size key → OD in mm (cableSizes OD is in inches)
   const odLookup = {};
@@ -43,11 +50,67 @@ document.addEventListener('DOMContentLoaded', () => {
     odLookup[key] = entry.OD * 25.4;  // convert inches → mm
   });
 
+  let unitSystem = 'metric';
+
+  function mmToIn(mm) {
+    return mm / 25.4;
+  }
+
+  function inToMm(inches) {
+    return inches * 25.4;
+  }
+
+  function setLengthLabels() {
+    document.getElementById('spacingUnitLabel').textContent = unitSystem === 'metric' ? 'mm' : 'in';
+    document.getElementById('odUnitLabel').textContent = unitSystem === 'metric' ? 'mm' : 'in';
+    document.getElementById('cleatUnitLabel').textContent = unitSystem === 'metric' ? 'mm' : 'in';
+  }
+
+  function toggleUnits(next) {
+    if (next === unitSystem) return;
+    if (next === 'metric' && unitSystem === 'imperial') {
+      spacingInput.value = inToMm(parseFloat(spacingInput.value || '0')).toFixed(1);
+      cableODInput.value = inToMm(parseFloat(cableODInput.value || '0')).toFixed(1);
+      cleatSpacingInput.value = inToMm(parseFloat(cleatSpacingInput.value || '0')).toFixed(1);
+    } else if (next === 'imperial' && unitSystem === 'metric') {
+      spacingInput.value = mmToIn(parseFloat(spacingInput.value || '0')).toFixed(2);
+      cableODInput.value = mmToIn(parseFloat(cableODInput.value || '0')).toFixed(2);
+      cleatSpacingInput.value = mmToIn(parseFloat(cleatSpacingInput.value || '0')).toFixed(2);
+    }
+    unitSystem = next;
+    unitsImperialBtn.setAttribute('aria-pressed', String(unitSystem === 'imperial'));
+    unitsMetricBtn.setAttribute('aria-pressed', String(unitSystem === 'metric'));
+    setLengthLabels();
+    updateDerivedSpacing();
+  }
+
+  unitsImperialBtn.addEventListener('click', () => toggleUnits('imperial'));
+  unitsMetricBtn.addEventListener('click', () => toggleUnits('metric'));
+  unitsImperialBtn.setAttribute('aria-pressed', 'false');
+  unitsMetricBtn.setAttribute('aria-pressed', 'true');
+  setLengthLabels();
+
   // ── Arrangement row visibility ───────────────────────────────────────────
   function updateArrangementVisibility() {
-    arrangementRow.hidden = systemTypeSel.value !== 'three-phase';
+    const isThreePhase = systemTypeSel.value === 'three-phase';
+    arrangementRow.hidden = !isThreePhase;
+    forceVectorsPanel.classList.toggle('hidden', !isThreePhase || !resultsDiv.innerHTML);
   }
+  function setArrangement(arrangement) {
+    arrangementSel.value = arrangement;
+    arrangementCards.forEach(card => {
+      const active = card.dataset.arrangement === arrangement;
+      card.classList.toggle('active', active);
+      card.setAttribute('aria-checked', String(active));
+    });
+  }
+  arrangementGallery.addEventListener('click', event => {
+    const card = event.target.closest('.arrangement-card');
+    if (!card) return;
+    setArrangement(card.dataset.arrangement);
+  });
   systemTypeSel.addEventListener('change', updateArrangementVisibility);
+  setArrangement('trefoil');
   updateArrangementVisibility();
 
   // ── Spacing mode toggle ──────────────────────────────────────────────────
@@ -62,8 +125,9 @@ document.addEventListener('DOMContentLoaded', () => {
   function updateDerivedSpacing() {
     const od = parseFloat(cableODInput.value);
     if (Number.isFinite(od) && od > 0) {
+      const odMm = unitSystem === 'metric' ? od : inToMm(od);
       derivedSpacingNote.textContent =
-        `Derived centre-to-centre spacing: ${od.toFixed(1)} mm (touching cables, spacing = OD).`;
+        `Derived centre-to-centre spacing: ${unitSystem === 'metric' ? `${odMm.toFixed(1)} mm` : `${mmToIn(odMm).toFixed(2)} in`} (${odMm.toFixed(1)} mm physical).`;
     } else {
       derivedSpacingNote.textContent = 'Enter a valid cable OD above.';
     }
@@ -98,6 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
     scheduleSection.hidden = isSingle;
     resultsDiv.innerHTML = '';
     scheduleResultsDiv.innerHTML = '';
+    forceVectorsPanel.classList.add('hidden');
   }
   singleModeRadio.addEventListener('change', updateMode);
   scheduleModeRadio.addEventListener('change', updateMode);
@@ -105,10 +170,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // ── Resolve spacing (mm) from current UI state ───────────────────────────
   function resolveSpacingMm() {
+    const factor = unitSystem === 'metric' ? 1 : 25.4;
     if (spacingFromODRadio.checked) {
-      return parseFloat(cableODInput.value);
+      return parseFloat(cableODInput.value) * factor;
     }
-    return parseFloat(spacingInput.value);
+    return parseFloat(spacingInput.value) * factor;
   }
 
   // ── Single-cable calculation ─────────────────────────────────────────────
@@ -118,7 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const sysType    = systemTypeSel.value;
     const arrg       = arrangementSel.value;
     const spacing    = resolveSpacingMm();
-    const cleatSpan  = parseFloat(cleatSpacingInput.value);
+    const cleatSpan  = parseFloat(cleatSpacingInput.value) * (unitSystem === 'metric' ? 1 : 25.4);
     const sf         = parseFloat(safetyFactorInput.value);
     const knownRating = parseFloat(cleatRatingInput.value);
 
@@ -165,9 +231,49 @@ document.addEventListener('DOMContentLoaded', () => {
     renderSingleResult(result, {
       iSc, xr, sysType, arrg, spacing, cleatSpan, sf, userRating,
     });
+    renderForceVectors(result, { sysType, arrg });
   });
 
+  function renderForceVectors(result, params) {
+    if (params.sysType !== 'three-phase') {
+      forceVectorsPanel.classList.add('hidden');
+      return;
+    }
+    const f = result.forcePerMeter_Nm;
+    const toLbfFt = f * 0.0685218;
+    vectorLegend.textContent = `Vector magnitude reference: ${f.toFixed(1)} N/m (${toLbfFt.toFixed(2)} lbf/ft).`;
+    if (params.arrg === 'trefoil') {
+      forceVectorSvg.innerHTML = `
+      <defs><marker id="vArrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
+      <circle cx="210" cy="60" r="24" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="155" cy="154" r="24" fill="#dcfce7" stroke="#15803d"></circle><circle cx="265" cy="154" r="24" fill="#fee2e2" stroke="#dc2626"></circle>
+      <text x="210" y="66" text-anchor="middle" class="phase-label">A</text><text x="155" y="160" text-anchor="middle" class="phase-label">B</text><text x="265" y="160" text-anchor="middle" class="phase-label">C</text>
+      <line x1="210" y1="60" x2="210" y2="20" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
+      <line x1="155" y1="154" x2="118" y2="181" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
+      <line x1="265" y1="154" x2="302" y2="181" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
+      <text x="222" y="18">${f.toFixed(1)} N/m</text><text x="74" y="186">${f.toFixed(1)} N/m</text><text x="304" y="186">${f.toFixed(1)} N/m</text>`;
+    } else {
+      forceVectorSvg.innerHTML = `
+      <defs><marker id="vArrow2" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
+      <circle cx="100" cy="120" r="24" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="210" cy="120" r="24" fill="#dcfce7" stroke="#15803d"></circle><circle cx="320" cy="120" r="24" fill="#fee2e2" stroke="#dc2626"></circle>
+      <text x="100" y="126" text-anchor="middle" class="phase-label">A</text><text x="210" y="126" text-anchor="middle" class="phase-label">B</text><text x="320" y="126" text-anchor="middle" class="phase-label">C</text>
+      <line x1="100" y1="120" x2="58" y2="120" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
+      <line x1="210" y1="120" x2="210" y2="80" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
+      <line x1="320" y1="120" x2="362" y2="120" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
+      <text x="14" y="115">${f.toFixed(1)} N/m</text><text x="184" y="72">${(f * 0.25).toFixed(1)} N/m</text><text x="366" y="115">${f.toFixed(1)} N/m</text>`;
+    }
+    forceVectorsPanel.classList.remove('hidden');
+  }
+
   function renderSingleResult(r, params) {
+    const spacingDisplay = unitSystem === 'metric'
+      ? `${params.spacing.toFixed(1)} mm`
+      : `${mmToIn(params.spacing).toFixed(2)} in`;
+    const cleatSpanDisplay = unitSystem === 'metric'
+      ? `${params.cleatSpan.toFixed(0)} mm`
+      : `${mmToIn(params.cleatSpan).toFixed(2)} in`;
+    const forceDisplay = unitSystem === 'metric'
+      ? `${r.forcePerMeter_Nm.toFixed(1)} N/m (${r.forcePerMeter_lbfFt.toFixed(1)} lbf/ft)`
+      : `${r.forcePerMeter_lbfFt.toFixed(1)} lbf/ft (${r.forcePerMeter_Nm.toFixed(1)} N/m)`;
     const adequate = params.userRating !== null
       ? params.userRating >= r.requiredStrength_kN
       : null;
@@ -197,9 +303,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 <td>${r.peakFactor.toFixed(4)}</td></tr>
             <tr><th scope="row">Peak fault current i<sub>peak</sub></th>
                 <td><strong>${r.iPeak_kA.toFixed(3)} kA</strong></td></tr>
+            <tr><th scope="row">Cable spacing (d)</th>
+                <td>${spacingDisplay}</td></tr>
             <tr><th scope="row">Electromagnetic force</th>
-                <td>${r.forcePerMeter_Nm.toFixed(1)} N/m
-                    &nbsp;<span class="unit-note">(${r.forcePerMeter_lbfFt.toFixed(1)} lbf/ft)</span></td></tr>
+                <td>${forceDisplay}</td></tr>
             <tr><th scope="row">Cleat tensile load (T = F × L)</th>
                 <td>${r.cleatLoad_kN.toFixed(3)} kN
                     &nbsp;<span class="unit-note">(${(r.cleatLoad_N).toFixed(0)} N)</span></td></tr>
@@ -218,10 +325,10 @@ document.addEventListener('DOMContentLoaded', () => {
           <pre>κ = 1.02 + 0.98 × e^(−3/${params.xr.toFixed(1)}) = ${r.peakFactor.toFixed(4)}</pre>
           <p>Peak fault current:</p>
           <pre>i_peak = κ × √2 × ${params.iSc.toFixed(1)} kA = ${r.iPeak_kA.toFixed(3)} kA</pre>
-          <p>Electromagnetic force per unit length (${params.sysType === 'three-phase' ? '√3' : '2'}×10⁻⁷ coefficient):</p>
+          <p>Electromagnetic force per unit length (${params.sysType === 'three-phase' ? '√3' : '2'}×10⁻⁷ coefficient, d = ${spacingDisplay}):</p>
           <pre>F = ${params.sysType === 'three-phase' ? '√3' : '2'}×10⁻⁷ × (${(r.iPeak_kA * 1000).toFixed(0)} A)² / ${params.spacing.toFixed(0)} mm
   = ${r.forcePerMeter_Nm.toFixed(1)} N/m</pre>
-          <p>Cleat tensile load over ${params.cleatSpan.toFixed(0)} mm span:</p>
+          <p>Cleat tensile load over ${cleatSpanDisplay} span:</p>
           <pre>T = ${r.forcePerMeter_Nm.toFixed(1)} N/m × ${(params.cleatSpan / 1000).toFixed(3)} m
   = ${r.cleatLoad_N.toFixed(0)} N  (${r.cleatLoad_kN.toFixed(3)} kN)</pre>
           <p>Required rated cleat strength (IEC 61914 SF = ${r.safetyFactor}):</p>
@@ -241,7 +348,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const iSc       = parseFloat(faultCurrentInput.value);
     const xr        = parseFloat(xrRatioInput.value);
-    const cleatSpan = parseFloat(cleatSpacingInput.value);
+    const cleatSpan = parseFloat(cleatSpacingInput.value) * (unitSystem === 'metric' ? 1 : 25.4);
     const sf        = parseFloat(safetyFactorInput.value);
 
     if (!Number.isFinite(iSc) || iSc <= 0) {
@@ -310,10 +417,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const tableRows = rows.map(({ cable, spacing_mm, result, err }) => {
       const tag  = esc(cable.tag || cable.cable_tag || '—');
       const size = esc(cable.conductor_size || cable.size || '—');
+      const spacingDisplay = unitSystem === 'metric' ? spacing_mm.toFixed(1) : mmToIn(spacing_mm).toFixed(2);
+      const forceDisplay = result
+        ? (unitSystem === 'metric' ? result.forcePerMeter_Nm.toFixed(1) : result.forcePerMeter_lbfFt.toFixed(1))
+        : '—';
       if (err || !result) {
         return `<tr>
           <td>${tag}</td><td>${size}</td>
-          <td>${spacing_mm > 0 ? spacing_mm.toFixed(1) : '—'}</td>
+          <td>${spacing_mm > 0 ? spacingDisplay : '—'}</td>
           <td>—</td><td>—</td>
           <td class="status-badge result-fail">Error${err ? ': ' + esc(err) : ''}</td>
         </tr>`;
@@ -321,8 +432,8 @@ document.addEventListener('DOMContentLoaded', () => {
       return `<tr>
         <td>${tag}</td>
         <td>${size}</td>
-        <td>${spacing_mm.toFixed(1)}</td>
-        <td>${result.forcePerMeter_Nm.toFixed(1)}</td>
+        <td>${spacingDisplay}</td>
+        <td>${forceDisplay}</td>
         <td>${result.cleatLoad_kN.toFixed(3)}</td>
         <td class="status-badge result-ok">≥ ${result.requiredStrength_kN.toFixed(2)} kN</td>
       </tr>`;
@@ -332,7 +443,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <h2>Cable Schedule Results</h2>
       <p class="field-hint">
         I<sub>sc</sub> = ${params.iSc.toFixed(1)} kA, X/R = ${params.xr.toFixed(1)},
-        cleat spacing = ${params.cleatSpan.toFixed(0)} mm, SF = ${params.sf}.
+        cleat spacing = ${unitSystem === 'metric' ? `${params.cleatSpan.toFixed(0)} mm` : `${mmToIn(params.cleatSpan).toFixed(2)} in`}, SF = ${params.sf}.
         Cable OD derived from conductor size where available; 50 mm assumed otherwise.
       </p>
       <table class="result-table schedule-result-table"
@@ -341,8 +452,8 @@ document.addEventListener('DOMContentLoaded', () => {
           <tr>
             <th scope="col">Cable Tag</th>
             <th scope="col">Size</th>
-            <th scope="col">Spacing (mm)</th>
-            <th scope="col">Force (N/m)</th>
+            <th scope="col">Spacing (${unitSystem === 'metric' ? 'mm' : 'in'})</th>
+            <th scope="col">Force (${unitSystem === 'metric' ? 'N/m' : 'lbf/ft'})</th>
             <th scope="col">Cleat Load (kN)</th>
             <th scope="col">Required Strength</th>
           </tr>


### PR DESCRIPTION
### Motivation
- Improve usability of the Fault Cable Bracing calculator by letting users switch between imperial and metric units for spacing/cleat inputs and outputs.
- Replace the arrangement drop-down with image-based choices (trefoil / flat) so users can select the layout visually.
- Provide a visual vector preview (A/B/C labeled with arrows) to illustrate the direction and magnitude of the electromagnetic forces applied to each conductor during a fault.

### Description
- Added an in-page unit toggle UI (imperial / metric) and conversion logic, plus label tokens for spacing/OD/cleat-span so inputs and results update to the selected units; helper functions `mmToIn`/`inToMm` and `toggleUnits` were introduced in `cableFaultBracing.js`.
- Replaced the arrangement `<select>` with clickable image cards (SVG thumbnails) and a hidden `#arrangement` input; selection updates are handled with `setArrangement` and card event wiring in `cableFaultBracing.js`.
- Added a force-vector preview panel that renders A/B/C phase circles and directional arrows (trefoil vs flat) and shows the calculated force magnitude via `renderForceVectors(result, params)`; the panel appears for three-phase results.
- Updated single-result and schedule-result renderers to display spacing and force using the selected unit system and to convert cleat spacing when toggling units; UI changes are in `cableFaultBracing.html` and logic in `cableFaultBracing.js`.
- Files modified: `cableFaultBracing.html` (UI + inline styles + SVG thumbnails), `cableFaultBracing.js` (unit handling, arrangement gallery, vector rendering, result formatting).

### Testing
- Ran `node tests/cableFaultBracing.test.mjs` and it passed successfully.
- Ran `npm run build` which completed (tooling produced unrelated unresolved-dependency/export warnings from the broader build, not caused by these UI changes).
- Attempted full `npm test` in this environment but the suite timed out while running multiple test groups (`EXIT:124`).
- Attempted to produce a page preview with Playwright but Chromium is not installed in the environment, so automatic screenshot generation failed with the Playwright browser-install error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd586c608c83249bd84af3f337ff04)