### PR TITLE
Align component coverage audit with CTR-COMP-012 baseline and add DC voltage handling

### DIFF
--- a/docs/component-gap-analysis.md
+++ b/docs/component-gap-analysis.md
@@ -11,32 +11,32 @@ Generated on 2026-04-14 from `componentLibrary.json`.
 
 | Component Type | Missing Attributes (common baseline) |
 | --- | --- |
-| mcc | tag, description, manufacturer, model, phases, kw, efficiency, power_factor |
-| load | tag, description, manufacturer, model, phases, kw, demand_factor |
-| ats | tag, description, manufacturer, model, volts, phases |
-| cable | volts, phases, size, insulation, ampacity, length |
-| contactor | tag, description, manufacturer, model, volts, phases |
-| ct | tag, description, manufacturer, model, volts, phases |
-| double_throw | tag, description, manufacturer, model, volts, phases |
-| grounding_transformer | tag, description, manufacturer, model, volts, phases |
-| single_throw | tag, description, manufacturer, model, volts, phases |
-| text_box | tag, description, manufacturer, model, volts, phases |
-| transformer | tag, description, manufacturer, model, volts, phases |
-| vt | tag, description, manufacturer, model, volts, phases |
-| reactor | tag, description, manufacturer, model, phases |
-| ups | tag, description, manufacturer, model, phases |
-| utility | tag, description, manufacturer, model, phases |
-| panel | volts, kw, kvar, demand_factor |
-| switchboard | volts, kw, kvar, demand_factor |
-| bus | manufacturer, model, phases |
-| generator | phases, efficiency, power_factor |
-| battery | volts, phases |
-| breaker | volts, time_dial |
-| fuse | volts, time_dial |
-| meter | volts, phases |
-| inverter | phases |
-| recloser | time_dial |
-| relay | volts |
+| mcc | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv, kw, efficiency, power_factor |
+| load | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv, kw, demand_factor |
+| ats | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| cable | phases, commissioning_state, service_status, notes, rated_voltage_kv, size, insulation, ampacity, length |
+| contactor | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| ct | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| double_throw | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| grounding_transformer | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| reactor | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| single_throw | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| text_box | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| transformer | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| ups | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| vt | tag, description, manufacturer, model, phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| utility | tag, description, manufacturer, model, phases, commissioning_state, service_status, rated_voltage_kv |
+| generator | phases, commissioning_state, service_status, notes, rated_voltage_kv, efficiency, power_factor |
+| bus | manufacturer, model, phases, commissioning_state, service_status, rated_voltage_kv |
+| panel | commissioning_state, service_status, notes, kw, kvar, demand_factor |
+| switchboard | commissioning_state, service_status, notes, kw, kvar, demand_factor |
+| inverter | phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| meter | phases, commissioning_state, service_status, notes, rated_voltage_kv |
+| battery | phases, commissioning_state, service_status, notes |
+| breaker | commissioning_state, service_status, notes, time_dial |
+| fuse | commissioning_state, service_status, notes, time_dial |
+| recloser | commissioning_state, service_status, notes, time_dial |
+| relay | commissioning_state, service_status, notes |
 
 ## Notes
 

--- a/docs/component-study-ticket-backlog.md
+++ b/docs/component-study-ticket-backlog.md
@@ -234,7 +234,7 @@ This ticket set translates the current component/attribute gaps into implementat
 
 **Status:** Completed on April 14, 2026.
 
-**Completion note (April 14, 2026):** Updated `scripts/componentCoverageAudit.mjs` to canonicalize subtype aliases (e.g., `synchronous`/`asynchronous` → `generator`, inverter families, breaker/fuse aliases) and aggregate attribute coverage across all matching definitions so the generated gap analysis reflects baseline progress accurately.
+**Completion note (April 14, 2026):** Updated `scripts/componentCoverageAudit.mjs` to canonicalize subtype aliases (e.g., `synchronous`/`asynchronous` → `generator`, inverter families, breaker/fuse aliases), aggregate attribute coverage across matching definitions, and align baseline voltage checks with the shared schema (`rated_voltage_kv` for AC assets, `nominal_voltage_vdc` for DC assets).
 
 **Study impact:** All studies (consistency, validation, report reliability).
 

