### PR TITLE
Add switchboard component (CTR-COMP-003) with schema, validation, tests, and docs

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -73,6 +73,26 @@
       }
     },
     {
+      "type": "switchboard",
+      "subtype": "switchboard",
+      "label": "Switchboard",
+      "icon": "icons/components/Switchboard.svg",
+      "iconIEC": "icons/components/iec/IEC_Breaker.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_voltage_kv": 0.48,
+        "phases": 3,
+        "bus_rating_a": 4000,
+        "withstand_1s_ka": 65,
+        "interrupting_ka": 65,
+        "arc_resistant_type": "none",
+        "maintenance_mode_supported": false
+      }
+    },
+    {
       "type": "utility_source",
       "subtype": "utility",
       "label": "Utility",

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -51,6 +51,8 @@ This ticket set translates the current component/attribute gaps into implementat
 ## CTR-COMP-003 — Add `switchboard` / switchgear lineup component
 **Component:** LV/MV switchboard block.
 
+**Status:** Completed on April 14, 2026.
+
 **Study impact:** Short circuit, arc flash, protection coordination, protection zones.
 
 **Required attributes (minimum):**

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -73,6 +73,26 @@
       }
     },
     {
+      "type": "switchboard",
+      "subtype": "switchboard",
+      "label": "Switchboard",
+      "icon": "icons/components/Switchboard.svg",
+      "iconIEC": "icons/components/iec/IEC_Breaker.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_voltage_kv": 0.48,
+        "phases": 3,
+        "bus_rating_a": 4000,
+        "withstand_1s_ka": 65,
+        "interrupting_ka": 65,
+        "arc_resistant_type": "none",
+        "maintenance_mode_supported": false
+      }
+    },
+    {
       "type": "utility_source",
       "subtype": "utility",
       "label": "Utility",

--- a/docs/components.md
+++ b/docs/components.md
@@ -34,6 +34,12 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - DC bus fields include `tag`, `description`, `nominal_voltage_vdc`, `grounding_scheme`, `max_continuous_current_a`, and `short_circuit_rating_ka`.
 - Validation flags DC bus records missing any of the required DC study fields so DC short-circuit and DC arc-flash workflows do not run on incomplete bus metadata.
 
+## Switchboard component fields
+
+- The one-line palette now includes a `switchboard` subtype for LV/MV lineup modeling.
+- Switchboard fields include `tag`, `description`, `manufacturer`, `model`, `rated_voltage_kv`, `phases`, `bus_rating_a`, `withstand_1s_ka`, `interrupting_ka`, `arc_resistant_type`, and `maintenance_mode_supported`.
+- Validation flags switchboard records missing any required short-circuit and protection metadata so study inputs are complete before execution.
+
 ## UI consistency checklist
 
 Use this checklist when shipping UI updates so layout and component styling stay aligned with shared tokens:

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -349,6 +349,81 @@ describe('runValidation - panel required attributes', () => {
   });
 });
 
