### PR TITLE
Add generator study defaults, metadata hydration, and validation

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -22,6 +22,12 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Utility, generator, and inverter sources show the `thevenin_mva` field as calculated output. The value derives from the short-circuit capacity and present base voltage. Entries such as `25 kA` are normalized to MVA using the current voltage base, while raw MVA inputs are passed through directly.
 - Source base voltage fields (`baseKV`, `kV`, `kv`, and `prefault_voltage`) mirror the active source voltage automatically. Custom overrides are highlighted with the **Custom** badge so manual entries persist without being replaced by the auto-derived value.
 
+## Generator study model fields
+
+- Generator components now pre-populate study-ready dynamic and dispatch metadata for both `synchronous` and `asynchronous` subtypes.
+- Added fields include `rated_mva`, `rated_kv`, `xdpp_pu`, `xdp_pu`, `xd_pu`, `h_constant_s`, `governor_mode`, `avr_mode`, `min_kw`, `max_kw`, and `ramp_kw_per_min`.
+- Existing diagrams are migrated in-memory so missing generator study fields are filled with safe defaults when projects load, and generator property forms mark these fields as required.
+
 ## Meter component fields
 
 - The one-line palette now includes a `meter` component subtype for revenue and power-quality instrumentation.

--- a/oneline.js
+++ b/oneline.js
@@ -1125,6 +1125,29 @@ const capacitorBankPropertyFields = [
     'Defines operation behavior. Used in network control.')
 ];
 
+const generatorStudyFieldSpecs = [
+  { name: 'rated_mva', label: 'Rated Power (MVA)', type: 'number', required: true, defaultValue: comp => {
+    const ratedKw = Number(comp?.rated_kw ?? comp?.props?.rated_kw);
+    return Number.isFinite(ratedKw) && ratedKw > 0 ? Number((ratedKw / 1000).toFixed(3)) : 1;
+  } },
+  { name: 'rated_kv', label: 'Rated Voltage (kV)', type: 'number', required: true, defaultValue: comp => {
+    const baseKv = Number(comp?.kV ?? comp?.baseKV ?? comp?.props?.kV ?? comp?.props?.baseKV);
+    return Number.isFinite(baseKv) && baseKv > 0 ? baseKv : 0.48;
+  } },
+  { name: 'xdpp_pu', label: "X''d (pu)", type: 'number', required: true, defaultValue: 0.2 },
+  { name: 'xdp_pu', label: "X'd (pu)", type: 'number', required: true, defaultValue: 0.3 },
+  { name: 'xd_pu', label: 'Xd (pu)', type: 'number', required: true, defaultValue: 1.8 },
+  { name: 'h_constant_s', label: 'Inertia Constant H (s)', type: 'number', required: true, defaultValue: 3.5 },
+  { name: 'governor_mode', label: 'Governor Mode', type: 'text', required: true, defaultValue: 'droop' },
+  { name: 'avr_mode', label: 'AVR Mode', type: 'text', required: true, defaultValue: 'automatic' },
+  { name: 'min_kw', label: 'Minimum Output (kW)', type: 'number', required: true, defaultValue: 0 },
+  { name: 'max_kw', label: 'Maximum Output (kW)', type: 'number', required: true, defaultValue: comp => {
+    const ratedKw = Number(comp?.rated_kw ?? comp?.props?.rated_kw);
+    return Number.isFinite(ratedKw) && ratedKw > 0 ? ratedKw : 1000;
+  } },
+  { name: 'ramp_kw_per_min', label: 'Ramp Rate (kW/min)', type: 'number', required: true, defaultValue: 100 }
+];
+
 const baselineComponentFieldSpecs = [
   { name: 'tag', label: 'Tag', type: 'text', required: true, defaultValue: comp => comp.ref || comp.label || comp.id || '' },
   { name: 'description', label: 'Description', type: 'text', required: true, defaultValue: comp => comp.label || '' },
@@ -1240,6 +1263,62 @@ function ensureBaselineComponentMetadata() {
         type: 'number',
         required: true
       });
