### PR TITLE
Add live ground grid layout preview (SVG) to Ground Grid tool

### DIFF
--- a/groundgrid.html
+++ b/groundgrid.html
@@ -299,6 +299,18 @@
         </div>
       </form>
 
+      <section class="results-panel grid-visual-panel" aria-labelledby="grid-visual-title">
+        <h2 id="grid-visual-title">Grid Layout Preview</h2>
+        <p id="grid-preview-summary" class="field-hint">
+          Visual preview updates as you edit grid dimensions and conductor counts.
+        </p>
+        <div class="ground-grid-preview-wrap">
+          <svg id="ground-grid-preview" class="ground-grid-preview" viewBox="0 0 520 360"
+               role="img" aria-labelledby="grid-visual-title grid-preview-summary">
+          </svg>
+        </div>
+      </section>
+
       <div id="results" role="region" aria-live="polite" aria-label="Ground grid analysis results"></div>
 
       <nav class="step-nav" aria-label="Workflow navigation">

--- a/groundgrid.js
+++ b/groundgrid.js
@@ -9,6 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const resultsDiv = document.getElementById('results');
   const form = document.getElementById('ground-grid-form');
+  const previewSvg = document.getElementById('ground-grid-preview');
+  const previewSummary = document.getElementById('grid-preview-summary');
 
   function getNum(id) { return parseFloat(document.getElementById(id).value); }
   function getInt(id) { return parseInt(document.getElementById(id).value, 10); }
@@ -34,6 +36,97 @@ document.addEventListener('DOMContentLoaded', () => {
     b.setAttribute('role', 'status');
     b.textContent = passed ? `✓ ${label} — PASS` : `✗ ${label} — FAIL`;
     return b;
+  }
+
+  function renderGridPreview() {
+    if (!previewSvg || !previewSummary) {
+      return;
+    }
+
+    const gridLxInput = getNum('grid-lx');
+    const gridLyInput = getNum('grid-ly');
+    const nxInput = getInt('nx');
+    const nyInput = getInt('ny');
+    const hasRods = document.getElementById('has-rods').checked;
+
+    const gridLx = Number.isFinite(gridLxInput) && gridLxInput > 0 ? gridLxInput : 1;
+    const gridLy = Number.isFinite(gridLyInput) && gridLyInput > 0 ? gridLyInput : 1;
+    const nx = Math.max(2, Number.isFinite(nxInput) ? nxInput : 2);
+    const ny = Math.max(2, Number.isFinite(nyInput) ? nyInput : 2);
+
+    const unit = getUnits() === 'imperial' ? 'ft' : 'm';
+    const spacingX = ny > 1 ? gridLx / (ny - 1) : 0;
+    const spacingY = nx > 1 ? gridLy / (nx - 1) : 0;
+
+    const svgWidth = 520;
+    const svgHeight = 360;
+    const margin = 52;
+    const drawableWidth = svgWidth - (margin * 2);
+    const drawableHeight = svgHeight - (margin * 2);
+    const scale = Math.min(drawableWidth / gridLx, drawableHeight / gridLy);
+    const drawWidth = gridLx * scale;
+    const drawHeight = gridLy * scale;
+    const startX = (svgWidth - drawWidth) / 2;
+    const startY = (svgHeight - drawHeight) / 2;
+    const endX = startX + drawWidth;
+    const endY = startY + drawHeight;
+
+    previewSvg.innerHTML = '';
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const make = (name, attrs = {}) => {
+      const node = document.createElementNS(ns, name);
+      Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, String(value)));
+      return node;
+    };
+
+    previewSvg.appendChild(make('rect', {
+      x: startX,
+      y: startY,
+      width: drawWidth,
+      height: drawHeight,
+      class: 'grid-outline'
+    }));
+
+    const dx = ny > 1 ? drawWidth / (ny - 1) : 0;
+    const dy = nx > 1 ? drawHeight / (nx - 1) : 0;
+
+    for (let i = 0; i < ny; i += 1) {
+      const x = startX + (i * dx);
+      previewSvg.appendChild(make('line', {
+        x1: x,
+        y1: startY,
+        x2: x,
+        y2: endY,
+        class: 'grid-conductor'
+      }));
+    }
+    for (let i = 0; i < nx; i += 1) {
+      const y = startY + (i * dy);
+      previewSvg.appendChild(make('line', {
+        x1: startX,
+        y1: y,
+        x2: endX,
+        y2: y,
+        class: 'grid-conductor'
+      }));
+    }
+
+    if (hasRods) {
+      [[startX, startY], [endX, startY], [startX, endY], [endX, endY]].forEach(([x, y]) => {
+        previewSvg.appendChild(make('circle', {
+          cx: x,
+          cy: y,
+          r: 5,
+          class: 'grid-rod'
+        }));
+      });
+    }
+
+    previewSummary.textContent = `Lx: ${gridLx.toFixed(1)} ${unit} • Ly: ${gridLy.toFixed(1)} ${unit} • `
+      + `${nx} horizontal runs • ${ny} vertical runs • `
+      + `Spacing: ${spacingX.toFixed(1)} ${unit} (x), ${spacingY.toFixed(1)} ${unit} (y)`
+      + (hasRods ? ' • Corner rods enabled' : '');
   }
 
   function calculate() {
@@ -163,4 +256,17 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     calculate();
   });
