### PR TITLE
Fix project-display insertBefore crash and make Copilot endpoint configurable

### DIFF
--- a/site.js
+++ b/site.js
@@ -523,8 +523,12 @@ async function updateProjectDisplay(snapshot){
         span.id='project-display';
         span.style.marginLeft='auto';
         span.style.marginRight='var(--space-4)';
-        nav.insertBefore(span,settingsBtn);
-        if(settingsBtn) settingsBtn.style.marginLeft='0';
+        if(settingsBtn&&settingsBtn.parentNode===nav){
+          nav.insertBefore(span,settingsBtn);
+          settingsBtn.style.marginLeft='0';
+        }else{
+          nav.appendChild(span);
+        }
       }
     }
     if(span) span.textContent=`Project: ${name} (hash: ${hash.slice(0,8)})`;

--- a/src/copilot.js
+++ b/src/copilot.js
@@ -4,6 +4,18 @@ import { openModal } from './components/modal.js';
 let panel = null;
 let isOpen = false;
 
+function getCopilotEndpoint() {
+  const metaEndpoint = document.querySelector('meta[name="copilot-endpoint"]')?.content?.trim();
+  if (metaEndpoint) return metaEndpoint;
+  if (typeof window !== 'undefined' && typeof window.__COPILOT_API_URL__ === 'string' && window.__COPILOT_API_URL__.trim()) {
+    return window.__COPILOT_API_URL__.trim();
+  }
+  if (window.location.hostname.endsWith('github.io')) {
+    return null;
+  }
+  return '/api/copilot';
+}
+
 function getProjectData() {
   try {
     const cables = JSON.parse(localStorage.getItem('cableSchedule') || '[]');
@@ -53,15 +65,21 @@ async function submitQuery(query) {
   document.getElementById('copilot-send').disabled = true;
 
   try {
+    const endpoint = getCopilotEndpoint();
+    if (!endpoint) {
+      appendMessage('Copilot API is not configured for this site. Set a <meta name="copilot-endpoint" content="https://your-server/api/copilot"> tag or window.__COPILOT_API_URL__.', 'error');
+      return;
+    }
     const csrfMeta = document.querySelector('meta[name="csrf-token"]');
     const csrf = csrfMeta ? csrfMeta.content : '';
-    const res = await fetch('/api/copilot', {
+    const isSameOrigin = endpoint.startsWith('/') || endpoint.startsWith(window.location.origin);
+    const res = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-csrf-token': csrf
+        ...(isSameOrigin ? { 'x-csrf-token': csrf } : {})
       },
-      credentials: 'include',
+      credentials: isSameOrigin ? 'include' : 'omit',
       body: JSON.stringify({ query: query.trim(), projectData: getProjectData() })
     });
     if (!res.ok) throw new Error(`Server error ${res.status}`);


### PR DESCRIPTION
### Motivation
- Prevent a runtime `NotFoundError` when `updateProjectDisplay` tries to `insertBefore` a node that is not a child of the nav container. 
- Avoid spurious failing Copilot POSTs (405) on static hosts like GitHub Pages and allow deployments to configure the Copilot API endpoint.

### Description
- Change `updateProjectDisplay` in `site.js` to only call `nav.insertBefore(span, settingsBtn)` when `settingsBtn.parentNode === nav`, otherwise append the display element to `nav` to avoid the `insertBefore` error. 
- Add `getCopilotEndpoint()` to `src/copilot.js` to resolve the Copilot API endpoint from a `<meta name="copilot-endpoint">`, `window.__COPILOT_API_URL__`, or default to `'/api/copilot'` with a GitHub Pages safeguard that disables the automatic POST when on `*.github.io`.
- Update `submitQuery` to use the resolved endpoint, to show a helpful message when no endpoint is configured, and to only send same-origin CSRF header and `credentials: 'include'` for same-origin endpoints while omitting them for cross-origin endpoints.

### Testing
- Ran `npm run build` successfully to verify bundling and asset copy steps completed. 
- Executed `node tests/projectDisplayScheduler.test.mjs && node tests/autoSaveScheduler.test.mjs` and both tests passed. 
- Launched the test runner (`npm test`) but the full suite did not complete within this environment during the run. 
- Attempted a Playwright screenshot to produce a preview image but it failed because Playwright browser binaries are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd68546acc8324b363628ec744dce7)