### PR TITLE
Add panel component to library and validation (CTR-COMP-002)

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -53,6 +53,26 @@
       }
     },
     {
+      "type": "panel",
+      "subtype": "panel",
+      "label": "Panel",
+      "icon": "icons/components/MLO.svg",
+      "iconIEC": "icons/components/iec/IEC_Switch.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_voltage_kv": 0.48,
+        "phases": 3,
+        "bus_rating_a": 1200,
+        "main_device_type": "mcb",
+        "main_interrupting_ka": 35,
+        "grounding_type": "solidly_grounded_wye",
+        "service_type": "distribution"
+      }
+    },
+    {
       "type": "utility_source",
       "subtype": "utility",
       "label": "Utility",

--- a/dist/componentLibrary.json
+++ b/dist/componentLibrary.json
@@ -39,6 +39,40 @@
       }
     },
     {
+      "type": "bus",
+      "subtype": "dc_bus",
+      "label": "DC Bus",
+      "icon": "icons/components/DCBus.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "nominal_voltage_vdc": 750,
+        "grounding_scheme": "ungrounded",
+        "max_continuous_current_a": 1600,
+        "short_circuit_rating_ka": 35
+      }
+    },
+    {
+      "type": "panel",
+      "subtype": "panel",
+      "label": "Panel",
+      "icon": "icons/components/MLO.svg",
+      "iconIEC": "icons/components/iec/IEC_Switch.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_voltage_kv": 0.48,
+        "phases": 3,
+        "bus_rating_a": 1200,
+        "main_device_type": "mcb",
+        "main_interrupting_ka": 35,
+        "grounding_type": "solidly_grounded_wye",
+        "service_type": "distribution"
+      }
+    },
+    {
       "type": "utility_source",
       "subtype": "utility",
       "label": "Utility",
@@ -222,7 +256,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -270,7 +304,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -378,7 +412,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -426,7 +460,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -533,7 +567,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -581,7 +615,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -684,7 +718,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Connection Type (Δ/Y)",
+          "PropertyName": "Connection Type (\u0394/Y)",
           "PurposeUseCase": "Defines vector group and grounding",
           "NotesOrComments": "Determines phase shift"
         },
@@ -732,7 +766,7 @@
         },
         {
           "DeviceType": "Transformer",
-          "PropertyName": "Taps (±%)",
+          "PropertyName": "Taps (\u00b1%)",
           "PurposeUseCase": "For regulation modeling",
           "NotesOrComments": "Used in tap changer simulation"
         },
@@ -1077,14 +1111,20 @@
         },
         {
           "DeviceType": "Fuse",
-          "PropertyName": "Let-Through I²t",
+          "PropertyName": "Let-Through I\u00b2t",
           "PurposeUseCase": "Supports incident energy calculations",
           "NotesOrComments": "Used in arc flash evaluations"
         }
       ],
       "ports": [
-        { "x": 0, "y": 20 },
-        { "x": 80, "y": 20 }
+        {
+          "x": 0,
+          "y": 20
+        },
+        {
+          "x": 80,
+          "y": 20
+        }
       ]
     },
     {
@@ -1220,7 +1260,7 @@
         },
         {
           "DeviceType": "Reactor",
-          "PropertyName": "Reactance (Ω or %)",
+          "PropertyName": "Reactance (\u03a9 or %)",
           "PurposeUseCase": "Defines impedance",
           "NotesOrComments": "Used for fault calc"
         },
@@ -1232,7 +1272,7 @@
         },
         {
           "DeviceType": "Reactor",
-          "PropertyName": "Connection Type (Y/Δ)",
+          "PropertyName": "Connection Type (Y/\u0394)",
           "PurposeUseCase": "Defines phase configuration",
           "NotesOrComments": "Grounding relevance"
         },
@@ -1314,13 +1354,13 @@
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Transient Reactance (Xd’)",
+          "PropertyName": "Transient Reactance (Xd\u2019)",
           "PurposeUseCase": "Defines transient fault current",
           "NotesOrComments": "Key in protection"
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Subtransient Reactance (Xd”)",
+          "PropertyName": "Subtransient Reactance (Xd\u201d)",
           "PurposeUseCase": "Defines short circuit current",
           "NotesOrComments": "Used in protection"
         },
