### PR TITLE
Add busway subtype support in one-line modeling, studies, and validation

### DIFF
--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -678,6 +678,34 @@ export function cloneData(value) {
   return value;
 }
 
+function deriveLinearSegmentImpedance(comp) {
+  if (!comp || typeof comp !== 'object') return null;
+  const containers = [comp, comp.props, comp.parameters, comp.cable].filter(v => v && typeof v === 'object');
+  let lengthFt = null;
+  let rPerKft = null;
+  let xPerKft = null;
+  for (const container of containers) {
+    if (lengthFt === null) {
+      const val = Number(container.length_ft ?? container.length);
+      if (Number.isFinite(val) && val > 0) lengthFt = val;
+    }
+    if (rPerKft === null) {
+      const val = Number(container.r_ohm_per_kft);
+      if (Number.isFinite(val) && val >= 0) rPerKft = val;
+    }
+    if (xPerKft === null) {
+      const val = Number(container.x_ohm_per_kft);
+      if (Number.isFinite(val) && val >= 0) xPerKft = val;
+    }
+  }
+  if (!Number.isFinite(lengthFt) || lengthFt <= 0) return null;
+  if (!Number.isFinite(rPerKft) || !Number.isFinite(xPerKft)) return null;
+  return normalizeImpedance({
+    r: (rPerKft * lengthFt) / 1000,
+    x: (xPerKft * lengthFt) / 1000
+  });
+}
+
 function extractImpedance(comp) {
   const candidates = [
     comp?.impedance,
@@ -693,6 +721,8 @@ function extractImpedance(comp) {
   if (typeof comp?.r === 'number' || typeof comp?.x === 'number') {
     return normalizeImpedance({ r: comp.r, x: comp.x });
   }
+  const derived = deriveLinearSegmentImpedance(comp);
+  if (derived) return derived;
   return { r: 0, x: 0 };
 }
 

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -32,6 +32,52 @@ function toImpedance(value) {
   };
 }
 
+function deriveLinearSegmentImpedance(comp) {
+  if (!comp || typeof comp !== 'object') return null;
+  const containers = [comp, comp.props, comp.parameters, comp.cable].filter(v => v && typeof v === 'object');
+  let lengthFt = null;
+  let rPerKft = null;
+  let xPerKft = null;
+  for (const container of containers) {
+    if (lengthFt === null) {
+      const val = Number(container.length_ft ?? container.length);
+      if (Number.isFinite(val) && val > 0) lengthFt = val;
+    }
+    if (rPerKft === null) {
+      const val = Number(container.r_ohm_per_kft);
+      if (Number.isFinite(val) && val >= 0) rPerKft = val;
+    }
+    if (xPerKft === null) {
+      const val = Number(container.x_ohm_per_kft);
+      if (Number.isFinite(val) && val >= 0) xPerKft = val;
+    }
+  }
+  if (!Number.isFinite(lengthFt) || !Number.isFinite(rPerKft) || !Number.isFinite(xPerKft)) return null;
+  return {
+    r: (rPerKft * lengthFt) / 1000,
+    x: (xPerKft * lengthFt) / 1000
+  };
+}
+
+function extractComponentImpedance(comp) {
+  const directCandidates = [
+    comp?.impedance,
+    comp?.seriesImpedance,
+    comp?.cable?.impedance,
+    comp?.cable,
+    comp?.props?.impedance,
+    comp?.parameters?.impedance
+  ];
+  for (const candidate of directCandidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const normalized = toImpedance(candidate);
+    if (Math.abs(normalized.r) > 0 || Math.abs(normalized.x) > 0) return normalized;
+  }
+  const derived = deriveLinearSegmentImpedance(comp);
+  if (derived) return toImpedance(derived);
+  return toImpedance(comp?.impedance);
+}
+
 function parseNumeric(value) {
   if (value === undefined || value === null) return null;
   if (typeof value === 'number') {
@@ -66,7 +112,7 @@ const protectiveDeviceMap = new Map(protectiveDeviceLibrary.map(device => [devic
 const DEFAULT_TCC_SETTINGS = { devices: [], settings: {}, componentOverrides: {} };
 const DEFAULT_LET_THROUGH_WINDOW = 0.008;
 
-const fallbackTypes = new Set(['motor_load', 'static_load', 'load', 'panel', 'equipment', 'bus', 'cable', 'mcc']);
+const fallbackTypes = new Set(['motor_load', 'static_load', 'load', 'panel', 'equipment', 'bus', 'cable', 'busway', 'mcc']);
 const protectionTypes = new Set(['breaker', 'fuse', 'recloser', 'relay', 'contactor', 'switch', 'protective_device']);
 const upstreamCandidateTypes = new Set([
   'transformer',
@@ -425,7 +471,7 @@ function computeImpedance(comp, comps, compMap, cache, visited = new Set()) {
   if (cache.has(comp.id)) return cache.get(comp.id);
   if (visited.has(comp.id)) return { r: 0, x: 0 };
   visited.add(comp.id);
-  let total = toImpedance(comp.impedance);
+  let total = extractComponentImpedance(comp);
   if (isSourceComponent(comp)) {
     total = add(total, getSourceImpedance(comp));
   }
@@ -552,8 +598,8 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
   });
 
   comps.forEach(component => {
-    if (component?.type !== 'cable' || !component.id) return;
-    const base = toImpedance(component.impedance);
+    if (!['cable', 'busway'].includes(component?.type) || !component.id) return;
+    const base = extractComponentImpedance(component);
     if (Math.abs(base.r) >= 1e-9 || Math.abs(base.x) >= 1e-9) return;
     cablesMissingImpedance.add(component.id);
     (component.connections || []).forEach(conn => {
@@ -575,12 +621,12 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       if (fallbackZ && (Math.abs(fallbackZ.r) >= 1e-9 || Math.abs(fallbackZ.x) >= 1e-9)) {
         return { r: fallbackZ.r, x: fallbackZ.x };
       }
-      const isCableMissing = comp?.type === 'cable' && comp?.id && cablesMissingImpedance.has(comp.id);
+      const isConductorMissing = (comp?.type === 'cable' || comp?.type === 'busway') && comp?.id && cablesMissingImpedance.has(comp.id);
       const isTargetOfMissingCable = comp?.id && cableDefaultTargets.has(comp.id);
-      if ((isCableMissing || isTargetOfMissingCable) && comp?.id) {
+      if ((isConductorMissing || isTargetOfMissingCable) && comp?.id) {
         defaultedLowImpedanceComponents.set(
           comp.id,
-          'Cable impedance incomplete; defaulted to very low resistance for fault monitoring.'
+          `${comp?.type === 'busway' ? 'Busway' : 'Cable'} impedance incomplete; defaulted to very low resistance for fault monitoring.`
         );
         return { r: 1e-6, x: 1e-6 };
       }

--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -8710,14 +8710,22 @@ function resolveInrushDuration(comp) {
   return DEFAULT_INRUSH_DURATION;
 }
 
+function isConductorSegmentComponent(comp) {
+  const type = String(comp?.type || '').toLowerCase();
+  const subtype = String(comp?.subtype || '').toLowerCase();
+  return type === 'cable' || type === 'busway' || subtype === 'cable' || subtype === 'busway';
+}
+
 function resolveCableInfo(source, target, conn) {
-  if (source?.type === 'cable') {
+  if (isConductorSegmentComponent(source)) {
     if (source.cable) return source.cable;
     if (source.props && source.props.cable) return source.props.cable;
+    if (source.props && typeof source.props === 'object') return source.props;
   }
-  if (target?.type === 'cable') {
+  if (isConductorSegmentComponent(target)) {
     if (target.cable) return target.cable;
     if (target.props && target.props.cable) return target.props.cable;
+    if (target.props && typeof target.props === 'object') return target.props;
   }
   if (conn?.cable) return conn.cable;
   return null;

--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -7,7 +7,8 @@
     "sources",
     "links",
     "annotations",
-    "cable"
+    "cable",
+    "busway"
   ],
   "components": [
     {
@@ -110,6 +111,37 @@
         "parallel_sets": 1,
         "r_ohm_per_kft": 0.0216,
         "x_ohm_per_kft": 0.015
+      }
+    },
+    {
+      "type": "busway",
+      "subtype": "busway",
+      "label": "Busway Segment",
+      "icon": "icons/components/Busway.svg",
+      "ports": [
+        {
+          "x": 0,
+          "y": 20
+        },
+        {
+          "x": 80,
+          "y": 20
+        }
+      ],
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "length_ft": 100,
+        "material": "aluminum",
+        "insulation_type": "epoxy",
+        "enclosure_rating": "NEMA 1",
+        "busway_type": "feeder",
+        "ampacity_a": 1600,
+        "r_ohm_per_kft": 0.015,
+        "x_ohm_per_kft": 0.012,
+        "short_circuit_rating_ka": 65
       }
     },
     {

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -7,7 +7,8 @@
     "sources",
     "links",
     "annotations",
-    "cable"
+    "cable",
+    "busway"
   ],
   "components": [
     {
@@ -110,6 +111,37 @@
         "parallel_sets": 1,
         "r_ohm_per_kft": 0.0216,
         "x_ohm_per_kft": 0.015
+      }
+    },
+    {
+      "type": "busway",
+      "subtype": "busway",
+      "label": "Busway Segment",
+      "icon": "icons/components/Busway.svg",
+      "ports": [
+        {
+          "x": 0,
+          "y": 20
+        },
+        {
+          "x": 80,
+          "y": 20
+        }
+      ],
+      "props": {
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
+        "length_ft": 100,
+        "material": "aluminum",
+        "insulation_type": "epoxy",
+        "enclosure_rating": "NEMA 1",
+        "busway_type": "feeder",
+        "ampacity_a": 1600,
+        "r_ohm_per_kft": 0.015,
+        "x_ohm_per_kft": 0.012,
+        "short_circuit_rating_ka": 65
       }
     },
     {

--- a/docs/components.md
+++ b/docs/components.md
@@ -59,6 +59,12 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Cable segment fields include `tag`, `description`, `manufacturer`, `model`, `length_ft`, `material`, `insulation_type`, `temp_rating_c`, `size_awg_kcmil`, `parallel_sets`, `r_ohm_per_kft`, and `x_ohm_per_kft`.
 - Validation flags cable segments missing required impedance and construction metadata so voltage-drop and short-circuit path calculations do not silently fall back to assumed values.
 
+## Busway segment component fields
+
+- The one-line palette now includes a `busway` subtype for explicit inter-device busway runs.
+- Busway segment fields include `length_ft`, `material`, `insulation_type`, `enclosure_rating`, `busway_type` (`feeder` or `plug-in`), `ampacity_a`, `r_ohm_per_kft`, `x_ohm_per_kft`, and `short_circuit_rating_ka`.
+- Validation now requires positive impedance values and complete ampacity/short-circuit ratings so study ingestion can treat busway distinctly from cable assumptions.
+
 ## Protective component normalized fields
 
 - Breakers, fuses, relays, and reclosers now share a common protection schema baseline for study ingestion.

--- a/docs/icons/components/Busway.svg
+++ b/docs/icons/components/Busway.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40" fill="none">
+  <rect x="10" y="10" width="60" height="20" rx="4" fill="#F59E0B" stroke="#92400E" stroke-width="2"/>
+  <line x1="0" y1="20" x2="10" y2="20" stroke="#374151" stroke-width="2"/>
+  <line x1="70" y1="20" x2="80" y2="20" stroke="#374151" stroke-width="2"/>
+  <line x1="20" y1="14" x2="20" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="30" y1="14" x2="30" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="40" y1="14" x2="40" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="50" y1="14" x2="50" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="60" y1="14" x2="60" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+</svg>

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -8,7 +8,7 @@ integration with other design tools.
 `reports/exportAll.mjs` can assemble a ZIP archive containing:
 
 - A consolidated PDF report generated from a Handlebars template.
-- CSV files for equipment, panel, cable schedules and study results.
+- CSV files for equipment, panel, cable schedules (including cable- and busway-segment conductor metadata), and study results.
 - Arc‑flash warning labels as individual SVG files.
 - TCC plot metadata when available.
 

--- a/icons/components/Busway.svg
+++ b/icons/components/Busway.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40" viewBox="0 0 80 40" fill="none">
+  <rect x="10" y="10" width="60" height="20" rx="4" fill="#F59E0B" stroke="#92400E" stroke-width="2"/>
+  <line x1="0" y1="20" x2="10" y2="20" stroke="#374151" stroke-width="2"/>
+  <line x1="70" y1="20" x2="80" y2="20" stroke="#374151" stroke-width="2"/>
+  <line x1="20" y1="14" x2="20" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="30" y1="14" x2="30" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="40" y1="14" x2="40" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="50" y1="14" x2="50" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+  <line x1="60" y1="14" x2="60" y2="26" stroke="#7C2D12" stroke-width="1.5"/>
+</svg>

--- a/oneline.js
+++ b/oneline.js
@@ -154,6 +154,7 @@ const typeIcons = {
   load: asset('icons/load.svg'),
   bus: asset('icons/Bus.svg'),
   cable: asset('icons/oneline.svg'),
+  busway: asset('icons/components/Busway.svg'),
   sources: asset('icons/sources.svg'),
   links: asset('icons/links.svg'),
   annotations: asset('icons/annotation.svg')
@@ -3763,9 +3764,15 @@ const cableColors = {
   Signal: '#0a0'
 };
 
+function isConductorSegmentComponent(comp) {
+  const type = String(comp?.type || '').toLowerCase();
+  const subtype = String(comp?.subtype || '').toLowerCase();
+  return type === 'cable' || type === 'busway' || subtype === 'cable' || subtype === 'busway';
+}
+
 function getCableForConnection(source, target, conn) {
-  if (source?.type === 'cable') return source.cable || null;
-  if (target?.type === 'cable') return target.cable || null;
+  if (isConductorSegmentComponent(source)) return source.cable || source.props?.cable || source.props || null;
+  if (isConductorSegmentComponent(target)) return target.cable || target.props?.cable || target.props || null;
   return conn?.cable || null;
 }
 
@@ -6478,13 +6485,13 @@ function render() {
       if (dir === 'bottom') return { x: pt.x, y: pt.y + len };
       return pt;
     };
-    if (src.type === 'cable' && sDir && path.length > 1) {
+    if (isConductorSegmentComponent(src) && sDir && path.length > 1) {
       const stub = offsetPoint(path[0], sDir);
       if (!samePoint(path[0], stub) && (!path[1] || !samePoint(path[1], stub))) {
         path.splice(1, 0, stub);
       }
     }
-    if (tgt.type === 'cable' && tDir && path.length > 1) {
+    if (isConductorSegmentComponent(tgt) && tDir && path.length > 1) {
       const stub = offsetPoint(path[path.length - 1], tDir);
       const insertAt = path.length - 1;
       if (!samePoint(path[insertAt], stub) && (!path[insertAt - 1] || !samePoint(path[insertAt - 1], stub))) {
@@ -6582,7 +6589,7 @@ function render() {
       poly.addEventListener('dblclick', async e => {
         e.stopPropagation();
         cancelPendingClickSelection();
-        const cableComp = c.type === 'cable' ? c : target.type === 'cable' ? target : null;
+        const cableComp = isConductorSegmentComponent(c) ? c : isConductorSegmentComponent(target) ? target : null;
         if (cableComp) {
           await editCableComponent(cableComp);
         }
@@ -6637,7 +6644,7 @@ function render() {
       label.addEventListener('dblclick', async e => {
         e.stopPropagation();
         cancelPendingClickSelection();
-        const cableComp = c.type === 'cable' ? c : target.type === 'cable' ? target : null;
+        const cableComp = isConductorSegmentComponent(c) ? c : isConductorSegmentComponent(target) ? target : null;
         if (cableComp) {
           await editCableComponent(cableComp);
         }
@@ -6824,7 +6831,7 @@ function render() {
         g.appendChild(shape);
       }
     } else {
-      if (c.type === 'cable') {
+      if (isConductorSegmentComponent(c)) {
         const wLocal = c.width || compWidth;
         const hLocal = c.height || compHeight;
         const centerLocal = { x: wLocal / 2, y: hLocal / 2 };
@@ -8458,7 +8465,7 @@ function selectComponent(compOrId) {
       return;
     }
 
-    if (targetComp.type === 'cable' && (!targetComp.cable || typeof targetComp.cable !== 'object')) {
+    if (isConductorSegmentComponent(targetComp) && (!targetComp.cable || typeof targetComp.cable !== 'object')) {
       targetComp.cable = {};
     }
 
@@ -8676,7 +8683,7 @@ function selectComponent(compOrId) {
       return next;
     });
 
-    if (targetComp.type === 'cable') {
+    if (isConductorSegmentComponent(targetComp)) {
       schema = schema.filter(f => !['cable_cable_rating', 'cable_impedance_r', 'cable_impedance_x'].includes(f.name));
     }
 
@@ -8687,7 +8694,7 @@ function selectComponent(compOrId) {
     }
 
     let baseFields;
-    if (targetComp.type === 'cable') {
+    if (isConductorSegmentComponent(targetComp)) {
       baseFields = [
         { name: 'label', label: 'Label', type: 'text' },
         { name: 'ref', label: 'Ref ID', type: 'text' },
@@ -10063,12 +10070,12 @@ function selectComponent(compOrId) {
           edit.classList.add('btn');
           edit.addEventListener('click', async e => {
             e.stopPropagation();
-            const cableComp = targetComp.type === 'cable' ? targetComp : target?.type === 'cable' ? target : null;
+            const cableComp = isConductorSegmentComponent(targetComp) ? targetComp : isConductorSegmentComponent(target) ? target : null;
             if (cableComp) {
               await editCableComponent(cableComp);
               renderPropertiesFor(targetComp);
             } else {
-              showToast('No cable component on this connection');
+              showToast('No conductor segment on this connection');
             }
           });
           li.appendChild(edit);
@@ -10136,7 +10143,7 @@ function selectComponent(compOrId) {
       }
     }
 
-    if (targetComp.type === 'cable') {
+    if (isConductorSegmentComponent(targetComp)) {
       const generalPanel = getTabPanel('general');
       if (generalPanel) {
         const cable = targetComp.cable || {};
@@ -10178,7 +10185,7 @@ function selectComponent(compOrId) {
         cableActions.className = 'prop-tab-actions';
         const editCableBtn = document.createElement('button');
         editCableBtn.type = 'button';
-        editCableBtn.textContent = 'Edit Cable Details';
+        editCableBtn.textContent = 'Edit Segment Details';
         editCableBtn.classList.add('btn');
         editCableBtn.addEventListener('click', async () => {
           await editCableComponent(targetComp);
@@ -10449,7 +10456,7 @@ async function chooseCable(source, target, existingConn = null) {
     }
   });
   components.forEach(c => {
-    if (c.type === 'cable' && c.cable && !seen.has(c.cable.tag)) {
+    if (isConductorSegmentComponent(c) && c.cable && !seen.has(c.cable.tag)) {
       const template = {
         ...c.cable,
         phases: formatCablePhases(c.cable),
@@ -12287,11 +12294,11 @@ async function init() {
       const conn = component.connections[index];
       if (action === 'edit') {
         const target = components.find(t => t.id === conn.target);
-        const cableComp = component.type === 'cable' ? component : target?.type === 'cable' ? target : null;
+        const cableComp = isConductorSegmentComponent(component) ? component : isConductorSegmentComponent(target) ? target : null;
         if (cableComp) {
           await editCableComponent(cableComp);
         } else {
-          showToast('No cable component on this connection');
+          showToast('No conductor segment on this connection');
         }
       } else if (action === 'delete') {
         component.connections.splice(index, 1);
@@ -13278,9 +13285,9 @@ function syncSchedules(notify = true) {
     const description = c.description || c.notes || '';
     const src = all.find(s => (s.connections || []).some(conn => conn.target === c.id));
     const conn = src ? (src.connections || []).find(cc => cc.target === c.id) : null;
-    const inboundCable = src && src.type === 'cable'
+    const inboundCable = src && isConductorSegmentComponent(src)
       ? src
-      : all.find(item => item.type === 'cable' && (item.connections || []).some(cc => cc.target === c.id));
+      : all.find(item => isConductorSegmentComponent(item) && (item.connections || []).some(cc => cc.target === c.id));
     const cableInfo = inboundCable?.cable || null;
     const connPhases = hasStoredPhases(conn?.phases)
       ? formatCablePhases(conn.phases)
@@ -13350,7 +13357,7 @@ function syncSchedules(notify = true) {
   const cableSpecs = [];
   const seenTags = new Set();
   all
-    .filter(c => c.type === 'cable')
+    .filter(c => isConductorSegmentComponent(c))
     .forEach(cableComp => {
       const spec = buildCableSpecFromComponent(cableComp, all);
       if (!spec) return;
@@ -13387,9 +13394,9 @@ function serializeState() {
     const mapFields = c => {
       const src = comps.find(s => (s.connections || []).some(conn => conn.target === c.id));
       const conn = src ? (src.connections || []).find(cc => cc.target === c.id) : null;
-      const inboundCable = src && src.type === 'cable'
+      const inboundCable = src && isConductorSegmentComponent(src)
         ? src
-        : comps.find(item => item.type === 'cable' && (item.connections || []).some(cc => cc.target === c.id));
+        : comps.find(item => isConductorSegmentComponent(item) && (item.connections || []).some(cc => cc.target === c.id));
       const cableInfo = inboundCable?.cable || null;
       const connPhases = hasStoredPhases(conn?.phases)
         ? formatCablePhases(conn.phases)
@@ -13444,7 +13451,7 @@ function serializeState() {
     const cables = [];
     const seenTags = new Set();
     comps
-      .filter(c => c.type === 'cable')
+      .filter(c => isConductorSegmentComponent(c))
       .forEach(cableComp => {
         const spec = buildCableSpecFromComponent(cableComp, comps);
         if (!spec) return;

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -635,6 +635,63 @@ describe('runValidation - cable required attributes', () => {
   });
 });
 
+describe('runValidation - busway required attributes', () => {
+  it('flags a busway when required fields are missing', () => {
+    const components = [
+      {
+        id: 'busway-1',
+        type: 'busway',
+        subtype: 'busway',
+        props: {
+          length_ft: 0,
+          material: '',
+          insulation_type: '',
+          enclosure_rating: '',
+          busway_type: 'invalid',
+          ampacity_a: 0,
+          r_ohm_per_kft: 0,
+          x_ohm_per_kft: -1,
+          short_circuit_rating_ka: null
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const buswayIssue = issues.find(issue => issue.component === 'busway-1');
+    assert.ok(buswayIssue);
+    assert.ok(buswayIssue.message.includes('length_ft'));
+    assert.ok(buswayIssue.message.includes('material'));
+    assert.ok(buswayIssue.message.includes('insulation_type'));
+    assert.ok(buswayIssue.message.includes('enclosure_rating'));
+    assert.ok(buswayIssue.message.includes('busway_type'));
+    assert.ok(buswayIssue.message.includes('ampacity_a'));
+    assert.ok(buswayIssue.message.includes('r_ohm_per_kft'));
+    assert.ok(buswayIssue.message.includes('x_ohm_per_kft'));
+    assert.ok(buswayIssue.message.includes('short_circuit_rating_ka'));
+  });
+
+  it('does not flag a busway with all required fields present', () => {
+    const components = [
+      {
+        id: 'busway-2',
+        type: 'busway',
+        subtype: 'busway',
+        props: {
+          length_ft: 240,
+          material: 'aluminum',
+          insulation_type: 'epoxy',
+          enclosure_rating: 'NEMA 1',
+          busway_type: 'feeder',
+          ampacity_a: 1600,
+          r_ohm_per_kft: 0.015,
+          x_ohm_per_kft: 0.012,
+          short_circuit_rating_ka: 65
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 
 
 describe('runValidation - relay_87 required attributes', () => {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -250,6 +250,35 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // Busway required field completeness for feeder/path impedance studies
+  components.forEach(c => {
+    const isBusway = c?.type === 'busway' || c?.subtype === 'busway';
+    if (!isBusway) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    const lengthFt = Number(props.length_ft);
+    if (!Number.isFinite(lengthFt) || lengthFt <= 0) missing.push('length_ft');
+    if (!`${props.material ?? ''}`.trim()) missing.push('material');
+    if (!`${props.insulation_type ?? ''}`.trim()) missing.push('insulation_type');
+    if (!`${props.enclosure_rating ?? ''}`.trim()) missing.push('enclosure_rating');
+    const buswayType = `${props.busway_type ?? ''}`.trim().toLowerCase();
+    if (!['feeder', 'plug-in'].includes(buswayType)) missing.push('busway_type');
+    const ampacityA = Number(props.ampacity_a);
+    if (!Number.isFinite(ampacityA) || ampacityA <= 0) missing.push('ampacity_a');
+    const rOhmPerKft = Number(props.r_ohm_per_kft);
+    if (!Number.isFinite(rOhmPerKft) || rOhmPerKft <= 0) missing.push('r_ohm_per_kft');
+    const xOhmPerKft = Number(props.x_ohm_per_kft);
+    if (!Number.isFinite(xOhmPerKft) || xOhmPerKft <= 0) missing.push('x_ohm_per_kft');
+    const shortCircuitRatingKa = Number(props.short_circuit_rating_ka);
+    if (!Number.isFinite(shortCircuitRatingKa) || shortCircuitRatingKa <= 0) missing.push('short_circuit_rating_ka');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Busway missing required attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
   // Generator required field completeness for short-circuit/transient/dispatch studies
   components.forEach(c => {
     const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();


### PR DESCRIPTION
### Motivation
- Provide explicit `busway` conductor segments so busway runs can be modeled, validated, and consumed by studies instead of being treated as generic cables. 
- Ensure short‑circuit and load‑flow engines can derive realistic impedances and enforce ampacity/SCCR completeness for busway elements used as inter-device links.
- Surface the new subtype in the component library and docs so the one-line editor, schedules, and exports include busway metadata.

### Description
- Added a new `busway` subtype entry to `componentLibrary.json` and `docs/componentLibrary.json` with defaults and a unique icon under `icons/components/Busway.svg`. 
- Extended one-line UI and editor code in `oneline.js` to treat busway like cable for connection rendering, editing (`editCableComponent` flow), label/overlay rendering, and schedule extraction by introducing `isConductorSegmentComponent`. 
- Extended impedance handling in `analysis/loadFlowModel.js` and `analysis/shortCircuit.mjs` to derive linear-segment impedance from `length_ft` + `r_ohm_per_kft`/`x_ohm_per_kft` when explicit impedance is missing, and included `busway` in the short-circuit fallback/defaulting logic. 
- Added validation rules in `validation/rules.js` requiring busway attributes (`length_ft`, `material`, `insulation_type`, `enclosure_rating`, `busway_type`, `ampacity_a`, `r_ohm_per_kft`, `x_ohm_per_kft`, `short_circuit_rating_ka`) and updated UI/property plumbing to surface conductor fields for busway. 
- Updated docs in `docs/components.md` and `docs/interoperability.md` to document the new `busway` subtype and its inclusion in exports. 
- Added tests in `tests/validation.test.mjs` to cover busway required-field pass/fail scenarios and updated study helpers (`analysis/tcc.js`) to resolve conductor metadata from busway components where applicable. 

### Testing
- Ran `node tests/validation.test.mjs` and the new busway validation tests passed. 
- Ran `node tests/shortcircuit/shortCircuit.test.cjs` and short‑circuit checks continued to pass. 
- Ran `npm run build` successfully (build completed with pre‑existing Rollup warnings unrelated to these changes). 
- Started the full `npm test` suite which progressed through many suites but did not complete in this environment due to a long chained run; individual affected tests above are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec50a78608324bc3cba5d8267a292)