### PR TITLE
Improve arrangement selector UX and show force vectors after calculation

### DIFF
--- a/cableFaultBracing.html
+++ b/cableFaultBracing.html
@@ -24,9 +24,9 @@
     .unit-pill { border: 0; border-radius: 999px; padding: 0.4rem 0.9rem; cursor: pointer; background: transparent; color: inherit; font-weight: 600; }
     .unit-pill[aria-pressed="true"] { background: color-mix(in srgb, var(--primary-color, #2563eb) 22%, white); }
     .arrangement-gallery { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.75rem; margin-top: 0.25rem; }
-    .arrangement-card { border: 1px solid var(--border-color, #cbd5e1); border-radius: 10px; padding: 0.7rem; background: var(--secondary-color, #f8fafc); cursor: pointer; text-align: left; }
-    .arrangement-card.active { border-color: var(--primary-color, #2563eb); box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color, #2563eb) 18%, transparent); }
-    .arrangement-card svg { width: 100%; height: auto; }
+    .arrangement-card { border: 1px solid var(--border-color, #cbd5e1); border-radius: 10px; padding: 0.7rem; background: var(--secondary-color, #f8fafc); cursor: pointer; text-align: left; display: grid; justify-items: center; gap: 0.4rem; }
+    .arrangement-card.active { border-color: var(--primary-color, #2563eb); box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color, #2563eb) 18%, transparent); background: color-mix(in srgb, var(--primary-color, #2563eb) 8%, var(--secondary-color, #f8fafc)); }
+    .arrangement-card svg { width: min(100%, 230px); height: auto; display: block; margin: 0 auto; }
     .phase-label { font-size: 14px; font-weight: 700; }
     .force-vectors { margin-top: 0.5rem; border: 1px solid var(--border-color, #cbd5e1); border-radius: 10px; padding: 0.75rem; background: var(--secondary-color, #f8fafc); }
     .force-vectors svg { width: 100%; max-width: 500px; height: auto; display: block; }
@@ -204,19 +204,15 @@ Three-phase:    F = √3×10⁻⁷ × i_peak² / d  [N/m]</pre>
           <div class="arrangement-gallery" id="arrangementGallery" role="radiogroup" aria-label="Cable arrangement selector">
             <button class="arrangement-card active" id="arrangementTrefoil" type="button" data-arrangement="trefoil" role="radio" aria-checked="true">
               <svg viewBox="0 0 180 120" aria-hidden="true">
-                <defs><marker id="arrowBlue" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
-                <circle cx="90" cy="28" r="16" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="57" cy="84" r="16" fill="#dcfce7" stroke="#15803d"></circle><circle cx="123" cy="84" r="16" fill="#fee2e2" stroke="#dc2626"></circle>
-                <text x="90" y="33" text-anchor="middle" class="phase-label">A</text><text x="57" y="89" text-anchor="middle" class="phase-label">B</text><text x="123" y="89" text-anchor="middle" class="phase-label">C</text>
-                <line x1="90" y1="28" x2="90" y2="7" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue)"></line><line x1="57" y1="84" x2="38" y2="99" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue)"></line><line x1="123" y1="84" x2="142" y2="99" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue)"></line>
+                <circle cx="90" cy="38" r="20" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.6"></circle><circle cx="72.7" cy="68" r="20" fill="#dcfce7" stroke="#15803d" stroke-width="1.6"></circle><circle cx="107.3" cy="68" r="20" fill="#fee2e2" stroke="#dc2626" stroke-width="1.6"></circle>
+                <text x="90" y="44" text-anchor="middle" class="phase-label">A</text><text x="72.7" y="74" text-anchor="middle" class="phase-label">B</text><text x="107.3" y="74" text-anchor="middle" class="phase-label">C</text>
               </svg>
-              <span>Trefoil (outward force vectors)</span>
+              <span>Trefoil (touching)</span>
             </button>
             <button class="arrangement-card" id="arrangementFlat" type="button" data-arrangement="flat" role="radio" aria-checked="false">
               <svg viewBox="0 0 180 120" aria-hidden="true">
-                <defs><marker id="arrowBlue2" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
-                <circle cx="42" cy="62" r="16" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="90" cy="62" r="16" fill="#dcfce7" stroke="#15803d"></circle><circle cx="138" cy="62" r="16" fill="#fee2e2" stroke="#dc2626"></circle>
-                <text x="42" y="67" text-anchor="middle" class="phase-label">A</text><text x="90" y="67" text-anchor="middle" class="phase-label">B</text><text x="138" y="67" text-anchor="middle" class="phase-label">C</text>
-                <line x1="42" y1="62" x2="18" y2="62" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue2)"></line><line x1="138" y1="62" x2="162" y2="62" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue2)"></line><line x1="90" y1="62" x2="90" y2="38" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowBlue2)"></line>
+                <circle cx="52" cy="62" r="20" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.6"></circle><circle cx="92" cy="62" r="20" fill="#dcfce7" stroke="#15803d" stroke-width="1.6"></circle><circle cx="132" cy="62" r="20" fill="#fee2e2" stroke="#dc2626" stroke-width="1.6"></circle>
+                <text x="52" y="68" text-anchor="middle" class="phase-label">A</text><text x="92" y="68" text-anchor="middle" class="phase-label">B</text><text x="132" y="68" text-anchor="middle" class="phase-label">C</text>
               </svg>
               <span>Flat / single-layer</span>
             </button>

--- a/cableFaultBracing.js
+++ b/cableFaultBracing.js
@@ -17,7 +17,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const xrRatioInput       = document.getElementById('xrRatio');
   const systemTypeSel      = document.getElementById('systemType');
   const arrangementSel     = document.getElementById('arrangement');
-  const arrangementGallery = document.getElementById('arrangementGallery');
   const arrangementCards   = Array.from(document.querySelectorAll('.arrangement-card'));
   const arrangementRow     = document.getElementById('arrangementRow');
   const unitsImperialBtn   = document.getElementById('unitsImperial');
@@ -102,12 +101,19 @@ document.addEventListener('DOMContentLoaded', () => {
       const active = card.dataset.arrangement === arrangement;
       card.classList.toggle('active', active);
       card.setAttribute('aria-checked', String(active));
+      card.setAttribute('aria-pressed', String(active));
     });
   }
-  arrangementGallery.addEventListener('click', event => {
-    const card = event.target.closest('.arrangement-card');
-    if (!card) return;
-    setArrangement(card.dataset.arrangement);
+  arrangementCards.forEach(card => {
+    card.addEventListener('click', () => {
+      setArrangement(card.dataset.arrangement);
+    });
+    card.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        setArrangement(card.dataset.arrangement);
+      }
+    });
   });
   systemTypeSel.addEventListener('change', updateArrangementVisibility);
   setArrangement('trefoil');
@@ -240,26 +246,29 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     const f = result.forcePerMeter_Nm;
+    const forceA = f.toFixed(1);
+    const forceB = (params.arrg === 'flat' ? 0 : f).toFixed(1);
+    const forceC = f.toFixed(1);
     const toLbfFt = f * 0.0685218;
-    vectorLegend.textContent = `Vector magnitude reference: ${f.toFixed(1)} N/m (${toLbfFt.toFixed(2)} lbf/ft).`;
+    vectorLegend.textContent = `Vector magnitudes shown per phase. Base force: ${f.toFixed(1)} N/m (${toLbfFt.toFixed(2)} lbf/ft).`;
     if (params.arrg === 'trefoil') {
       forceVectorSvg.innerHTML = `
       <defs><marker id="vArrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
-      <circle cx="210" cy="60" r="24" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="155" cy="154" r="24" fill="#dcfce7" stroke="#15803d"></circle><circle cx="265" cy="154" r="24" fill="#fee2e2" stroke="#dc2626"></circle>
-      <text x="210" y="66" text-anchor="middle" class="phase-label">A</text><text x="155" y="160" text-anchor="middle" class="phase-label">B</text><text x="265" y="160" text-anchor="middle" class="phase-label">C</text>
-      <line x1="210" y1="60" x2="210" y2="20" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
-      <line x1="155" y1="154" x2="118" y2="181" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
-      <line x1="265" y1="154" x2="302" y2="181" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
-      <text x="222" y="18">${f.toFixed(1)} N/m</text><text x="74" y="186">${f.toFixed(1)} N/m</text><text x="304" y="186">${f.toFixed(1)} N/m</text>`;
+      <circle cx="210" cy="70" r="26" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="187.5" cy="109" r="26" fill="#dcfce7" stroke="#15803d"></circle><circle cx="232.5" cy="109" r="26" fill="#fee2e2" stroke="#dc2626"></circle>
+      <text x="210" y="77" text-anchor="middle" class="phase-label">A</text><text x="187.5" y="116" text-anchor="middle" class="phase-label">B</text><text x="232.5" y="116" text-anchor="middle" class="phase-label">C</text>
+      <line x1="210" y1="70" x2="210" y2="28" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
+      <line x1="187.5" y1="109" x2="149" y2="137" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
+      <line x1="232.5" y1="109" x2="271" y2="137" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow)"></line>
+      <text x="218" y="24">A ↑ ${forceA} N/m</text><text x="89" y="145">B ↙ ${forceB} N/m</text><text x="274" y="145">C ↘ ${forceC} N/m</text>`;
     } else {
       forceVectorSvg.innerHTML = `
       <defs><marker id="vArrow2" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#2563eb"></path></marker></defs>
-      <circle cx="100" cy="120" r="24" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="210" cy="120" r="24" fill="#dcfce7" stroke="#15803d"></circle><circle cx="320" cy="120" r="24" fill="#fee2e2" stroke="#dc2626"></circle>
-      <text x="100" y="126" text-anchor="middle" class="phase-label">A</text><text x="210" y="126" text-anchor="middle" class="phase-label">B</text><text x="320" y="126" text-anchor="middle" class="phase-label">C</text>
-      <line x1="100" y1="120" x2="58" y2="120" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
-      <line x1="210" y1="120" x2="210" y2="80" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
-      <line x1="320" y1="120" x2="362" y2="120" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
-      <text x="14" y="115">${f.toFixed(1)} N/m</text><text x="184" y="72">${(f * 0.25).toFixed(1)} N/m</text><text x="366" y="115">${f.toFixed(1)} N/m</text>`;
+      <circle cx="122" cy="120" r="24" fill="#dbeafe" stroke="#1d4ed8"></circle><circle cx="170" cy="120" r="24" fill="#dcfce7" stroke="#15803d"></circle><circle cx="218" cy="120" r="24" fill="#fee2e2" stroke="#dc2626"></circle>
+      <text x="122" y="126" text-anchor="middle" class="phase-label">A</text><text x="170" y="126" text-anchor="middle" class="phase-label">B</text><text x="218" y="126" text-anchor="middle" class="phase-label">C</text>
+      <line x1="122" y1="120" x2="78" y2="120" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
+      <line x1="170" y1="120" x2="170" y2="120" stroke="#2563eb" stroke-width="0"></line>
+      <line x1="218" y1="120" x2="262" y2="120" stroke="#2563eb" stroke-width="3" marker-end="url(#vArrow2)"></line>
+      <text x="26" y="116">A ← ${forceA} N/m</text><text x="150" y="84">B net ${forceB} N/m</text><text x="268" y="116">C → ${forceC} N/m</text>`;
     }
     forceVectorsPanel.classList.remove('hidden');
   }


### PR DESCRIPTION
### Motivation
- Fix the arrangement thumbnail not responding when clicked or pressed and make the selector keyboard-accessible and properly announced to assistive tech. 
- Reduce oversized thumbnail images and make the cable circles appear touching in the selector to reflect touching/trefoil geometry. 
- Move the directional force arrows out of the selector thumbnails and present them only after the calculation so the thumbnails act solely as arrangement selectors.

### Description
- Update styling in `cableFaultBracing.html` to constrain selector thumbnail size, center content, and add a clearer active background for the selected card. 
- Replace the thumbnail SVGs in `cableFaultBracing.html` with touching-circle layouts (trefoil and flat) and remove the inline arrows from those selector images. 
- In `cableFaultBracing.js` wire per-card `click` and `keydown` handlers (Enter / Space) and synchronize `aria-checked` / `aria-pressed` on selection to fix the non-responsive image selection and improve keyboard accessibility. 
- Change `renderForceVectors` in `cableFaultBracing.js` to render directional arrows and per-phase force labels in the dedicated post-calculation vector panel and to compute per-phase labels (flat arrangement shows a net/zero on the middle conductor where applicable).

### Testing
- Ran the component unit tests with `node tests/cableFaultBracing.test.mjs` and all assertions passed. 
- Built the frontend with `npm run build` and the build completed successfully. 
- Attempted an automated browser preview using Playwright to produce a screenshot, but Playwright browser binaries are not installed in the environment so the screenshot step failed (requires `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5d0b35688324aa734cf23306aaf0)