### PR TITLE
Add meter one-line component and CT/PT validation

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -222,7 +222,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -270,7 +270,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -378,7 +378,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -426,7 +426,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -533,7 +533,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -581,7 +581,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -684,7 +684,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -732,7 +732,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -1077,14 +1077,20 @@
         },
         {
           "DeviceType": "Fuse",
-          "PropertyName": "Let-Through I²t",
+          "PropertyName": "Let-Through I\u00b2t",
           "PurposeUseCase": "Supports incident energy calculations",
           "NotesOrComments": "Used in arc flash evaluations"
         }
       ],
       "ports": [
-        { "x": 0, "y": 20 },
-        { "x": 80, "y": 20 }
+        {
+          "x": 0,
+          "y": 20
+        },
+        {
+          "x": 80,
+          "y": 20
+        }
       ]
     },
     {
@@ -1220,7 +1226,7 @@
         },
         {
           "DeviceType": "Reactor",
-          "PropertyName": "Reactance (Ω or %)",
+          "PropertyName": "Reactance (\u03a9 or %)",
           "PurposeUseCase": "Defines impedance",
           "NotesOrComments": "Used for fault calc"
         },
@@ -1232,7 +1238,7 @@
         },
         {
           "DeviceType": "Reactor",
-          "PropertyName": "Connection Type (Y/Δ)",
+          "PropertyName": "Connection Type (Y/\u0394)",
           "PurposeUseCase": "Defines phase configuration",
           "NotesOrComments": "Grounding relevance"
         },
@@ -1314,13 +1320,13 @@
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Transient Reactance (Xd’)",
+          "PropertyName": "Transient Reactance (Xd\u2019)",
           "PurposeUseCase": "Defines transient fault current",
           "NotesOrComments": "Key in protection"
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Subtransient Reactance (Xd”)",
+          "PropertyName": "Subtransient Reactance (Xd\u201d)",
           "PurposeUseCase": "Defines short circuit current",
           "NotesOrComments": "Used in protection"
         },
@@ -1460,13 +1466,13 @@
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Transient Reactance (Xd’)",
+          "PropertyName": "Transient Reactance (Xd\u2019)",
           "PurposeUseCase": "Defines transient fault current",
           "NotesOrComments": "Key in protection"
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Subtransient Reactance (Xd”)",
+          "PropertyName": "Subtransient Reactance (Xd\u201d)",
           "PurposeUseCase": "Defines short circuit current",
           "NotesOrComments": "Used in protection"
         },
@@ -1642,6 +1648,25 @@
         "mva": 0.5,
         "thevenin_mva": 0.5,
         "battery_runtime_min": 15
+      }
+    },
+    {
+      "type": "meter",
+      "subtype": "meter",
+      "label": "Meter",
+      "icon": "icons/components/Meter.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "meter_class": "revenue",
+        "ct_ratio": "",
+        "pt_ratio": "",
+        "sample_rate_hz": 1024,
+        "supports_thd": true,
+        "supports_flicker": false,
+        "supports_waveform_capture": false
       }
     },
     {
@@ -1848,13 +1873,13 @@
         },
         {
           "DeviceType": "Motor",
-          "PropertyName": "Transient Reactance (X’d)",
+          "PropertyName": "Transient Reactance (X\u2019d)",
           "PurposeUseCase": "Short circuit and stability studies",
           "NotesOrComments": "For dynamic machine modeling"
         },
         {
           "DeviceType": "Motor",
-          "PropertyName": "Subtransient Reactance (X”d)",
+          "PropertyName": "Subtransient Reactance (X\u201dd)",
           "PurposeUseCase": "Fault and transient current shaping",
           "NotesOrComments": "Key for symmetrical components"
         },

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -67,6 +67,8 @@ This ticket set translates the current component/attribute gaps into implementat
 ## CTR-COMP-004 — Add `meter` component (PQM / energy meter)
 **Component:** Revenue or power quality meter.
 
+**Status:** Completed on April 14, 2026.
+
 **Study impact:** Harmonics, load profile calibration, energy analytics, reporting.
 
 **Required attributes (minimum):**

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -222,7 +222,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -270,7 +270,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -378,7 +378,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -426,7 +426,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -533,7 +533,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -581,7 +581,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -684,7 +684,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -732,7 +732,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -1077,14 +1077,20 @@
         },
         {
           "DeviceType": "Fuse",
-          "PropertyName": "Let-Through I²t",
+          "PropertyName": "Let-Through I\u00b2t",
           "PurposeUseCase": "Supports incident energy calculations",
           "NotesOrComments": "Used in arc flash evaluations"
         }
       ],
       "ports": [
-        { "x": 0, "y": 20 },
-        { "x": 80, "y": 20 }
+        {
+          "x": 0,
+          "y": 20
+        },
+        {
+          "x": 80,
+          "y": 20
+        }
       ]
     },
     {
@@ -1220,7 +1226,7 @@
         },
         {
           "DeviceType": "Reactor",
-          "PropertyName": "Reactance (Ω or %)",
+          "PropertyName": "Reactance (\u03a9 or %)",
           "PurposeUseCase": "Defines impedance",
           "NotesOrComments": "Used for fault calc"
         },
