### PR TITLE
Group Workflow and Studies navigation menus into clearer sub-categories

### DIFF
--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -4,16 +4,16 @@ const NAV_ROUTES = [
   { href: 'scenarios.html', label: 'Scenario Comparison', section: 'Workflow', group: 'Planning', icon: 'icons/toolbar/copy.svg' },
   { href: 'equipmentlist.html', label: 'Equipment List', section: 'Workflow', group: 'Planning', icon: 'icons/equipment.svg' },
   { href: 'loadlist.html', label: 'Load List', section: 'Workflow', group: 'Planning', icon: 'icons/load.svg' },
-  { href: 'cableschedule.html', label: 'Cable Schedule', section: 'Workflow', group: 'Cable & Raceway', icon: 'icons/cable.svg' },
-  { href: 'panelschedule.html', label: 'Panel Schedule', section: 'Workflow', group: 'Cable & Raceway', icon: 'icons/panel.svg' },
-  { href: 'racewayschedule.html', label: 'Raceway Schedule', section: 'Workflow', group: 'Cable & Raceway', icon: 'icons/raceway.svg' },
-  { href: 'ductbankroute.html', label: 'Ductbank', section: 'Workflow', group: 'Cable & Raceway', icon: 'icons/ductbank.svg' },
-  { href: 'cabletrayfill.html', label: 'Tray Fill', section: 'Workflow', group: 'Cable & Raceway', icon: 'icons/tray.svg' },
-  { href: 'conduitfill.html', label: 'Conduit Fill', section: 'Workflow', group: 'Cable & Raceway', icon: 'icons/conduit.svg' },
-  { href: 'supportspan.html', label: 'Support Span', section: 'Workflow', group: 'Mechanical', icon: 'icons/toolbar/dimension.svg' },
-  { href: 'seismicBracing.html', label: 'Seismic Bracing', section: 'Workflow', group: 'Mechanical', icon: 'icons/toolbar/validate.svg' },
-  { href: 'cableFaultBracing.html', label: 'Fault Cable Bracing', section: 'Workflow', group: 'Mechanical', icon: 'icons/toolbar/validate.svg' },
-  { href: 'trayhardwarebom.html', label: 'Tray Hardware BOM', section: 'Workflow', group: 'Mechanical', icon: 'icons/raceway.svg' },
+  { href: 'cableschedule.html', label: 'Cable Schedule', section: 'Workflow', group: 'Cable', icon: 'icons/cable.svg' },
+  { href: 'panelschedule.html', label: 'Panel Schedule', section: 'Workflow', group: 'Cable', icon: 'icons/panel.svg' },
+  { href: 'racewayschedule.html', label: 'Raceway Schedule', section: 'Workflow', group: 'Raceway', icon: 'icons/raceway.svg' },
+  { href: 'ductbankroute.html', label: 'Ductbank', section: 'Workflow', group: 'Raceway', icon: 'icons/ductbank.svg' },
+  { href: 'cabletrayfill.html', label: 'Tray Fill', section: 'Workflow', group: 'Raceway', icon: 'icons/tray.svg' },
+  { href: 'conduitfill.html', label: 'Conduit Fill', section: 'Workflow', group: 'Raceway', icon: 'icons/conduit.svg' },
+  { href: 'supportspan.html', label: 'Support Span', section: 'Workflow', group: 'Raceway', icon: 'icons/toolbar/dimension.svg' },
+  { href: 'seismicBracing.html', label: 'Seismic Bracing', section: 'Workflow', group: 'Structural', icon: 'icons/toolbar/validate.svg' },
+  { href: 'cableFaultBracing.html', label: 'Fault Cable Bracing', section: 'Workflow', group: 'Cable', icon: 'icons/toolbar/validate.svg' },
+  { href: 'trayhardwarebom.html', label: 'Tray Hardware BOM', section: 'Workflow', group: 'Raceway', icon: 'icons/raceway.svg' },
   { href: 'clashdetect.html', label: 'Clash Detection', section: 'Workflow', group: 'Validation', icon: 'icons/toolbar/validate.svg' },
   { href: 'designrulechecker.html', label: 'Design Rule Checker', section: 'Workflow', group: 'Validation', icon: 'icons/toolbar/validate.svg' },
   { href: 'spoolsheets.html', label: 'Spool Sheets', section: 'Workflow', group: 'Deliverables', icon: 'icons/toolbar/copy.svg' },
@@ -115,12 +115,20 @@ function buildDropdown(section, routes, currentRoute) {
     return acc;
   }, {});
   const groupNames = Object.keys(groupedRoutes);
+  const sectionGroupOrder = {
+    Workflow: ['Planning', 'Raceway', 'Cable', 'Structural', 'Validation', 'Optimization', 'Deliverables'],
+    Studies: ['Grounding', 'Cable', 'Protection', 'Power System', 'Power Quality', 'Equipment Sizing', 'Motor']
+  };
+  const orderedGroupNames = [
+    ...(sectionGroupOrder[section] || []).filter(groupName => groupNames.includes(groupName)),
+    ...groupNames.filter(groupName => !(sectionGroupOrder[section] || []).includes(groupName))
+  ];
   const hasGroups = groupNames.length > 1;
   if (!hasGroups && routes.length >= 12) {
     menu.dataset.cols = '2';
   }
 
-  groupNames.forEach((groupName) => {
+  orderedGroupNames.forEach((groupName) => {
     if (hasGroups) {
       const heading = document.createElement('li');
       heading.className = 'nav-dropdown-group-heading';

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -183,20 +183,20 @@
 
 .nav-dropdown-menu .nav-dropdown-group-heading {
     display: block;
-    padding: 0.5rem 0.75rem 0.2rem;
-    margin-top: 0.2rem;
-    border-top: 1px solid color-mix(in srgb, var(--color-border) 85%, transparent);
-    color: var(--color-text-muted, #64748b);
-    font-size: 0.72rem;
+    padding: 0.5rem 0.75rem 0.35rem;
+    margin-top: 0.35rem;
+    border-top: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+    color: var(--color-primary, #2563eb);
+    font-size: 0.76rem;
     font-weight: 700;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
 }
 
 .nav-dropdown-menu .nav-dropdown-group-heading:first-child {
     margin-top: 0;
     border-top: 0;
-    padding-top: 0.35rem;
+    padding-top: 0.45rem;
 }
 
 .nav-dropdown-menu li a {


### PR DESCRIPTION
### Motivation
- The Workflow and Studies dropdowns were long and difficult to scan, so items need clearer subgrouping to help users find actions like Grounding, Raceway, and Cable features more quickly.
- Category headings should appear in a predictable order so the menus are easier to scan across pages and sessions.

### Description
- Reassigned several `NAV_ROUTES` entries into finer-grained groups (e.g. `Cable`, `Raceway`, `Structural`, etc.) to separate Cable vs Raceway features and improve scanability in `src/components/navigation.js`.
- Added a `sectionGroupOrder` map and `orderedGroupNames` in `buildDropdown` so group headings are emitted in a deterministic, user-friendly order per section in `src/components/navigation.js`.
- Updated dropdown group heading CSS (padding, margin, divider opacity, heading color, font-size, and letter-spacing) to increase visual separation and legibility in `src/styles/navigation.css`.

### Testing
- Ran `node tests/pageNavigation.test.cjs`, which passed.
- Ran `npm run build`, which completed successfully.
- Attempted the full `npm test` suite, but the run did not complete in this environment due to long-running/hanging test processes, so the full suite was not fully validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd65731a84832498a862bcc23253cc)