### PR TITLE
Add relay_87 differential relay component and validation (CTR-COMP-007)

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -2146,6 +2146,75 @@
     },
     {
       "type": "relay",
+      "subtype": "relay_87",
+      "label": "Differential Relay (87)",
+      "icon": "icons/placeholder.svg",
+      "props": {
+        "tag": "87R-1",
+        "description": "Differential protection relay",
+        "manufacturer": "",
+        "model": "",
+        "protected_zone_type": "bus",
+        "pickup_pu": 0.35,
+        "slope1_pct": 25,
+        "slope2_pct": 45,
+        "breakpoint_pu": 2.0,
+        "inrush_blocking_enabled": true,
+        "second_harmonic_pct": 15
+      },
+      "ports": [
+        {
+          "x": 20,
+          "y": 0
+        }
+      ],
+      "deviceProperties": [
+        {
+          "DeviceType": "Relay",
+          "PropertyName": "Protected Zone Type",
+          "PurposeUseCase": "Defines what differential zone is protected",
+          "NotesOrComments": "Valid values: bus, transformer, generator"
+        },
+        {
+          "DeviceType": "Relay",
+          "PropertyName": "Pickup (pu)",
+          "PurposeUseCase": "Sets minimum differential current pickup",
+          "NotesOrComments": "Used when building differential characteristic"
+        },
+        {
+          "DeviceType": "Relay",
+          "PropertyName": "Slope 1 (%)",
+          "PurposeUseCase": "Low-bias restraint slope",
+          "NotesOrComments": "First segment of dual-slope characteristic"
+        },
+        {
+          "DeviceType": "Relay",
+          "PropertyName": "Slope 2 (%)",
+          "PurposeUseCase": "High-bias restraint slope",
+          "NotesOrComments": "Second segment of dual-slope characteristic"
+        },
+        {
+          "DeviceType": "Relay",
+          "PropertyName": "Breakpoint (pu)",
+          "PurposeUseCase": "Transition bias point between slope segments",
+          "NotesOrComments": "Used for dual-slope characteristic plotting"
+        },
+        {
+          "DeviceType": "Relay",
+          "PropertyName": "Inrush Blocking Enabled",
+          "PurposeUseCase": "Blocks tripping for inrush events",
+          "NotesOrComments": "Uses second-harmonic supervision"
+        },
+        {
+          "DeviceType": "Relay",
+          "PropertyName": "Second Harmonic (%)",
+          "PurposeUseCase": "Defines harmonic threshold for inrush blocking",
+          "NotesOrComments": "Applied when inrush blocking is enabled"
+        }
+      ]
+    },
+    {
+      "type": "relay",
       "label": "Relay",
       "icon": "icons/placeholder.svg",
       "props": {

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -127,6 +127,8 @@ This ticket set translates the current component/attribute gaps into implementat
 ## CTR-COMP-007 — Add differential protection relay component (`relay_87`)
 **Component:** Bus/transformer/generator differential relay.
 
+**Status:** Completed on April 14, 2026.
+
 **Study impact:** Differential protection characteristic plotting and settings checks.
 
 **Required attributes (minimum):**

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -493,6 +493,67 @@ describe('runValidation - switchboard required attributes', () => {
   });
 });
 
