### PR TITLE
Add battery one-line component with required-field validation

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -1705,6 +1705,27 @@
       }
     },
     {
+      "type": "battery",
+      "subtype": "battery",
+      "label": "Battery",
+      "icon": "icons/components/UPS.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "nominal_voltage_vdc": 480,
+        "cell_chemistry": "li_ion",
+        "cell_count": 144,
+        "capacity_ah": 200,
+        "internal_resistance_ohm": 0.05,
+        "initial_soc_pct": 50,
+        "min_soc_pct": 20,
+        "max_charge_current_a": 100,
+        "max_discharge_current_a": 100
+      }
+    },
+    {
       "type": "meter",
       "subtype": "meter",
       "label": "Meter",

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -13,6 +13,8 @@ This ticket set translates the current component/attribute gaps into implementat
 ## CTR-COMP-001 — Add `battery` one-line component
 **Component:** Stationary battery / battery bank.
 
+**Status:** Completed on April 14, 2026.
+
 **Study impact:** DC short circuit, DC arc flash, battery / UPS sizing, time-series dispatch.
 
 **Required attributes (minimum):**

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -1705,6 +1705,27 @@
       }
     },
     {
+      "type": "battery",
+      "subtype": "battery",
+      "label": "Battery",
+      "icon": "icons/components/UPS.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "nominal_voltage_vdc": 480,
+        "cell_chemistry": "li_ion",
+        "cell_count": 144,
+        "capacity_ah": 200,
+        "internal_resistance_ohm": 0.05,
+        "initial_soc_pct": 50,
+        "min_soc_pct": 20,
+        "max_charge_current_a": 100,
+        "max_discharge_current_a": 100
+      }
+    },
+    {
       "type": "meter",
       "subtype": "meter",
       "label": "Meter",

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -220,6 +220,75 @@ describe('runValidation - meter CT/PT completeness', () => {
   });
 });
 
