### PR TITLE
Canonicalize component types in coverage audit and refresh gap analysis

### DIFF
--- a/docs/component-gap-analysis.md
+++ b/docs/component-gap-analysis.md
@@ -4,51 +4,39 @@ Generated on 2026-04-14 from `componentLibrary.json`.
 
 ## Missing Common Component Types
 
-- generator
-- breaker
-- fuse
-- panel
-- switchboard
-- battery
+- motor
 - pv_array
-- cable
-- meter
 
 ## Attribute Coverage by Existing Component Type
 
 | Component Type | Missing Attributes (common baseline) |
 | --- | --- |
-| link_source | tag, description, manufacturer, model, volts, phases, short_circuit_capacity, xr_ratio, frequency_hz |
 | mcc | tag, description, manufacturer, model, phases, kw, efficiency, power_factor |
-| recloser | tag, description, manufacturer, model, phases, pickup_amps, time_dial, interrupting_rating_ka |
-| relay | tag, description, manufacturer, model, volts, phases, pickup_amps, interrupting_rating_ka |
-| static_load | tag, description, manufacturer, model, phases, kw, kvar, demand_factor |
-| motor_load | tag, description, manufacturer, model, phases, kw, power_factor |
+| load | tag, description, manufacturer, model, phases, kw, demand_factor |
 | ats | tag, description, manufacturer, model, volts, phases |
-| auto_transformer | tag, description, manufacturer, model, volts, phases |
-| class_rk1 | tag, description, manufacturer, model, volts, phases |
+| cable | volts, phases, size, insulation, ampacity, length |
 | contactor | tag, description, manufacturer, model, volts, phases |
 | ct | tag, description, manufacturer, model, volts, phases |
 | double_throw | tag, description, manufacturer, model, volts, phases |
 | grounding_transformer | tag, description, manufacturer, model, volts, phases |
-| hv_cb | tag, description, manufacturer, model, volts, phases |
-| link_target | tag, description, manufacturer, model, volts, phases |
-| lv_cb | tag, description, manufacturer, model, volts, phases |
-| mv_cb | tag, description, manufacturer, model, volts, phases |
 | single_throw | tag, description, manufacturer, model, volts, phases |
 | text_box | tag, description, manufacturer, model, volts, phases |
-| three_winding | tag, description, manufacturer, model, volts, phases |
-| two_winding | tag, description, manufacturer, model, volts, phases |
+| transformer | tag, description, manufacturer, model, volts, phases |
 | vt | tag, description, manufacturer, model, volts, phases |
-| asynchronous | tag, description, manufacturer, model, phases |
-| bus | tag, description, manufacturer, model, phases |
-| feeder | tag, description, manufacturer, model, phases |
-| pv_inverter | tag, description, manufacturer, model, phases |
 | reactor | tag, description, manufacturer, model, phases |
-| shunt_capacitor_bank | tag, description, manufacturer, model, phases |
-| synchronous | tag, description, manufacturer, model, phases |
 | ups | tag, description, manufacturer, model, phases |
 | utility | tag, description, manufacturer, model, phases |
+| panel | volts, kw, kvar, demand_factor |
+| switchboard | volts, kw, kvar, demand_factor |
+| bus | manufacturer, model, phases |
+| generator | phases, efficiency, power_factor |
+| battery | volts, phases |
+| breaker | volts, time_dial |
+| fuse | volts, time_dial |
+| meter | volts, phases |
+| inverter | phases |
+| recloser | time_dial |
+| relay | volts |
 
 ## Notes
 

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -234,6 +234,8 @@ This ticket set translates the current component/attribute gaps into implementat
 
 **Status:** Completed on April 14, 2026.
 
+**Completion note (April 14, 2026):** Updated `scripts/componentCoverageAudit.mjs` to canonicalize subtype aliases (e.g., `synchronous`/`asynchronous` → `generator`, inverter families, breaker/fuse aliases) and aggregate attribute coverage across all matching definitions so the generated gap analysis reflects baseline progress accurately.
+
 **Study impact:** All studies (consistency, validation, report reliability).
 
 **Required attributes (minimum):**

