### PR TITLE
Handle cloud library save conflicts with resolution modal

### DIFF
--- a/docs/componentLibrary.md
+++ b/docs/componentLibrary.md
@@ -61,6 +61,12 @@ The **Library Manager** (`library.html`) supports saving your component library 
 
 When you click the regular **Save** button while logged in, the library is also auto-synced to the cloud.
 
+If the server returns **409 Version conflict**, Library Manager now fetches the latest cloud copy and opens a conflict modal with three choices:
+
+- **Overwrite cloud with my local edits** (retries save against the latest `baseVersion`)
+- **Reload cloud version** (loads cloud data into the editor)
+- **Merge non-conflicting changes** (merges by `component.subtype`, flags subtype collisions for manual review, then retries save with updated `baseVersion`)
+
 ### Loading from the Cloud
 
 On page load, the Library Manager automatically fetches your cloud library (if you are logged in) and populates the editor. To reload manually at any time, click **Load from Cloud**.

--- a/library.html
+++ b/library.html
@@ -183,7 +183,7 @@
   <script type="module">
     import './src/components/navigation.js';
     import { getItem, setItem } from './dataStore.mjs';
-    import { showAlertModal } from './src/components/modal.js';
+    import openModal, { showAlertModal } from './src/components/modal.js';
     import { getAuthContextState } from './projectStorage.js';
     import { validateLibraryPayload } from './src/validation/librarySchema.mjs';
 
@@ -234,9 +234,161 @@
           const details = await res.json().catch(() => ({}));
           return { validationErrors: details?.details || [] };
         }
+        if (res.status === 409) {
+          const details = await res.json().catch(() => ({}));
+          return {
+            conflict: true,
+            currentVersion: details?.currentVersion || null,
+          };
+        }
         return null;
       }
       return res.json();
