### PR TITLE
Split ground grid preview into top and elevation SVG views

### DIFF
--- a/groundgrid.html
+++ b/groundgrid.html
@@ -305,9 +305,18 @@
           Visual preview updates as you edit grid dimensions and conductor counts.
         </p>
         <div class="ground-grid-preview-wrap">
-          <svg id="ground-grid-preview" class="ground-grid-preview" viewBox="0 0 520 360"
-               role="img" aria-labelledby="grid-visual-title grid-preview-summary">
-          </svg>
+          <div class="ground-grid-preview-panel">
+            <h3>Layout / Top View</h3>
+            <svg id="ground-grid-preview-top" class="ground-grid-preview" viewBox="0 0 520 360"
+                 role="img" aria-label="Ground grid top view showing conductor matrix and spacing dimensions">
+            </svg>
+          </div>
+          <div class="ground-grid-preview-panel">
+            <h3>Section / Elevation View</h3>
+            <svg id="ground-grid-preview-elevation" class="ground-grid-preview" viewBox="0 0 520 360"
+                 role="img" aria-label="Ground grid elevation showing burial depth and layer bands">
+            </svg>
+          </div>
         </div>
       </section>
 

--- a/groundgrid.js
+++ b/groundgrid.js
@@ -3,7 +3,8 @@ import { analyzeGroundGrid } from './analysis/groundGrid.mjs';
 document.addEventListener('DOMContentLoaded', () => {
   const resultsDiv = document.getElementById('results');
   const form = document.getElementById('ground-grid-form');
-  const previewSvg = document.getElementById('ground-grid-preview');
+  const previewTopSvg = document.getElementById('ground-grid-preview-top');
+  const previewElevationSvg = document.getElementById('ground-grid-preview-elevation');
   const previewSummary = document.getElementById('grid-preview-summary');
 
   let hadInitError = false;
@@ -49,108 +50,188 @@ document.addEventListener('DOMContentLoaded', () => {
     return b;
   }
 
-  function renderGridPreview() {
-    if (!previewSvg) {
-      return;
-    }
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const svgWidth = 520;
+  const svgHeight = 360;
 
+  function makeSvg(name, attrs = {}) {
+    const node = document.createElementNS(SVG_NS, name);
+    Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, String(value)));
+    return node;
+  }
+
+  function formatDim(value, unit) {
+    return `${value.toFixed(value < 10 ? 2 : 1)} ${unit}`;
+  }
+
+  function getPreviewParams() {
+    const unit = getUnits() === 'imperial' ? 'ft' : 'm';
     const gridLxInput = getNum('grid-lx');
     const gridLyInput = getNum('grid-ly');
+    const burialDepthInput = getNum('burial-depth');
+    const hsInput = getNum('surface-hs') || 0;
+    const conductorInput = getNum('conductor-diameter');
     const nxInput = getInt('nx');
     const nyInput = getInt('ny');
     const hasRods = document.getElementById('has-rods').checked;
+    const diameterUnit = unit === 'ft' ? 'in' : 'mm';
 
     const gridLx = Number.isFinite(gridLxInput) && gridLxInput > 0 ? gridLxInput : 1;
     const gridLy = Number.isFinite(gridLyInput) && gridLyInput > 0 ? gridLyInput : 1;
+    const burialDepth = Number.isFinite(burialDepthInput) && burialDepthInput > 0 ? burialDepthInput : 1;
+    const hs = Number.isFinite(hsInput) && hsInput > 0 ? hsInput : 0;
+    const conductorDiameter = Number.isFinite(conductorInput) && conductorInput > 0 ? conductorInput : 0;
     const nx = Math.max(2, Number.isFinite(nxInput) ? nxInput : 2);
     const ny = Math.max(2, Number.isFinite(nyInput) ? nyInput : 2);
-
-    const unit = getUnits() === 'imperial' ? 'ft' : 'm';
     const spacingX = ny > 1 ? gridLx / (ny - 1) : 0;
     const spacingY = nx > 1 ? gridLy / (nx - 1) : 0;
+    const rodLength = hasRods ? Math.max(burialDepth * 2.5, burialDepth + Math.max(gridLx, gridLy) * 0.03) : 0;
 
-    const svgWidth = 520;
-    const svgHeight = 360;
-    const margin = 52;
+    return { unit, diameterUnit, gridLx, gridLy, nx, ny, spacingX, spacingY, burialDepth, hs, conductorDiameter, hasRods, rodLength };
+  }
+
+  function clearAndPrimeSvg(svgEl, titleText) {
+    svgEl.innerHTML = '';
+    svgEl.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
+    svgEl.setAttribute('width', String(svgWidth));
+    svgEl.setAttribute('height', String(svgHeight));
+    const title = makeSvg('title');
+    title.textContent = titleText;
+    svgEl.appendChild(title);
+  }
+
+  function drawDimension(svgEl, x1, y1, x2, y2, label, textOffset = -8) {
+    const g = makeSvg('g', { class: 'grid-dimension' });
+    g.appendChild(makeSvg('line', { x1, y1, x2, y2, class: 'grid-dimension-line' }));
+    g.appendChild(makeSvg('line', { x1, y1, x2: x1 + (x1 <= x2 ? 7 : -7), y2: y1 - 4, class: 'grid-dimension-arrow' }));
+    g.appendChild(makeSvg('line', { x1, y1, x2: x1 + (x1 <= x2 ? 7 : -7), y2: y1 + 4, class: 'grid-dimension-arrow' }));
+    g.appendChild(makeSvg('line', { x1: x2, y1: y2, x2: x2 + (x2 >= x1 ? -7 : 7), y2: y2 - 4, class: 'grid-dimension-arrow' }));
+    g.appendChild(makeSvg('line', { x1: x2, y1: y2, x2: x2 + (x2 >= x1 ? -7 : 7), y2: y2 + 4, class: 'grid-dimension-arrow' }));
+    const text = makeSvg('text', { x: (x1 + x2) / 2, y: (y1 + y2) / 2 + textOffset, class: 'grid-dimension-text' });
+    text.textContent = label;
+    g.appendChild(text);
+    svgEl.appendChild(g);
+  }
+
+  function renderTopView(params, svgEl) {
+    if (!svgEl) {
+      return;
+    }
+    clearAndPrimeSvg(svgEl, 'Ground grid top view with conductor matrix and spacing dimensions');
+    const margin = 62;
     const drawableWidth = svgWidth - (margin * 2);
-    const drawableHeight = svgHeight - (margin * 2);
-    const scale = Math.min(drawableWidth / gridLx, drawableHeight / gridLy);
-    const drawWidth = gridLx * scale;
-    const drawHeight = gridLy * scale;
+    const drawableHeight = svgHeight - (margin * 2) - 24;
+    const scale = Math.min(drawableWidth / params.gridLx, drawableHeight / params.gridLy);
+    const drawWidth = params.gridLx * scale;
+    const drawHeight = params.gridLy * scale;
     const startX = (svgWidth - drawWidth) / 2;
-    const startY = (svgHeight - drawHeight) / 2;
+    const startY = (svgHeight - drawHeight) / 2 + 10;
     const endX = startX + drawWidth;
     const endY = startY + drawHeight;
+    const dx = params.ny > 1 ? drawWidth / (params.ny - 1) : 0;
+    const dy = params.nx > 1 ? drawHeight / (params.nx - 1) : 0;
 
-    previewSvg.innerHTML = '';
-    previewSvg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
-    previewSvg.setAttribute('width', String(svgWidth));
-    previewSvg.setAttribute('height', String(svgHeight));
-
-    const ns = 'http://www.w3.org/2000/svg';
-    const make = (name, attrs = {}) => {
-      const node = document.createElementNS(ns, name);
-      Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, String(value)));
-      return node;
-    };
-
-    previewSvg.appendChild(make('rect', {
-      x: startX,
-      y: startY,
-      width: drawWidth,
-      height: drawHeight,
-      class: 'grid-outline',
-      fill: 'none',
-      stroke: 'var(--border-strong, #5b6780)',
-      'stroke-width': 2
-    }));
-
-    const dx = ny > 1 ? drawWidth / (ny - 1) : 0;
-    const dy = nx > 1 ? drawHeight / (nx - 1) : 0;
-
-    for (let i = 0; i < ny; i += 1) {
+    svgEl.appendChild(makeSvg('rect', { x: startX, y: startY, width: drawWidth, height: drawHeight, class: 'grid-outline' }));
+    for (let i = 0; i < params.ny; i += 1) {
       const x = startX + (i * dx);
-      previewSvg.appendChild(make('line', {
-        x1: x,
-        y1: startY,
-        x2: x,
-        y2: endY,
-        class: 'grid-conductor',
-        stroke: 'var(--accent, #0074d9)',
-        'stroke-width': 2
-      }));
+      svgEl.appendChild(makeSvg('line', { x1: x, y1: startY, x2: x, y2: endY, class: 'grid-conductor' }));
     }
-    for (let i = 0; i < nx; i += 1) {
+    for (let i = 0; i < params.nx; i += 1) {
       const y = startY + (i * dy);
-      previewSvg.appendChild(make('line', {
-        x1: startX,
-        y1: y,
-        x2: endX,
-        y2: y,
-        class: 'grid-conductor',
-        stroke: 'var(--accent, #0074d9)',
-        'stroke-width': 2
-      }));
+      svgEl.appendChild(makeSvg('line', { x1: startX, y1: y, x2: endX, y2: y, class: 'grid-conductor' }));
     }
-
-    if (hasRods) {
+    if (params.hasRods) {
       [[startX, startY], [endX, startY], [startX, endY], [endX, endY]].forEach(([x, y]) => {
-        previewSvg.appendChild(make('circle', {
-          cx: x,
-          cy: y,
-          r: 5,
-          class: 'grid-rod',
-          fill: 'var(--danger, #cf3f5c)',
-          stroke: 'var(--surface, #ffffff)',
-          'stroke-width': 1.5
-        }));
+        svgEl.appendChild(makeSvg('circle', { cx: x, cy: y, r: 5, class: 'grid-rod' }));
       });
     }
 
-    const summaryText = `Lx: ${gridLx.toFixed(1)} ${unit} • Ly: ${gridLy.toFixed(1)} ${unit} • `
-      + `${nx} horizontal runs • ${ny} vertical runs • `
-      + `Spacing: ${spacingX.toFixed(1)} ${unit} (x), ${spacingY.toFixed(1)} ${unit} (y)`
-      + (hasRods ? ' • Corner rods enabled' : '');
+    drawDimension(svgEl, startX, endY + 24, endX, endY + 24, `Lx = ${formatDim(params.gridLx, params.unit)}`);
+    drawDimension(svgEl, startX - 24, endY, startX - 24, startY, `Ly = ${formatDim(params.gridLy, params.unit)}`, -10);
+    drawDimension(svgEl, startX, startY - 18, Math.min(endX, startX + dx), startY - 18, `Sx = ${formatDim(params.spacingX, params.unit)}`);
+    drawDimension(svgEl, endX + 18, startY, endX + 18, Math.min(endY, startY + dy), `Sy = ${formatDim(params.spacingY, params.unit)}`, -10);
+
+    const legend = makeSvg('g', { class: 'grid-legend' });
+    legend.appendChild(makeSvg('rect', { x: 16, y: 14, width: 190, height: 66, rx: 6, class: 'grid-legend-box' }));
+    legend.appendChild(makeSvg('line', { x1: 28, y1: 34, x2: 58, y2: 34, class: 'grid-conductor' }));
+    const conductorText = makeSvg('text', { x: 65, y: 38, class: 'grid-legend-text' });
+    conductorText.textContent = 'Grid conductor';
+    legend.appendChild(conductorText);
+    legend.appendChild(makeSvg('circle', { cx: 43, cy: 56, r: 5, class: 'grid-rod' }));
+    const rodText = makeSvg('text', { x: 65, y: 60, class: 'grid-legend-text' });
+    rodText.textContent = params.hasRods ? 'Perimeter/corner rod' : 'Corner rod (disabled)';
+    legend.appendChild(rodText);
+    svgEl.appendChild(legend);
+  }
+
+  function renderElevationView(params, svgEl) {
+    if (!svgEl) {
+      return;
+    }
+    clearAndPrimeSvg(svgEl, 'Ground grid elevation with burial depth, layer thickness, and rod depth');
+    const left = 70;
+    const right = svgWidth - 60;
+    const gradeY = 102;
+    const maxDepth = Math.max(params.burialDepth + params.hs + params.rodLength, params.burialDepth + 0.3);
+    const depthScale = (svgHeight - 96 - gradeY) / maxDepth;
+    const surfaceBottom = gradeY + (params.hs * depthScale);
+    const conductorY = gradeY + (params.burialDepth * depthScale);
+    const conductorBand = Math.max(4, Math.min(10, (params.conductorDiameter / (params.unit === 'ft' ? 12 : 1000)) * depthScale * 6));
+
+    svgEl.appendChild(makeSvg('line', { x1: left, y1: gradeY, x2: right, y2: gradeY, class: 'grid-grade-line' }));
+    if (params.hs > 0) {
+      svgEl.appendChild(makeSvg('rect', { x: left, y: gradeY, width: right - left, height: surfaceBottom - gradeY, class: 'grid-layer-surface' }));
+    }
+    svgEl.appendChild(makeSvg('rect', { x: left, y: surfaceBottom, width: right - left, height: svgHeight - 54 - surfaceBottom, class: 'grid-layer-soil' }));
+    svgEl.appendChild(makeSvg('rect', { x: left + 18, y: conductorY - (conductorBand / 2), width: right - left - 36, height: conductorBand, class: 'grid-conductor-band' }));
+    svgEl.appendChild(makeSvg('rect', { x: left + 18, y: conductorY - 16, width: right - left - 36, height: 32, class: 'grid-trench-band' }));
+
+    if (params.hasRods) {
+      const rodX = right - 52;
+      const rodBottom = Math.min(svgHeight - 54, gradeY + ((params.burialDepth + params.rodLength) * depthScale));
+      svgEl.appendChild(makeSvg('line', { x1: rodX, y1: conductorY, x2: rodX, y2: rodBottom, class: 'grid-rod' }));
+      drawDimension(svgEl, rodX + 18, conductorY, rodX + 18, rodBottom, `Rod = ${formatDim(params.rodLength, params.unit)}`, -10);
+    }
+
+    drawDimension(svgEl, left - 24, gradeY, left - 24, conductorY, `h = ${formatDim(params.burialDepth, params.unit)}`, -10);
+    if (params.hs > 0) {
+      drawDimension(svgEl, right + 20, gradeY, right + 20, surfaceBottom, `hs = ${formatDim(params.hs, params.unit)}`, -10);
+    }
+
+    const gradeLabel = makeSvg('text', { x: left + 4, y: gradeY - 8, class: 'grid-legend-text' });
+    gradeLabel.textContent = 'Grade line';
+    svgEl.appendChild(gradeLabel);
+    const conductorLabel = makeSvg('text', { x: left + 24, y: conductorY - 10, class: 'grid-legend-text' });
+    conductorLabel.textContent = `Conductor depth @ ${formatDim(params.burialDepth, params.unit)}`;
+    svgEl.appendChild(conductorLabel);
+
+    const legend = makeSvg('g', { class: 'grid-legend' });
+    legend.appendChild(makeSvg('rect', { x: 16, y: 14, width: 214, height: 84, rx: 6, class: 'grid-legend-box' }));
+    legend.appendChild(makeSvg('line', { x1: 28, y1: 32, x2: 56, y2: 32, class: 'grid-grade-line' }));
+    const t1 = makeSvg('text', { x: 64, y: 36, class: 'grid-legend-text' });
+    t1.textContent = 'Grade';
+    legend.appendChild(t1);
+    legend.appendChild(makeSvg('rect', { x: 28, y: 44, width: 28, height: 10, class: 'grid-layer-surface' }));
+    const t2 = makeSvg('text', { x: 64, y: 53, class: 'grid-legend-text' });
+    t2.textContent = params.hs > 0 ? 'Surface layer (hs)' : 'No surface layer';
+    legend.appendChild(t2);
+    legend.appendChild(makeSvg('rect', { x: 28, y: 63, width: 28, height: 8, class: 'grid-conductor-band' }));
+    const t3 = makeSvg('text', { x: 64, y: 70, class: 'grid-legend-text' });
+    t3.textContent = 'Cable / trench zone';
+    legend.appendChild(t3);
+    svgEl.appendChild(legend);
+  }
+
+  function renderGridPreview() {
+    const params = getPreviewParams();
+    renderTopView(params, previewTopSvg);
+    renderElevationView(params, previewElevationSvg);
+    const summaryText = `Lx: ${params.gridLx.toFixed(1)} ${params.unit} • Ly: ${params.gridLy.toFixed(1)} ${params.unit} • `
+      + `${params.nx} horizontal runs • ${params.ny} vertical runs • `
+      + `Spacing: ${params.spacingX.toFixed(1)} ${params.unit} (x), ${params.spacingY.toFixed(1)} ${params.unit} (y)`
+      + ` • h: ${params.burialDepth.toFixed(2)} ${params.unit}`
+      + (params.hs > 0 ? ` • hs: ${params.hs.toFixed(2)} ${params.unit}` : '')
+      + (params.hasRods ? ' • Corner rods enabled' : '');
 
     if (previewSummary) {
       previewSummary.textContent = hadInitError

--- a/src/styles/groundgrid.css
+++ b/src/styles/groundgrid.css
@@ -1,11 +1,17 @@
 .ground-grid-preview-wrap {
   width: 100%;
-  overflow-x: auto;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.ground-grid-preview-panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
 }
 
 .ground-grid-preview {
   width: 100%;
-  max-width: 520px;
   aspect-ratio: 13 / 9;
   min-height: 260px;
   border: 1px solid var(--border-subtle, #ccd2dd);
@@ -29,6 +35,58 @@
   fill: var(--danger, #cf3f5c);
   stroke: var(--surface, #ffffff);
   stroke-width: 1.5;
+}
+
+.ground-grid-preview .grid-legend-box {
+  fill: color-mix(in srgb, var(--surface, #fff) 90%, transparent);
+  stroke: var(--border-subtle, #ccd2dd);
+}
+
+.ground-grid-preview .grid-legend-text,
+.ground-grid-preview .grid-dimension-text {
+  fill: var(--text-color, #1f2937);
+  font-size: 12px;
+  font-family: sans-serif;
+}
+
+.ground-grid-preview .grid-dimension-line,
+.ground-grid-preview .grid-dimension-arrow {
+  stroke: var(--text-muted, #546074);
+  stroke-width: 1.4;
+}
+
+.ground-grid-preview .grid-dimension-text {
+  text-anchor: middle;
+}
+
+.ground-grid-preview .grid-grade-line {
+  stroke: var(--border-strong, #5b6780);
+  stroke-width: 2;
+  stroke-dasharray: 5 3;
+}
+
+.ground-grid-preview .grid-layer-surface {
+  fill: color-mix(in srgb, var(--warning, #f7b84b) 28%, transparent);
+  stroke: var(--warning, #f7b84b);
+  stroke-width: 1;
+}
+
+.ground-grid-preview .grid-layer-soil {
+  fill: color-mix(in srgb, var(--surface-raised, #f7f9fd) 70%, #9db4d3 30%);
+  stroke: none;
+}
+
+.ground-grid-preview .grid-conductor-band {
+  fill: color-mix(in srgb, var(--accent, #0074d9) 35%, transparent);
+  stroke: var(--accent, #0074d9);
+  stroke-width: 1.2;
+}
+
+.ground-grid-preview .grid-trench-band {
+  fill: color-mix(in srgb, var(--accent, #0074d9) 15%, transparent);
+  stroke: color-mix(in srgb, var(--accent, #0074d9) 55%, transparent);
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
 }
 
 .grid-visual-panel {


### PR DESCRIPTION
### Motivation
- Provide clearer visual feedback by separating the preview into a layout/top view and a section/elevation view so users can see conductor matrix and burial details simultaneously.
- Move preview drawing into reusable, unit-aware helpers so both views scale consistently and update live on form `input` and `unit-select` changes.
- Add explicit legends and arrowed dimension markers to improve interpretability of spacing, Lx/Ly, burial depth `h`, surface thickness `hs`, and optional rod depth.

### Description
- Updated `groundgrid.html` to replace the single preview SVG with two panels: `#ground-grid-preview-top` (layout/top view) and `#ground-grid-preview-elevation` (section/elevation view), each with accessible labels and headings.
- Refactored preview rendering in `groundgrid.js` by adding shared helpers (`makeSvg`, `clearAndPrimeSvg`, `drawDimension`, `getPreviewParams`, `formatDim`) and implementing `renderTopView(params, svgEl)` and `renderElevationView(params, svgEl)`; `renderGridPreview()` now calls both views and updates the summary.
- Rendered items in the top view include conductor matrix, perimeter outline, corner/perimeter rods and spacing/Lx/Ly dimension markers; elevation view renders grade line, surface layer band, conductor/trench bands, burial depth `h`, optional rod depth, and legends.
- Updated `src/styles/groundgrid.css` to provide a responsive two-panel layout and to style legends, dimension lines/arrows, grade/soil/surface bands, and conductor/trench fills.

### Testing
- `npm run build` completed successfully (build warnings unrelated to this change were observed but did not fail the build).
- `node tests/groundGrid.test.mjs` executed and all ground grid-related tests passed.
- `node --check groundgrid.js` ran with no syntax errors reported.
- `npm test` (full suite) was started and progressed through many suites in this environment but could not be completed end-to-end here due to environment time/size constraints.  Additionally, an attempt to capture a browser screenshot using Playwright failed because `npx playwright install chromium` could not download browser binaries (remote 403), so no automated screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8f26cb648324b0026dfd71975b22)