--- a/scripts/componentCoverageAudit.mjs
+++ b/scripts/componentCoverageAudit.mjs
@@ -42,6 +42,35 @@ function normalizeType(value) {
     .toLowerCase();
 }
 
+const TYPE_ALIASES = new Map([
+  ['synchronous', 'generator'],
+  ['asynchronous', 'generator'],
+  ['pv_inverter', 'inverter'],
+  ['bess_inverter', 'inverter'],
+  ['rectifier', 'inverter'],
+  ['shunt_capacitor_bank', 'load'],
+  ['static_load', 'load'],
+  ['motor_load', 'load'],
+  ['feeder', 'load'],
+  ['link_source', 'utility'],
+  ['link_target', 'bus'],
+  ['relay_87', 'relay'],
+  ['class_rk1', 'fuse'],
+  ['lv_cb', 'breaker'],
+  ['mv_cb', 'breaker'],
+  ['hv_cb', 'breaker'],
+  ['two_winding', 'transformer'],
+  ['three_winding', 'transformer'],
+  ['auto_transformer', 'transformer'],
+  ['dc_bus', 'bus']
+]);
+
+function canonicalType(type) {
+  const normalized = normalizeType(type);
+  if (!normalized) return '';
+  return TYPE_ALIASES.get(normalized) || normalized;
+}
+
 function classifyType(type) {
   if (/utility|source|grid/.test(type)) return 'source';
   if (/transformer/.test(type)) return 'transformer';
@@ -53,7 +82,8 @@ function classifyType(type) {
 }
 
 function getPropKeys(component) {
-  return Object.keys(component?.props || {}).map((key) => normalizeType(key));
+  const props = component?.props && typeof component.props === 'object' ? component.props : {};
+  return Object.keys(props).map((key) => normalizeType(key));
 }
 
 function formatList(items) {
@@ -68,10 +98,12 @@ async function main() {
   const typeToProps = new Map();
 
   components.forEach((component) => {
-    const type = normalizeType(component?.subtype || component?.type || component?.label);
+    const type = canonicalType(component?.subtype || component?.type || component?.label);
     if (!type) return;
     discoveredTypes.add(type);
-    typeToProps.set(type, getPropKeys(component));
+    const existingProps = typeToProps.get(type) || [];
+    const mergedProps = Array.from(new Set([...existingProps, ...getPropKeys(component)]));
+    typeToProps.set(type, mergedProps);
   });
 
   const missingComponents = COMMON_COMPONENT_TYPES.filter((baselineType) => {


### PR DESCRIPTION
### Motivation
- The component coverage audit produced misleading gaps because variant subtypes and aliases (e.g., `synchronous`/`asynchronous`, inverter families, breaker/fuse aliases) were treated as distinct types and properties from multiple definitions were overwritten rather than aggregated. This made the generated gap analysis less useful for prioritizing schema work.

### Description
- Added a `TYPE_ALIASES` map and `canonicalType()` helper to `scripts/componentCoverageAudit.mjs` to map common subtype aliases into canonical baseline families (for example `synchronous` → `generator`, `pv_inverter` → `inverter`).
- Changed property aggregation so `typeToProps` merges property keys across all components of the same canonical type instead of replacing them, and made `getPropKeys` robust when `props` is absent.
- Regenerated `docs/component-gap-analysis.md` with the improved audit logic and added a completion note to `docs/component-study-ticket-backlog.md` documenting the audit canonicalization and aggregation improvement.

### Testing
- Ran `node scripts/componentCoverageAudit.mjs`, which completed successfully and wrote `docs/component-gap-analysis.md`.
- Ran the full test suite via `npm test`, which completed successfully (tests passed in the CI-like run captured here).
- Ran `npm run build`, which completed; the Rollup build emitted preexisting warnings about unresolved externals/missing exports but the build finished as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb9ce5a8c8324945fe409092bd9f5)