### PR TITLE
docs: document Cost Estimator and EMF workflow validation guidance

### DIFF
--- a/docs/cost-estimate-pricing.md
+++ b/docs/cost-estimate-pricing.md
@@ -156,3 +156,38 @@ Each browser profile and device maintains its own pricing book. For team use, ex
 ## XLSX Export
 
 When exporting the estimate to XLSX, the **Summary** sheet includes a "Pricing basis" row identifying whether default or custom pricing was used, along with the source name and date. This provides an audit trail in the delivered estimate document.
+
+
+---
+
+## Workflow Assumptions and Validation Expectations
+
+This section summarizes the behavior expected by integration checks and user workflows for `costestimate.html`.
+
+### Input assumptions
+
+- At least one schedule category (cable, tray, or conduit) is present in project data before generating a meaningful estimate.
+- Contingency is a numeric percent, typically in the `0` to `100` UI range.
+- Pricing source is either built-in defaults or imported CSV values, with manual labor/fitting overrides taking precedence when entered.
+
+### Expected outputs
+
+- The UI renders category subtotals, subtotal before contingency, contingency amount, and grand total.
+- Displayed currency is rounded for readability in UI tables, while internal/exported values retain full calculation precision where applicable.
+- Empty project data yields guidance text instead of broken or blank result tables.
+
+### Compliance interpretation
+
+- For Cost Estimator workflows, “compliance” means **formula and validation contract compliance** with automated checks (correct math, deterministic rounding behavior, and guardrails), not code/regulatory compliance.
+
+### Export behavior
+
+- **Export XLSX** is intentionally blocked until an estimate is generated.
+- The exported workbook is expected to align with on-screen totals for the same run and include pricing basis metadata for traceability.
+
+### Troubleshooting (common validation failures)
+
+- **No data message shown after Generate Estimate**: load/import project schedule data and rerun.
+- **Unexpected contingency result**: verify contingency is numeric and in range; malformed values can trigger fallback handling.
+- **Export blocked with warning**: run **Generate Estimate** first in the current state, then retry **Export XLSX**.
+- **Imported CSV appears partially applied**: check warning dialog for skipped rows (invalid category/key/price) and correct the CSV.

--- a/docs/emf-analysis-workflow.md
+++ b/docs/emf-analysis-workflow.md
@@ -1,0 +1,69 @@
+# EMF Analysis Workflow and Validation Contract
+
+## Overview
+
+This guide documents user expectations for the EMF workflow (`emf.html`) after integration coverage is in place. It aligns field-calculation behavior with automated checks so operators and testers use the same acceptance criteria.
+
+---
+
+## Input Assumptions
+
+- **Load current** must be greater than zero.
+- **Frequency** is selected from supported mains options (`50 Hz` or `60 Hz`).
+- Geometry inputs are valid numbers:
+  - cable sets,
+  - tray width (in),
+  - cable outer diameter (in),
+  - measurement distance (in).
+- For deterministic comparisons, use fixed fixtures (same geometry/current/frequency each run).
+
+---
+
+## Expected Outputs
+
+- **Calculate Field** returns both:
+  - `B_rms` (µT),
+  - `B_peak` (µT).
+- Compliance section always includes both labels:
+  - `ICNIRP Occupational`,
+  - `ICNIRP General Public`.
+- Status badges are constrained to `PASS` or `FAIL`.
+- **Field Profile (0–120 in)** renders a non-empty profile curve when inputs are valid.
+
+---
+
+## Compliance Interpretation
+
+- In this workflow, PASS/FAIL reflects threshold comparisons used by the application UI and tests:
+  - **General Public:** 200 µT,
+  - **Occupational:** 1000 µT.
+- Near-threshold scenarios should be interpreted using tolerance bands from integration acceptance policy (to account for numeric sampling resolution).
+- A PASS result does not replace formal site-specific engineering studies; it confirms behavior against the configured ICNIRP-style limits in the tool.
+
+---
+
+## Export Behavior
+
+- The EMF workflow is primarily analytical/on-screen in the current integration contract.
+- There is no dedicated EMF file export requirement in the targeted acceptance scenarios.
+- If EMF data is captured in downstream reports, it should use the same computed result state shown in the UI.
+
+---
+
+## Troubleshooting (Common Validation Failures)
+
+- **Input Error modal appears immediately**
+  - Cause: current entered as `0` or negative.
+  - Fix: set current to a value `> 0` and rerun.
+
+- **Compliance badge unexpectedly flips near a limit**
+  - Cause: value is close to a threshold where tolerance policy applies.
+  - Fix: verify fixture inputs and compare measured `B_rms` against tolerance-aware boundary expectations.
+
+- **Field profile stays hidden or empty**
+  - Cause: one or more invalid numeric inputs blocked profile generation.
+  - Fix: correct all numeric fields (especially current), then rerun **Field Profile (0–120 in)**.
+
+- **Results look stale after a failed run**
+  - Cause: validation blocked recalculation, so prior successful result remains visible.
+  - Fix: resolve input errors and rerun calculation to refresh values.

--- a/docs/next-features-acceptance.md
+++ b/docs/next-features-acceptance.md
@@ -304,3 +304,62 @@ This table maps each existing smoke test in the two targeted describe blocks to 
 - `AT-EMF-04`: Invalid-current modal contract
 
 These IDs should be used as traceable links from future `playwright-tests/nextFeatures.spec.js` upgrades.
