### PR TITLE
Fix ground grid preview rendering visibility

### DIFF
--- a/groundgrid.js
+++ b/groundgrid.js
@@ -72,6 +72,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const endY = startY + drawHeight;
 
     previewSvg.innerHTML = '';
+    previewSvg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
+    previewSvg.setAttribute('width', String(svgWidth));
+    previewSvg.setAttribute('height', String(svgHeight));
 
     const ns = 'http://www.w3.org/2000/svg';
     const make = (name, attrs = {}) => {
@@ -85,7 +88,10 @@ document.addEventListener('DOMContentLoaded', () => {
       y: startY,
       width: drawWidth,
       height: drawHeight,
-      class: 'grid-outline'
+      class: 'grid-outline',
+      fill: 'none',
+      stroke: 'var(--border-strong, #5b6780)',
+      'stroke-width': 2
     }));
 
     const dx = ny > 1 ? drawWidth / (ny - 1) : 0;
@@ -98,7 +104,9 @@ document.addEventListener('DOMContentLoaded', () => {
         y1: startY,
         x2: x,
         y2: endY,
-        class: 'grid-conductor'
+        class: 'grid-conductor',
+        stroke: 'var(--accent, #0074d9)',
+        'stroke-width': 2
       }));
     }
     for (let i = 0; i < nx; i += 1) {
@@ -108,7 +116,9 @@ document.addEventListener('DOMContentLoaded', () => {
         y1: y,
         x2: endX,
         y2: y,
-        class: 'grid-conductor'
+        class: 'grid-conductor',
+        stroke: 'var(--accent, #0074d9)',
+        'stroke-width': 2
       }));
     }
 
@@ -118,7 +128,10 @@ document.addEventListener('DOMContentLoaded', () => {
           cx: x,
           cy: y,
           r: 5,
-          class: 'grid-rod'
+          class: 'grid-rod',
+          fill: 'var(--danger, #cf3f5c)',
+          stroke: 'var(--surface, #ffffff)',
+          'stroke-width': 1.5
         }));
       });
     }

--- a/src/styles/groundgrid.css
+++ b/src/styles/groundgrid.css
@@ -6,6 +6,8 @@
 .ground-grid-preview {
   width: 100%;
   max-width: 520px;
+  aspect-ratio: 13 / 9;
+  min-height: 260px;
   border: 1px solid var(--border-subtle, #ccd2dd);
   border-radius: 8px;
   background: var(--surface-raised, #f7f9fd);


### PR DESCRIPTION
### Motivation
- The ground grid preview SVG could render blank or be invisible after clicking `Analyze Ground Grid` because the SVG lacked explicit viewport/size attributes and relied solely on CSS for stroke/fill, which can fail in some runtime conditions.

### Description
- Ensure the preview SVG always has an explicit `viewBox`, `width`, and `height` before drawing by setting these attributes in `renderGridPreview` in `groundgrid.js`.
- Add inline SVG attributes (`stroke`, `stroke-width`, `fill`) to the generated `rect`, `line`, and `circle` elements so the outline, conductors, and rods remain visible even if stylesheet rules or CSS variables are not applied.
- Add layout stability styles (`aspect-ratio` and `min-height`) to `.ground-grid-preview` in `src/styles/groundgrid.css` to avoid a collapsed or inconsistent render area.

### Testing
- Ran `node tests/groundGrid.test.mjs` and the ground grid unit tests completed successfully (all assertions passed).
- Ran `npm run build` and the project built successfully without errors.
- Executed `npm test` (full suite run started) and the ground-grid related tests reported as passing; the full-suite run completed its earlier checks in this environment.
- Attempted to capture a browser preview screenshot via Playwright, but the environment is missing the required Chromium binary so a screenshot could not be produced (Playwright failed with missing `chromium_headless_shell`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd88acf59083248b305fd5004d3ad4)