### PR TITLE
Add library schema validation across UI save/import and API persistence

### DIFF
--- a/library.html
+++ b/library.html
@@ -179,6 +179,7 @@
     import { getItem, setItem } from './dataStore.mjs';
     import { showAlertModal } from './src/components/modal.js';
     import { getAuthContextState } from './projectStorage.js';
+    import { validateLibraryPayload } from './src/validation/librarySchema.mjs';
 
     // -------------------------------------------------------------------------
     // Sync status badge
@@ -222,7 +223,13 @@
         },
         body: JSON.stringify(body),
       });
-      if (!res.ok) return null;
+      if (!res.ok) {
+        if (res.status === 400) {
+          const details = await res.json().catch(() => ({}));
+          return { validationErrors: details?.details || [] };
+        }
+        return null;
+      }
       return res.json();
     }
 
@@ -253,6 +260,33 @@
       categories: [],
       icons: {},
     };
+
+    function renderValidationErrors(errors) {
+      const filtered = Array.isArray(errors) ? errors : [];
+      const title = filtered.some((entry) => entry.severity === 'error')
+        ? 'Library validation failed'
+        : 'Library validation warnings';
+      const list = filtered
+        .map((entry) => `• [${entry.severity || 'error'}] ${entry.path || 'root'} — ${entry.message}`)
+        .join('\n');
+      if (!list) {
+        return '';
+      }
+      return `${title}\n\n${list}`;
+    }
+
+    async function validateLibraryForPersistence(payload) {
+      const validation = validateLibraryPayload(payload);
+      if (!validation.errors.length) {
+        return true;
+      }
+      const hasError = validation.errors.some((item) => item.severity !== 'warning');
+      if (hasError) {
+        await showAlertModal('Validation Error', renderValidationErrors(validation.errors));
+        return false;
+      }
+      return true;
+    }
 
     function parseJsonSafe(value, fallback) {
       try {
@@ -525,6 +559,8 @@
       try {
         syncStructuredFromTextareas();
         const { categories, components, icons } = getStructuredPayload();
+        const isValid = await validateLibraryForPersistence({ categories, components, icons });
+        if (!isValid) return;
         const version = versionInput.value.trim() || 'user';
         setItem('componentLibraryVersion', version);
         setItem('componentLibrary_' + version, { components, categories, icons });
@@ -533,9 +569,12 @@
         if (authState()) {
           setStatus('pending', '⟳ Saving…');
           const saved = await cloudPut({ categories, components, icons }, _cloudVersion || undefined);
-          if (saved) {
+          if (saved && !saved.validationErrors) {
             _cloudVersion = saved.version;
             setStatus('synced', '☁ Synced');
+          } else if (saved?.validationErrors?.length) {
+            setStatus('local', '⚠ Validation failed');
+            await showAlertModal('Cloud Validation Failed', renderValidationErrors(saved.validationErrors));
           } else {
             setStatus('offline', '⚠ Cloud save failed');
           }
@@ -588,8 +627,15 @@
             ? obj
             : [];
           const categories = Array.isArray(obj.categories) ? obj.categories : [];
+          const icons = obj.icons || {};
+          const validation = validateLibraryPayload({ categories, components, icons });
+          const hasErrors = validation.errors.some((item) => item.severity !== 'warning');
+          if (hasErrors) {
+            showAlertModal('Invalid File', renderValidationErrors(validation.errors));
+            return;
+          }
           document.getElementById('library-version').value = version;
-          hydrateStructuredState({ categories, components }, obj.icons || {});
+          hydrateStructuredState({ categories, components }, icons);
           setStatus('pending', '⟳ Unsaved');
         } catch {
           showAlertModal('Invalid File', 'Please select a valid JSON library file.');
@@ -609,12 +655,17 @@
       try {
         syncStructuredFromTextareas();
         const { categories, components, icons } = getStructuredPayload();
+        const isValid = await validateLibraryForPersistence({ categories, components, icons });
+        if (!isValid) return;
         setStatus('pending', '⟳ Saving…');
         const saved = await cloudPut({ categories, components, icons });
-        if (saved) {
+        if (saved && !saved.validationErrors) {
           _cloudVersion = saved.version;
           setStatus('synced', '☁ Synced');
           await showAlertModal('Saved to Cloud', 'Library saved to your cloud account.');
+        } else if (saved?.validationErrors?.length) {
+          setStatus('local', '⚠ Validation failed');
+          await showAlertModal('Cloud Validation Failed', renderValidationErrors(saved.validationErrors));
         } else {
           setStatus('offline', '⚠ Cloud save failed');
           await showAlertModal('Cloud Save Failed', 'Could not save to cloud. Check your connection or log in again.');

--- a/server.mjs
+++ b/server.mjs
@@ -5,6 +5,7 @@ import path from 'path';
 import crypto from 'crypto';
 import { promisify } from 'util';
 import { attachCollaborationServer } from './src/collaborationServer.mjs';
+import { validateLibraryPayload } from './src/validation/librarySchema.mjs';
 
 const scrypt = promisify(crypto.scrypt);
 
@@ -1592,6 +1593,21 @@ When answering queries:
     auth,
     csrfProtection,
     asyncHandler(async (req, res) => {
+      const normalized = normalizeSaveRequest(req.body);
+      const payload = normalized.mode === 'patch'
+        ? applyMergePatch(
+          (await cloudLibraryStore.loadLatest(req.username).catch(() => ({ data: {} }))).data,
+          normalized.patch ?? {},
+        )
+        : normalized.data ?? {};
+      const validation = validateLibraryPayload(payload);
+      if (!validation.valid) {
+        res.status(400).json({
+          error: 'Library payload validation failed',
+          details: validation.errors,
+        });
+        return;
+      }
       try {
         const saved = await cloudLibraryStore.save(req.username, req.body);
         res.json({ version: saved.version, unchanged: saved.metrics.skippedWrite });

--- a/src/validation/librarySchema.mjs
+++ b/src/validation/librarySchema.mjs
@@ -1,0 +1,150 @@
+function buildError(path, message, severity = 'error') {
+  return { path, message, severity };
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function validateComponent(component, index, categoriesSet, subtypeMap, errors) {
+  if (!isPlainObject(component)) {
+    errors.push(buildError(`components[${index}]`, 'Component must be an object.'));
+    return;
+  }
+
+  const requiredFields = ['subtype', 'label', 'icon', 'category'];
+  requiredFields.forEach((field) => {
+    if (!isNonEmptyString(component[field])) {
+      errors.push(
+        buildError(`components[${index}].${field}`, `${field} is required and must be a non-empty string.`),
+      );
+    }
+  });
+
+  if (component.ports !== undefined && !isFiniteNumber(component.ports)) {
+    errors.push(buildError(`components[${index}].ports`, 'ports must be a finite number.'));
+  }
+
+  if (component.schema !== undefined && !isPlainObject(component.schema)) {
+    errors.push(buildError(`components[${index}].schema`, 'schema must be a JSON object.'));
+  }
+
+  if (isNonEmptyString(component.category) && categoriesSet.size && !categoriesSet.has(component.category.trim())) {
+    errors.push(
+      buildError(
+        `components[${index}].category`,
+        `category "${component.category}" is not listed in categories.`,
+        'warning',
+      ),
+    );
+  }
+
+  if (isNonEmptyString(component.subtype)) {
+    const normalizedSubtype = component.subtype.trim();
+    const firstIndex = subtypeMap.get(normalizedSubtype);
+    if (firstIndex === undefined) {
+      subtypeMap.set(normalizedSubtype, index);
+    } else {
+      errors.push(
+        buildError(
+          `components[${index}].subtype`,
+          `Duplicate subtype "${normalizedSubtype}" already used at components[${firstIndex}].subtype.`,
+        ),
+      );
+    }
+  }
+}
+
+/**
+ * Primary validator for library payloads before local/cloud persistence.
+ * Future spreadsheet import parsers should call this function before saving.
+ */
+export function validateLibraryPayload(payload) {
+  const errors = [];
+
+  if (!isPlainObject(payload)) {
+    return {
+      valid: false,
+      errors: [buildError('', 'Library payload must be an object with { categories, components, icons }.')],
+    };
+  }
+
+  const expectedTopLevel = ['categories', 'components', 'icons'];
+  expectedTopLevel.forEach((key) => {
+    if (!(key in payload)) {
+      errors.push(buildError(key, `${key} is required.`));
+    }
+  });
+
+  const categories = payload.categories;
+  const components = payload.components;
+  const icons = payload.icons;
+
+  if (!Array.isArray(categories)) {
+    errors.push(buildError('categories', 'categories must be an array of strings.'));
+  }
+  if (!Array.isArray(components)) {
+    errors.push(buildError('components', 'components must be an array of component objects.'));
+  }
+  if (!isPlainObject(icons)) {
+    errors.push(buildError('icons', 'icons must be an object map of icon keys to paths.'));
+  }
+
+  const categorySet = new Set();
+  if (Array.isArray(categories)) {
+    categories.forEach((value, index) => {
+      if (!isNonEmptyString(value)) {
+        errors.push(buildError(`categories[${index}]`, 'Category must be a non-empty string.'));
+        return;
+      }
+      const category = value.trim();
+      if (categorySet.has(category)) {
+        errors.push(buildError(`categories[${index}]`, `Duplicate category "${category}".`));
+        return;
+      }
+      categorySet.add(category);
+    });
+  }
+
+  if (isPlainObject(icons)) {
+    Object.entries(icons).forEach(([key, value]) => {
+      if (!isNonEmptyString(key)) {
+        errors.push(buildError('icons', 'Icon keys must be non-empty strings.'));
+      }
+      if (!isNonEmptyString(value)) {
+        errors.push(buildError(`icons.${key || '(empty)'}`, 'Icon path must be a non-empty string.'));
+      }
+    });
+  }
+
+  if (Array.isArray(components)) {
+    const subtypeMap = new Map();
+    components.forEach((component, index) => {
+      validateComponent(component, index, categorySet, subtypeMap, errors);
+    });
+  }
+
+  return {
+    valid: errors.filter((item) => item.severity !== 'warning').length === 0,
+    errors,
+  };
+}
+
+export function assertValidLibraryPayload(payload) {
+  const validation = validateLibraryPayload(payload);
+  if (!validation.valid) {
+    const error = new Error('library-validation-failed');
+    error.code = 'LIBRARY_VALIDATION_FAILED';
+    error.validation = validation;
+    throw error;
+  }
+  return validation;
+}


### PR DESCRIPTION
### Motivation

- Prevent invalid component library payloads from being persisted or imported by enforcing a clear schema for `{categories, components, icons}`.
- Provide friendly, UI-renderable validation errors (`{ path, message, severity }`) so users see actionable feedback when a library is malformed.
- Ensure server-side enforcement for cloud saves so invalid payloads cannot be written to disk or cause downstream issues.

### Description

- Added a shared validator module at `src/validation/librarySchema.mjs` that validates top-level shape, required component fields (`subtype`, `label`, `icon`, `category`), type checks for `ports` and `schema`, duplicate `subtype` detection, category/Icons checks, and returns errors in `{ path, message, severity }` format; it also exports `assertValidLibraryPayload` for throwing on failure.
- Integrated client-side validation in `library.html` by importing `validateLibraryPayload`, gating file upload imports, validating in `saveComponents` and `handleCloudSave`, and rendering validation details in the existing modal UI; client now also parses backend `400` responses and shows server-side validation details to users.
- Added server-side pre-save validation in `PUT /api/v1/library` inside `server.mjs` (normalizes incoming save requests, applies patch if needed, validates resulting payload) and returns `400` with structured `details` when validation fails to prevent invalid persistence.

### Testing

- Ran `npm run build` successfully which produced the application bundle without build-time errors.
- Ran `npm test`; the test runner executed a large portion of the suite (many tests passed) but the full suite stalled in this environment at `node tests/collaboration.test.mjs` before completion; partial results indicate no failures related to the new validator code during the portion that executed.
- Attempted a Playwright-based page screenshot for a preview but the environment lacks a browser binary (`npx playwright install` not available), so an automated browser preview could not be produced in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddab19b1608324958686e726455119)