@@ -1460,13 +1500,13 @@
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Transient Reactance (Xd’)",
+          "PropertyName": "Transient Reactance (Xd\u2019)",
           "PurposeUseCase": "Defines transient fault current",
           "NotesOrComments": "Key in protection"
         },
         {
           "DeviceType": "Generator",
-          "PropertyName": "Subtransient Reactance (Xd”)",
+          "PropertyName": "Subtransient Reactance (Xd\u201d)",
           "PurposeUseCase": "Defines short circuit current",
           "NotesOrComments": "Used in protection"
         },
@@ -1642,6 +1682,25 @@
         "mva": 0.5,
         "thevenin_mva": 0.5,
         "battery_runtime_min": 15
+      }
+    },
+    {
+      "type": "meter",
+      "subtype": "meter",
+      "label": "Meter",
+      "icon": "icons/components/Meter.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "meter_class": "revenue",
+        "ct_ratio": "",
+        "pt_ratio": "",
+        "sample_rate_hz": 1024,
+        "supports_thd": true,
+        "supports_flicker": false,
+        "supports_waveform_capture": false
       }
     },
     {
@@ -1848,13 +1907,13 @@
         },
         {
           "DeviceType": "Motor",
-          "PropertyName": "Transient Reactance (X’d)",
+          "PropertyName": "Transient Reactance (X\u2019d)",
           "PurposeUseCase": "Short circuit and stability studies",
           "NotesOrComments": "For dynamic machine modeling"
         },
         {
           "DeviceType": "Motor",
-          "PropertyName": "Subtransient Reactance (X”d)",
+          "PropertyName": "Subtransient Reactance (X\u201dd)",
           "PurposeUseCase": "Fault and transient current shaping",
           "NotesOrComments": "Key for symmetrical components"
         },

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -32,6 +32,8 @@ This ticket set translates the current component/attribute gaps into implementat
 ## CTR-COMP-002 — Add `panel` component with feeder/load roll-up metadata
 **Component:** Distribution panelboard.
 
+**Status:** Completed on April 14, 2026.
+
 **Study impact:** Load flow, short-circuit, arc flash labeling, panel schedules.
 
 **Required attributes (minimum):**

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -53,6 +53,26 @@
       }
     },
     {
+      "type": "panel",
+      "subtype": "panel",
+      "label": "Panel",
+      "icon": "icons/components/MLO.svg",
+      "iconIEC": "icons/components/iec/IEC_Switch.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_voltage_kv": 0.48,
+        "phases": 3,
+        "bus_rating_a": 1200,
+        "main_device_type": "mcb",
+        "main_interrupting_ka": 35,
+        "grounding_type": "solidly_grounded_wye",
+        "service_type": "distribution"
+      }
+    },
+    {
       "type": "utility_source",
       "subtype": "utility",
       "label": "Utility",

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -274,6 +274,81 @@ describe('runValidation - dc_bus required attributes', () => {
   });
 });
 