--- a/scripts/componentCoverageAudit.mjs
+++ b/scripts/componentCoverageAudit.mjs
@@ -27,7 +27,7 @@ const COMMON_COMPONENT_TYPES = [
 ];
 
 const ATTRIBUTE_BASELINE = {
-  all: ['tag', 'description', 'manufacturer', 'model', 'volts', 'phases'],
+  all: ['tag', 'description', 'manufacturer', 'model', 'phases', 'commissioning_state', 'service_status', 'notes'],
   source: ['short_circuit_capacity', 'xr_ratio', 'frequency_hz'],
   transformer: ['kva', 'percent_z', 'primary_connection', 'secondary_connection'],
   protective: ['pickup_amps', 'time_dial', 'interrupting_rating_ka'],
@@ -35,6 +35,12 @@ const ATTRIBUTE_BASELINE = {
   load: ['kw', 'kvar', 'demand_factor'],
   cable: ['size', 'material', 'insulation', 'ampacity', 'length']
 };
+
+const DC_COMPONENT_TYPES = new Set([
+  'battery',
+  'dc_bus',
+  'rectifier'
+]);
 
 function normalizeType(value) {
   return String(value || '')
@@ -81,6 +87,10 @@ function classifyType(type) {
   return 'all';
 }
 
+function resolveVoltageBaselineKey(type) {
+  return DC_COMPONENT_TYPES.has(type) ? 'nominal_voltage_vdc' : 'rated_voltage_kv';
+}
+
 function getPropKeys(component) {
   const props = component?.props && typeof component.props === 'object' ? component.props : {};
   return Object.keys(props).map((key) => normalizeType(key));
@@ -116,6 +126,7 @@ async function main() {
       const classKey = classifyType(type);
       const expected = Array.from(new Set([
         ...ATTRIBUTE_BASELINE.all,
+        resolveVoltageBaselineKey(type),
         ...(ATTRIBUTE_BASELINE[classKey] || [])
       ])).map((item) => normalizeType(item));
       const missing = expected.filter((key) => !props.includes(key));


### PR DESCRIPTION
### Motivation
- Ensure the component coverage audit reflects the CTR-COMP-012 cross-cutting baseline by checking for shared metadata fields and using appropriate voltage keys for AC vs DC assets.

### Description
- Updated `scripts/componentCoverageAudit.mjs` to include `commissioning_state`, `service_status`, and `notes` in the common baseline attributes and to add DC-aware voltage key resolution (`nominal_voltage_vdc` for DC components, `rated_voltage_kv` for AC components). 
- Added a `DC_COMPONENT_TYPES` set and `resolveVoltageBaselineKey` helper and incorporated the resolved voltage key into the expected attribute list used to compute missing attributes.
- Regenerated `docs/component-gap-analysis.md` using the updated audit logic and updated the CTR-COMP-012 completion note in `docs/component-study-ticket-backlog.md` to document the AC/DC voltage-key behavior.
- Files modified: `scripts/componentCoverageAudit.mjs`, `docs/component-gap-analysis.md`, `docs/component-study-ticket-backlog.md`.

### Testing
- Ran `node scripts/componentCoverageAudit.mjs` which completed and wrote `docs/component-gap-analysis.md` successfully. 
- Ran `node tests/validation.test.mjs` which passed the validation-related tests. 
- Ran `npm run build` which completed with expected rollup warnings but produced the distribution artifacts. 
- Started `npm test`; the suite produced extensive passing output in this environment but the run was terminated before full completion due to environmental constraints (validation subset and build steps above were exercised and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69debc374088832492ed158b6edb4743)