+
+
+describe('runValidation - relay_87 required attributes', () => {
+  it('flags a relay_87 when required fields are missing', () => {
+    const components = [
+      {
+        id: 'relay-87-1',
+        type: 'relay',
+        subtype: 'relay_87',
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          protected_zone_type: 'line',
+          pickup_pu: 0,
+          slope1_pct: '',
+          slope2_pct: null,
+          breakpoint_pu: -1,
+          inrush_blocking_enabled: 'yes',
+          second_harmonic_pct: -5
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const relayIssue = issues.find(issue => issue.component === 'relay-87-1');
+    assert.ok(relayIssue);
+    assert.ok(relayIssue.message.includes('protected_zone_type'));
+    assert.ok(relayIssue.message.includes('pickup_pu'));
+    assert.ok(relayIssue.message.includes('slope1_pct'));
+    assert.ok(relayIssue.message.includes('slope2_pct'));
+    assert.ok(relayIssue.message.includes('breakpoint_pu'));
+    assert.ok(relayIssue.message.includes('inrush_blocking_enabled'));
+    assert.ok(relayIssue.message.includes('second_harmonic_pct'));
+  });
+
+  it('does not flag a relay_87 with all required fields present', () => {
+    const components = [
+      {
+        id: 'relay-87-2',
+        type: 'relay',
+        subtype: 'relay_87',
+        props: {
+          tag: '87R-2',
+          description: 'Transformer differential relay',
+          manufacturer: 'SEL',
+          model: '487E',
+          protected_zone_type: 'transformer',
+          pickup_pu: 0.35,
+          slope1_pct: 25,
+          slope2_pct: 45,
+          breakpoint_pu: 2.0,
+          inrush_blocking_enabled: true,
+          second_harmonic_pct: 15
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - TCC duty violations', () => {
   it('passes through duty violation messages from studies', () => {
     const studies = {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -185,6 +185,38 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+
+  // Differential relay (87) required field completeness
+  components.forEach(c => {
+    const isRelay87 = c?.subtype === 'relay_87';
+    if (!isRelay87) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    const zone = `${props.protected_zone_type ?? ''}`.trim();
+    if (!['bus', 'transformer', 'generator'].includes(zone)) missing.push('protected_zone_type');
+    const pickupPu = Number(props.pickup_pu);
+    if (!Number.isFinite(pickupPu) || pickupPu <= 0) missing.push('pickup_pu');
+    const slope1 = Number(props.slope1_pct);
+    if (!Number.isFinite(slope1) || slope1 <= 0) missing.push('slope1_pct');
+    const slope2 = Number(props.slope2_pct);
+    if (!Number.isFinite(slope2) || slope2 <= 0) missing.push('slope2_pct');
+    const breakpointPu = Number(props.breakpoint_pu);
+    if (!Number.isFinite(breakpointPu) || breakpointPu <= 0) missing.push('breakpoint_pu');
+    if (typeof props.inrush_blocking_enabled !== 'boolean') missing.push('inrush_blocking_enabled');
+    const secondHarmonic = Number(props.second_harmonic_pct);
+    if (!Number.isFinite(secondHarmonic) || secondHarmonic < 0) missing.push('second_harmonic_pct');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Differential relay missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
   // TCC duty/coordination violations from studies
   Object.entries(studies.duty || {}).forEach(([id, msgs = []]) => {
     msgs.forEach(msg => issues.push({ component: id, message: msg }));


### PR DESCRIPTION
### Motivation
- Implement the CTR-COMP-007 ticket to add a study-ready differential protection relay so differential protection studies can consume explicit settings and validation can prevent running studies with incomplete inputs.
- Provide a library entry and metadata so the one-line editor and export flows can surface the new relay subtype in the palette and property editor.
- Ensure the validation framework enforces the required fields for `relay_87` to meet the acceptable outcome in the backlog.

### Description
- Added a new `relay_87` component definition to `componentLibrary.json` including properties `protected_zone_type`, `pickup_pu`, `slope1_pct`, `slope2_pct`, `breakpoint_pu`, `inrush_blocking_enabled`, and `second_harmonic_pct`, plus descriptive `deviceProperties` metadata.
- Extended `validation/rules.js` with checks that flag `relay_87` components missing or containing invalid required attributes and emit a clear, human-readable message listing missing fields.
- Added unit tests in `tests/validation.test.mjs` that assert invalid `relay_87` payloads are flagged and valid payloads pass validation.
- Updated `docs/component-study-ticket-backlog.md` to mark CTR-COMP-007 as completed and reflect the new required attributes and status.

### Testing
- Ran `node tests/validation.test.mjs` and all validation-related tests (including the new `relay_87` cases) passed.
- Ran `npm run build` which completed successfully but produced Rollup warnings about unresolved/missing exports unrelated to the changes (build succeeded with warnings).
- Attempted `npm test` (full suite) but the full run stalls in this environment around `tests/collaboration.test.mjs`, so the complete CI suite was not finished here.
- Attempted to create a webpage preview screenshot via Playwright, but browser tooling could not be installed in this environment (`npx playwright install chromium` failed with HTTP 403), so no preview image could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de812bc51883248b9d7bedcd7b1a1e)