+    });
+  });
+}
+
+function isGeneratorStudyComponentMeta(meta) {
+  if (!meta || typeof meta !== 'object') return false;
+  const type = `${meta.type || ''}`.trim().toLowerCase();
+  const subtype = `${meta.subtype || ''}`.trim().toLowerCase();
+  return type === 'generator' || subtype === 'generator' || subtype === 'synchronous' || subtype === 'asynchronous';
+}
+
+function ensureGeneratorStudyFieldsOnComponent(comp, meta) {
+  if (!comp || typeof comp !== 'object') return comp;
+  if (!isGeneratorStudyComponentMeta(meta || comp)) return comp;
+  if (!comp.props || typeof comp.props !== 'object') {
+    comp.props = { ...(comp.props || {}) };
+  }
+  generatorStudyFieldSpecs.forEach(spec => {
+    const hasCompValue = Object.prototype.hasOwnProperty.call(comp, spec.name) && comp[spec.name] !== '';
+    const hasPropsValue = Object.prototype.hasOwnProperty.call(comp.props, spec.name) && comp.props[spec.name] !== '';
+    if (hasCompValue || hasPropsValue) {
+      if (!hasCompValue && hasPropsValue) comp[spec.name] = comp.props[spec.name];
+      if (hasCompValue && !hasPropsValue) comp.props[spec.name] = comp[spec.name];
+      return;
+    }
+    const nextValue = typeof spec.defaultValue === 'function' ? spec.defaultValue(comp, meta) : spec.defaultValue;
+    comp[spec.name] = nextValue;
+    comp.props[spec.name] = nextValue;
+  });
+  const minKw = Number(comp.min_kw ?? comp.props.min_kw);
+  const maxKw = Number(comp.max_kw ?? comp.props.max_kw);
+  if (Number.isFinite(minKw) && Number.isFinite(maxKw) && minKw > maxKw) {
+    comp.min_kw = maxKw;
+    comp.props.min_kw = maxKw;
+  }
+  return comp;
+}
+
+function ensureGeneratorStudyMetadata() {
+  Object.entries(componentMeta).forEach(([key, meta]) => {
+    if (!isGeneratorStudyComponentMeta(meta)) return;
+    if (!meta.props || typeof meta.props !== 'object') {
+      meta.props = { ...(meta.props || {}) };
+    }
+    generatorStudyFieldSpecs.forEach(spec => {
+      if (!Object.prototype.hasOwnProperty.call(meta.props, spec.name)) {
+        const nextValue = typeof spec.defaultValue === 'function' ? spec.defaultValue(meta.props) : spec.defaultValue;
+        meta.props[spec.name] = nextValue;
+      }
+    });
+    const schemaKeys = new Set([key, meta.subtype].filter(Boolean));
+    schemaKeys.forEach(schemaKey => {
+      if (!Array.isArray(propSchemas[schemaKey])) {
+        propSchemas[schemaKey] = inferSchemaFromProps(meta.props || {});
+      }
+      generatorStudyFieldSpecs.forEach(spec => ensureBaselineFieldSchema(propSchemas[schemaKey], spec));
     });
   });
 }
@@ -1419,6 +1498,7 @@ async function loadComponentLibrary() {
   builtinComponents.forEach(def => registerDefinition(def, { allowOverride: false }));
 
   ensureCapacitorReactorPropertyMetadata();
+  ensureGeneratorStudyMetadata();
   ensureBaselineComponentMetadata();
 
   buildPalette();
@@ -5508,6 +5588,7 @@ function normalizeComponent(c) {
   }
   applyDefaults(nc);
   ensureBaselineFieldsOnComponent(nc, componentMeta[nc.subtype]);
+  ensureGeneratorStudyFieldsOnComponent(nc, componentMeta[nc.subtype]);
   return nc;
 }
 
