### PR TITLE
Guard settings/menu insertions against stale DOM references

### DIFF
--- a/site.js
+++ b/site.js
@@ -517,15 +517,15 @@ async function updateProjectDisplay(snapshot){
     let span=document.getElementById('project-display');
     if(!span){
       const nav=document.querySelector('.top-nav .nav-links');
-      const settingsBtn=document.getElementById('settings-btn');
       if(nav){
         span=document.createElement('span');
         span.id='project-display';
         span.style.marginLeft='auto';
         span.style.marginRight='var(--space-4)';
-        if(settingsBtn&&settingsBtn.parentNode===nav){
-          nav.insertBefore(span,settingsBtn);
-          settingsBtn.style.marginLeft='0';
+        const currentSettingsBtn=document.getElementById('settings-btn');
+        if(currentSettingsBtn&&currentSettingsBtn.parentNode===nav){
+          nav.insertBefore(span,currentSettingsBtn);
+          currentSettingsBtn.style.marginLeft='0';
         }else{
           nav.appendChild(span);
         }
@@ -946,7 +946,14 @@ function initSettings(){
     nameInput.value=initialProjectName;
     nameInput.dataset.originalName=(initialProjectName||'').trim();
     nameLabel.appendChild(nameInput);
-    settingsMenu.insertBefore(nameLabel,settingsMenu.firstChild);
+    if(!document.getElementById('project-name-input')&&nameLabel.parentNode!==settingsMenu){
+      const currentFirstChild=settingsMenu.firstChild;
+      if(currentFirstChild&&currentFirstChild.parentNode===settingsMenu){
+        settingsMenu.insertBefore(nameLabel,currentFirstChild);
+      }else{
+        settingsMenu.appendChild(nameLabel);
+      }
+    }
     nameInput.addEventListener('focus',()=>{
       try{nameInput.dataset.originalName=(getProjectState().name||'').trim();}
       catch{nameInput.dataset.originalName=nameInput.value.trim();}
@@ -1157,7 +1164,15 @@ function initDarkMode(){
       <option value="high-contrast">High Contrast</option>
     `;
     wrapper.appendChild(themeSelect);
-    settingsMenu.insertBefore(wrapper,settingsMenu.firstChild);
+    const currentThemeSelect=document.getElementById('theme-select');
+    if(!currentThemeSelect&&wrapper.parentNode!==settingsMenu){
+      const currentFirstChild=settingsMenu.firstChild;
+      if(currentFirstChild&&currentFirstChild.parentNode===settingsMenu){
+        settingsMenu.insertBefore(wrapper,currentFirstChild);
+      }else{
+        settingsMenu.appendChild(wrapper);
+      }
+    }
   }
 
   const resolveTheme=theme=>{


### PR DESCRIPTION
### Motivation
- Prevent DOM mutation errors caused by reusing stale node references when inserting controls into the settings menu and top-nav across async flows.
- Avoid duplicating existing controls (e.g., project name input or theme select) when init routines run multiple times or references become stale.

### Description
- Reworked `updateProjectDisplay()` to re-query `#settings-btn` immediately before insertion and only call `insertBefore` if the button is currently a child of `.top-nav .nav-links`, otherwise fall back to `appendChild` and adjust margins accordingly.
- Hardened `initSettings()` project-name insertion to skip adding the label if `#project-name-input` already exists and to verify `settingsMenu.firstChild` is still parented by `settingsMenu` right before inserting, with `appendChild` fallback when stale.
- Applied the same guarded insertion pattern in `initDarkMode()` for the theme `label/select` wrapper, including duplicate detection and parent-child validation with an append fallback.

### Testing
- Ran `npm run build` successfully (build completed with unrelated warnings about unresolved/missing exports).
- Executed `node tests/projectDisplayScheduler.test.mjs && node tests/autoSaveScheduler.test.mjs` which both passed.
- Started the full test suite via `npm test`; the suite progressed through many tests but the environment hung on `node tests/collaboration.test.mjs` so the run was terminated (partial success prior to termination).
- Attempted to produce a preview screenshot via Playwright but the browser binaries were not installed in this environment, so the preview image could not be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8cf342448324bacdff4bf1e0a66c)