### PR TITLE
Add pv_inverter/bess_inverter/rectifier subtypes and study attributes (CTR-COMP-009)

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -1721,7 +1721,20 @@
         "electrode_config": "VCB",
         "mva": 1.0,
         "thevenin_mva": 1.0,
-        "pf": 1.0
+        "pf": 1.0,
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_kw": 1000,
+        "rated_kva": 1000,
+        "ac_voltage_kv": 0.48,
+        "dc_voltage_v": 1000,
+        "fault_current_multiple": 1.2,
+        "thd_current_pct": 3.0,
+        "control_mode": "volt_var",
+        "volt_var_enabled": true,
+        "freq_watt_enabled": false
       },
       "deviceProperties": [
         {
@@ -1784,7 +1797,52 @@
           "PurposeUseCase": "Defines reference and safety",
           "NotesOrComments": "Used for fault modeling"
         }
-      ]
+      ],
+      "subtype": "pv_inverter"
+    },
+    {
+      "type": "bess_inverter",
+      "subtype": "bess_inverter",
+      "label": "BESS Inverter",
+      "icon": "icons/components/UPS.svg",
+      "iconIEC": "icons/components/iec/IEC_Generator.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_kw": 1500,
+        "rated_kva": 1650,
+        "ac_voltage_kv": 0.48,
+        "dc_voltage_v": 1000,
+        "fault_current_multiple": 1.2,
+        "thd_current_pct": 2.5,
+        "control_mode": "grid_forming",
+        "volt_var_enabled": true,
+        "freq_watt_enabled": true
+      }
+    },
+    {
+      "type": "rectifier",
+      "subtype": "rectifier",
+      "label": "Rectifier",
+      "icon": "icons/components/UPS.svg",
+      "iconIEC": "icons/components/iec/IEC_Transformer.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_kw": 500,
+        "rated_kva": 550,
+        "ac_voltage_kv": 0.48,
+        "dc_voltage_v": 125,
+        "fault_current_multiple": 1.1,
+        "thd_current_pct": 5.0,
+        "control_mode": "constant_voltage",
+        "volt_var_enabled": false,
+        "freq_watt_enabled": false
+      }
     },
     {
       "type": "ups",

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -166,6 +166,8 @@ This ticket set translates the current component/attribute gaps into implementat
 ---
 
 ## CTR-COMP-009 — Add inverter/converter detail expansion (`pv_inverter`, `bess_inverter`, `rectifier`)
+
+**Status:** Completed on April 14, 2026.
 **Component:** Power electronic conversion devices.
 
 **Study impact:** Harmonics, DER dispatch, volt-var behavior, fault current contribution.

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -1721,7 +1721,20 @@
         "electrode_config": "VCB",
         "mva": 1.0,
         "thevenin_mva": 1.0,
-        "pf": 1.0
+        "pf": 1.0,
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_kw": 1000,
+        "rated_kva": 1000,
+        "ac_voltage_kv": 0.48,
+        "dc_voltage_v": 1000,
+        "fault_current_multiple": 1.2,
+        "thd_current_pct": 3.0,
+        "control_mode": "volt_var",
+        "volt_var_enabled": true,
+        "freq_watt_enabled": false
       },
       "deviceProperties": [
         {
@@ -1784,7 +1797,52 @@
           "PurposeUseCase": "Defines reference and safety",
           "NotesOrComments": "Used for fault modeling"
         }
-      ]
+      ],
+      "subtype": "pv_inverter"
+    },
+    {
+      "type": "bess_inverter",
+      "subtype": "bess_inverter",
+      "label": "BESS Inverter",
+      "icon": "icons/components/UPS.svg",
+      "iconIEC": "icons/components/iec/IEC_Generator.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_kw": 1500,
+        "rated_kva": 1650,
+        "ac_voltage_kv": 0.48,
+        "dc_voltage_v": 1000,
+        "fault_current_multiple": 1.2,
+        "thd_current_pct": 2.5,
+        "control_mode": "grid_forming",
+        "volt_var_enabled": true,
+        "freq_watt_enabled": true
+      }
+    },
+    {
+      "type": "rectifier",
+      "subtype": "rectifier",
+      "label": "Rectifier",
+      "icon": "icons/components/UPS.svg",
+      "iconIEC": "icons/components/iec/IEC_Transformer.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_kw": 500,
+        "rated_kva": 550,
+        "ac_voltage_kv": 0.48,
+        "dc_voltage_v": 125,
+        "fault_current_multiple": 1.1,
+        "thd_current_pct": 5.0,
+        "control_mode": "constant_voltage",
+        "volt_var_enabled": false,
+        "freq_watt_enabled": false
+      }
     },
     {
       "type": "ups",


### PR DESCRIPTION
### Motivation
- Implement the backlog ticket `CTR-COMP-009` to expand one-line component coverage for power-electronic converters so harmonic, DER dispatch, volt‑var and fault‑contribution studies can consume explicit device parameters.
- Provide minimal study-ready attributes and selectable subtypes so converter models appear in the library and persistently expose the required metadata to analysis modules.

### Description
- Extended `pv_inverter` in `componentLibrary.json` with study attributes and normalized it to include a `subtype` of `pv_inverter` and the fields `tag`, `description`, `manufacturer`, `model`, `rated_kw`, `rated_kva`, `ac_voltage_kv`, `dc_voltage_v`, `fault_current_multiple`, `thd_current_pct`, `control_mode`, `volt_var_enabled`, and `freq_watt_enabled`.
- Added two new selectable component entries/subtypes: `bess_inverter` and `rectifier`, each with the same baseline metadata and sensible defaults for study consumption, and mirrored the same changes into `docs/componentLibrary.json` to keep runtime and docs payloads aligned.
- Marked the ticket complete by updating `docs/component-study-ticket-backlog.md` to show `CTR-COMP-009` as completed, and attempted to produce a UI preview screenshot but the environment lacks Playwright browser binaries so no automated image was produced.

### Testing
- Ran `node tests/validation.test.mjs` and the validation tests passed (no regressions for component schema checks).
- Ran `npm run build` and the build completed successfully with existing, non‑blocking Rollup warnings reported by the project toolchain.
- Started the full test suite with `npm test`; the suite progressed extensively in this environment but the run could not be allowed to finish to completion before process management intervention.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de93114a948324b262869ab221b608)