### PR TITLE
Add CT component type, validation, and study-metadata wiring

### DIFF
--- a/analysis/ctMetadata.mjs
+++ b/analysis/ctMetadata.mjs
@@ -1,0 +1,100 @@
+function coerceNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function readField(comp, key) {
+  if (!comp || typeof comp !== 'object') return undefined;
+  if (Object.prototype.hasOwnProperty.call(comp, key)) return comp[key];
+  if (comp.props && typeof comp.props === 'object' && Object.prototype.hasOwnProperty.call(comp.props, key)) {
+    return comp.props[key];
+  }
+  return undefined;
+}
+
+export function isCtComponent(comp) {
+  if (!comp || typeof comp !== 'object') return false;
+  const subtype = `${comp.subtype || ''}`.trim().toLowerCase();
+  const type = `${comp.type || ''}`.trim().toLowerCase();
+  return subtype === 'ct' || type === 'ct';
+}
+
+export function parseCtRatio(ctLike) {
+  const primary = coerceNumber(readField(ctLike, 'ratio_primary'));
+  const secondary = coerceNumber(readField(ctLike, 'ratio_secondary'));
+  if (!Number.isFinite(primary) || !Number.isFinite(secondary) || secondary <= 0) {
+    return null;
+  }
+  return {
+    primary,
+    secondary,
+    ratio: primary / secondary
+  };
+}
+
+export function normalizeCtMetadata(ctLike) {
+  if (!isCtComponent(ctLike)) return null;
+  const ratio = parseCtRatio(ctLike);
+  const locationContextRaw = `${readField(ctLike, 'location_context') || ''}`.trim().toLowerCase();
+  const location_context = locationContextRaw === 'metering' ? 'metering' : 'protection';
+  const metadata = {
+    id: `${ctLike.id || ''}`.trim() || null,
+    tag: `${readField(ctLike, 'tag') || ''}`.trim(),
+    ratio_primary: coerceNumber(readField(ctLike, 'ratio_primary')),
+    ratio_secondary: coerceNumber(readField(ctLike, 'ratio_secondary')),
+    accuracy_class: `${readField(ctLike, 'accuracy_class') || ''}`.trim(),
+    burden_va: coerceNumber(readField(ctLike, 'burden_va')),
+    knee_point_v: coerceNumber(readField(ctLike, 'knee_point_v')),
+    polarity: `${readField(ctLike, 'polarity') || ''}`.trim(),
+    location_context,
+    protected_device_id: `${readField(ctLike, 'protected_device_id') || ''}`.trim(),
+    meter_id: `${readField(ctLike, 'meter_id') || ''}`.trim(),
+    relay_id: `${readField(ctLike, 'relay_id') || ''}`.trim(),
+    ratio
+  };
+  return metadata;
+}
+
+function findCtByExplicitLink(component, allComponents, compMap) {
+  const lookup = compMap || new Map((allComponents || []).map(c => [c.id, c]));
+  const explicitId = `${readField(component, 'ct_id') || readField(component, 'current_transformer_id') || ''}`.trim();
+  if (!explicitId) return null;
+  const linked = lookup.get(explicitId);
+  return isCtComponent(linked) ? linked : null;
+}
+
+function findCtByReverseLink(component, allComponents) {
+  const targetId = `${component?.id || ''}`.trim();
+  if (!targetId) return null;
+  return (allComponents || []).find(candidate => {
+    if (!isCtComponent(candidate)) return false;
+    const candidateMeta = normalizeCtMetadata(candidate);
+    if (!candidateMeta) return false;
+    return candidateMeta.protected_device_id === targetId
+      || candidateMeta.meter_id === targetId
+      || candidateMeta.relay_id === targetId;
+  }) || null;
+}
+
+function findCtByConnection(component, allComponents) {
+  const targetId = `${component?.id || ''}`.trim();
+  if (!targetId) return null;
+  return (allComponents || []).find(candidate => {
+    if (!isCtComponent(candidate) || !Array.isArray(candidate.connections)) return false;
+    return candidate.connections.some(conn => `${conn?.target || ''}`.trim() === targetId);
+  }) || null;
+}
+
+export function resolveCtForComponent(component, allComponents = [], compMap = null) {
+  const map = compMap || new Map((allComponents || []).map(c => [c.id, c]));
+  const byExplicit = findCtByExplicitLink(component, allComponents, map);
+  if (byExplicit) return normalizeCtMetadata(byExplicit);
+
+  const byReverse = findCtByReverseLink(component, allComponents);
+  if (byReverse) return normalizeCtMetadata(byReverse);
+
+  const byConnection = findCtByConnection(component, allComponents);
+  if (byConnection) return normalizeCtMetadata(byConnection);
+
+  return null;
+}