+describe('runValidation - switchboard required attributes', () => {
+  it('flags a switchboard when required fields are missing', () => {
+    const components = [
+      {
+        id: 'switchboard-ref',
+        type: 'bus',
+        connections: [{ target: 'swbd-1' }]
+      },
+      {
+        id: 'swbd-1',
+        type: 'switchboard',
+        subtype: 'switchboard',
+        connections: [{ target: 'switchboard-ref' }],
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          rated_voltage_kv: 0,
+          phases: 0,
+          bus_rating_a: '',
+          withstand_1s_ka: '',
+          interrupting_ka: null,
+          arc_resistant_type: '',
+          maintenance_mode_supported: 'yes'
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const switchboardIssue = issues.find(issue => issue.component === 'swbd-1');
+    assert.ok(switchboardIssue);
+    assert.ok(switchboardIssue.message.includes('tag'));
+    assert.ok(switchboardIssue.message.includes('description'));
+    assert.ok(switchboardIssue.message.includes('manufacturer'));
+    assert.ok(switchboardIssue.message.includes('model'));
+    assert.ok(switchboardIssue.message.includes('rated_voltage_kv'));
+    assert.ok(switchboardIssue.message.includes('phases'));
+    assert.ok(switchboardIssue.message.includes('bus_rating_a'));
+    assert.ok(switchboardIssue.message.includes('withstand_1s_ka'));
+    assert.ok(switchboardIssue.message.includes('interrupting_ka'));
+    assert.ok(switchboardIssue.message.includes('arc_resistant_type'));
+    assert.ok(switchboardIssue.message.includes('maintenance_mode_supported'));
+  });
+
+  it('does not flag a switchboard with all required fields present', () => {
+    const components = [
+      {
+        id: 'switchboard-ref-2',
+        type: 'bus',
+        connections: [{ target: 'swbd-2' }]
+      },
+      {
+        id: 'swbd-2',
+        type: 'switchboard',
+        subtype: 'switchboard',
+        connections: [{ target: 'switchboard-ref-2' }],
+        props: {
+          tag: 'SWBD-MAIN',
+          description: 'Main LV switchboard',
+          manufacturer: 'Eaton',
+          model: 'Pow-R-Line',
+          rated_voltage_kv: 0.48,
+          phases: 3,
+          bus_rating_a: 4000,
+          withstand_1s_ka: 65,
+          interrupting_ka: 65,
+          arc_resistant_type: 'type_2b',
+          maintenance_mode_supported: true
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - TCC duty violations', () => {
   it('passes through duty violation messages from studies', () => {
     const studies = {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -120,6 +120,36 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Switchboard required field completeness for fault/protection studies
+  components.forEach(c => {
+    const isSwitchboard = c?.type === 'switchboard' || c?.subtype === 'switchboard';
+    if (!isSwitchboard) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    const ratedVoltageKv = Number(props.rated_voltage_kv);
+    if (!Number.isFinite(ratedVoltageKv) || ratedVoltageKv <= 0) missing.push('rated_voltage_kv');
+    const phases = Number(props.phases);
+    if (!Number.isFinite(phases) || phases <= 0) missing.push('phases');
+    const busRatingA = Number(props.bus_rating_a);
+    if (!Number.isFinite(busRatingA) || busRatingA <= 0) missing.push('bus_rating_a');
+    const withstand1sKa = Number(props.withstand_1s_ka);
+    if (!Number.isFinite(withstand1sKa) || withstand1sKa <= 0) missing.push('withstand_1s_ka');
+    const interruptingKa = Number(props.interrupting_ka);
+    if (!Number.isFinite(interruptingKa) || interruptingKa <= 0) missing.push('interrupting_ka');
+    if (!`${props.arc_resistant_type ?? ''}`.trim()) missing.push('arc_resistant_type');
+    if (typeof props.maintenance_mode_supported !== 'boolean') missing.push('maintenance_mode_supported');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Switchboard missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
   // TCC duty/coordination violations from studies
   Object.entries(studies.duty || {}).forEach(([id, msgs = []]) => {
     msgs.forEach(msg => issues.push({ component: id, message: msg }));


### PR DESCRIPTION
### Motivation
- Implement backlog ticket `CTR-COMP-003` to add a first-class `switchboard` one-line component so protection and short-circuit studies can consume lineup metadata. 
- Ensure study safety by validating that switchboard records include required ratings and flags before executing protection and fault workflows.

### Description
- Added a `switchboard` subtype to the component library in `componentLibrary.json` and the docs copy `docs/componentLibrary.json` with props including `tag`, `description`, `manufacturer`, `model`, `rated_voltage_kv`, `phases`, `bus_rating_a`, `withstand_1s_ka`, `interrupting_ka`, `arc_resistant_type`, and `maintenance_mode_supported`.
- Extended validation logic in `validation/rules.js` to enforce presence and numeric validity of the required `switchboard` fields and to emit clear missing-attribute messages.
- Added unit tests in `tests/validation.test.mjs` that cover both the failing (missing fields / wrong types) and passing (all required fields present) cases for `switchboard` validation.
- Updated user docs in `docs/components.md` and marked the ticket complete in `docs/component-study-ticket-backlog.md` so the new subtype and its required fields are documented.

### Testing
- Ran `node tests/validation.test.mjs` and all validation tests (including the new `switchboard` cases) passed successfully.
- Ran `npm run build` and the build completed successfully in this environment.
- Attempted to run the full suite via `npm test`; the full test run was initiated but did not complete within the environment/time window (validation tests executed and passed before the run continued into longer suites).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de744c549c832491945226a34dbb35)