### PR TITLE
Add component coverage audit and generated gap analysis report

### DIFF
--- a/docs/component-gap-analysis.md
+++ b/docs/component-gap-analysis.md
@@ -1,0 +1,56 @@
+# Component & Attribute Gap Analysis
+
+Generated on 2026-04-14 from `componentLibrary.json`.
+
+## Missing Common Component Types
+
+- generator
+- breaker
+- fuse
+- panel
+- switchboard
+- battery
+- pv_array
+- cable
+- meter
+
+## Attribute Coverage by Existing Component Type
+
+| Component Type | Missing Attributes (common baseline) |
+| --- | --- |
+| link_source | tag, description, manufacturer, model, volts, phases, short_circuit_capacity, xr_ratio, frequency_hz |
+| mcc | tag, description, manufacturer, model, phases, kw, efficiency, power_factor |
+| recloser | tag, description, manufacturer, model, phases, pickup_amps, time_dial, interrupting_rating_ka |
+| relay | tag, description, manufacturer, model, volts, phases, pickup_amps, interrupting_rating_ka |
+| static_load | tag, description, manufacturer, model, phases, kw, kvar, demand_factor |
+| motor_load | tag, description, manufacturer, model, phases, kw, power_factor |
+| ats | tag, description, manufacturer, model, volts, phases |
+| auto_transformer | tag, description, manufacturer, model, volts, phases |
+| class_rk1 | tag, description, manufacturer, model, volts, phases |
+| contactor | tag, description, manufacturer, model, volts, phases |
+| ct | tag, description, manufacturer, model, volts, phases |
+| double_throw | tag, description, manufacturer, model, volts, phases |
+| grounding_transformer | tag, description, manufacturer, model, volts, phases |
+| hv_cb | tag, description, manufacturer, model, volts, phases |
+| link_target | tag, description, manufacturer, model, volts, phases |
+| lv_cb | tag, description, manufacturer, model, volts, phases |
+| mv_cb | tag, description, manufacturer, model, volts, phases |
+| single_throw | tag, description, manufacturer, model, volts, phases |
+| text_box | tag, description, manufacturer, model, volts, phases |
+| three_winding | tag, description, manufacturer, model, volts, phases |
+| two_winding | tag, description, manufacturer, model, volts, phases |
+| vt | tag, description, manufacturer, model, volts, phases |
+| asynchronous | tag, description, manufacturer, model, phases |
+| bus | tag, description, manufacturer, model, phases |
+| feeder | tag, description, manufacturer, model, phases |
+| pv_inverter | tag, description, manufacturer, model, phases |
+| reactor | tag, description, manufacturer, model, phases |
+| shunt_capacitor_bank | tag, description, manufacturer, model, phases |
+| synchronous | tag, description, manufacturer, model, phases |
+| ups | tag, description, manufacturer, model, phases |
+| utility | tag, description, manufacturer, model, phases |
+
+## Notes
+
+- Baseline attributes are derived from common fields found in peer one-line/power-system design tools.
+- This report is a heuristic gap check and should be reviewed before schema enforcement.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "e2e:next-features-integration": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js",
     "e2e:next-features-cost": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"cost estimator\"",
     "e2e:next-features-emf": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"emf\"",
-    "e2e:next-features-export": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"xlsx export|export downloads\""
+    "e2e:next-features-export": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"xlsx export|export downloads\"",
+    "audit:components": "node scripts/componentCoverageAudit.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.8.5",