--- a/analysis/harmonics.js
+++ b/analysis/harmonics.js
@@ -1,5 +1,6 @@
 import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
 import { getOneLine, getStudies, setStudies } from '../dataStore.mjs';
+import { resolveCtForComponent } from './ctMetadata.mjs';
 
 // Convert spectrum description to a map of harmonic order to percent
 export function parseSpectrum(spec) {
@@ -90,11 +91,13 @@ export function runHarmonics() {
     const ithd = I1 ? Math.sqrt(i2) / I1 * 100 : 0;
     const vthd = Math.sqrt(v2) * 100;
     const limit = limitForVoltage(V / 1000);
+    const ct = resolveCtForComponent(c, comps);
     results[c.id] = {
       ithd: Number(ithd.toFixed(2)),
       vthd: Number(vthd.toFixed(2)),
       limit,
-      warning: vthd > limit
+      warning: vthd > limit,
+      ct
     };
   });
 
@@ -214,10 +217,12 @@ export function runHarmonicsUnbalanced(phaseData = {}) {
     const limit = limitForVoltage(kv);
     const worstVthd = Math.max(phaseA.vthd, phaseB.vthd, phaseC.vthd);
 
+    const ct = resolveCtForComponent(c, comps);
     results[c.id] = {
       phaseA,
       phaseB,
       phaseC,
+      ct,
       neutral: {
         ithd_pct_of_phase: Number(neutralPct.toFixed(2)),
         rms_amps: Number(neutralRms.toFixed(2)),

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -1,5 +1,6 @@
 import { getOneLine, getItem } from '../dataStore.mjs';
 import { scaleCurve } from './tccUtils.js';
+import { resolveCtForComponent } from './ctMetadata.mjs';
 import protectiveDevices from '../data/protectiveDevices.mjs';
 import { calculateTransformerImpedance } from '../utils/transformerImpedance.js';
 import { computeIEC60909Bus } from './iec60909.mjs';
@@ -718,6 +719,8 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     }
 
     limitFaultByProtection(entry, comp, comps, compMap, protectiveLookupCache, scaledDeviceCache, tccSettings);
+    const ct = resolveCtForComponent(comp, comps, compMap);
+    if (ct) entry.ct = ct;
     results[comp.id] = entry;
   });
 

