### PR TITLE
Add cable component subtype and validation (CTR-COMP-005)

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -93,6 +93,26 @@
       }
     },
     {
+      "type": "cable",
+      "subtype": "cable",
+      "label": "Cable Segment",
+      "icon": "icons/components/Feeder.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "length_ft": 100,
+        "material": "copper",
+        "insulation_type": "xlpe",
+        "temp_rating_c": 90,
+        "size_awg_kcmil": "500 kcmil",
+        "parallel_sets": 1,
+        "r_ohm_per_kft": 0.0216,
+        "x_ohm_per_kft": 0.015
+      }
+    },
+    {
       "type": "utility_source",
       "subtype": "utility",
       "label": "Utility",

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -92,6 +92,8 @@ This ticket set translates the current component/attribute gaps into implementat
 ## CTR-COMP-005 — Add `cable` network component for explicit inter-device segments
 **Component:** Cable segment/feeder segment in one-line graph.
 
+**Status:** Completed on April 14, 2026.
+
 **Study impact:** Voltage drop, short circuit (R/X path), DC fault, ampacity validation.
 
 **Required attributes (minimum):**

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -93,6 +93,26 @@
       }
     },
     {
+      "type": "cable",
+      "subtype": "cable",
+      "label": "Cable Segment",
+      "icon": "icons/components/Feeder.svg",
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "length_ft": 100,
+        "material": "copper",
+        "insulation_type": "xlpe",
+        "temp_rating_c": 90,
+        "size_awg_kcmil": "500 kcmil",
+        "parallel_sets": 1,
+        "r_ohm_per_kft": 0.0216,
+        "x_ohm_per_kft": 0.015
+      }
+    },
+    {
       "type": "utility_source",
       "subtype": "utility",
       "label": "Utility",

--- a/docs/components.md
+++ b/docs/components.md
@@ -40,6 +40,12 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Switchboard fields include `tag`, `description`, `manufacturer`, `model`, `rated_voltage_kv`, `phases`, `bus_rating_a`, `withstand_1s_ka`, `interrupting_ka`, `arc_resistant_type`, and `maintenance_mode_supported`.
 - Validation flags switchboard records missing any required short-circuit and protection metadata so study inputs are complete before execution.
 
+## Cable segment component fields
+
+- The one-line palette now includes a `cable` subtype for explicit inter-device cable segments.
+- Cable segment fields include `tag`, `description`, `manufacturer`, `model`, `length_ft`, `material`, `insulation_type`, `temp_rating_c`, `size_awg_kcmil`, `parallel_sets`, `r_ohm_per_kft`, and `x_ohm_per_kft`.
+- Validation flags cable segments missing required impedance and construction metadata so voltage-drop and short-circuit path calculations do not silently fall back to assumed values.
+
 ## Protective component normalized fields
 
 - Breakers, fuses, relays, and reclosers now share a common protection schema baseline for study ingestion.

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -493,6 +493,72 @@ describe('runValidation - switchboard required attributes', () => {
   });
 });
 