+
+
+---
+
+## 7) Workflow Documentation Snapshot (Post-Integration Tests)
+
+The integration tests in `playwright-tests/nextFeatures.spec.js` now act as executable contracts. Keep user-facing docs aligned with the assumptions below so manual workflows and automated checks stay in sync.
+
+### 7.1 Cost Estimator workflow contract
+
+**Input assumptions**
+- Project schedule data exists for at least one of: cable, tray, or conduit records.
+- Contingency is treated as a percentage and expected in the UI range `0` to `100` (with fallback handling for malformed input).
+- Pricing basis is either default RS Means values or an imported pricing book, with optional labor/fitting UI overrides taking precedence.
+
+**Expected outputs**
+- Category subtotals, pre-contingency subtotal, contingency amount, and grand total render deterministically for fixed fixture data.
+- Currency displayed in the UI rounds to whole dollars while internal math/workbook values preserve cents precision.
+- Empty-data runs show guidance text instead of an empty result table.
+
+**Compliance interpretation**
+- Cost Estimator compliance is interpreted as **calculation contract compliance** (formula correctness, rounding policy, and guardrail behavior), not regulatory code compliance.
+- A passing integration test means totals and labels match fixture-derived expectations within defined tolerances.
+
+**Export behavior**
+- `Export XLSX` is blocked until an estimate has been generated (modal guardrail).
+- After a successful estimate, exported workbook totals must match the same calculation path used by the UI summary and line items.
+- Summary export includes pricing basis metadata for audit traceability.
+
+### 7.2 EMF workflow contract
+
+**Input assumptions**
+- Current must be greater than zero; invalid values (`<= 0`) are rejected before computation.
+- Frequency is selected from supported options (`50 Hz` or `60 Hz`).
+- Geometry fields (cable sets, tray width, cable OD, and measurement distance) are valid numeric values in accepted UI domains.
+
+**Expected outputs**
+- `B_rms` and `B_peak` are shown with stable values for canonical fixtures and bounded tolerance checks.
+- Compliance table always includes both rows (`ICNIRP Occupational`, `ICNIRP General Public`) and status badges constrained to `PASS`/`FAIL`.
+- Field profile renders a non-empty curve over the expected distance domain when inputs are valid.
+
+**Compliance interpretation**
+- PASS/FAIL labels represent threshold comparison against ICNIRP reference levels used by the product (`200 µT` general public and `1000 µT` occupational in the tested workflow).
+- Near-threshold validations should be interpreted with the numeric tolerance policy in Section 3.2 to account for sampling granularity.
+
+**Export behavior**
+- EMF workflow currently emphasizes on-screen analytical validation; no dedicated file export is required by the integration contract in this plan.
+- If downstream reporting captures EMF results, values should be sourced from the same computed result state validated by `AT-EMF-*` scenarios.
+
+### 7.3 Concise troubleshooting (validation-aligned)
+
+| Symptom seen by user/test | Likely cause | Recommended fix |
+|---|---|---|
+| Cost estimate shows “No project data found...” | Empty cable/tray/conduit stores | Import/load project data first, then rerun **Generate Estimate**. |
+| Contingency appears to ignore typed value | Input was nonnumeric or outside allowed handling path | Enter a numeric percent in the supported range; rerun and confirm row label reflects the chosen percent. |
+| `Export XLSX` opens a warning and no file downloads | Estimate was not generated in current session/state | Run **Generate Estimate** successfully, then export. |
+| EMF calculation opens Input Error modal | Load current is `0` or negative | Enter current `> 0` and rerun **Calculate Field** or **Field Profile**. |
+| EMF compliance badge seems unexpected near limit | Value is near threshold and within tolerance band | Re-run with the same fixture, inspect computed `B_rms`, and compare against Section 3.2 boundary tolerance guidance. |
+| Field profile area stays hidden/empty | Invalid numeric input prevented profile generation | Correct invalid fields (especially current), then run **Field Profile (0–120 in)** again. |


### PR DESCRIPTION
### Motivation

- Keep user-facing documentation aligned with the newly implemented integration/acceptance tests for the Cost Estimator and EMF workflows by capturing input assumptions, expected outputs, compliance interpretation, export behavior, and common validation failures. 

### Description

- Add a focused EMF workflow guide at `docs/emf-analysis-workflow.md` describing input assumptions, expected outputs (`B_rms`/`B_peak`), ICNIRP threshold interpretation, export expectations, and concise troubleshooting. 
- Extend `docs/cost-estimate-pricing.md` with a `## Workflow Assumptions and Validation Expectations` section that documents input contracts, deterministic output expectations, export guardrails, compliance framing, and troubleshooting aligned with automated checks. 
- Append a post-integration `Workflow Documentation Snapshot` to `docs/next-features-acceptance.md` that summarizes the Cost Estimator and EMF acceptance contracts and maps to the recommended `AT-CE-*` and `AT-EMF-*` IDs used by CI tests. 
- Include a concise troubleshooting matrix in the new/updated docs that maps common symptoms to likely causes and recommended fixes for validation-aligned workflows. 

### Testing

- Ran `npm test`; the suites began and executed many test files but the run was long and was manually terminated after progress reached `tests/collaboration.test.mjs` in this environment. 
- Ran `npm run build`; the build completed successfully and produced the `dist` output while reporting existing Rollup warnings about unresolved dependencies and missing exports that are present in baseline output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8553c6f88324a3c4b8c98a52eb7f)