--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -2341,21 +2341,38 @@
     {
       "type": "ct",
       "label": "CT",
-      "icon": "icons/placeholder.svg",
+      "icon": "icons/components/CT.svg",
       "props": {
-        "ratio": "600:5",
+        "tag": "CT-1",
+        "ratio_primary": 600,
+        "ratio_secondary": 5,
+        "accuracy_class": "C200",
         "burden_va": 10,
-        "class": "C200"
-      }
+        "knee_point_v": 200,
+        "polarity": "H1-X1",
+        "location_context": "protection",
+        "protected_device_id": "",
+        "meter_id": "",
+        "relay_id": ""
+      },
+      "subtype": "ct",
+      "category": "protection",
+      "ports": [
+        {
+          "x": 40,
+          "y": 0
+        }
+      ]
     },
     {
       "type": "vt",
       "label": "PT",
-      "icon": "icons/placeholder.svg",
+      "icon": "icons/components/Transformer.svg",
       "props": {
         "ratio": "69000V:120V",
         "class": "0.3WZ"
-      }
+      },
+      "subtype": "vt"
     },
     {
       "type": "relay",

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -2341,21 +2341,38 @@
     {
       "type": "ct",
       "label": "CT",
-      "icon": "icons/placeholder.svg",
+      "icon": "icons/components/CT.svg",
       "props": {
-        "ratio": "600:5",
+        "tag": "CT-1",
+        "ratio_primary": 600,
+        "ratio_secondary": 5,
+        "accuracy_class": "C200",
         "burden_va": 10,
-        "class": "C200"
-      }
+        "knee_point_v": 200,
+        "polarity": "H1-X1",
+        "location_context": "protection",
+        "protected_device_id": "",
+        "meter_id": "",
+        "relay_id": ""
+      },
+      "subtype": "ct",
+      "category": "protection",
+      "ports": [
+        {
+          "x": 40,
+          "y": 0
+        }
+      ]
     },
     {
       "type": "vt",
       "label": "PT",
-      "icon": "icons/placeholder.svg",
+      "icon": "icons/components/Transformer.svg",
       "props": {
         "ratio": "69000V:120V",
         "class": "0.3WZ"
-      }
+      },
+      "subtype": "vt"
     },
     {
       "type": "relay",

--- a/docs/components.md
+++ b/docs/components.md
@@ -34,6 +34,15 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Meter fields include `tag`, `description`, `manufacturer`, `model`, `meter_class`, `ct_ratio`, `pt_ratio`, `sample_rate_hz`, and study capability flags (`supports_thd`, `supports_flicker`, `supports_waveform_capture`).
 - Validation enforces both `ct_ratio` and `pt_ratio` when any meter study capability flag is enabled so harmonics/power-quality workflows do not run with incomplete instrument transformer scaling.
 
+
+## Current transformer (CT) component fields
+
+- The one-line palette now includes a `ct` subtype under **Protection** with a dedicated CT icon and default study-ready metadata.
+- Required CT fields are `tag`, `ratio_primary`, `ratio_secondary`, `accuracy_class`, `burden_va`, `knee_point_v`, `polarity`, and `location_context` (`metering` or `protection`).
+- Optional linkage fields (`protected_device_id`, `meter_id`, `relay_id`) let each CT reference the protected asset or instrument endpoint using existing component-id conventions.
+- Validation enforces physically valid values (positive ratios, positive burden/knee-point, and `ratio_primary >= ratio_secondary`) so study scaling inputs are not silently invalid.
+- Protection and metering study builders now receive normalized CT metadata in the study input object (`ct`) whenever a linked CT is found (explicit `ct_id`, reverse CT link fields, or direct CT connection).
+
 ## DC bus component fields
 
 - The one-line palette now includes a `dc_bus` subtype under the Bus category with a dedicated DC icon.

--- a/docs/ground-fault-protection.md
+++ b/docs/ground-fault-protection.md
@@ -146,3 +146,15 @@ The feeder GFP relay operates first for low-level ground faults (< 200 A). The m
 | GFP coordination | `analysis/tccAutoCoord.mjs` | `greedyCoordinateGFP()` — validates GFP-only chain, delegates to `greedyCoordinate()` |
 | TCC renderer | `analysis/tcc.js` | `groundFault` view option in `TCC_VIEW_OPTIONS`; `GFP_COLOR_PALETTE`; `buildGFPLibraryEntries()`; dashed purple path styling in `plot()`; GFP dispatch in `autoCoordinate()` |
 | Tests | `tests/tcc/groundFaultProtection.test.mjs` | 27 assertions covering library schema, curve generation, coordination, and NEC metadata |
+
+## CT metadata in study inputs
+
+Protection and metering study input builders now attach normalized CT metadata when a linked CT is present on the one-line model. The attached `ct` block includes `tag`, `ratio_primary`, `ratio_secondary`, computed ratio, `accuracy_class`, `burden_va`, `knee_point_v`, `polarity`, `location_context`, and optional linkage ids (`protected_device_id`, `meter_id`, `relay_id`).
+
+Link resolution precedence:
+1. Explicit component reference (`ct_id` / `current_transformer_id`).
+2. Reverse CT links via `protected_device_id`, `meter_id`, or `relay_id`.
+3. Direct CT-to-component connection on the active one-line graph.
+
+This makes scaling assumptions explicit and traceable when reviewing protection and metering calculations.
+

--- a/docs/icons/components/CT.svg
+++ b/docs/icons/components/CT.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="72" height="32" rx="6" ry="6" />
+  <circle cx="40" cy="20" r="10" />
+  <path d="M18 20h12" />
+  <path d="M50 20h12" />
+  <path d="M28 12l8 8-8 8" />
+</svg>

--- a/icons/components/CT.svg
+++ b/icons/components/CT.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="72" height="32" rx="6" ry="6" />
+  <circle cx="40" cy="20" r="10" />
+  <path d="M18 20h12" />
+  <path d="M50 20h12" />
+  <path d="M28 12l8 8-8 8" />
+</svg>

--- a/oneline.js
+++ b/oneline.js
@@ -8622,7 +8622,25 @@ function selectComponent(compOrId) {
       short_circuit_duration_cycles: {
         label: 'Short Circuit Duration (cycles)',
         help: 'For thermal withstand calc. Time-dependent modeling.'
-      }
+      },
+      ratio_primary: 'CT Ratio Primary (A)',
+      ratio_secondary: 'CT Ratio Secondary (A)',
+      accuracy_class: 'CT Accuracy Class',
+      burden_va: 'CT Burden (VA)',
+      knee_point_v: 'CT Knee-Point Voltage (V)',
+      polarity: {
+        label: 'CT Polarity',
+        type: 'select',
+        options: ['H1-X1', 'H1-X2']
+      },
+      location_context: {
+        label: 'CT Context',
+        type: 'select',
+        options: ['protection', 'metering']
+      },
+      protected_device_id: 'Protected Device ID',
+      meter_id: 'Linked Meter ID',
+      relay_id: 'Linked Relay ID'
     };
 
     let schema = rawSchema

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -50,6 +50,41 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+
+  // Current transformer (CT) required field completeness and physical validity
+  components.forEach(c => {
+    const isCt = c?.subtype === 'ct' || c?.type === 'ct';
+    if (!isCt) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    const ratioPrimary = Number(props.ratio_primary);
+    const ratioSecondary = Number(props.ratio_secondary);
+    if (!Number.isFinite(ratioPrimary) || ratioPrimary <= 0) missing.push('ratio_primary');
+    if (!Number.isFinite(ratioSecondary) || ratioSecondary <= 0) missing.push('ratio_secondary');
+    if (Number.isFinite(ratioPrimary) && Number.isFinite(ratioSecondary) && ratioPrimary < ratioSecondary) {
+      missing.push('ratio_primary>=ratio_secondary');
+    }
+
+    if (!`${props.accuracy_class ?? ''}`.trim()) missing.push('accuracy_class');
+    const burdenVa = Number(props.burden_va);
+    if (!Number.isFinite(burdenVa) || burdenVa <= 0) missing.push('burden_va');
+    const kneePointV = Number(props.knee_point_v);
+    if (!Number.isFinite(kneePointV) || kneePointV <= 0) missing.push('knee_point_v');
+    if (!`${props.polarity ?? ''}`.trim()) missing.push('polarity');
+
+    const locationContext = `${props.location_context ?? ''}`.trim().toLowerCase();
+    if (!['metering', 'protection'].includes(locationContext)) missing.push('location_context');
+
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `Current transformer missing/invalid attributes: ${missing.join(', ')}.`
+      });
+    }
+  });
+
   // Meter ratio completeness for study-enabled metering features
   components.forEach(c => {
     if (c.type !== 'meter') return;


### PR DESCRIPTION
### Motivation
- Introduce explicit Current Transformer (CT) support so protection and metering flows have explicit, persisted scaling metadata instead of relying on implicit assumptions. 
- Allow CTs to reference protected equipment or meters/relays so study engines can resolve which CT applies to a device. 
- Enforce CT data completeness and physical validity to avoid silently incorrect study inputs. 
- Surface normalized CT metadata to protection/metering study builders so scaling is traceable in results.

### Description
- Added a `ct` subtype entry to the component libraries (`componentLibrary.json`, `docs/componentLibrary.json`) with default props (`tag`, `ratio_primary`, `ratio_secondary`, `accuracy_class`, `burden_va`, `knee_point_v`, `polarity`, `location_context`) and optional linkage IDs (`protected_device_id`, `meter_id`, `relay_id`), assigned to the `protection` category and given an explicit port and icon. 
- Added a CT icon (`icons/components/CT.svg` and docs mirror) and updated the PT entry to include a subtype and better icon. 
- Extended property form labels/schema in `oneline.js` to render CT-specific fields (selects for `polarity` and `location_context`) so values persist through the existing props serialization flow. 
- Implemented validation rules in `validation/rules.js` to check CT completeness and simple physical constraints (`ratio_primary`, `ratio_secondary` positive; `ratio_primary >= ratio_secondary`; positive `burden_va` and `knee_point_v`; valid `location_context`). 
- Added `analysis/ctMetadata.mjs`, a small resolver that normalizes CT metadata and locates a CT for a component via (1) explicit `ct_id` / `current_transformer_id`, (2) reverse linkage fields (`protected_device_id`, `meter_id`, `relay_id`), or (3) direct CT-to-device diagram connections. 
- Wired CT metadata into study builders by calling `resolveCtForComponent` and attaching a normalized `ct` block into short-circuit (`analysis/shortCircuit.mjs`) and harmonics (`analysis/harmonics.js`) outputs when a CT is found. 
- Updated docs (`docs/components.md`, `docs/ground-fault-protection.md`) to describe CT fields, linkage precedence, and what study inputs receive. 

### Testing
- Ran validation and study unit tests: `node tests/validation.test.mjs`, `node tests/shortcircuit/shortCircuit.test.cjs`, and `node tests/harmonics.test.mjs`, all of which passed. 
- Built the web assets with `npm run build`, which completed successfully. 
- Attempted the full test suite via `npm test`; the long chained run was started in this environment but the aggregate run stalled/was not practical to complete here (local smoke and targeted tests above were used for verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded5254d54832495c6ffd9b880ee95)