### PR TITLE
Add MCC subtype: defaults, UI fields, migration, and validation

### DIFF
--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -1971,24 +1971,23 @@
       "ports": []
     },
     {
-      "type": "mcc",
-      "label": "MCC",
+      "type": "panel",
+      "subtype": "mcc",
+      "label": "Motor Control Center",
       "icon": "icons/components/MCC.svg",
+      "iconIEC": "icons/components/iec/IEC_Switch.svg",
       "props": {
-        "volts": 480,
-        "sections": 6,
-        "baseKV": 0.48,
-        "kV": 0.48,
-        "voltage": 480,
-        "prefault_voltage": 0.48,
-        "enclosure": "box",
-        "gap": 32,
-        "working_distance": 455,
-        "electrode_config": "VCB",
-        "load": {
-          "kw": 0,
-          "kvar": 0
-        }
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_voltage_kv": 0.48,
+        "bus_rating_a": 1600,
+        "main_device_type": "mccb",
+        "sccr_ka": 65,
+        "bucket_count": 6,
+        "spare_bucket_count": 1,
+        "form_type": "form_2b"
       }
     },
     {

--- a/docs/componentLibrary.html
+++ b/docs/componentLibrary.html
@@ -51,6 +51,8 @@
       <li><code>schema</code> – array of property descriptors with <code>name</code>, <code>label</code>, and <code>type</code>.</li>
     </ul>
     <p>Add new components by appending objects to the JSON array and providing corresponding icons. The application reloads the file at startup, so no JavaScript changes are required.</p>
+    <h2 id="mcc-subtype">MCC subtype</h2>
+    <p>The default library now includes a <code>mcc</code> (Motor Control Center) subtype under the panel family. It uses <code>icons/components/MCC.svg</code> and includes lineup defaults such as <code>sccr_ka</code>, <code>bucket_count</code>, and <code>form_type</code> so MCC properties render in the one-line drawer with required-field badges.</p>
     <h2 id="icons">Icons</h2>
     <p>Place custom SVG files under <code>icons/components/</code> and reference them in <code>componentLibrary.json</code>. Missing icons fall back to <code>icons/placeholder.svg</code>.</p>
   </main>

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -1971,24 +1971,23 @@
       "ports": []
     },
     {
-      "type": "mcc",
-      "label": "MCC",
+      "type": "panel",
+      "subtype": "mcc",
+      "label": "Motor Control Center",
       "icon": "icons/components/MCC.svg",
+      "iconIEC": "icons/components/iec/IEC_Switch.svg",
       "props": {
-        "volts": 480,
-        "sections": 6,
-        "baseKV": 0.48,
-        "kV": 0.48,
-        "voltage": 480,
-        "prefault_voltage": 0.48,
-        "enclosure": "box",
-        "gap": 32,
-        "working_distance": 455,
-        "electrode_config": "VCB",
-        "load": {
-          "kw": 0,
-          "kvar": 0
-        }
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "rated_voltage_kv": 0.48,
+        "bus_rating_a": 1600,
+        "main_device_type": "mccb",
+        "sccr_ka": 65,
+        "bucket_count": 6,
+        "spare_bucket_count": 1,
+        "form_type": "form_2b"
       }
     },
     {

--- a/docs/components.md
+++ b/docs/components.md
@@ -46,6 +46,13 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Switchboard fields include `tag`, `description`, `manufacturer`, `model`, `rated_voltage_kv`, `phases`, `bus_rating_a`, `withstand_1s_ka`, `interrupting_ka`, `arc_resistant_type`, and `maintenance_mode_supported`.
 - Validation flags switchboard records missing any required short-circuit and protection metadata so study inputs are complete before execution.
 
+## MCC component fields
+
+- The one-line palette now includes an `mcc` subtype (Motor Control Center) under the Panel category with a dedicated MCC icon.
+- MCC fields include `tag`, `description`, `manufacturer`, `model`, `rated_voltage_kv`, `bus_rating_a`, `main_device_type`, `sccr_ka`, `bucket_count`, `spare_bucket_count`, and `form_type`.
+- Legacy diagrams are migrated in-memory so MCC records missing any required fields are assigned safe defaults when projects load.
+- Validation flags MCC records with missing/invalid required metadata so lineup and short-circuit workflows remain study-ready.
+
 ## Cable segment component fields
 
 - The one-line palette now includes a `cable` subtype for explicit inter-device cable segments.

--- a/oneline.js
+++ b/oneline.js
@@ -1148,6 +1148,24 @@ const generatorStudyFieldSpecs = [
   { name: 'ramp_kw_per_min', label: 'Ramp Rate (kW/min)', type: 'number', required: true, defaultValue: 100 }
 ];
 
+
+const mccFieldSpecs = [
+  { name: 'tag', label: 'Tag', type: 'text', required: true, defaultValue: comp => comp.ref || comp.label || comp.id || '' },
+  { name: 'description', label: 'Description', type: 'text', required: true, defaultValue: comp => comp.label || '' },
+  { name: 'manufacturer', label: 'Manufacturer', type: 'text', required: true, defaultValue: '' },
+  { name: 'model', label: 'Model', type: 'text', required: true, defaultValue: '' },
+  { name: 'rated_voltage_kv', label: 'Rated Voltage (kV)', type: 'number', required: true, defaultValue: comp => {
+    const ratedKv = Number(comp?.rated_voltage_kv ?? comp?.props?.rated_voltage_kv ?? comp?.kV ?? comp?.baseKV);
+    return Number.isFinite(ratedKv) && ratedKv > 0 ? ratedKv : 0.48;
+  } },
+  { name: 'bus_rating_a', label: 'Bus Rating (A)', type: 'number', required: true, defaultValue: 1600 },
+  { name: 'main_device_type', label: 'Main Device Type', type: 'text', required: true, defaultValue: 'mccb' },
+  { name: 'sccr_ka', label: 'SCCR (kA)', type: 'number', required: true, defaultValue: 65 },
+  { name: 'bucket_count', label: 'Bucket Count', type: 'number', required: true, defaultValue: 6 },
+  { name: 'spare_bucket_count', label: 'Spare Bucket Count', type: 'number', required: true, defaultValue: 1 },
+  { name: 'form_type', label: 'Form Type', type: 'text', required: true, defaultValue: 'form_2b' }
+];
+
 const baselineComponentFieldSpecs = [
   { name: 'tag', label: 'Tag', type: 'text', required: true, defaultValue: comp => comp.ref || comp.label || comp.id || '' },
   { name: 'description', label: 'Description', type: 'text', required: true, defaultValue: comp => comp.label || '' },
@@ -1324,6 +1342,63 @@ function ensureGeneratorStudyMetadata() {
 }
 
 
+
+function isMccComponentMeta(meta) {
+  if (!meta || typeof meta !== 'object') return false;
+  const type = `${meta.type || ''}`.trim().toLowerCase();
+  const subtype = `${meta.subtype || ''}`.trim().toLowerCase();
+  return subtype === 'mcc' || type === 'mcc';
+}
+
+function ensureMccFieldsOnComponent(comp, meta) {
+  if (!comp || typeof comp !== 'object') return comp;
+  if (!isMccComponentMeta(meta || comp)) return comp;
+  if (!comp.props || typeof comp.props !== 'object') {
+    comp.props = { ...(comp.props || {}) };
+  }
+  mccFieldSpecs.forEach(spec => {
+    const hasCompValue = Object.prototype.hasOwnProperty.call(comp, spec.name) && comp[spec.name] !== '';
+    const hasPropsValue = Object.prototype.hasOwnProperty.call(comp.props, spec.name) && comp.props[spec.name] !== '';
+    if (hasCompValue || hasPropsValue) {
+      if (!hasCompValue && hasPropsValue) comp[spec.name] = comp.props[spec.name];
+      if (hasCompValue && !hasPropsValue) comp.props[spec.name] = comp[spec.name];
+      return;
+    }
+    const nextValue = typeof spec.defaultValue === 'function' ? spec.defaultValue(comp, meta) : spec.defaultValue;
+    comp[spec.name] = nextValue;
+    comp.props[spec.name] = nextValue;
+  });
+  const bucketCount = Number(comp.bucket_count ?? comp.props.bucket_count);
+  const spareBucketCount = Number(comp.spare_bucket_count ?? comp.props.spare_bucket_count);
+  if (Number.isFinite(bucketCount) && Number.isFinite(spareBucketCount) && spareBucketCount > bucketCount) {
+    comp.spare_bucket_count = bucketCount;
+    comp.props.spare_bucket_count = bucketCount;
+  }
+  return comp;
+}
+
+function ensureMccMetadata() {
+  Object.entries(componentMeta).forEach(([key, meta]) => {
+    if (!isMccComponentMeta(meta)) return;
+    if (!meta.props || typeof meta.props !== 'object') {
+      meta.props = { ...(meta.props || {}) };
+    }
+    mccFieldSpecs.forEach(spec => {
+      if (!Object.prototype.hasOwnProperty.call(meta.props, spec.name)) {
+        const nextValue = typeof spec.defaultValue === 'function' ? spec.defaultValue(meta.props) : spec.defaultValue;
+        meta.props[spec.name] = nextValue;
+      }
+    });
+    const schemaKeys = new Set([key, meta.subtype].filter(Boolean));
+    schemaKeys.forEach(schemaKey => {
+      if (!Array.isArray(propSchemas[schemaKey])) {
+        propSchemas[schemaKey] = inferSchemaFromProps(meta.props || {});
+      }
+      mccFieldSpecs.forEach(spec => ensureBaselineFieldSchema(propSchemas[schemaKey], spec));
+    });
+  });
+}
+
 function loadStoredCustomComponents() {
   const stored = getItem(customComponentStorageKey, [], customComponentScenarioKey);
   if (!Array.isArray(stored)) return [];
@@ -1499,6 +1574,7 @@ async function loadComponentLibrary() {
 
   ensureCapacitorReactorPropertyMetadata();
   ensureGeneratorStudyMetadata();
+  ensureMccMetadata();
   ensureBaselineComponentMetadata();
 
   buildPalette();
@@ -5589,6 +5665,7 @@ function normalizeComponent(c) {
   applyDefaults(nc);
   ensureBaselineFieldsOnComponent(nc, componentMeta[nc.subtype]);
   ensureGeneratorStudyFieldsOnComponent(nc, componentMeta[nc.subtype]);
+  ensureMccFieldsOnComponent(nc, componentMeta[nc.subtype]);
   return nc;
 }
 
@@ -7989,6 +8066,7 @@ function addComponent(cfg) {
   applyDefaults(comp);
   ensureBaselineFieldsOnComponent(comp, meta);
   ensureGeneratorStudyFieldsOnComponent(comp, meta);
+  ensureMccFieldsOnComponent(comp, meta);
   ensureShapeDefaults(comp);
   if (comp.type === 'transformer') {
     syncTransformerDefaults(comp, { forceBase: true });
@@ -11132,6 +11210,7 @@ async function init() {
       }
       ensureBaselineFieldsOnComponent(c, componentMeta[c.subtype]);
       ensureGeneratorStudyFieldsOnComponent(c, componentMeta[c.subtype]);
+      ensureMccFieldsOnComponent(c, componentMeta[c.subtype]);
     });
   });
   rebuildComponentMaps();
@@ -11140,6 +11219,7 @@ async function init() {
   });
   ensureBaselineComponentMetadata();
   ensureGeneratorStudyMetadata();
+  ensureMccMetadata();
   sheets.forEach(s => {
     s.components.forEach(c => {
       (c.connections || []).forEach(conn => {

--- a/src/validation/librarySchema.mjs
+++ b/src/validation/librarySchema.mjs
@@ -14,6 +14,56 @@ function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function validateMccComponent(component, index, errors) {
+  const subtype = `${component?.subtype || ''}`.trim().toLowerCase();
+  if (subtype !== 'mcc') return;
+  if (!isPlainObject(component.props)) {
+    errors.push(buildError(`components[${index}].props`, 'mcc component props must be an object.'));
+    return;
+  }
+  const requiredStringProps = [
+    'tag',
+    'description',
+    'manufacturer',
+    'model',
+    'main_device_type',
+    'form_type'
+  ];
+  requiredStringProps.forEach((propKey) => {
+    if (!isNonEmptyString(component.props[propKey])) {
+      errors.push(buildError(
+        `components[${index}].props.${propKey}`,
+        `mcc.${propKey} is required and must be a non-empty string.`,
+      ));
+    }
+  });
+
+  const positiveNumberProps = ['rated_voltage_kv', 'bus_rating_a', 'sccr_ka', 'bucket_count'];
+  positiveNumberProps.forEach((propKey) => {
+    const value = Number(component.props[propKey]);
+    if (!Number.isFinite(value) || value <= 0) {
+      errors.push(buildError(
+        `components[${index}].props.${propKey}`,
+        `mcc.${propKey} must be a finite number greater than 0.`,
+      ));
+    }
+  });
+
+  const spareBucketCount = Number(component.props.spare_bucket_count);
+  const bucketCount = Number(component.props.bucket_count);
+  if (!Number.isFinite(spareBucketCount) || spareBucketCount < 0) {
+    errors.push(buildError(
+      `components[${index}].props.spare_bucket_count`,
+      'mcc.spare_bucket_count must be a finite number greater than or equal to 0.',
+    ));
+  } else if (Number.isFinite(bucketCount) && spareBucketCount > bucketCount) {
+    errors.push(buildError(
+      `components[${index}].props.spare_bucket_count`,
+      'mcc.spare_bucket_count cannot exceed mcc.bucket_count.',
+    ));
+  }
+}
+
 function validateComponent(component, index, categoriesSet, subtypeMap, errors) {
   if (!isPlainObject(component)) {
     errors.push(buildError(`components[${index}]`, 'Component must be an object.'));
@@ -46,6 +96,8 @@ function validateComponent(component, index, categoriesSet, subtypeMap, errors) 
       ),
     );
   }
+
+  validateMccComponent(component, index, errors);
 
   if (isNonEmptyString(component.subtype)) {
     const normalizedSubtype = component.subtype.trim();

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -493,6 +493,82 @@ describe('runValidation - switchboard required attributes', () => {
   });
 });
 
+
+describe('runValidation - mcc required attributes', () => {
+  it('flags an mcc when required fields are missing', () => {
+    const components = [
+      {
+        id: 'mcc-ref',
+        type: 'bus',
+        connections: [{ target: 'mcc-1' }]
+      },
+      {
+        id: 'mcc-1',
+        type: 'panel',
+        subtype: 'mcc',
+        connections: [{ target: 'mcc-ref' }],
+        props: {
+          tag: '',
+          description: '',
+          manufacturer: '',
+          model: '',
+          rated_voltage_kv: 0,
+          bus_rating_a: 0,
+          main_device_type: '',
+          sccr_ka: null,
+          bucket_count: '',
+          spare_bucket_count: -1,
+          form_type: ''
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const mccIssue = issues.find(issue => issue.component === 'mcc-1' && issue.message.startsWith('MCC missing required attributes'));
+    assert.ok(mccIssue);
+    assert.ok(mccIssue.message.includes('tag'));
+    assert.ok(mccIssue.message.includes('description'));
+    assert.ok(mccIssue.message.includes('manufacturer'));
+    assert.ok(mccIssue.message.includes('model'));
+    assert.ok(mccIssue.message.includes('rated_voltage_kv'));
+    assert.ok(mccIssue.message.includes('bus_rating_a'));
+    assert.ok(mccIssue.message.includes('main_device_type'));
+    assert.ok(mccIssue.message.includes('sccr_ka'));
+    assert.ok(mccIssue.message.includes('bucket_count'));
+    assert.ok(mccIssue.message.includes('spare_bucket_count'));
+    assert.ok(mccIssue.message.includes('form_type'));
+  });
+
+  it('does not flag an mcc with all required fields present', () => {
+    const components = [
+      {
+        id: 'mcc-ref-2',
+        type: 'bus',
+        connections: [{ target: 'mcc-2' }]
+      },
+      {
+        id: 'mcc-2',
+        type: 'panel',
+        subtype: 'mcc',
+        connections: [{ target: 'mcc-ref-2' }],
+        props: {
+          tag: 'MCC-01',
+          description: '480 V Process MCC',
+          manufacturer: 'Rockwell',
+          model: 'CENTERLINE 2500',
+          rated_voltage_kv: 0.48,
+          bus_rating_a: 1600,
+          main_device_type: 'mccb',
+          sccr_ka: 65,
+          bucket_count: 12,
+          spare_bucket_count: 2,
+          form_type: 'form_2b'
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - cable required attributes', () => {
   it('flags a cable when required fields are missing', () => {
     const components = [

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -128,7 +128,8 @@ export function runValidation(components = [], studies = {}) {
 
   // Panel required field completeness for panel studies and reports
   components.forEach(c => {
-    const isPanel = c?.type === 'panel' || c?.subtype === 'panel' || c?.subtype === 'Panel';
+    const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();
+    const isPanel = (c?.type === 'panel' || subtype === 'panel') && subtype !== 'mcc';
     if (!isPanel) return;
     const props = c.props && typeof c.props === 'object' ? c.props : c;
     const missing = [];
@@ -151,6 +152,39 @@ export function runValidation(components = [], studies = {}) {
       issues.push({
         component: c.id,
         message: `Panel missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
+
+  // MCC required field completeness for lineup and study metadata
+  components.forEach(c => {
+    const isMcc = c?.subtype === 'mcc' || c?.type === 'mcc';
+    if (!isMcc) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.description ?? ''}`.trim()) missing.push('description');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    const ratedVoltageKv = Number(props.rated_voltage_kv);
+    if (!Number.isFinite(ratedVoltageKv) || ratedVoltageKv <= 0) missing.push('rated_voltage_kv');
+    const busRatingA = Number(props.bus_rating_a);
+    if (!Number.isFinite(busRatingA) || busRatingA <= 0) missing.push('bus_rating_a');
+    if (!`${props.main_device_type ?? ''}`.trim()) missing.push('main_device_type');
+    const sccrKa = Number(props.sccr_ka);
+    if (!Number.isFinite(sccrKa) || sccrKa <= 0) missing.push('sccr_ka');
+    const bucketCount = Number(props.bucket_count);
+    if (!Number.isFinite(bucketCount) || bucketCount <= 0) missing.push('bucket_count');
+    const spareBucketCount = Number(props.spare_bucket_count);
+    if (!Number.isFinite(spareBucketCount) || spareBucketCount < 0 || (Number.isFinite(bucketCount) && spareBucketCount > bucketCount)) {
+      missing.push('spare_bucket_count');
+    }
+    if (!`${props.form_type ?? ''}`.trim()) missing.push('form_type');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `MCC missing required attributes: ${missing.join(', ')}.`
       });
     }
   });


### PR DESCRIPTION
### Motivation
- Introduce a first-class MCC (Motor Control Center) subtype so MCCs can be modeled, edited, persisted, and validated like panels and switchboards. 
- Ensure legacy projects load safely by backfilling MCC metadata and that the one-line properties drawer renders MCC fields consistently with existing component patterns.
- Prevent study workflows from running on incomplete MCC metadata by adding validation at both runtime and library/schema save time, and document the new subtype for users.

### Description
- Added a normalized `mcc` panel subtype with icon metadata and default props to `componentLibrary.json` and `docs/componentLibrary.json` (fields: `tag`, `description`, `manufacturer`, `model`, `rated_voltage_kv`, `bus_rating_a`, `main_device_type`, `sccr_ka`, `bucket_count`, `spare_bucket_count`, `form_type`).
- Extended the one-line editor (`oneline.js`) with `mccFieldSpecs`, `ensureMccFieldsOnComponent`, and `ensureMccMetadata` to backfill defaults, expose required-field schema in the one-line property drawer, and include MCC in schema generation used by the drawer.
- Wired MCC metadata/migration into existing lifecycle points (component normalization, new-component creation, component-library load, and sheet/component rehydration) so persistence flows remain routed through the existing project storage APIs and migration hooks rather than direct localStorage writes.
- Added runtime validation for MCC records in `validation/rules.js` and excluded MCC from the generic panel-only checks to avoid false positives, and added library/schema-level validation in `src/validation/librarySchema.mjs` via `validateMccComponent` so saved libraries must include valid MCC props.
- Added unit tests covering MCC validation behavior (`tests/validation.test.mjs`) and updated user docs (`docs/components.md`, `docs/componentLibrary.html`) describing the new subtype.

### Testing
- Ran the validation suite `node tests/validation.test.mjs` and the new MCC validation tests passed (no failures).
- Built the app with `npm run build`; the build completed successfully (with non-blocking warnings reported by the bundler).
- Executed the full automated test suite via `npm test`; the run completed successfully for the validation-related tests exercised during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec0a07ad883248b103bd4ec3d3c9e)