+    }
+
+    function normalizeComponent(component) {
+      return JSON.stringify(component ?? {});
+    }
+
+    function mergeLibraryForConflict(localPayload, cloudPayload) {
+      const localComponents = Array.isArray(localPayload?.components) ? localPayload.components : [];
+      const cloudComponents = Array.isArray(cloudPayload?.components) ? cloudPayload.components : [];
+      const cloudBySubtype = new Map(
+        cloudComponents
+          .filter((component) => component && component.subtype)
+          .map((component) => [component.subtype, component]),
+      );
+      const localBySubtype = new Map(
+        localComponents
+          .filter((component) => component && component.subtype)
+          .map((component) => [component.subtype, component]),
+      );
+      const mergedComponents = [];
+      const collisions = [];
+      cloudBySubtype.forEach((cloudComponent, subtype) => {
+        const localComponent = localBySubtype.get(subtype);
+        if (!localComponent) {
+          mergedComponents.push(cloudComponent);
+          return;
+        }
+        if (normalizeComponent(localComponent) !== normalizeComponent(cloudComponent)) {
+          collisions.push(subtype);
+        }
+        mergedComponents.push(localComponent);
+        localBySubtype.delete(subtype);
+      });
+      localBySubtype.forEach((localComponent) => {
+        mergedComponents.push(localComponent);
+      });
+      const categories = [...new Set([
+        ...(Array.isArray(cloudPayload?.categories) ? cloudPayload.categories : []),
+        ...(Array.isArray(localPayload?.categories) ? localPayload.categories : []),
+      ])];
+      const icons = {
+        ...(cloudPayload?.icons && typeof cloudPayload.icons === 'object' ? cloudPayload.icons : {}),
+        ...(localPayload?.icons && typeof localPayload.icons === 'object' ? localPayload.icons : {}),
+      };
+      return {
+        payload: {
+          categories,
+          components: mergedComponents,
+          icons,
+        },
+        collisions,
+      };
+    }
+
+    async function showConflictResolutionModal(conflictSummary) {
+      const { collisions = [], currentVersion } = conflictSummary || {};
+      return openModal({
+        title: 'Cloud Version Conflict',
+        primaryText: 'Cancel',
+        secondaryText: null,
+        closeOnBackdrop: false,
+        closeOnEscape: true,
+        render(body, controller) {
+          const intro = document.createElement('p');
+          intro.textContent = `The cloud library changed since your last sync.${currentVersion ? ` Latest version: ${currentVersion}.` : ''}`;
+          body.appendChild(intro);
+
+          const detail = document.createElement('p');
+          if (collisions.length) {
+            detail.textContent = `Merge found ${collisions.length} component subtype collision(s). These entries need manual review.`;
+          } else {
+            detail.textContent = 'Merge can apply all changes without subtype collisions.';
+          }
+          body.appendChild(detail);
+
+          if (collisions.length) {
+            const collisionList = document.createElement('p');
+            collisionList.textContent = `Collisions: ${collisions.join(', ')}`;
+            body.appendChild(collisionList);
+          }
+
+          const buttonWrap = document.createElement('div');
+          buttonWrap.className = 'modal-actions';
+
+          const overwriteBtn = document.createElement('button');
+          overwriteBtn.type = 'button';
+          overwriteBtn.className = 'btn';
+          overwriteBtn.textContent = 'Overwrite cloud with local edits';
+          overwriteBtn.addEventListener('click', () => controller.close('overwrite'));
+
+          const reloadBtn = document.createElement('button');
+          reloadBtn.type = 'button';
+          reloadBtn.className = 'btn';
+          reloadBtn.textContent = 'Reload cloud version';
+          reloadBtn.addEventListener('click', () => controller.close('reload'));
+
+          const mergeBtn = document.createElement('button');
+          mergeBtn.type = 'button';
+          mergeBtn.className = 'btn primary-btn';
+          mergeBtn.textContent = 'Merge non-conflicting changes';
+          mergeBtn.addEventListener('click', () => controller.close('merge'));
+
+          buttonWrap.append(overwriteBtn, reloadBtn, mergeBtn);
+          body.appendChild(buttonWrap);
+        },
+      });
+    }
+
+    async function saveLibraryToCloudWithConflictResolution(payload, baseVersion) {
+      let effectiveBaseVersion = baseVersion || undefined;
+      let attempt = await cloudPut(payload, effectiveBaseVersion);
+      if (!attempt?.conflict) {
+        return attempt;
+      }
+      const latest = await cloudGet();
+      if (!latest || latest.notFound) {
+        return attempt;
+      }
+      const mergeResult = mergeLibraryForConflict(payload, latest.data || {});
+      const decision = await showConflictResolutionModal({
+        collisions: mergeResult.collisions,
+        currentVersion: latest.version || attempt.currentVersion || null,
+      });
+      if (!decision) {
+        return { cancelled: true };
+      }
+      if (decision === 'reload') {
+        populateFromData(latest.data);
+        _cloudVersion = latest.version || null;
+        return { reloaded: true };
+      }
+      if (decision === 'merge') {
+        attempt = await cloudPut(mergeResult.payload, latest.version || attempt.currentVersion || undefined);
+        if (attempt && !attempt.validationErrors && !attempt.conflict) {
+          hydrateStructuredState({
+            categories: mergeResult.payload.categories,
+            components: mergeResult.payload.components,
+          }, mergeResult.payload.icons);
+        }
+        return {
+          ...attempt,
+          mergeCollisions: mergeResult.collisions,
+        };
+      }
+      return cloudPut(payload, latest.version || attempt.currentVersion || undefined);
     }
 
     async function cloudShare() {
@@ -574,13 +726,26 @@
         // Auto-sync to cloud if authenticated
         if (authState()) {
           setStatus('pending', '⟳ Saving…');
-          const saved = await cloudPut({ categories, components, icons }, _cloudVersion || undefined);
-          if (saved && !saved.validationErrors) {
+          const saved = await saveLibraryToCloudWithConflictResolution({ categories, components, icons }, _cloudVersion || undefined);
+          if (saved?.reloaded) {
+            setStatus('synced', '☁ Synced');
+            await showAlertModal('Cloud Version Loaded', 'Loaded the latest cloud version. Review it, then save again if needed.');
+          } else if (saved && !saved.validationErrors && !saved.conflict && !saved.cancelled) {
             _cloudVersion = saved.version;
             setStatus('synced', '☁ Synced');
+            if (saved?.mergeCollisions?.length) {
+              await showAlertModal(
+                'Merged with Collisions',
+                `Merged updates and kept local edits for: ${saved.mergeCollisions.join(', ')}.\nPlease review these components.`
+              );
+            }
           } else if (saved?.validationErrors?.length) {
             setStatus('local', '⚠ Validation failed');
             await showAlertModal('Cloud Validation Failed', renderValidationErrors(saved.validationErrors));
+          } else if (saved?.cancelled) {
+            setStatus('local', '⚠ Save cancelled');
+          } else if (saved?.conflict) {
+            setStatus('local', '⚠ Conflict unresolved');
           } else {
             setStatus('offline', '⚠ Cloud save failed');
           }
@@ -881,14 +1046,29 @@
         const isValid = await validateLibraryForPersistence({ categories, components, icons });
         if (!isValid) return;
         setStatus('pending', '⟳ Saving…');
-        const saved = await cloudPut({ categories, components, icons });
-        if (saved && !saved.validationErrors) {
+        const saved = await saveLibraryToCloudWithConflictResolution({ categories, components, icons }, _cloudVersion || undefined);
+        if (saved?.reloaded) {
+          setStatus('synced', '☁ Synced');
+          await showAlertModal('Cloud Version Loaded', 'Loaded the latest cloud version. Review it, then save again if needed.');
+        } else if (saved && !saved.validationErrors && !saved.conflict && !saved.cancelled) {
           _cloudVersion = saved.version;
           setStatus('synced', '☁ Synced');
-          await showAlertModal('Saved to Cloud', 'Library saved to your cloud account.');
+          if (saved?.mergeCollisions?.length) {
+            await showAlertModal(
+              'Saved with Merge Collisions',
+              `Saved merged data. Manual review is still needed for: ${saved.mergeCollisions.join(', ')}.`
+            );
+          } else {
+            await showAlertModal('Saved to Cloud', 'Library saved to your cloud account.');
+          }
         } else if (saved?.validationErrors?.length) {
           setStatus('local', '⚠ Validation failed');
           await showAlertModal('Cloud Validation Failed', renderValidationErrors(saved.validationErrors));
+        } else if (saved?.cancelled) {
+          setStatus('local', '⚠ Save cancelled');
+        } else if (saved?.conflict) {
+          setStatus('local', '⚠ Conflict unresolved');
+          await showAlertModal('Conflict Unresolved', 'The cloud library changed and no resolution was applied.');
         } else {
           setStatus('offline', '⚠ Cloud save failed');
           await showAlertModal('Cloud Save Failed', 'Could not save to cloud. Check your connection or log in again.');


### PR DESCRIPTION
### Motivation
- Prevent silent data loss when saving the component library to cloud by detecting HTTP 409 version conflicts and offering the user an explicit resolution flow.
- Provide a user-friendly merge option that can automatically combine non-conflicting edits keyed by `component.subtype` while surfacing collisions for manual review.
- Reuse the server `baseVersion` contract so saves can be retried against the latest cloud version without changing backend auth/CSRF/rate-limit middleware.

### Description
- Detect `409` responses in `cloudPut` and return structured conflict metadata (`{ conflict: true, currentVersion }`) so callers can react programmatically.
- Add `saveLibraryToCloudWithConflictResolution` which on conflict performs `cloudGet`, computes a merge by `component.subtype`, and shows a conflict modal via `openModal` offering `overwrite`, `reload`, and `merge` choices.
- Implement `mergeLibraryForConflict` to merge `categories`, `icons`, and upsert `components` by `subtype`, and to collect `collisions` when local and cloud component objects differ.
- Wire the new conflict-resolution flow into both the auto-sync `save` handler (`saveComponents`) and the explicit `Save to Cloud` handler (`handleCloudSave`), and show appropriate status/alert messages for reload, merge collisions, cancellation, and unresolved conflicts.
- Update `docs/componentLibrary.md` to document the new 409 conflict behavior and user options.

### Testing
- Ran the build with `npm run build` successfully (Rollup warnings unrelated to this change were observed and are unchanged).
- Executed the test suite with `npm test`; many unit/integration tests ran and reported passing results, but the full suite did not exit cleanly in this environment (the run reached late-stage collaboration tests and was terminated while capturing output).
- Attempted an automated page preview via Playwright to produce a screenshot, but Playwright browser binaries are not installed in this environment so the screenshot step failed with a missing Chromium executable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3894958883248d6a33bd464cf079)