--- a/scripts/componentCoverageAudit.mjs
+++ b/scripts/componentCoverageAudit.mjs
@@ -1,0 +1,129 @@
+import fs from 'node:fs/promises';
+
+const SOURCE_FILE = 'componentLibrary.json';
+const OUTPUT_FILE = 'docs/component-gap-analysis.md';
+
+const COMMON_COMPONENT_TYPES = [
+  'bus',
+  'utility',
+  'generator',
+  'transformer',
+  'breaker',
+  'fuse',
+  'relay',
+  'motor',
+  'panel',
+  'mcc',
+  'switchboard',
+  'ups',
+  'battery',
+  'pv_array',
+  'inverter',
+  'load',
+  'cable',
+  'meter',
+  'grounding_transformer',
+  'bus_duct'
+];
+
+const ATTRIBUTE_BASELINE = {
+  all: ['tag', 'description', 'manufacturer', 'model', 'volts', 'phases'],
+  source: ['short_circuit_capacity', 'xr_ratio', 'frequency_hz'],
+  transformer: ['kva', 'percent_z', 'primary_connection', 'secondary_connection'],
+  protective: ['pickup_amps', 'time_dial', 'interrupting_rating_ka'],
+  rotating: ['kw', 'efficiency', 'power_factor'],
+  load: ['kw', 'kvar', 'demand_factor'],
+  cable: ['size', 'material', 'insulation', 'ampacity', 'length']
+};
+
+function normalizeType(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+function classifyType(type) {
+  if (/utility|source|grid/.test(type)) return 'source';
+  if (/transformer/.test(type)) return 'transformer';
+  if (/breaker|fuse|relay|protection|recloser/.test(type)) return 'protective';
+  if (/motor|generator|mcc/.test(type)) return 'rotating';
+  if (/load|panel|switchboard/.test(type)) return 'load';
+  if (/cable|tray|conduit|duct/.test(type)) return 'cable';
+  return 'all';
+}
+
+function getPropKeys(component) {
+  return Object.keys(component?.props || {}).map((key) => normalizeType(key));
+}
+
+function formatList(items) {
+  return items.length ? items.join(', ') : '—';
+}
+
+async function main() {
+  const library = JSON.parse(await fs.readFile(SOURCE_FILE, 'utf8'));
+  const components = Array.isArray(library.components) ? library.components : [];
+
+  const discoveredTypes = new Set();
+  const typeToProps = new Map();
+
+  components.forEach((component) => {
+    const type = normalizeType(component?.subtype || component?.type || component?.label);
+    if (!type) return;
+    discoveredTypes.add(type);
+    typeToProps.set(type, getPropKeys(component));
+  });
+
+  const missingComponents = COMMON_COMPONENT_TYPES.filter((baselineType) => {
+    const normalized = normalizeType(baselineType);
+    return !Array.from(discoveredTypes).some((existingType) => existingType.includes(normalized) || normalized.includes(existingType));
+  });
+
+  const attributeRows = Array.from(typeToProps.entries())
+    .map(([type, props]) => {
+      const classKey = classifyType(type);
+      const expected = Array.from(new Set([
+        ...ATTRIBUTE_BASELINE.all,
+        ...(ATTRIBUTE_BASELINE[classKey] || [])
+      ])).map((item) => normalizeType(item));
+      const missing = expected.filter((key) => !props.includes(key));
+      return {
+        type,
+        expected,
+        missing
+      };
+    })
+    .sort((a, b) => b.missing.length - a.missing.length || a.type.localeCompare(b.type));
+
+  const today = new Date().toISOString().slice(0, 10);
+  const lines = [
+    '# Component & Attribute Gap Analysis',
+    '',
+    `Generated on ${today} from \`${SOURCE_FILE}\`.`,
+    '',
+    '## Missing Common Component Types',
+    '',
+    missingComponents.length
+      ? missingComponents.map((type) => `- ${type}`).join('\n')
+      : '- None from the baseline list.',
+    '',
+    '## Attribute Coverage by Existing Component Type',
+    '',
+    '| Component Type | Missing Attributes (common baseline) |',
+    '| --- | --- |',
+    ...attributeRows.map((row) => `| ${row.type} | ${formatList(row.missing)} |`),
+    '',
+    '## Notes',
+    '',
+    '- Baseline attributes are derived from common fields found in peer one-line/power-system design tools.',
+    '- This report is a heuristic gap check and should be reviewed before schema enforcement.'
+  ];
+
+  await fs.writeFile(OUTPUT_FILE, `${lines.join('\n')}\n`);
+  console.log(`Wrote ${OUTPUT_FILE}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Provide a lightweight, repeatable analysis that compares `componentLibrary.json` to a baseline set of commonly expected one-line/power-system component types and attributes to inform product planning and schema hardening. 
- Emit a human-readable artifact to make coverage gaps (missing types and missing common attributes) visible to developers and product managers.

### Description
- Add `scripts/componentCoverageAudit.mjs`, a node ES module that scans `componentLibrary.json` and writes a markdown gap report to `docs/component-gap-analysis.md`. 
- The analyzer uses a configurable baseline (common component types and attribute sets) and reports both missing baseline component types and missing baseline attributes per existing component type. 
- Commit the generated report `docs/component-gap-analysis.md` and add an npm shortcut `audit:components` in `package.json` to regenerate the report via `npm run audit:components`. 
- The generated report currently lists missing common types such as `generator`, `breaker`, `fuse`, `panel`, `switchboard`, `battery`, `pv_array`, `cable`, and `meter` and details attribute gaps per existing subtype.

### Testing
- Ran `npm run audit:components` and it completed successfully and produced `docs/component-gap-analysis.md` as expected. 
- Ran `npm run build` which completed; existing Rollup warnings about unresolved dependencies / missing exports were observed but are unrelated to this change. 
- Started the full automated test suite via `npm test`; the suite executed many tests successfully (large portion of the matrix passed) but did not complete within this environment (progressed extensively and stalled late in the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4853f2188324a80250879e87a13a)