### PR TITLE
Strengthen cost estimator integration specs with fixtures and deterministic assertions

### DIFF
--- a/playwright-tests/nextFeatures.helpers.js
+++ b/playwright-tests/nextFeatures.helpers.js
@@ -6,9 +6,56 @@ const root = path.join(__dirname, '..');
 
 export const pageUrl = file => `file://${path.join(root, file)}?e2e=1&e2e_reset=1`;
 
+export const COST_ESTIMATOR_FIXTURES = {
+  baselineProject: {
+    cableSchedule: [
+      { cable_tag: 'C-101', conductor_size: '4 AWG', conductors: 3, length_ft: 150 },
+    ],
+    traySchedule: [
+      { tray_id: 'T-101', tray_type: 'Ladder', inside_width: '12', length_ft: 120, fitting_count: 2 },
+    ],
+    conduitSchedule: [
+      { conduit_id: 'CD-101', conduit_type: 'EMT', trade_size: '2', length_ft: 80 },
+    ],
+    studyResults: {
+      routeResults: [{ cable: 'C-101', total_length: 150 }],
+    },
+  },
+  highContingency: {
+    contingencyPct: '35',
+  },
+  laborOverrideScenario: {
+    laborCableRate: '95',
+    laborTrayRate: '110',
+    laborConduitRate: '105',
+  },
+  emptyInvalidInputScenario: {
+    cableSchedule: [],
+    traySchedule: [],
+    conduitSchedule: [],
+    studyResults: {},
+    contingencyPct: 'not-a-number',
+    laborCableRate: '',
+    laborTrayRate: 'invalid',
+    laborConduitRate: '',
+  },
+};
+
 export async function navigateForE2E(page, file) {
   await page.goto(pageUrl(file));
   await page.waitForLoadState('networkidle');
+}
+
+export async function applyCostEstimatorFixture(page, fixture) {
+  await page.evaluate(data => {
+    const scenario = 'base';
+    localStorage.setItem('ctr_current_scenario_v1', scenario);
+    localStorage.setItem('ctr_scenarios_v1', JSON.stringify([scenario]));
+    localStorage.setItem(`${scenario}:cableSchedule`, JSON.stringify(data.cableSchedule || []));
+    localStorage.setItem(`${scenario}:traySchedule`, JSON.stringify(data.traySchedule || []));
+    localStorage.setItem(`${scenario}:conduitSchedule`, JSON.stringify(data.conduitSchedule || []));
+    localStorage.setItem(`${scenario}:studyResults`, JSON.stringify(data.studyResults || {}));
+  }, fixture);
 }
 
 export async function fillCostEstimatorForm(page, overrides = {}) {
@@ -64,6 +111,11 @@ export function parseCurrency(text) {
 export async function getCostEstimateGrandTotal(page) {
   const grandTotalText = await page.locator('.summary-grand-total td strong').innerText();
   return parseCurrency(grandTotalText);
+}
+
+export async function getCostEstimateContingencyAmount(page) {
+  const contingencyText = await page.locator('tr:has(th:has-text("Contingency")) td').last().innerText();
+  return parseCurrency(contingencyText);
 }
 
 export async function getEmfRmsMicroTesla(page) {

--- a/playwright-tests/nextFeatures.integration.spec.js
+++ b/playwright-tests/nextFeatures.integration.spec.js
@@ -1,16 +1,28 @@
 import { test, expect } from '@playwright/test';
 import {
   navigateForE2E,
+  applyCostEstimatorFixture,
+  COST_ESTIMATOR_FIXTURES,
   fillCostEstimatorForm,
   fillEmfForm,
   getResultText,
+  getCostEstimateContingencyAmount,
+  getCostEstimateGrandTotal,
   getEmfRmsMicroTesla,
 } from './nextFeatures.helpers.js';
 
 test.describe('next features integration: cost estimator scenarios and exports', () => {
-  test('integration: cost estimator scenario with empty project shows deterministic guidance', async ({ page }) => {
+  test('integration: cost estimator heading and empty/invalid fixture show deterministic guidance', async ({ page }) => {
     await navigateForE2E(page, 'costestimate.html');
-    await fillCostEstimatorForm(page, { contingencyPct: '12' });
+    await expect(page.locator('h1')).toHaveText('Project Cost Estimator');
+
+    await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario);
+    await fillCostEstimatorForm(page, {
+      contingencyPct: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.contingencyPct,
+      laborCableRate: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.laborCableRate,
+      laborTrayRate: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.laborTrayRate,
+      laborConduitRate: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.laborConduitRate,
+    });
 
     await page.click('#estimate-btn');
 
@@ -25,6 +37,60 @@ test.describe('next features integration: cost estimator scenarios and exports',
 
     const bodyText = await page.locator('body').innerText();
     expect(bodyText).toContain('No Data');
+  });
+
+  test('integration: baseline fixture renders detailed line items, totals, and contingency impact', async ({ page }) => {
+    await navigateForE2E(page, 'costestimate.html');
+    await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.baselineProject);
+    await fillCostEstimatorForm(page, { contingencyPct: '10' });
+
+    await page.click('#estimate-btn');
+
+    const results = page.locator('#results');
+    await expect(results.locator('h2')).toHaveText('Cost Summary');
+    await expect(results.locator('table[aria-label="Cost summary by category"]')).toBeVisible();
+    await expect(results.locator('table[aria-label="Cost summary by category"] tbody tr')).toHaveCount(3);
+    await expect(results).toContainText('Cable');
+    await expect(results).toContainText('Tray');
+    await expect(results).toContainText('Conduit');
+    await expect(results).toContainText('Contingency (10%)');
+    await expect(results).toContainText('Grand Total (incl. contingency)');
+    await expect(results.locator('summary')).toContainText('Line Item Detail (3 items)');
+    await expect(results.locator('table[aria-label="Line item cost detail"] tbody tr')).toHaveCount(3);
+  });
+
+  test('integration: changing contingency and labor inputs predictably increases totals', async ({ page }) => {
+    await navigateForE2E(page, 'costestimate.html');
+    await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.baselineProject);
+
+    await fillCostEstimatorForm(page, { contingencyPct: '10' });
+    await page.click('#estimate-btn');
+    const baseGrandTotal = await getCostEstimateGrandTotal(page);
+    const baseContingencyAmount = await getCostEstimateContingencyAmount(page);
+
+    await fillCostEstimatorForm(page, { contingencyPct: COST_ESTIMATOR_FIXTURES.highContingency.contingencyPct });
+    await page.click('#estimate-btn');
+    const highContingencyGrandTotal = await getCostEstimateGrandTotal(page);
+    const highContingencyAmount = await getCostEstimateContingencyAmount(page);
+
+    await fillCostEstimatorForm(page, {
+      contingencyPct: COST_ESTIMATOR_FIXTURES.highContingency.contingencyPct,
+      laborCableRate: COST_ESTIMATOR_FIXTURES.laborOverrideScenario.laborCableRate,
+      laborTrayRate: COST_ESTIMATOR_FIXTURES.laborOverrideScenario.laborTrayRate,
+      laborConduitRate: COST_ESTIMATOR_FIXTURES.laborOverrideScenario.laborConduitRate,
+    });
+    await page.click('#estimate-btn');
+    const laborOverrideGrandTotal = await getCostEstimateGrandTotal(page);
+
+    expect(baseGrandTotal).not.toBeNull();
+    expect(baseContingencyAmount).not.toBeNull();
+    expect(highContingencyGrandTotal).not.toBeNull();
+    expect(highContingencyAmount).not.toBeNull();
+    expect(laborOverrideGrandTotal).not.toBeNull();
+
+    expect(highContingencyAmount).toBeGreaterThan(baseContingencyAmount);
+    expect(highContingencyGrandTotal).toBeGreaterThan(baseGrandTotal);
+    expect(laborOverrideGrandTotal).toBeGreaterThan(highContingencyGrandTotal);
   });
 
   test('integration: submittal preview scenario renders expected structured output', async ({ page }) => {


### PR DESCRIPTION
### Motivation
- Provide deterministic, reproducible integration tests for the Cost Estimator by seeding scenario-scoped storage and asserting specific labels and numeric outputs instead of permissive text matches.

### Description
- Added reusable fixtures in `playwright-tests/nextFeatures.helpers.js` under `COST_ESTIMATOR_FIXTURES` for `baselineProject`, `highContingency`, `laborOverrideScenario`, and `emptyInvalidInputScenario`.
- Added `applyCostEstimatorFixture(page, fixture)` to seed scenario-scoped localStorage keys (`base:cableSchedule`, `base:traySchedule`, `base:conduitSchedule`, `base:studyResults`) so the estimator runs with deterministic data.
- Added numeric parsing helpers `getCostEstimateGrandTotal` and `getCostEstimateContingencyAmount` to `nextFeatures.helpers.js` to support robust assertions on monetary outputs.
- Updated `playwright-tests/nextFeatures.integration.spec.js` to assert the exact page heading (`Project Cost Estimator`), use the empty/invalid fixture for no-data behavior, verify structured `#results` content for the baseline fixture (summary heading, per-category rows, line-item counts, contingency label, grand total), and assert that changing `#contingency-pct` and labor inputs predictably increases totals.

### Testing
- Ran `npm run build`, which completed successfully (Rollup emitted pre-existing warnings unrelated to these test changes).
- Attempted to run the Playwright integration spec with `npx playwright test playwright-tests/nextFeatures.integration.spec.js`, which failed in this environment due to missing Playwright browser binaries (`firefox`/`msedge`), so the new E2E assertions were not executed here.
- Started `npm test`; the test run began and produced many passing suite outputs but did not complete in this environment due to a long-running test process and was terminated before finishing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd785529508324872ba760c46109cf)