+
+  form.addEventListener('input', () => {
+    renderGridPreview();
+  });
+
+  const unitSelect = document.getElementById('unit-select');
+  if (unitSelect) {
+    unitSelect.addEventListener('change', () => {
+      renderGridPreview();
+    });
+  }
+
+  renderGridPreview();
 });

--- a/src/styles/groundgrid.css
+++ b/src/styles/groundgrid.css
@@ -1,0 +1,34 @@
+.ground-grid-preview-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.ground-grid-preview {
+  width: 100%;
+  max-width: 520px;
+  border: 1px solid var(--border-subtle, #ccd2dd);
+  border-radius: 8px;
+  background: var(--surface-raised, #f7f9fd);
+  display: block;
+}
+
+.ground-grid-preview .grid-outline {
+  fill: none;
+  stroke: var(--border-strong, #5b6780);
+  stroke-width: 2;
+}
+
+.ground-grid-preview .grid-conductor {
+  stroke: var(--accent, #0074d9);
+  stroke-width: 2;
+}
+
+.ground-grid-preview .grid-rod {
+  fill: var(--danger, #cf3f5c);
+  stroke: var(--surface, #ffffff);
+  stroke-width: 1.5;
+}
+
+.grid-visual-panel {
+  margin-top: 1rem;
+}

--- a/style.css
+++ b/style.css
@@ -21,3 +21,4 @@
 @import "./src/styles/copilot.css";
 @import "./src/styles/dashboard.css";
 @import "./src/styles/scenarioComparison.css";
+@import "./src/styles/groundgrid.css";


### PR DESCRIPTION
### Motivation

- Provide an immediate visual representation of the ground grid so users can verify dimensions, conductor counts, spacing, and corner rods while editing form inputs.
- Improve ergonomics of the Ground Grid analysis workflow by reducing guesswork when configuring grid geometry.
- Include accessible labeling so the preview can be described by assistive technologies.

### Description

- Added a new results panel with an SVG preview in `groundgrid.html` that is labelled and summarizes the preview (`Grid Layout Preview` and `grid-preview-summary`).
- Implemented `renderGridPreview()` in `groundgrid.js` which computes scale, draws the grid outline, conductor runs, and optional corner rods, and updates a textual summary; wired it to form `input` events, `unit-select` changes, and an initial render.
- Added styles in `src/styles/groundgrid.css` to style the preview SVG and imported the stylesheet from `style.css`.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6cc3daf48324b8881fbc01abf48c)