+describe('runValidation - battery required attributes', () => {
+  it('flags a battery when required fields are missing', () => {
+    const components = [
+      {
+        id: 'battery-1',
+        type: 'battery',
+        subtype: 'battery',
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          nominal_voltage_vdc: 0,
+          cell_chemistry: '',
+          cell_count: 0,
+          capacity_ah: '',
+          internal_resistance_ohm: -1,
+          initial_soc_pct: 120,
+          min_soc_pct: -5,
+          max_charge_current_a: null,
+          max_discharge_current_a: ''
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const batteryIssue = issues.find(issue => issue.component === 'battery-1');
+    assert.ok(batteryIssue);
+    assert.ok(batteryIssue.message.includes('tag'));
+    assert.ok(batteryIssue.message.includes('description'));
+    assert.ok(batteryIssue.message.includes('manufacturer'));
+    assert.ok(batteryIssue.message.includes('model'));
+    assert.ok(batteryIssue.message.includes('nominal_voltage_vdc'));
+    assert.ok(batteryIssue.message.includes('cell_chemistry'));
+    assert.ok(batteryIssue.message.includes('cell_count'));
+    assert.ok(batteryIssue.message.includes('capacity_ah'));
+    assert.ok(batteryIssue.message.includes('internal_resistance_ohm'));
+    assert.ok(batteryIssue.message.includes('initial_soc_pct'));
+    assert.ok(batteryIssue.message.includes('min_soc_pct'));
+    assert.ok(batteryIssue.message.includes('max_charge_current_a'));
+    assert.ok(batteryIssue.message.includes('max_discharge_current_a'));
+  });
+
+  it('does not flag a battery with all required fields present', () => {
+    const components = [
+      {
+        id: 'battery-2',
+        type: 'battery',
+        subtype: 'battery',
+        props: {
+          tag: 'BAT-01',
+          description: 'UPS battery bank',
+          manufacturer: 'Test Manufacturer',
+          model: 'LFP-1000',
+          nominal_voltage_vdc: 480,
+          cell_chemistry: 'li_ion',
+          cell_count: 144,
+          capacity_ah: 200,
+          internal_resistance_ohm: 0.05,
+          initial_soc_pct: 75,
+          min_soc_pct: 20,
+          max_charge_current_a: 100,
+          max_discharge_current_a: 120
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - dc_bus required attributes', () => {
   it('flags a dc_bus when required fields are missing', () => {
     const components = [

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -70,6 +70,41 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Battery required field completeness for DC short-circuit and battery studies
+  components.forEach(c => {
+    const isBattery = c?.type === 'battery' || c?.subtype === 'battery';
+    if (!isBattery) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    const nominalVoltageVdc = Number(props.nominal_voltage_vdc);
+    if (!Number.isFinite(nominalVoltageVdc) || nominalVoltageVdc <= 0) missing.push('nominal_voltage_vdc');
+    if (!`${props.cell_chemistry ?? ''}`.trim()) missing.push('cell_chemistry');
+    const cellCount = Number(props.cell_count);
+    if (!Number.isFinite(cellCount) || cellCount <= 0) missing.push('cell_count');
+    const capacityAh = Number(props.capacity_ah);
+    if (!Number.isFinite(capacityAh) || capacityAh <= 0) missing.push('capacity_ah');
+    const internalResistanceOhm = Number(props.internal_resistance_ohm);
+    if (!Number.isFinite(internalResistanceOhm) || internalResistanceOhm < 0) missing.push('internal_resistance_ohm');
+    const initialSocPct = Number(props.initial_soc_pct);
+    if (!Number.isFinite(initialSocPct) || initialSocPct < 0 || initialSocPct > 100) missing.push('initial_soc_pct');
+    const minSocPct = Number(props.min_soc_pct);
+    if (!Number.isFinite(minSocPct) || minSocPct < 0 || minSocPct > 100) missing.push('min_soc_pct');
+    const maxChargeCurrentA = Number(props.max_charge_current_a);
+    if (!Number.isFinite(maxChargeCurrentA) || maxChargeCurrentA <= 0) missing.push('max_charge_current_a');
+    const maxDischargeCurrentA = Number(props.max_discharge_current_a);
+    if (!Number.isFinite(maxDischargeCurrentA) || maxDischargeCurrentA <= 0) missing.push('max_discharge_current_a');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Battery missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
   // DC bus required field completeness for DC-focused studies
   components.forEach(c => {
     const isDcBus = c?.subtype === 'dc_bus';


### PR DESCRIPTION
### Motivation
- Provide study-ready support for stationary batteries so DC short-circuit, DC arc-flash, UPS sizing and BESS dispatch workflows can consume explicit battery metadata.
- Ensure library, UI prefill and automated validation enforce a minimal, consistent battery schema so projects remain importable and studies do not rely on fragile fallbacks.

### Description
- Added a `battery` component entry to the component library in `componentLibrary.json` (and synced copy in `docs/componentLibrary.json`) with default props including `tag`, `manufacturer`, `model`, `nominal_voltage_vdc`, `cell_chemistry`, `cell_count`, `capacity_ah`, `internal_resistance_ohm`, `initial_soc_pct`, `min_soc_pct`, `max_charge_current_a`, and `max_discharge_current_a`.
- Implemented required-field and range validation for batteries in `validation/rules.js` which accumulates missing/invalid attributes and emits a single message listing the offending keys.
- Added unit tests in `tests/validation.test.mjs` covering both failing and passing battery validation scenarios.
- Marked ticket `CTR-COMP-001` as completed in `docs/component-study-ticket-backlog.md` and updated the docs copy of the library in `docs/componentLibrary.json`.

### Testing
- Ran `node tests/validation.test.mjs` which passed and validated the new battery checks.
- Ran `npm run build` which completed successfully and produced the build artifacts used to sync the `docs/` copy of the library.
- Started `npm test` (full suite); a large subset of the test suite executed successfully but the full run was terminated in this environment so the full-suite result is partial rather than a clean green.
- Attempted to capture a UI preview with Playwright (`npx playwright screenshot`), but the run failed because Playwright browser binaries are not installed in this environment and `npx playwright install` would be required to produce the screenshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7c12e81c832499646b11f9a7457a)