@@ -1232,7 +1238,7 @@
         },
         {
           "DeviceType": "Reactor",
-          "PropertyName": "Connection Type (Y/Δ)",
+          "PropertyName": "Connection Type (Y/\u0394)",
           "PurposeUseCase": "Defines phase configuration",
           "NotesOrComments": "Grounding relevance"
         },
@@ -1314,13 +1320,13 @@
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Transient Reactance (Xd’)",
+          "PropertyName": "Transient Reactance (Xd\u2019)",
           "PurposeUseCase": "Defines transient fault current",
           "NotesOrComments": "Key in protection"
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Subtransient Reactance (Xd”)",
+          "PropertyName": "Subtransient Reactance (Xd\u201d)",
           "PurposeUseCase": "Defines short circuit current",
           "NotesOrComments": "Used in protection"
         },
@@ -1460,13 +1466,13 @@
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Transient Reactance (Xd’)",
+          "PropertyName": "Transient Reactance (Xd\u2019)",
           "PurposeUseCase": "Defines transient fault current",
           "NotesOrComments": "Key in protection"
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Subtransient Reactance (Xd”)",
+          "PropertyName": "Subtransient Reactance (Xd\u201d)",
           "PurposeUseCase": "Defines short circuit current",
           "NotesOrComments": "Used in protection"
         },
@@ -1642,6 +1648,25 @@
         "mva": 0.5,
         "thevenin_mva": 0.5,
         "battery_runtime_min": 15
+      }
+    },
+    {
+      "type": "meter",
+      "subtype": "meter",
+      "label": "Meter",
+      "icon": "icons/components/Meter.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "meter_class": "revenue",
+        "ct_ratio": "",
+        "pt_ratio": "",
+        "sample_rate_hz": 1024,
+        "supports_thd": true,
+        "supports_flicker": false,
+        "supports_waveform_capture": false
       }
     },
     {
@@ -1848,13 +1873,13 @@
         },
         {
           "DeviceType": "Motor",
-          "PropertyName": "Transient Reactance (X’d)",
+          "PropertyName": "Transient Reactance (X\u2019d)",
           "PurposeUseCase": "Short circuit and stability studies",
           "NotesOrComments": "For dynamic machine modeling"
         },
         {
           "DeviceType": "Motor",
-          "PropertyName": "Subtransient Reactance (X”d)",
+          "PropertyName": "Subtransient Reactance (X\u201dd)",
           "PurposeUseCase": "Fault and transient current shaping",
           "NotesOrComments": "Key for symmetrical components"
         },

--- a/docs/components.md
+++ b/docs/components.md
@@ -22,6 +22,12 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Utility, generator, and inverter sources show the `thevenin_mva` field as calculated output. The value derives from the short-circuit capacity and present base voltage. Entries such as `25 kA` are normalized to MVA using the current voltage base, while raw MVA inputs are passed through directly.
 - Source base voltage fields (`baseKV`, `kV`, `kv`, and `prefault_voltage`) mirror the active source voltage automatically. Custom overrides are highlighted with the **Custom** badge so manual entries persist without being replaced by the auto-derived value.
 
+## Meter component fields
+
+- The one-line palette now includes a `meter` component subtype for revenue and power-quality instrumentation.
+- Meter fields include `tag`, `description`, `manufacturer`, `model`, `meter_class`, `ct_ratio`, `pt_ratio`, `sample_rate_hz`, and study capability flags (`supports_thd`, `supports_flicker`, `supports_waveform_capture`).
+- Validation enforces both `ct_ratio` and `pt_ratio` when any meter study capability flag is enabled so harmonics/power-quality workflows do not run with incomplete instrument transformer scaling.
+
 ## UI consistency checklist
 
 Use this checklist when shipping UI updates so layout and component styling stay aligned with shared tokens:

