### PR TITLE
Add validation for capacitor/reactor tuning metadata (CTR-COMP-011)

### DIFF
--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -212,6 +212,8 @@ This ticket set translates the current component/attribute gaps into implementat
 
 **Status:** Completed on April 14, 2026.
 
+**Completion note (April 14, 2026):** Validation now enforces required capacitor/reactor tuning metadata and checks `tuning_hz` / `reactor_pct` when `detuned` is enabled.
+
 **Study impact:** Harmonic resonance scan, PF correction, capacitor bank sizing checks.
 
 **Required attributes (minimum):**

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -620,6 +620,68 @@ describe('runValidation - relay_87 required attributes', () => {
   });
 });
 
+describe('runValidation - capacitor/reactor tuning attributes', () => {
+  it('flags capacitor/reactor components when required tuning metadata is missing', () => {
+    const components = [
+      {
+        id: 'cap-1',
+        type: 'shunt_capacitor_bank',
+        subtype: 'shunt_capacitor_bank',
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          rated_kvar: 0,
+          rated_kv: '',
+          steps: -1,
+          detuned: true,
+          tuning_hz: '',
+          reactor_pct: -5,
+          switching_transient_class: ''
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const capIssue = issues.find(issue => issue.component === 'cap-1');
+    assert.ok(capIssue);
+    assert.ok(capIssue.message.includes('tag'));
+    assert.ok(capIssue.message.includes('description'));
+    assert.ok(capIssue.message.includes('manufacturer'));
+    assert.ok(capIssue.message.includes('model'));
+    assert.ok(capIssue.message.includes('rated_kvar'));
+    assert.ok(capIssue.message.includes('rated_kv'));
+    assert.ok(capIssue.message.includes('steps'));
+    assert.ok(capIssue.message.includes('tuning_hz'));
+    assert.ok(capIssue.message.includes('reactor_pct'));
+    assert.ok(capIssue.message.includes('switching_transient_class'));
+  });
+
+  it('does not flag non-detuned capacitor/reactor entries when optional tuning values are omitted', () => {
+    const components = [
+      {
+        id: 'reactor-2',
+        type: 'reactor',
+        subtype: 'reactor',
+        props: {
+          tag: 'R-201',
+          description: 'Detuning reactor block',
+          manufacturer: 'Eaton',
+          model: 'HRC-7',
+          rated_kvar: 1200,
+          rated_kv: 4.16,
+          steps: 6,
+          detuned: false,
+          tuning_hz: '',
+          reactor_pct: '',
+          switching_transient_class: 'R1'
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - TCC duty violations', () => {
   it('passes through duty violation messages from studies', () => {
     const studies = {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -216,6 +216,62 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Capacitor/reactor required tuning metadata completeness
+  components.forEach(c => {
+    const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();
+    const type = `${c?.type ?? ''}`.trim().toLowerCase();
+    const isCapacitorOrReactor = subtype === 'shunt_capacitor_bank'
+      || subtype === 'reactor'
+      || subtype === 'capacitorbank'
+      || type === 'shunt_capacitor_bank'
+      || type === 'reactor';
+    if (!isCapacitorOrReactor) return;
+
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+
+    const ratedKvar = Number(props.rated_kvar);
+    if (!Number.isFinite(ratedKvar) || ratedKvar <= 0) missing.push('rated_kvar');
+    const ratedKv = Number(props.rated_kv);
+    if (!Number.isFinite(ratedKv) || ratedKv <= 0) missing.push('rated_kv');
+    const steps = Number(props.steps);
+    if (!Number.isFinite(steps) || steps <= 0) missing.push('steps');
+
+    const hasDetuned = typeof props.detuned === 'boolean';
+    if (!hasDetuned) {
+      missing.push('detuned');
+    }
+
+    if (!`${props.switching_transient_class ?? ''}`.trim()) missing.push('switching_transient_class');
+
+    const validatePositiveOptionalNumber = (value, key) => {
+      if (value === '' || value === null || value === undefined) return;
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) missing.push(key);
+    };
+
+    if (props.detuned === true) {
+      const tuningHz = Number(props.tuning_hz);
+      if (!Number.isFinite(tuningHz) || tuningHz <= 0) missing.push('tuning_hz');
+      const reactorPct = Number(props.reactor_pct);
+      if (!Number.isFinite(reactorPct) || reactorPct <= 0) missing.push('reactor_pct');
+    } else {
+      validatePositiveOptionalNumber(props.tuning_hz, 'tuning_hz');
+      validatePositiveOptionalNumber(props.reactor_pct, 'reactor_pct');
+    }
+
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Capacitor/reactor missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
 
   // Differential relay (87) required field completeness
   components.forEach(c => {


### PR DESCRIPTION
### Motivation
- Enforce CTR-COMP-011 by validating capacitor/reactor components so harmonic and detuning studies can rely on complete tuning metadata.

### Description
- Add a capacitor/reactor validation block in `validation/rules.js` that requires baseline metadata (`tag`, `description`, `manufacturer`, `model`) and tuning fields (`rated_kvar`, `rated_kv`, `steps`, `detuned`, `switching_transient_class`).
- Require `tuning_hz` and `reactor_pct` when `detuned` is `true`, and validate provided optional tuning values when `detuned` is `false`.
- Add unit tests in `tests/validation.test.mjs` covering a failing missing-fields case and a passing non-detuned case.
- Update `docs/component-study-ticket-backlog.md` with a completion note for CTR-COMP-011.

### Testing
- Ran `node tests/validation.test.mjs` and the validation test cases passed. 
- Ran `npm run build` and the build completed successfully. 
- Attempted `npm test` (full suite); the run made substantial progress and validation-related tests passed, but the full suite could not be completed in this environment (execution was terminated/time-limited). 
- Attempted an automated page preview with Playwright (`npx playwright screenshot ...`) but browser binaries could not be downloaded (HTTP 403), so a screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb2ad2e988324aaf15c4751bbe663)