### PR TITLE
Expose Units selector on Custom Components page

### DIFF
--- a/custom-components.html
+++ b/custom-components.html
@@ -40,6 +40,12 @@
       <option value="high-contrast">High Contrast</option>
     </select>
   </label>
+  <label for="unit-select">Units
+    <select id="unit-select">
+      <option value="imperial">Imperial (ft / in)</option>
+      <option value="metric">Metric (m / mm)</option>
+    </select>
+  </label>
   </div>
   <div class="container">
     <main id="main-content" class="main-content">

--- a/custom-components.js
+++ b/custom-components.js
@@ -1,5 +1,6 @@
 import './src/components/navigation.js';
 import { getItem as getStoredItem, setItem as setStoredItem } from './dataStore.mjs';
+import { getProjectState, setProjectState } from './projectStorage.js';
 
 const STORAGE_KEY = 'customComponents';
 const STORAGE_SCENARIO = '__ctr_custom_components__';
@@ -73,6 +74,30 @@ let suppressTextControlEvents = false;
 const urlParams = new URLSearchParams(window.location.search);
 const initialEditSubtype = urlParams.get('edit');
 let editQueryHandled = false;
+
+function initializeUnitSelection() {
+  const unitSelect = document.getElementById('unit-select');
+  if (!unitSelect) return;
+  try {
+    unitSelect.value = getProjectState().settings?.units || 'imperial';
+  } catch (error) {
+    console.warn('Could not read unit setting:', error);
+    unitSelect.value = 'imperial';
+  }
+  unitSelect.addEventListener('change', (event) => {
+    try {
+      const project = getProjectState();
+      project.settings = project.settings || {};
+      project.settings.units = event.target.value === 'metric' ? 'metric' : 'imperial';
+      setProjectState(project);
+    } catch (error) {
+      console.warn('Could not save unit setting:', error);
+    }
+  });
+}
+
+initializeUnitSelection();
+
 function showToast(message, kind = 'info') {
   const toast = document.getElementById('custom-toast');
   if (!toast) return;
@@ -1673,4 +1698,3 @@ updateTable();
 setupListeners();
 handleInitialEditQuery();
 handlePalettePrefill();
-


### PR DESCRIPTION
### Motivation
- Ensure the Custom Components page exposes the same project-level units preference (Imperial / Metric) as other pages so users can select and persist unit system from that page.

### Description
- Added a `Units` dropdown to `custom-components.html` settings with `Imperial (ft / in)` and `Metric (m / mm)` options.  
- Wired the selector in `custom-components.js` to read and persist the choice via `projectStorage` by importing and using `getProjectState` and `setProjectState`, via a new `initializeUnitSelection()` helper.  
- Files changed: `custom-components.html`, `custom-components.js`.

### Testing
- Ran the full test suite with `npm test` and all automated tests completed successfully.  
- Built the app with `npm run build` and the build completed successfully.  
- Attempted to capture a preview screenshot with Playwright, but the environment lacks Playwright browser binaries (`chromium_headless_shell`), so screenshot generation was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda378aad88324a16246fc3279fc60)