@@ -7907,6 +7988,7 @@ function addComponent(cfg) {
   }
   applyDefaults(comp);
   ensureBaselineFieldsOnComponent(comp, meta);
+  ensureGeneratorStudyFieldsOnComponent(comp, meta);
   ensureShapeDefaults(comp);
   if (comp.type === 'transformer') {
     syncTransformerDefaults(comp, { forceBase: true });
@@ -11049,6 +11131,7 @@ async function init() {
         propSchemas[c.subtype] = inferSchemaFromProps(raw);
       }
       ensureBaselineFieldsOnComponent(c, componentMeta[c.subtype]);
+      ensureGeneratorStudyFieldsOnComponent(c, componentMeta[c.subtype]);
     });
   });
   rebuildComponentMaps();
@@ -11056,6 +11139,7 @@ async function init() {
     if (!propSchemas[sub]) propSchemas[sub] = inferSchemaFromProps(componentMeta[sub].props || {});
   });
   ensureBaselineComponentMetadata();
+  ensureGeneratorStudyMetadata();
   sheets.forEach(s => {
     s.components.forEach(c => {
       (c.connections || []).forEach(conn => {

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -620,6 +620,81 @@ describe('runValidation - relay_87 required attributes', () => {
   });
 });
 
+describe('runValidation - generator required attributes', () => {
+  it('flags a generator when required fields are missing', () => {
+    const components = [
+      {
+        id: 'gen-1',
+        type: 'generator',
+        subtype: 'synchronous',
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          rated_mva: 0,
+          rated_kv: 0,
+          xdpp_pu: 0,
+          xdp_pu: '',
+          xd_pu: -1,
+          h_constant_s: 0,
+          governor_mode: '',
+          avr_mode: '',
+          min_kw: -5,
+          max_kw: 0,
+          ramp_kw_per_min: 0
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const generatorIssue = issues.find(issue => issue.component === 'gen-1');
+    assert.ok(generatorIssue);
+    assert.ok(generatorIssue.message.includes('tag'));
+    assert.ok(generatorIssue.message.includes('description'));
+    assert.ok(generatorIssue.message.includes('manufacturer'));
+    assert.ok(generatorIssue.message.includes('model'));
+    assert.ok(generatorIssue.message.includes('rated_mva'));
+    assert.ok(generatorIssue.message.includes('rated_kv'));
+    assert.ok(generatorIssue.message.includes('xdpp_pu'));
+    assert.ok(generatorIssue.message.includes('xdp_pu'));
+    assert.ok(generatorIssue.message.includes('xd_pu'));
+    assert.ok(generatorIssue.message.includes('h_constant_s'));
+    assert.ok(generatorIssue.message.includes('governor_mode'));
+    assert.ok(generatorIssue.message.includes('avr_mode'));
+    assert.ok(generatorIssue.message.includes('min_kw'));
+    assert.ok(generatorIssue.message.includes('max_kw'));
+    assert.ok(generatorIssue.message.includes('ramp_kw_per_min'));
+  });
+
+  it('does not flag a generator with all required fields present', () => {
+    const components = [
+      {
+        id: 'gen-2',
+        type: 'generator',
+        subtype: 'asynchronous',
+        props: {
+          tag: 'GEN-2',
+          description: 'Standby generator',
+          manufacturer: 'Generac',
+          model: 'SG500',
+          rated_mva: 0.625,
+          rated_kv: 0.48,
+          xdpp_pu: 0.25,
+          xdp_pu: 0.35,
+          xd_pu: 1.9,
+          h_constant_s: 4.2,
+          governor_mode: 'droop',
+          avr_mode: 'automatic',
+          min_kw: 100,
+          max_kw: 500,
+          ramp_kw_per_min: 75
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - capacitor/reactor tuning attributes', () => {
   it('flags capacitor/reactor components when required tuning metadata is missing', () => {
     const components = [

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -216,6 +216,46 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Generator required field completeness for short-circuit/transient/dispatch studies
+  components.forEach(c => {
+    const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();
+    const type = `${c?.type ?? ''}`.trim().toLowerCase();
+    const isGenerator = type === 'generator' || subtype === 'generator' || subtype === 'synchronous' || subtype === 'asynchronous';
+    if (!isGenerator) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    const ratedMva = Number(props.rated_mva);
+    if (!Number.isFinite(ratedMva) || ratedMva <= 0) missing.push('rated_mva');
+    const ratedKv = Number(props.rated_kv);
+    if (!Number.isFinite(ratedKv) || ratedKv <= 0) missing.push('rated_kv');
+    const xdppPu = Number(props.xdpp_pu);
+    if (!Number.isFinite(xdppPu) || xdppPu <= 0) missing.push('xdpp_pu');
+    const xdpPu = Number(props.xdp_pu);
+    if (!Number.isFinite(xdpPu) || xdpPu <= 0) missing.push('xdp_pu');
+    const xdPu = Number(props.xd_pu);
+    if (!Number.isFinite(xdPu) || xdPu <= 0) missing.push('xd_pu');
+    const hConstant = Number(props.h_constant_s);
+    if (!Number.isFinite(hConstant) || hConstant <= 0) missing.push('h_constant_s');
+    if (!`${props.governor_mode ?? ''}`.trim()) missing.push('governor_mode');
+    if (!`${props.avr_mode ?? ''}`.trim()) missing.push('avr_mode');
+    const minKw = Number(props.min_kw);
+    if (!Number.isFinite(minKw) || minKw < 0) missing.push('min_kw');
+    const maxKw = Number(props.max_kw);
+    if (!Number.isFinite(maxKw) || maxKw <= 0 || (Number.isFinite(minKw) && minKw > maxKw)) missing.push('max_kw');
+    const rampKwPerMin = Number(props.ramp_kw_per_min);
+    if (!Number.isFinite(rampKwPerMin) || rampKwPerMin <= 0) missing.push('ramp_kw_per_min');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Generator missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
   // Capacitor/reactor required tuning metadata completeness
   components.forEach(c => {
     const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();


### PR DESCRIPTION
### Motivation
- Provide study-ready generator metadata so short-circuit, transient, and dispatch analyses can consume explicit generator parameters instead of heuristics.
- Ensure new study fields are hydrated for existing diagrams and surfaced as required inputs in the one-line editor to prevent silent study fallbacks.

### Description
- Introduced `generatorStudyFieldSpecs` and defaults in `oneline.js` and wired them into component metadata so `rated_mva`, `rated_kv`, `xdpp_pu`, `xdp_pu`, `xd_pu`, `h_constant_s`, `governor_mode`, `avr_mode`, `min_kw`, `max_kw`, and `ramp_kw_per_min` are auto-populated and exposed in schemas.
- Added `ensureGeneratorStudyFieldsOnComponent` and `ensureGeneratorStudyMetadata` in `oneline.js` and invoked them during library load, component normalization, and new component creation so both loaded and new generator components are hydrated.
- Added validation rules in `validation/rules.js` that assert presence and basic range sanity for the generator study fields and guard `min_kw <= max_kw` logic.
- Added unit tests in `tests/validation.test.mjs` covering both failing (missing/invalid fields) and passing generator scenarios, and updated documentation in `docs/components.md` describing the new generator study model fields.

### Testing
- Ran `node tests/validation.test.mjs` and the generator validation test cases passed locally with expected assertions.
- Ran `npm run build` successfully (build completed with standard warnings about unresolved externals during bundling but produced `dist/`).
- Attempted the full `npm test` suite; the run progressed through many tests but stalled/hung in this environment during long-running collaboration tests before completion (no validation failures were observed prior to the hang).
- Attempted to capture a webpage preview via `npx playwright screenshot` but the Playwright browser binaries were not installed in this environment so a screenshot artifact could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb695b1f08324869657931a8f829c)