### PR TITLE
Improve signup reliability: client-side confirm-password validation

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -15,13 +15,35 @@ function showStatus(formEl, message, isError) {
   statusEl.dataset.error = isError ? 'true' : 'false';
 }
 
+function validateSignupPasswords(form, showMessage = false) {
+  const passwordInput = document.getElementById('signup-pass');
+  const confirmInput = document.getElementById('signup-pass-confirm');
+  const password = passwordInput.value;
+  const confirm = confirmInput.value;
+
+  if (confirm.length > 0 && password !== confirm) {
+    confirmInput.setCustomValidity('Passwords must match.');
+    if (showMessage) {
+      showStatus(form, 'Passwords do not match.', true);
+    }
+    return false;
+  }
+
+  confirmInput.setCustomValidity('');
+  return true;
+}
+
 async function signup(e) {
   e.preventDefault();
   const form = e.currentTarget;
   const submitBtn = form.querySelector('button[type="submit"]');
   const username = document.getElementById('signup-user').value.trim();
   const password = document.getElementById('signup-pass').value;
-  const confirm = document.getElementById('signup-pass-confirm').value;
+  const passwordsMatch = validateSignupPasswords(form, true);
+
+  if (!form.reportValidity()) {
+    return;
+  }
 
   if (!/^[a-zA-Z0-9_-]{1,100}$/.test(username)) {
     showStatus(form, 'Username may only contain letters, numbers, underscores, and hyphens (1–100 characters).', true);
@@ -33,8 +55,7 @@ async function signup(e) {
     return;
   }
 
-  if (password !== confirm) {
-    showStatus(form, 'Passwords do not match.', true);
+  if (!passwordsMatch) {
     return;
   }
 
@@ -90,5 +111,17 @@ async function login(e) {
   }
 }
 
-document.getElementById('signup-form').addEventListener('submit', signup);
+const signupForm = document.getElementById('signup-form');
+const signupPasswordInput = document.getElementById('signup-pass');
+const signupConfirmInput = document.getElementById('signup-pass-confirm');
+
+signupPasswordInput.addEventListener('input', () => {
+  validateSignupPasswords(signupForm);
+});
+
+signupConfirmInput.addEventListener('input', () => {
+  validateSignupPasswords(signupForm, true);
+});
+
+signupForm.addEventListener('submit', signup);
 document.getElementById('login-form').addEventListener('submit', login);

--- a/login.html
+++ b/login.html
@@ -63,7 +63,7 @@
               <input id="signup-pass-confirm" name="signup-pass-confirm" type="password" autocomplete="new-password"
                      placeholder="Repeat password" required minlength="8"
                      aria-describedby="signup-pass-confirm-hint" aria-required="true">
-              <span id="signup-pass-confirm-hint" class="field-hint">Re-enter your password to confirm.</span>
+              <span id="signup-pass-confirm-hint" class="field-hint">Re-enter the same password to prevent typos.</span>
             </div>
             <button type="submit" class="primary-btn">Sign Up</button>
           </form>


### PR DESCRIPTION
### Motivation
- Reduce avoidable signup failures and account lockouts by preventing typo-driven mismatches before the `/signup` request is sent.

### Description
- Added a reusable `validateSignupPasswords` helper in `auth.js` that uses `setCustomValidity` to mark the confirm field invalid when passwords differ and optionally shows an inline status message.
- Enforced browser-native validity checks with `form.reportValidity()` in `signup` to block network submission when the form is invalid.
- Added `input` listeners on the password and confirm fields to provide live mismatch feedback while typing and updated the confirm-password hint text in `login.html` for clarity.
- Modified files: `auth.js` (new validator, listeners, submit gating) and `login.html` (hint copy update).

### Testing
- Ran `npm run build` which completed successfully and produced build artifacts, with unrelated Rollup warnings reported.
- Ran `npm test` (full suite) in this environment but the process timed out after a long run; no failing assertions were observed in the test output prior to the timeout.
- Attempted to capture a Playwright screenshot preview but the environment lacked downloaded browser binaries, so no image artifact could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda05d3c7883249a15991314d5f020)