--- a/docs/icons/components/Meter.svg
+++ b/docs/icons/components/Meter.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40" fill="none">
+  <rect x="6" y="6" width="68" height="28" rx="4" stroke="#1D4ED8" stroke-width="2" fill="#EFF6FF"/>
+  <circle cx="40" cy="20" r="9" stroke="#1D4ED8" stroke-width="2" fill="#DBEAFE"/>
+  <path d="M40 20L45 15" stroke="#1D4ED8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M16 20H31" stroke="#1D4ED8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M49 20H64" stroke="#1D4ED8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/icons/components/Meter.svg
+++ b/icons/components/Meter.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40" fill="none">
+  <rect x="6" y="6" width="68" height="28" rx="4" stroke="#1D4ED8" stroke-width="2" fill="#EFF6FF"/>
+  <circle cx="40" cy="20" r="9" stroke="#1D4ED8" stroke-width="2" fill="#DBEAFE"/>
+  <path d="M40 20L45 15" stroke="#1D4ED8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M16 20H31" stroke="#1D4ED8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M49 20H64" stroke="#1D4ED8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -165,6 +165,61 @@ describe('runValidation - breaker interrupt rating', () => {
   });
 });
 
+describe('runValidation - meter CT/PT completeness', () => {
+  it('flags a meter missing CT/PT ratios when metering studies are enabled', () => {
+    const components = [
+      {
+        id: 'meter-1',
+        type: 'meter',
+        props: {
+          supports_thd: true,
+          supports_flicker: false,
+          supports_waveform_capture: false,
+          ct_ratio: '',
+          pt_ratio: ''
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    assert.strictEqual(issues.length, 1);
+    assert.strictEqual(issues[0].component, 'meter-1');
+    assert.ok(issues[0].message.includes('CT ratio'));
+    assert.ok(issues[0].message.includes('PT ratio'));
+  });
+
+  it('does not flag a meter with both CT/PT ratios provided', () => {
+    const components = [
+      {
+        id: 'meter-2',
+        type: 'meter',
+        props: {
+          supports_thd: true,
+          ct_ratio: '1200:5',
+          pt_ratio: '4160:120'
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+
+  it('does not flag a meter when metering studies are disabled', () => {
+    const components = [
+      {
+        id: 'meter-3',
+        type: 'meter',
+        props: {
+          supports_thd: false,
+          supports_flicker: false,
+          supports_waveform_capture: false,
+          ct_ratio: '',
+          pt_ratio: ''
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - TCC duty violations', () => {
   it('passes through duty violation messages from studies', () => {
     const studies = {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -50,6 +50,26 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Meter ratio completeness for study-enabled metering features
+  components.forEach(c => {
+    if (c.type !== 'meter') return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const meteringEnabled = Boolean(
+      props.supports_thd
+      || props.supports_flicker
+      || props.supports_waveform_capture
+    );
+    if (!meteringEnabled) return;
+    const ctRatio = `${props.ct_ratio ?? ''}`.trim();
+    const ptRatio = `${props.pt_ratio ?? ''}`.trim();
+    if (!ctRatio || !ptRatio) {
+      issues.push({
+        component: c.id,
+        message: 'Meter requires both CT ratio and PT ratio when metering studies are enabled.'
+      });
+    }
+  });
+
   // TCC duty/coordination violations from studies
   Object.entries(studies.duty || {}).forEach(([id, msgs = []]) => {
     msgs.forEach(msg => issues.push({ component: id, message: msg }));


### PR DESCRIPTION
### Motivation
- Deliver CTR-COMP-004 by adding a study-ready `meter` subtype so harmonics/power-quality and load-profile workflows can reference explicit meter attributes.
- Prevent running metering studies with incomplete instrument transformer scaling by validating CT/PT presence when meter study features are enabled.

### Description
- Added a `meter` component definition to `componentLibrary.json` and the docs copy (`docs/componentLibrary.json`) including fields `tag`, `description`, `manufacturer`, `model`, `meter_class`, `ct_ratio`, `pt_ratio`, `sample_rate_hz`, `supports_thd`, `supports_flicker`, and `supports_waveform_capture`.
- Added a simple `icons/components/Meter.svg` and copied it to `docs/icons/components/Meter.svg` so the component displays in the palette and docs.
- Implemented validation in `validation/rules.js` to require both `ct_ratio` and `pt_ratio` when any metering capability flag is set.
- Added unit tests in `tests/validation.test.mjs` covering the new meter validation cases and updated `docs/components.md` and `docs/component-study-ticket-backlog.md` to document the meter fields and mark CTR-COMP-004 complete.

### Testing
- Ran the new validation unit tests via the full test run (`npm test`); the validation tests for the meter cases passed, while the full suite in this environment stalled later in `tests/collaboration.test.mjs` and was terminated (new tests confirmed passing).
- Built the project with `npm run build` successfully (Rollup warnings unrelated to the meter changes were reported but the build completed).
- Attempted an automated on-page preview screenshot using Playwright, but the environment lacked the Playwright browser binary so capture failed; as a fallback the new meter SVG icon is included at `icons/components/Meter.svg` and `docs/icons/components/Meter.svg` for visual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de604d14808324ac30a6499663f19d)