+describe('runValidation - cable required attributes', () => {
+  it('flags a cable when required fields are missing', () => {
+    const components = [
+      {
+        id: 'cable-1',
+        type: 'cable',
+        subtype: 'cable',
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          length_ft: 0,
+          material: '',
+          insulation_type: '',
+          temp_rating_c: null,
+          size_awg_kcmil: '',
+          parallel_sets: 0,
+          r_ohm_per_kft: -1,
+          x_ohm_per_kft: NaN
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const cableIssue = issues.find(issue => issue.component === 'cable-1');
+    assert.ok(cableIssue);
+    assert.ok(cableIssue.message.includes('tag'));
+    assert.ok(cableIssue.message.includes('description'));
+    assert.ok(cableIssue.message.includes('manufacturer'));
+    assert.ok(cableIssue.message.includes('model'));
+    assert.ok(cableIssue.message.includes('length_ft'));
+    assert.ok(cableIssue.message.includes('material'));
+    assert.ok(cableIssue.message.includes('insulation_type'));
+    assert.ok(cableIssue.message.includes('temp_rating_c'));
+    assert.ok(cableIssue.message.includes('size_awg_kcmil'));
+    assert.ok(cableIssue.message.includes('parallel_sets'));
+    assert.ok(cableIssue.message.includes('r_ohm_per_kft'));
+    assert.ok(cableIssue.message.includes('x_ohm_per_kft'));
+  });
+
+  it('does not flag a cable with all required fields present', () => {
+    const components = [
+      {
+        id: 'cable-2',
+        type: 'cable',
+        subtype: 'cable',
+        props: {
+          tag: 'CBL-MDB-1',
+          description: 'Feeder cable to MCC-1',
+          manufacturer: 'Prysmian',
+          model: 'XHHW-2',
+          length_ft: 420,
+          material: 'copper',
+          insulation_type: 'xlpe',
+          temp_rating_c: 90,
+          size_awg_kcmil: '500 kcmil',
+          parallel_sets: 2,
+          r_ohm_per_kft: 0.0216,
+          x_ohm_per_kft: 0.015
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 
 
 describe('runValidation - relay_87 required attributes', () => {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -185,6 +185,37 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Cable required field completeness for feeder/path impedance studies
+  components.forEach(c => {
+    const isCable = c?.type === 'cable' || c?.subtype === 'cable';
+    if (!isCable) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    const lengthFt = Number(props.length_ft);
+    if (!Number.isFinite(lengthFt) || lengthFt <= 0) missing.push('length_ft');
+    if (!`${props.material ?? ''}`.trim()) missing.push('material');
+    if (!`${props.insulation_type ?? ''}`.trim()) missing.push('insulation_type');
+    const tempRatingC = Number(props.temp_rating_c);
+    if (!Number.isFinite(tempRatingC) || tempRatingC <= 0) missing.push('temp_rating_c');
+    if (!`${props.size_awg_kcmil ?? ''}`.trim()) missing.push('size_awg_kcmil');
+    const parallelSets = Number(props.parallel_sets);
+    if (!Number.isFinite(parallelSets) || parallelSets <= 0) missing.push('parallel_sets');
+    const rOhmPerKft = Number(props.r_ohm_per_kft);
+    if (!Number.isFinite(rOhmPerKft) || rOhmPerKft < 0) missing.push('r_ohm_per_kft');
+    const xOhmPerKft = Number(props.x_ohm_per_kft);
+    if (!Number.isFinite(xOhmPerKft) || xOhmPerKft < 0) missing.push('x_ohm_per_kft');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Cable missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
 
   // Differential relay (87) required field completeness
   components.forEach(c => {


### PR DESCRIPTION
### Motivation
- Provide an explicit one-line `cable` component so studies can consume per-segment geometry and impedance instead of falling back to assumptions. 
- Ensure study inputs (voltage-drop, short-circuit, DC fault, ampacity) fail-fast when critical cable attributes are missing. 

### Description
- Added a `cable` component entry with study-facing defaults to `componentLibrary.json` and `docs/componentLibrary.json` including `length_ft`, `material`, `insulation_type`, `temp_rating_c`, `size_awg_kcmil`, `parallel_sets`, `r_ohm_per_kft`, and `x_ohm_per_kft`. 
- Implemented validation rules in `validation/rules.js` that report a `Cable missing required attributes` issue when any required cable field is absent or invalid. 
- Added unit tests in `tests/validation.test.mjs` covering both failing and passing cable validation cases. 
- Updated documentation in `docs/components.md` and marked CTR-COMP-005 complete in `docs/component-study-ticket-backlog.md`. 

### Testing
- Ran `node tests/validation.test.mjs` and the new cable validation tests passed. 
- Ran `npm run build` and the application bundles were produced successfully. 
- Attempted `npm test` (full suite); suite started but was interrupted in this environment during a long-running test (`tests/collaboration.test.mjs`) and was not completed. 
- Attempted to capture a preview screenshot with Playwright, but the environment is missing browser binaries so screenshot generation failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dead1c14e083249e0a98c07a87441a)