### PR TITLE
Expand EMF integration tests: frequency, numeric assertions, compliance, validation, and profile checks

### DIFF
--- a/playwright-tests/nextFeatures.integration.spec.js
+++ b/playwright-tests/nextFeatures.integration.spec.js
@@ -110,8 +110,43 @@ test.describe('next features integration: cost estimator scenarios and exports',
 });
 
 test.describe('next features integration: emf deterministic outputs', () => {
-  test('integration: emf calculation returns deterministic numeric output and compliance table', async ({ page }) => {
+  test('integration: emf calculation returns deterministic numeric output for fixed 60 Hz and 50 Hz scenarios', async ({ page }) => {
     await navigateForE2E(page, 'emf.html');
+    const fixedInputs = {
+      loadCurrent: '150',
+      nCables: '1',
+      trayWidth: '12',
+      cableOd: '1.0',
+      measDistance: '36',
+    };
+
+    for (const frequency of ['60', '50']) {
+      await fillEmfForm(page, { ...fixedInputs, frequency });
+      await page.click('#calc-btn');
+
+      await expect(page.locator('tr:has(th:has-text("Frequency")) td')).toHaveText(`${frequency} Hz`);
+
+      const rmsCell = page.locator('tr:has(th:has-text("RMS Flux Density")) td strong');
+      await expect(rmsCell).toHaveText(/^\d+\.\d{3}\sµT$/);
+      const rms = await getEmfRmsMicroTesla(page);
+      expect(rms).not.toBeNull();
+      expect(rms).toBeGreaterThan(20);
+      expect(rms).toBeLessThan(40);
+
+      const peakText = await page.locator('tr:has(th:has-text("Peak Flux Density")) td strong').innerText();
+      expect(peakText).toMatch(/^\d+\.\d{3}\sµT$/);
+      const peak = Number.parseFloat(peakText.replace(' µT', ''));
+      expect(peak).toBeGreaterThan(40);
+      expect(peak).toBeLessThan(70);
+
+      const resultText = await getResultText(page, '#results');
+      expect(resultText).toContain('ICNIRP 2010 Compliance');
+    }
+  });
+
+  test('integration: emf ICNIRP compliance status shows PASS and FAIL outcomes for supported scenarios', async ({ page }) => {
+    await navigateForE2E(page, 'emf.html');
+
     await fillEmfForm(page, {
       frequency: '60',
       loadCurrent: '150',
@@ -120,31 +155,65 @@ test.describe('next features integration: emf deterministic outputs', () => {
       cableOd: '1.0',
       measDistance: '36',
     });
-
     await page.click('#calc-btn');
+    await expect(page.locator('#results .status-badge', { hasText: 'PASS' })).toHaveCount(2);
+    await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(0);
 
-    const rms = await getEmfRmsMicroTesla(page);
-    expect(rms).not.toBeNull();
-    expect(rms).toBeGreaterThan(0);
-    expect(rms).toBeLessThan(5000);
-
-    const resultText = await getResultText(page, '#results');
-    expect(resultText).toContain('ICNIRP 2010 Compliance');
-    expect(resultText).toMatch(/PASS|FAIL/);
+    await fillEmfForm(page, {
+      frequency: '60',
+      loadCurrent: '5000',
+      nCables: '20',
+      trayWidth: '48',
+      cableOd: '6',
+      measDistance: '0',
+    });
+    await page.click('#calc-btn');
+    await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(2);
   });
 
-  test('integration: emf profile scenario shows chart and stable chart container state', async ({ page }) => {
+  test('integration: emf boundary and error handling uses deterministic UI messaging and defaults', async ({ page }) => {
+    await navigateForE2E(page, 'emf.html');
+
+    await fillEmfForm(page, { loadCurrent: '0' });
+    await page.click('#calc-btn');
+    const inputErrorDialog = page.getByRole('dialog');
+    await expect(inputErrorDialog).toContainText('Input Error');
+    await expect(inputErrorDialog).toContainText('Load current must be greater than zero.');
+    await inputErrorDialog.getByRole('button', { name: 'Close' }).click();
+
+    await fillEmfForm(page, { loadCurrent: '' });
+    await page.click('#calc-btn');
+    const missingValueDialog = page.getByRole('dialog');
+    await expect(missingValueDialog).toContainText('Load current must be greater than zero.');
+    await missingValueDialog.getByRole('button', { name: 'Close' }).click();
+
+    await fillEmfForm(page, {
+      loadCurrent: '150',
+      nCables: '-3',
+      measDistance: '',
+    });
+    await page.click('#calc-btn');
+    await expect(page.locator('#results .method-note')).toContainText('Configuration: 1 × 3-phase cable set(s)');
+    await expect(page.locator('tr:has(th:has-text("Measurement Distance (from tray edge)")) td')).toContainText('36.0 in');
+  });
+
+  test('integration: emf profile scenario shows deterministic profile container visibility and chart content', async ({ page }) => {
     await navigateForE2E(page, 'emf.html');
     await fillEmfForm(page);
 
+    const chartContainer = page.locator('#profile-container');
+    await expect(chartContainer).toBeHidden();
+    await expect(chartContainer).toHaveAttribute('hidden', '');
+
     await page.click('#profile-btn');
 
-    const chartContainer = page.locator('#profile-container');
     await expect(chartContainer).toBeVisible();
     await expect(chartContainer).not.toHaveAttribute('hidden');
+    await expect(chartContainer.locator('h2')).toHaveText('Field Profile vs. Distance from Tray Edge');
+    await expect(page.locator('#emf-chart')).toBeVisible();
 
     const points = await page.locator('#emf-chart polyline').getAttribute('points');
     expect(points).toBeTruthy();
-    expect(points.split(' ').length).toBeGreaterThan(100);
+    expect(points.trim().split(/\s+/).length).toBe(121);
   });
 });


### PR DESCRIPTION
### Motivation

- Ensure EMF E2E coverage exercises both `60 Hz` and `50 Hz` code paths via the `#frequency` control to detect frequency-specific rendering/limits.
- Strengthen output assertions to verify numeric formatting and value bands (not just presence of `µT`) from `#results` for deterministic checks.
- Explicitly verify ICNIRP compliance status logic (`PASS`/`FAIL`) with scenarios that exercise both outcomes when supported by the product logic.
- Add boundary and error-case checks (zero/missing current, invalid cable count/distance) and deterministic profile generation visibility/content after `#profile-btn`.

### Description

- Updated `playwright-tests/nextFeatures.integration.spec.js` to add/replace EMF tests including a fixed-input loop for `60` and `50` Hz and assertions that the `Frequency` row renders the expected value. 
- Added numeric-format assertions for RMS and Peak values with regex checks (e.g. `^\d+\.\d{3}\sµT$`) and bounded value assertions to verify expected bands for the deterministic fixtures. 
- Added ICNIRP compliance scenario checks that assert the count of `.status-badge` elements containing `PASS` or `FAIL` for low-field and high-field inputs. 
- Added boundary/error handling tests that assert the `Input Error` modal when `loadCurrent` is zero or blank, and tests that invalid `nCables` / missing `measDistance` fall back to deterministic defaults shown in the `.method-note` and measurement rows. 
- Strengthened profile checks to assert `#profile-container` is hidden before `#profile-btn`, becomes visible after clicking, includes the expected heading, and that the generated polyline has an exact deterministic point count (`121` points for 0–120 in at 1 in steps).

### Testing

- Ran `npm run build` and the build completed with Rollup warnings about external deps and missing exports; build artifacts were generated successfully. 
- Attempted to run the full test suite via `npm test`; the run started but did not complete in this environment (the environment process hung around collaborative tests), so the full suite is not shown as passing here. 
- Attempted to run the scoped Playwright specs with `npx playwright test playwright-tests/nextFeatures.integration.spec.js --grep "emf"`, but Playwright failed to launch browsers because the environment lacked browser binaries; `npx playwright install chromium` also failed due to remote download HTTP 403, preventing browser-based E2E execution here. 
- Performed a quick Node probe against `analysis/emf.mjs` to validate that the compliance logic can produce both `PASS` and `FAIL` outcomes with deterministic numeric outputs (ad-hoc verification succeeded), supporting the new test expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7becb3d08324b7cee821c7fc069a)