+describe('runValidation - panel required attributes', () => {
+  it('flags a panel when required fields are missing', () => {
+    const components = [
+      {
+        id: 'panel-ref',
+        type: 'bus',
+        connections: [{ target: 'panel-1' }]
+      },
+      {
+        id: 'panel-1',
+        type: 'panel',
+        subtype: 'panel',
+        connections: [{ target: 'panel-ref' }],
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          rated_voltage_kv: 0,
+          phases: 0,
+          bus_rating_a: '',
+          main_device_type: '',
+          main_interrupting_ka: null,
+          grounding_type: '',
+          service_type: ''
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const panelIssue = issues.find(issue => issue.component === 'panel-1');
+    assert.ok(panelIssue);
+    assert.ok(panelIssue.message.includes('tag'));
+    assert.ok(panelIssue.message.includes('description'));
+    assert.ok(panelIssue.message.includes('manufacturer'));
+    assert.ok(panelIssue.message.includes('model'));
+    assert.ok(panelIssue.message.includes('rated_voltage_kv'));
+    assert.ok(panelIssue.message.includes('phases'));
+    assert.ok(panelIssue.message.includes('bus_rating_a'));
+    assert.ok(panelIssue.message.includes('main_device_type'));
+    assert.ok(panelIssue.message.includes('main_interrupting_ka'));
+    assert.ok(panelIssue.message.includes('grounding_type'));
+    assert.ok(panelIssue.message.includes('service_type'));
+  });
+
+  it('does not flag a panel with all required fields present', () => {
+    const components = [
+      {
+        id: 'panel-ref-2',
+        type: 'bus',
+        connections: [{ target: 'panel-2' }]
+      },
+      {
+        id: 'panel-2',
+        type: 'panel',
+        subtype: 'panel',
+        connections: [{ target: 'panel-ref-2' }],
+        props: {
+          tag: 'PNL-1A',
+          description: 'Main lighting panel',
+          manufacturer: 'Square D',
+          model: 'NQOD',
+          rated_voltage_kv: 0.48,
+          phases: 3,
+          bus_rating_a: 1200,
+          main_device_type: 'mcb',
+          main_interrupting_ka: 35,
+          grounding_type: 'solidly_grounded_wye',
+          service_type: 'distribution'
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - TCC duty violations', () => {
   it('passes through duty violation messages from studies', () => {
     const studies = {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -91,6 +91,35 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Panel required field completeness for panel studies and reports
+  components.forEach(c => {
+    const isPanel = c?.type === 'panel' || c?.subtype === 'panel' || c?.subtype === 'Panel';
+    if (!isPanel) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    const ratedVoltageKv = Number(props.rated_voltage_kv);
+    if (!Number.isFinite(ratedVoltageKv) || ratedVoltageKv <= 0) missing.push('rated_voltage_kv');
+    const phases = Number(props.phases);
+    if (!Number.isFinite(phases) || phases <= 0) missing.push('phases');
+    const busRatingA = Number(props.bus_rating_a);
+    if (!Number.isFinite(busRatingA) || busRatingA <= 0) missing.push('bus_rating_a');
+    if (!`${props.main_device_type ?? ''}`.trim()) missing.push('main_device_type');
+    const mainInterruptingKa = Number(props.main_interrupting_ka);
+    if (!Number.isFinite(mainInterruptingKa) || mainInterruptingKa <= 0) missing.push('main_interrupting_ka');
+    if (!`${props.grounding_type ?? ''}`.trim()) missing.push('grounding_type');
+    if (!`${props.service_type ?? ''}`.trim()) missing.push('service_type');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Panel missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
   // TCC duty/coordination violations from studies
   Object.entries(studies.duty || {}).forEach(([id, msgs = []]) => {
     msgs.forEach(msg => issues.push({ component: id, message: msg }));


### PR DESCRIPTION
### Motivation
- Implement ticket CTR-COMP-002 by adding a study-ready distribution panelboard component so load-flow, short-circuit, arc-flash, and schedule exports can consume explicit panel metadata.

### Description
- Added a `panel` component definition to `componentLibrary.json` with study-facing props and icon/IEC icon and synced the same entry into `dist/componentLibrary.json` and `docs/componentLibrary.json`.
- Extended `validation/rules.js` to check panel components for required attributes and emit clear validation messages when fields are missing.
- Added regression tests in `tests/validation.test.mjs` covering both failing and passing panel attribute scenarios.
- Marked the ticket complete in `docs/component-study-ticket-backlog.md` and updated distributed docs copy.

### Testing
- Ran `node tests/validation.test.mjs` and the suite passed, including the new panel validation tests.
- Ran `npm run build` and the build completed successfully in this environment.
- Kicked off `npm test` (full suite); it progressed through a large portion of tests but stalled on collaboration-related tests in this environment, so targeted validation tests were used to confirm behavior.
- Attempted to capture an oneline UI preview via Playwright but the environment lacks Playwright browser binaries (`npx playwright install` required), so a screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de70fb320c8324a923285955a26c9e)