### PR TITLE
Add intermediate ground rod spacing controls and preview rendering

### DIFF
--- a/analysis/groundGrid.mjs
+++ b/analysis/groundGrid.mjs
@@ -160,7 +160,9 @@ export function tolerableStep(Cs, rhoS, tf, bw) {
  * @param {number} params.d         Conductor diameter (m)
  * @param {number} params.Ig        Maximum grid current (A)
  * @param {number} params.tf        Fault duration (s)
- * @param {boolean} [params.hasRods]  Whether corner/perimeter ground rods are present
+ * @param {boolean} [params.hasRods]  Whether ground rods are present
+ * @param {number}  [params.rodCount] Number of rods tied to the grid
+ * @param {number}  [params.rodLength] Length of each rod (m)
  * @param {number}  [params.rhoS]   Surface layer resistivity (Ω·m); 0 = no layer
  * @param {number}  [params.hs]     Surface layer thickness (m); 0 = no layer
  * @param {50|70}   [params.bw]     Body weight for tolerable limits (kg, default 70)
@@ -170,6 +172,8 @@ export function analyzeGroundGrid(params) {
   const {
     rho, gridLx, gridLy, nx, ny, h, d, Ig, tf,
     hasRods = false,
+    rodCount = hasRods ? 4 : 0,
+    rodLength = 0,
     rhoS = 0,
     hs = 0,
     bw = 70
@@ -183,11 +187,15 @@ export function analyzeGroundGrid(params) {
   if (d <= 0) throw new Error('Conductor diameter must be positive');
   if (Ig <= 0) throw new Error('Grid current must be positive');
   if (tf <= 0) throw new Error('Fault duration must be positive');
+  if (!Number.isFinite(rodCount) || rodCount < 0) throw new Error('Rod count must be non-negative');
+  if (!Number.isFinite(rodLength) || rodLength < 0) throw new Error('Rod length must be non-negative');
 
   // Grid geometry
   const A = gridLx * gridLy;                         // Grid area (m²)
   const Lp = 2 * (gridLx + gridLy);                  // Perimeter (m)
   const conductorLength = nx * gridLx + ny * gridLy;  // Total buried length (m)
+  const totalRodLength = hasRods ? rodCount * rodLength : 0;
+  const effectiveLength = conductorLength + totalRodLength;
 
   // Mesh spacing (average for non-square grids)
   const Dx = gridLx / (ny - 1);  // spacing between conductors running in x-direction
@@ -195,7 +203,7 @@ export function analyzeGroundGrid(params) {
   const D = Math.sqrt(Dx * Dy);  // geometric mean spacing
 
   // Effective n
-  const n = effectiveN(conductorLength, Lp, A);
+  const n = effectiveN(effectiveLength, Lp, A);
 
   // Km and Ks
   const Km = meshFactor(D, h, d, n, hasRods);
@@ -204,11 +212,11 @@ export function analyzeGroundGrid(params) {
 
   // Lm and Ls — effective lengths for voltage calculations (IEEE 80-2013 §16.5)
   // For grids without ground rods: Lm = Ls = L
-  const Lm = conductorLength;
-  const Ls = conductorLength;
+  const Lm = effectiveLength;
+  const Ls = effectiveLength;
 
   // Grid resistance
-  const Rg = gridResistance(rho, conductorLength, A, h);
+  const Rg = gridResistance(rho, effectiveLength, A, h);
 
   // Ground potential rise
   const GPR = Ig * Rg;
@@ -231,6 +239,10 @@ export function analyzeGroundGrid(params) {
     A,
     Lp,
     conductorLength,
+    totalRodLength,
+    effectiveLength,
+    rodCount,
+    rodLength,
     D,
     Dx,
     Dy,

--- a/groundgrid.html
+++ b/groundgrid.html
@@ -214,8 +214,9 @@
               Include perimeter / corner ground rods
             </label>
             <p id="has-rods-hint" class="field-hint">
-              When checked, uses the Kii correction in the mesh factor Km for grids
-              with rods at perimeter corners (IEEE 80-2013 §16.5).
+              When checked, includes rods tied to the grid for IEEE 80-style correction
+              factors and effective buried length. Rod spacing settings below place
+              intermediate rods at conductor intersections.
             </p>
           </div>
 

--- a/groundgrid.html
+++ b/groundgrid.html
@@ -218,6 +218,28 @@
               with rods at perimeter corners (IEEE 80-2013 §16.5).
             </p>
           </div>
+
+          <div class="field-row rod-spacing-field" id="rod-spacing-x-row" hidden>
+            <label for="rod-spacing-x">
+              Intermediate rod spacing in x-direction (<span class="unit-label-ft">ft</span><span class="unit-label-m" hidden>m</span>, 0 = corners only)
+            </label>
+            <input type="number" id="rod-spacing-x" min="0" step="0.1"
+                   value="0" aria-describedby="rod-spacing-x-hint">
+            <p id="rod-spacing-x-hint" class="field-hint">
+              Target spacing between rod columns along L<sub>x</sub>. Rods snap to nearest conductor intersections.
+            </p>
+          </div>
+
+          <div class="field-row rod-spacing-field" id="rod-spacing-y-row" hidden>
+            <label for="rod-spacing-y">
+              Intermediate rod spacing in y-direction (<span class="unit-label-ft">ft</span><span class="unit-label-m" hidden>m</span>, 0 = corners only)
+            </label>
+            <input type="number" id="rod-spacing-y" min="0" step="0.1"
+                   value="0" aria-describedby="rod-spacing-y-hint">
+            <p id="rod-spacing-y-hint" class="field-hint">
+              Target spacing between rod rows along L<sub>y</sub>. Set x and y spacing to place rods throughout the grid.
+            </p>
+          </div>
         </fieldset>
 
         <!-- Electrical Parameters -->

--- a/groundgrid.js
+++ b/groundgrid.js
@@ -75,6 +75,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const nxInput = getInt('nx');
     const nyInput = getInt('ny');
     const hasRods = document.getElementById('has-rods').checked;
+    const rodSpacingXInput = getNum('rod-spacing-x');
+    const rodSpacingYInput = getNum('rod-spacing-y');
     const diameterUnit = unit === 'ft' ? 'in' : 'mm';
 
     const normalized = normalizePreviewGeometry({
@@ -86,9 +88,21 @@ document.addEventListener('DOMContentLoaded', () => {
       nxInput,
       nyInput,
       hasRods,
+      rodSpacingXInput,
+      rodSpacingYInput,
     });
 
     return { unit, diameterUnit, hasRods, ...normalized };
+  }
+
+  function setRodSpacingVisibility() {
+    const hasRods = document.getElementById('has-rods')?.checked;
+    ['rod-spacing-x-row', 'rod-spacing-y-row'].forEach(id => {
+      const row = document.getElementById(id);
+      if (row) {
+        row.hidden = !hasRods;
+      }
+    });
   }
 
   function clearAndPrimeSvg(svgEl, titleText) {
@@ -142,7 +156,9 @@ document.addEventListener('DOMContentLoaded', () => {
       svgEl.appendChild(makeSvg('line', { x1: startX, y1: y, x2: endX, y2: y, class: 'grid-conductor' }));
     }
     if (params.hasRods) {
-      [[startX, startY], [endX, startY], [startX, endY], [endX, endY]].forEach(([x, y]) => {
+      params.rodLayout.points.forEach(point => {
+        const x = startX + (point.xIndex * dx);
+        const y = startY + (point.yIndex * dy);
         svgEl.appendChild(makeSvg('circle', { cx: x, cy: y, r: 5, class: 'grid-rod' }));
       });
     }
@@ -160,7 +176,13 @@ document.addEventListener('DOMContentLoaded', () => {
     legend.appendChild(conductorText);
     legend.appendChild(makeSvg('circle', { cx: 43, cy: 56, r: 5, class: 'grid-rod' }));
     const rodText = makeSvg('text', { x: 65, y: 60, class: 'grid-legend-text' });
-    rodText.textContent = params.hasRods ? 'Perimeter/corner rod' : 'Corner rod (disabled)';
+    if (!params.hasRods) {
+      rodText.textContent = 'Corner rod (disabled)';
+    } else if (params.rodLayout.intermediateCount > 0) {
+      rodText.textContent = `Rods @ intersections (${params.rodLayout.count} total)`;
+    } else {
+      rodText.textContent = 'Perimeter/corner rods';
+    }
     legend.appendChild(rodText);
     svgEl.appendChild(legend);
   }
@@ -188,10 +210,16 @@ document.addEventListener('DOMContentLoaded', () => {
     svgEl.appendChild(makeSvg('rect', { x: left + 18, y: conductorY - 16, width: right - left - 36, height: 32, class: 'grid-trench-band' }));
 
     if (params.hasRods) {
-      const rodX = right - 52;
+      const rodCount = params.rodLayout.intermediateCount > 0 ? 3 : 1;
+      const firstRodX = right - 112;
+      const rodGap = 32;
       const rodBottom = Math.min(svgHeight - 54, gradeY + ((params.burialDepth + params.rodLength) * depthScale));
-      svgEl.appendChild(makeSvg('line', { x1: rodX, y1: conductorY, x2: rodX, y2: rodBottom, class: 'grid-rod' }));
-      drawDimension(svgEl, rodX + 18, conductorY, rodX + 18, rodBottom, `Rod = ${formatDim(params.rodLength, params.unit)}`, -10);
+      for (let rodIndex = 0; rodIndex < rodCount; rodIndex += 1) {
+        const rodX = firstRodX + (rodIndex * rodGap);
+        svgEl.appendChild(makeSvg('line', { x1: rodX, y1: conductorY, x2: rodX, y2: rodBottom, class: 'grid-rod' }));
+      }
+      const dimX = firstRodX + ((rodCount - 1) * rodGap) + 16;
+      drawDimension(svgEl, dimX, conductorY, dimX, rodBottom, `Rod = ${formatDim(params.rodLength, params.unit)}`, -10);
     }
 
     drawDimension(svgEl, left - 24, gradeY, left - 24, conductorY, `h = ${formatDim(params.burialDepth, params.unit)}`, -10);
@@ -232,7 +260,9 @@ document.addEventListener('DOMContentLoaded', () => {
       + `Spacing: ${params.spacingX.toFixed(1)} ${params.unit} (x), ${params.spacingY.toFixed(1)} ${params.unit} (y)`
       + ` • h: ${params.burialDepth.toFixed(2)} ${params.unit}`
       + (params.hs > 0 ? ` • hs: ${params.hs.toFixed(2)} ${params.unit}` : '')
-      + (params.hasRods ? ' • Corner rods enabled' : '');
+      + (params.hasRods ? ` • Ground rods: ${params.rodLayout.count} (${params.rodLayout.intermediateCount} intermediate)` : '')
+      + (params.hasRods && params.rodLayout.axisSpacingX > 0 ? ` • Rod spacing x ≈ ${params.rodLayout.axisSpacingX.toFixed(1)} ${params.unit}` : '')
+      + (params.hasRods && params.rodLayout.axisSpacingY > 0 ? ` • Rod spacing y ≈ ${params.rodLayout.axisSpacingY.toFixed(1)} ${params.unit}` : '');
 
     if (previewSummary) {
       previewSummary.textContent = hadInitError
@@ -373,6 +403,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     form.addEventListener('input', () => {
+      setRodSpacingVisibility();
       renderGridPreview();
     });
   } else {
@@ -387,4 +418,5 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   renderGridPreview();
+  setRodSpacingVisibility();
 });

--- a/groundgrid.js
+++ b/groundgrid.js
@@ -302,12 +302,33 @@ document.addEventListener('DOMContentLoaded', () => {
     const ny = getInt('ny');
     const Ig = getNum('grid-current');
     const tf = getNum('fault-duration');
+    const previewParams = getPreviewParams();
     const hasRods = document.getElementById('has-rods').checked;
+    const rodCount = hasRods ? previewParams.rodLayout.count : 0;
+    const rodLength = hasRods
+      ? (imperial ? ftToM(previewParams.rodLength) : previewParams.rodLength)
+      : 0;
     const bw = parseInt(document.getElementById('body-weight').value, 10);
 
     let r;
     try {
-      r = analyzeGroundGrid({ rho, gridLx, gridLy, nx, ny, h, d, Ig, tf, hasRods, rhoS, hs, bw });
+      r = analyzeGroundGrid({
+        rho,
+        gridLx,
+        gridLy,
+        nx,
+        ny,
+        h,
+        d,
+        Ig,
+        tf,
+        hasRods,
+        rodCount,
+        rodLength,
+        rhoS,
+        hs,
+        bw,
+      });
     } catch (err) {
       resultsDiv.innerHTML = `<p class="alert-error" role="alert">Error: ${err.message}</p>`;
       return;
@@ -339,6 +360,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     section.appendChild(renderResult('Grid Area (A)', areaDisplay, '', null));
     section.appendChild(renderResult('Total Conductor Length (L)', lDisplay, '', null));
+    if (r.totalRodLength > 0) {
+      const rodLengthDisplay = imperial
+        ? `${(r.totalRodLength / 0.3048).toFixed(1)} ft`
+        : `${r.totalRodLength.toFixed(1)} m`;
+      const effectiveLengthDisplay = imperial
+        ? `${(r.effectiveLength / 0.3048).toFixed(1)} ft`
+        : `${r.effectiveLength.toFixed(1)} m`;
+      section.appendChild(renderResult('Total Rod Length (ΣLr)', rodLengthDisplay, '', null));
+      section.appendChild(renderResult('Effective Buried Length (L + ΣLr)', effectiveLengthDisplay, '', null));
+      section.appendChild(renderResult('Rod Count', String(r.rodCount), '', null));
+    }
     section.appendChild(renderResult('Effective n', r.n.toFixed(2), '', null));
     section.appendChild(renderResult('Mesh Spacing Km', r.Km.toFixed(3), '', null));
     section.appendChild(renderResult('Step Factor Ks', r.Ks.toFixed(3), '', null));

--- a/src/groundgridPreviewGeometry.js
+++ b/src/groundgridPreviewGeometry.js
@@ -5,6 +5,65 @@ export function estimateRodLength({ hasRods, burialDepth, gridLx, gridLy }) {
   return Math.max(burialDepth * 2.5, burialDepth + (Math.max(gridLx, gridLy) * 0.03));
 }
 
+function normalizeRodSpacing(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return value;
+}
+
+function buildAxisIndices(count, targetSpacing, conductorSpacing) {
+  const lastIndex = Math.max(0, count - 1);
+  if (lastIndex <= 1) {
+    return [0, lastIndex];
+  }
+  if (!Number.isFinite(targetSpacing) || targetSpacing <= 0 || conductorSpacing <= 0) {
+    return [0, lastIndex];
+  }
+  const step = Math.max(1, Math.round(targetSpacing / conductorSpacing));
+  const indices = new Set([0, lastIndex]);
+  for (let index = step; index < lastIndex; index += step) {
+    indices.add(index);
+  }
+  return [...indices].sort((a, b) => a - b);
+}
+
+export function deriveRodLayout({ hasRods, nx, ny, spacingX, spacingY, rodSpacingX, rodSpacingY }) {
+  if (!hasRods) {
+    return {
+      points: [],
+      count: 0,
+      intermediateCount: 0,
+      axisSpacingX: 0,
+      axisSpacingY: 0,
+    };
+  }
+
+  const xIndices = buildAxisIndices(ny, rodSpacingX, spacingX);
+  const yIndices = buildAxisIndices(nx, rodSpacingY, spacingY);
+  const points = [];
+  const corners = new Set([
+    '0:0',
+    `0:${nx - 1}`,
+    `${ny - 1}:0`,
+    `${ny - 1}:${nx - 1}`,
+  ]);
+
+  for (const xIndex of xIndices) {
+    for (const yIndex of yIndices) {
+      points.push({ xIndex, yIndex, isCorner: corners.has(`${xIndex}:${yIndex}`) });
+    }
+  }
+
+  return {
+    points,
+    count: points.length,
+    intermediateCount: points.filter(point => !point.isCorner).length,
+    axisSpacingX: xIndices.length > 1 ? (xIndices[1] - xIndices[0]) * spacingX : 0,
+    axisSpacingY: yIndices.length > 1 ? (yIndices[1] - yIndices[0]) * spacingY : 0,
+  };
+}
+
 export function normalizePreviewGeometry({
   gridLxInput,
   gridLyInput,
@@ -14,6 +73,8 @@ export function normalizePreviewGeometry({
   nxInput,
   nyInput,
   hasRods,
+  rodSpacingXInput,
+  rodSpacingYInput,
 }) {
   const gridLx = Number.isFinite(gridLxInput) && gridLxInput > 0 ? gridLxInput : 1;
   const gridLy = Number.isFinite(gridLyInput) && gridLyInput > 0 ? gridLyInput : 1;
@@ -25,6 +86,9 @@ export function normalizePreviewGeometry({
   const spacingX = ny > 1 ? gridLx / (ny - 1) : 0;
   const spacingY = nx > 1 ? gridLy / (nx - 1) : 0;
   const rodLength = estimateRodLength({ hasRods, burialDepth, gridLx, gridLy });
+  const rodSpacingX = normalizeRodSpacing(rodSpacingXInput);
+  const rodSpacingY = normalizeRodSpacing(rodSpacingYInput);
+  const rodLayout = deriveRodLayout({ hasRods, nx, ny, spacingX, spacingY, rodSpacingX, rodSpacingY });
 
   return {
     gridLx,
@@ -37,5 +101,8 @@ export function normalizePreviewGeometry({
     spacingX,
     spacingY,
     rodLength,
+    rodSpacingX,
+    rodSpacingY,
+    rodLayout,
   };
 }

--- a/tests/groundGrid.test.mjs
+++ b/tests/groundGrid.test.mjs
@@ -254,4 +254,21 @@ describe('analyzeGroundGrid — integration', () => {
     const r = analyzeGroundGrid(base);
     assert.strictEqual(typeof r.gprExceedsTouch, 'boolean');
   });
+
+  it('additional rods reduce Rg by increasing effective buried length', () => {
+    const withoutRods = analyzeGroundGrid({ ...base, hasRods: false });
+    const withRods = analyzeGroundGrid({
+      ...base,
+      hasRods: true,
+      rodCount: 12,
+      rodLength: 3,
+    });
+    assert.ok(withRods.totalRodLength > 0);
+    assert.ok(withRods.effectiveLength > withoutRods.effectiveLength);
+    assert.ok(withRods.Rg < withoutRods.Rg);
+  });
+
+  it('throws for negative rod length', () => {
+    assert.throws(() => analyzeGroundGrid({ ...base, hasRods: true, rodCount: 4, rodLength: -1 }));
+  });
 });

--- a/tests/groundGridPreviewGeometry.test.mjs
+++ b/tests/groundGridPreviewGeometry.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { estimateRodLength, normalizePreviewGeometry } from '../src/groundgridPreviewGeometry.js';
+import { deriveRodLayout, estimateRodLength, normalizePreviewGeometry } from '../src/groundgridPreviewGeometry.js';
 
 function describe(name, fn) {
   console.log(name);
@@ -39,6 +39,9 @@ describe('groundgrid preview geometry helpers', () => {
     assert.strictEqual(normalized.spacingX, 1);
     assert.strictEqual(normalized.spacingY, 1);
     assert.strictEqual(normalized.rodLength, 0);
+    assert.strictEqual(normalized.rodSpacingX, 0);
+    assert.strictEqual(normalized.rodSpacingY, 0);
+    assert.strictEqual(normalized.rodLayout.count, 0);
   });
 
   it('estimates rod length from burial depth and max grid span when enabled', () => {
@@ -61,5 +64,40 @@ describe('groundgrid preview geometry helpers', () => {
     });
 
     assert.strictEqual(rodLength, 0);
+  });
+
+  it('builds intermediate rod layout snapped to conductor intersections', () => {
+    const rodLayout = deriveRodLayout({
+      hasRods: true,
+      nx: 7,
+      ny: 7,
+      spacingX: 10,
+      spacingY: 10,
+      rodSpacingX: 20,
+      rodSpacingY: 30,
+    });
+
+    assert.strictEqual(rodLayout.count, 12);
+    assert.strictEqual(rodLayout.intermediateCount, 8);
+    assert.strictEqual(rodLayout.axisSpacingX, 20);
+    assert.strictEqual(rodLayout.axisSpacingY, 30);
+  });
+
+  it('uses corner rods only when intermediate spacing is not provided', () => {
+    const normalized = normalizePreviewGeometry({
+      gridLxInput: 120,
+      gridLyInput: 80,
+      burialDepthInput: 1.5,
+      hsInput: 0,
+      conductorInput: 0.5,
+      nxInput: 7,
+      nyInput: 5,
+      hasRods: true,
+      rodSpacingXInput: 0,
+      rodSpacingYInput: 0,
+    });
+
+    assert.strictEqual(normalized.rodLayout.count, 4);
+    assert.strictEqual(normalized.rodLayout.intermediateCount, 0);
   });
 });


### PR DESCRIPTION
### Motivation
- Provide users the ability to place additional ground rods inside the conductor grid (not just at corners) so intermediate rods can be added at conductor intersection points to lower earth resistance. 

### Description
- Added two new form controls `rod-spacing-x` and `rod-spacing-y` in `groundgrid.html` which are shown only when `has-rods` is enabled. 
- Extended preview normalization in `src/groundgridPreviewGeometry.js` with `deriveRodLayout` and rod-spacing normalization so rod positions snap to conductor intersections and produce a `rodLayout` structure. 
- Updated preview wiring and DOM logic in `groundgrid.js` to read the spacing inputs, toggle visibility via `setRodSpacingVisibility`, include rod layout in `getPreviewParams`, and render rods in the top and elevation SVGs using `rodLayout.points`. 
- Added unit tests in `tests/groundGridPreviewGeometry.test.mjs` to verify spacing normalization and derived rod layouts. 

### Testing
- Ran targeted preview and analysis tests with `node tests/groundGrid.test.mjs && node tests/groundGridPreviewGeometry.test.mjs` and both test files completed successfully. 
- Built the site bundle with `npm run build` which completed (build warnings only). 
- Invoked the full test chain with `npm test`; the suite started and many tests ran successfully but the full chained run did not finish within this session window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de43ec2bf48324bebef5578d77c54d)