### PR TITLE
Add PT/VT component subtype with editor, validation, linkage, and study preprocessing support

### DIFF
--- a/analysis/ptVtMetadata.mjs
+++ b/analysis/ptVtMetadata.mjs
@@ -1,0 +1,143 @@
+function coerceNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function readField(comp, key) {
+  if (!comp || typeof comp !== 'object') return undefined;
+  if (Object.prototype.hasOwnProperty.call(comp, key)) return comp[key];
+  if (comp.props && typeof comp.props === 'object' && Object.prototype.hasOwnProperty.call(comp.props, key)) {
+    return comp.props[key];
+  }
+  return undefined;
+}
+
+function parseIdList(value) {
+  if (Array.isArray(value)) return value.map(v => `${v || ''}`.trim()).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  return value.split(',').map(v => v.trim()).filter(Boolean);
+}
+
+function toVolts(value, keyHint = '') {
+  const num = coerceNumber(value);
+  if (!Number.isFinite(num)) return null;
+  const key = `${keyHint || ''}`.toLowerCase();
+  if (key.includes('_kv') || key === 'kv' || key.includes('basekv')) return num * 1000;
+  if (key.includes('nominal_voltage_vdc')) return num;
+  return num <= 100 ? num * 1000 : num;
+}
+
+function resolveComponentVoltageVolts(comp) {
+  if (!comp || typeof comp !== 'object') return null;
+  const candidates = [
+    ['voltage_v', readField(comp, 'voltage_v')],
+    ['rated_voltage_kv', readField(comp, 'rated_voltage_kv')],
+    ['baseKV', readField(comp, 'baseKV')],
+    ['kV', readField(comp, 'kV')],
+    ['prefault_voltage', readField(comp, 'prefault_voltage')],
+    ['voltage', readField(comp, 'voltage')],
+    ['volts', readField(comp, 'volts')],
+    ['nominal_voltage_vdc', readField(comp, 'nominal_voltage_vdc')]
+  ];
+  for (const [key, raw] of candidates) {
+    const volts = toVolts(raw, key);
+    if (Number.isFinite(volts) && volts > 0) return volts;
+  }
+  return null;
+}
+
+export function isPtVtComponent(comp) {
+  if (!comp || typeof comp !== 'object') return false;
+  const subtype = `${comp.subtype || ''}`.trim().toLowerCase();
+  const type = `${comp.type || ''}`.trim().toLowerCase();
+  return subtype === 'pt_vt' || subtype === 'vt' || type === 'vt' || type === 'pt_vt';
+}
+
+export function parsePtVtRatio(ptVtLike) {
+  const primary = coerceNumber(readField(ptVtLike, 'primary_voltage'));
+  const secondary = coerceNumber(readField(ptVtLike, 'secondary_voltage'));
+  if (!Number.isFinite(primary) || !Number.isFinite(secondary) || secondary <= 0) return null;
+  return {
+    primary,
+    secondary,
+    ratio: primary / secondary
+  };
+}
+
+export function normalizePtVtMetadata(ptVtLike) {
+  if (!isPtVtComponent(ptVtLike)) return null;
+  const ratio = parsePtVtRatio(ptVtLike);
+  return {
+    id: `${ptVtLike.id || ''}`.trim() || null,
+    tag: `${readField(ptVtLike, 'tag') || ''}`.trim(),
+    primary_voltage: coerceNumber(readField(ptVtLike, 'primary_voltage')),
+    secondary_voltage: coerceNumber(readField(ptVtLike, 'secondary_voltage')),
+    accuracy_class: `${readField(ptVtLike, 'accuracy_class') || ''}`.trim(),
+    burden_va: coerceNumber(readField(ptVtLike, 'burden_va')),
+    connection_type: `${readField(ptVtLike, 'connection_type') || ''}`.trim(),
+    fuse_protection: `${readField(ptVtLike, 'fuse_protection') || ''}`.trim(),
+    location_context: `${readField(ptVtLike, 'location_context') || ''}`.trim().toLowerCase() || 'protection',
+    protected_device_id: `${readField(ptVtLike, 'protected_device_id') || ''}`.trim(),
+    meter_id: `${readField(ptVtLike, 'meter_id') || ''}`.trim(),
+    relay_id: `${readField(ptVtLike, 'relay_id') || ''}`.trim(),
+    consumer_ids: parseIdList(readField(ptVtLike, 'consumer_ids')),
+    ratio
+  };
+}
+
+function findPtVtByExplicitLink(component, allComponents, compMap) {
+  const lookup = compMap || new Map((allComponents || []).map(c => [c.id, c]));
+  const explicitId = `${readField(component, 'pt_vt_id')
+    || readField(component, 'vt_id')
+    || readField(component, 'pt_id')
+    || readField(component, 'potential_transformer_id')
+    || readField(component, 'voltage_transformer_id')
+    || ''}`.trim();
+  if (!explicitId) return null;
+  const linked = lookup.get(explicitId);
+  return isPtVtComponent(linked) ? linked : null;
+}
+
+function findPtVtByReverseLink(component, allComponents) {
+  const targetId = `${component?.id || ''}`.trim();
+  if (!targetId) return null;
+  return (allComponents || []).find(candidate => {
+    if (!isPtVtComponent(candidate)) return false;
+    const metadata = normalizePtVtMetadata(candidate);
+    if (!metadata) return false;
+    return metadata.protected_device_id === targetId
+      || metadata.meter_id === targetId
+      || metadata.relay_id === targetId
+      || metadata.consumer_ids.includes(targetId);
+  }) || null;
+}
+
+function findPtVtByConnection(component, allComponents) {
+  const targetId = `${component?.id || ''}`.trim();
+  if (!targetId) return null;
+  return (allComponents || []).find(candidate => {
+    if (!isPtVtComponent(candidate) || !Array.isArray(candidate.connections)) return false;
+    return candidate.connections.some(conn => `${conn?.target || ''}`.trim() === targetId);
+  }) || null;
+}
+
+export function resolvePtVtForComponent(component, allComponents = [], compMap = null) {
+  const map = compMap || new Map((allComponents || []).map(c => [c.id, c]));
+  const linked = findPtVtByExplicitLink(component, allComponents, map)
+    || findPtVtByReverseLink(component, allComponents)
+    || findPtVtByConnection(component, allComponents);
+  if (!linked) return null;
+  const metadata = normalizePtVtMetadata(linked);
+  if (!metadata) return null;
+  const consumerVoltage = resolveComponentVoltageVolts(component);
+  const primaryVoltage = metadata.primary_voltage;
+  if (Number.isFinite(primaryVoltage) && primaryVoltage > 0 && Number.isFinite(consumerVoltage) && consumerVoltage > 0) {
+    const mismatchRatio = Math.abs(primaryVoltage - consumerVoltage) / Math.max(primaryVoltage, consumerVoltage);
+    metadata.voltage_base = {
+      primary_v: primaryVoltage,
+      consumer_v: Number(consumerVoltage.toFixed(3)),
+      compatible: mismatchRatio <= 0.35
+    };
+  }
+  return metadata;
+}

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -1,6 +1,7 @@
 import { getOneLine, getItem } from '../dataStore.mjs';
 import { scaleCurve } from './tccUtils.js';
 import { resolveCtForComponent } from './ctMetadata.mjs';
+import { resolvePtVtForComponent } from './ptVtMetadata.mjs';
 import protectiveDevices from '../data/protectiveDevices.mjs';
 import { calculateTransformerImpedance } from '../utils/transformerImpedance.js';
 import { computeIEC60909Bus } from './iec60909.mjs';
@@ -721,6 +722,14 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     limitFaultByProtection(entry, comp, comps, compMap, protectiveLookupCache, scaledDeviceCache, tccSettings);
     const ct = resolveCtForComponent(comp, comps, compMap);
     if (ct) entry.ct = ct;
+    const ptVt = resolvePtVtForComponent(comp, comps, compMap);
+    if (ptVt) entry.pt_vt = ptVt;
+    if (ct || ptVt) {
+      entry.instrument_transformers = {
+        ...(ct ? { ct } : {}),
+        ...(ptVt ? { pt_vt: ptVt } : {})
+      };
+    }
     results[comp.id] = entry;
   });
 

--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -2368,11 +2368,29 @@
       "type": "vt",
       "label": "PT",
       "icon": "icons/components/Transformer.svg",
+      "symbol": "icons/components/Transformer.svg",
       "props": {
-        "ratio": "69000V:120V",
-        "class": "0.3WZ"
+        "tag": "PT-1",
+        "primary_voltage": 12470,
+        "secondary_voltage": 120,
+        "accuracy_class": "0.3",
+        "burden_va": 50,
+        "connection_type": "wye-grounded",
+        "fuse_protection": "yes",
+        "location_context": "protection",
+        "protected_device_id": "",
+        "meter_id": "",
+        "relay_id": "",
+        "consumer_ids": ""
       },
-      "subtype": "vt"
+      "subtype": "pt_vt",
+      "category": "protection",
+      "ports": [
+        {
+          "x": 40,
+          "y": 0
+        }
+      ]
     },
     {
       "type": "relay",

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -2368,11 +2368,29 @@
       "type": "vt",
       "label": "PT",
       "icon": "icons/components/Transformer.svg",
+      "symbol": "icons/components/Transformer.svg",
       "props": {
-        "ratio": "69000V:120V",
-        "class": "0.3WZ"
+        "tag": "PT-1",
+        "primary_voltage": 12470,
+        "secondary_voltage": 120,
+        "accuracy_class": "0.3",
+        "burden_va": 50,
+        "connection_type": "wye-grounded",
+        "fuse_protection": "yes",
+        "location_context": "protection",
+        "protected_device_id": "",
+        "meter_id": "",
+        "relay_id": "",
+        "consumer_ids": ""
       },
-      "subtype": "vt"
+      "subtype": "pt_vt",
+      "category": "protection",
+      "ports": [
+        {
+          "x": 40,
+          "y": 0
+        }
+      ]
     },
     {
       "type": "relay",

--- a/docs/components.md
+++ b/docs/components.md
@@ -43,6 +43,18 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Validation enforces physically valid values (positive ratios, positive burden/knee-point, and `ratio_primary >= ratio_secondary`) so study scaling inputs are not silently invalid.
 - Protection and metering study builders now receive normalized CT metadata in the study input object (`ct`) whenever a linked CT is found (explicit `ct_id`, reverse CT link fields, or direct CT connection).
 
+## Potential/voltage transformer (PT/VT) component fields
+
+- The one-line palette now includes a `pt_vt` subtype under **Protection** (type `vt`) with transformer symbol defaults.
+- Required PT/VT fields are `tag`, `primary_voltage`, `secondary_voltage`, `accuracy_class`, `burden_va`, `connection_type`, and `fuse_protection`.
+- Optional linkage fields (`protected_device_id`, `meter_id`, `relay_id`, and `consumer_ids`) model downstream metering/protection consumers using component IDs.
+- Validation enforces:
+  - required-field completeness,
+  - physically valid ratio direction (`primary_voltage >= secondary_voltage`),
+  - ratio range (`1..2000`),
+  - linked voltage-base compatibility (PT/VT primary voltage vs linked consumer voltage base).
+- Protection and metering study preprocessing now attaches normalized PT/VT metadata in study inputs as `pt_vt` (and under `instrument_transformers.pt_vt` when CT/PT are both present), including computed scaling ratio and voltage-base compatibility flags.
+
 ## DC bus component fields
 
 - The one-line palette now includes a `dc_bus` subtype under the Bus category with a dedicated DC icon.

--- a/docs/ground-fault-protection.md
+++ b/docs/ground-fault-protection.md
@@ -158,3 +158,18 @@ Link resolution precedence:
 
 This makes scaling assumptions explicit and traceable when reviewing protection and metering calculations.
 
+## PT/VT metadata in study inputs
+
+Protection and metering study preprocessing now also attaches normalized PT/VT metadata when linked PT/VT components are present. The attached `pt_vt` block includes:
+
+- `tag`, `primary_voltage`, `secondary_voltage`, computed `ratio`
+- `accuracy_class`, `burden_va`, `connection_type`, `fuse_protection`
+- linkage fields (`protected_device_id`, `meter_id`, `relay_id`, `consumer_ids`)
+- optional `voltage_base` compatibility details (`primary_v`, `consumer_v`, `compatible`)
+
+PT/VT link resolution precedence:
+1. Explicit component reference (`pt_vt_id`, `vt_id`, `pt_id`, `potential_transformer_id`, `voltage_transformer_id`).
+2. Reverse PT/VT links via `protected_device_id`, `meter_id`, `relay_id`, or `consumer_ids`.
+3. Direct PT/VT-to-component connection on the one-line graph.
+
+When both CT and PT/VT are found, short-circuit/protection entries expose both under `instrument_transformers` so relay/meter post-processing can apply consistent scaling from a single payload.

--- a/oneline.js
+++ b/oneline.js
@@ -1167,6 +1167,21 @@ const mccFieldSpecs = [
   { name: 'form_type', label: 'Form Type', type: 'text', required: true, defaultValue: 'form_2b' }
 ];
 
+const ptVtFieldSpecs = [
+  { name: 'tag', label: 'Tag', type: 'text', required: true, defaultValue: comp => comp.ref || comp.label || comp.id || '' },
+  { name: 'primary_voltage', label: 'Primary Voltage (V)', type: 'number', required: true, defaultValue: 12470 },
+  { name: 'secondary_voltage', label: 'Secondary Voltage (V)', type: 'number', required: true, defaultValue: 120 },
+  { name: 'accuracy_class', label: 'Accuracy Class', type: 'text', required: true, defaultValue: '0.3' },
+  { name: 'burden_va', label: 'Burden (VA)', type: 'number', required: true, defaultValue: 50 },
+  { name: 'connection_type', label: 'Connection Type', type: 'text', required: true, defaultValue: 'wye-grounded' },
+  { name: 'fuse_protection', label: 'Fuse Protection', type: 'text', required: true, defaultValue: 'yes' },
+  { name: 'location_context', label: 'Context', type: 'text', required: false, defaultValue: 'protection' },
+  { name: 'protected_device_id', label: 'Protected Device ID', type: 'text', required: false, defaultValue: '' },
+  { name: 'meter_id', label: 'Linked Meter ID', type: 'text', required: false, defaultValue: '' },
+  { name: 'relay_id', label: 'Linked Relay ID', type: 'text', required: false, defaultValue: '' },
+  { name: 'consumer_ids', label: 'Consumer IDs (comma-separated)', type: 'text', required: false, defaultValue: '' }
+];
+
 const baselineComponentFieldSpecs = [
   { name: 'tag', label: 'Tag', type: 'text', required: true, defaultValue: comp => comp.ref || comp.label || comp.id || '' },
   { name: 'description', label: 'Description', type: 'text', required: true, defaultValue: comp => comp.label || '' },
@@ -1400,6 +1415,56 @@ function ensureMccMetadata() {
   });
 }
 
+function isPtVtComponentMeta(meta) {
+  if (!meta || typeof meta !== 'object') return false;
+  const type = `${meta.type || ''}`.trim().toLowerCase();
+  const subtype = `${meta.subtype || ''}`.trim().toLowerCase();
+  return subtype === 'pt_vt' || subtype === 'vt' || type === 'pt_vt' || type === 'vt';
+}
+
+function ensurePtVtFieldsOnComponent(comp, meta) {
+  if (!comp || typeof comp !== 'object') return comp;
+  if (!isPtVtComponentMeta(meta || comp)) return comp;
+  if (!comp.props || typeof comp.props !== 'object') {
+    comp.props = { ...(comp.props || {}) };
+  }
+  ptVtFieldSpecs.forEach(spec => {
+    const hasCompValue = Object.prototype.hasOwnProperty.call(comp, spec.name) && comp[spec.name] !== '';
+    const hasPropsValue = Object.prototype.hasOwnProperty.call(comp.props, spec.name) && comp.props[spec.name] !== '';
+    if (hasCompValue || hasPropsValue) {
+      if (!hasCompValue && hasPropsValue) comp[spec.name] = comp.props[spec.name];
+      if (hasCompValue && !hasPropsValue) comp.props[spec.name] = comp[spec.name];
+      return;
+    }
+    const nextValue = typeof spec.defaultValue === 'function' ? spec.defaultValue(comp, meta) : spec.defaultValue;
+    comp[spec.name] = nextValue;
+    comp.props[spec.name] = nextValue;
+  });
+  return comp;
+}
+
+function ensurePtVtMetadata() {
+  Object.entries(componentMeta).forEach(([key, meta]) => {
+    if (!isPtVtComponentMeta(meta)) return;
+    if (!meta.props || typeof meta.props !== 'object') {
+      meta.props = { ...(meta.props || {}) };
+    }
+    ptVtFieldSpecs.forEach(spec => {
+      if (!Object.prototype.hasOwnProperty.call(meta.props, spec.name)) {
+        const nextValue = typeof spec.defaultValue === 'function' ? spec.defaultValue(meta.props) : spec.defaultValue;
+        meta.props[spec.name] = nextValue;
+      }
+    });
+    const schemaKeys = new Set([key, meta.subtype].filter(Boolean));
+    schemaKeys.forEach(schemaKey => {
+      if (!Array.isArray(propSchemas[schemaKey])) {
+        propSchemas[schemaKey] = inferSchemaFromProps(meta.props || {});
+      }
+      ptVtFieldSpecs.forEach(spec => ensureBaselineFieldSchema(propSchemas[schemaKey], spec));
+    });
+  });
+}
+
 function loadStoredCustomComponents() {
   const stored = getItem(customComponentStorageKey, [], customComponentScenarioKey);
   if (!Array.isArray(stored)) return [];
@@ -1576,6 +1641,7 @@ async function loadComponentLibrary() {
   ensureCapacitorReactorPropertyMetadata();
   ensureGeneratorStudyMetadata();
   ensureMccMetadata();
+  ensurePtVtMetadata();
   ensureBaselineComponentMetadata();
 
   buildPalette();
@@ -5673,6 +5739,7 @@ function normalizeComponent(c) {
   ensureBaselineFieldsOnComponent(nc, componentMeta[nc.subtype]);
   ensureGeneratorStudyFieldsOnComponent(nc, componentMeta[nc.subtype]);
   ensureMccFieldsOnComponent(nc, componentMeta[nc.subtype]);
+  ensurePtVtFieldsOnComponent(nc, componentMeta[nc.subtype]);
   return nc;
 }
 
@@ -8074,6 +8141,7 @@ function addComponent(cfg) {
   ensureBaselineFieldsOnComponent(comp, meta);
   ensureGeneratorStudyFieldsOnComponent(comp, meta);
   ensureMccFieldsOnComponent(comp, meta);
+  ensurePtVtFieldsOnComponent(comp, meta);
   ensureShapeDefaults(comp);
   if (comp.type === 'transformer') {
     syncTransformerDefaults(comp, { forceBase: true });
@@ -8641,6 +8709,20 @@ function selectComponent(compOrId) {
       protected_device_id: 'Protected Device ID',
       meter_id: 'Linked Meter ID',
       relay_id: 'Linked Relay ID'
+      ,
+      primary_voltage: 'PT/VT Primary Voltage (V)',
+      secondary_voltage: 'PT/VT Secondary Voltage (V)',
+      connection_type: {
+        label: 'PT/VT Connection Type',
+        type: 'select',
+        options: ['wye-grounded', 'wye-ungrounded', 'delta', 'open-delta']
+      },
+      fuse_protection: {
+        label: 'PT/VT Fuse Protection',
+        type: 'select',
+        options: ['yes', 'no']
+      },
+      consumer_ids: 'Linked Consumer IDs'
     };
 
     let schema = rawSchema
@@ -11236,6 +11318,7 @@ async function init() {
       ensureBaselineFieldsOnComponent(c, componentMeta[c.subtype]);
       ensureGeneratorStudyFieldsOnComponent(c, componentMeta[c.subtype]);
       ensureMccFieldsOnComponent(c, componentMeta[c.subtype]);
+      ensurePtVtFieldsOnComponent(c, componentMeta[c.subtype]);
     });
   });
   rebuildComponentMaps();
@@ -11245,6 +11328,7 @@ async function init() {
   ensureBaselineComponentMetadata();
   ensureGeneratorStudyMetadata();
   ensureMccMetadata();
+  ensurePtVtMetadata();
   sheets.forEach(s => {
     s.components.forEach(c => {
       (c.connections || []).forEach(conn => {

--- a/tests/ptVtMetadata.test.mjs
+++ b/tests/ptVtMetadata.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'assert';
+import { resolvePtVtForComponent } from '../analysis/ptVtMetadata.mjs';
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  \u2713', name);
+  } catch (err) {
+    console.error('  \u2717', name, err.message || err);
+    process.exitCode = 1;
+  }
+}
+
+describe('ptVtMetadata', () => {
+  it('resolves PT/VT by explicit id and returns scaling ratio', () => {
+    const pt = {
+      id: 'pt-1',
+      subtype: 'pt_vt',
+      props: {
+        tag: 'PT-1',
+        primary_voltage: 12470,
+        secondary_voltage: 120,
+        accuracy_class: '0.3',
+        burden_va: 50,
+        connection_type: 'wye-grounded',
+        fuse_protection: 'yes'
+      }
+    };
+    const meter = {
+      id: 'meter-1',
+      type: 'meter',
+      props: { pt_vt_id: 'pt-1', rated_voltage_kv: 12.47 }
+    };
+    const resolved = resolvePtVtForComponent(meter, [pt, meter]);
+    assert.ok(resolved);
+    assert.strictEqual(resolved.tag, 'PT-1');
+    assert.ok(resolved.ratio);
+    assert.strictEqual(Number(resolved.ratio.ratio.toFixed(6)), Number((12470 / 120).toFixed(6)));
+    assert.strictEqual(resolved.voltage_base?.compatible, true);
+  });
+
+  it('resolves PT/VT by reverse link and reports incompatibility', () => {
+    const relay = { id: 'relay-1', type: 'relay', props: { voltage: 480 } };
+    const pt = {
+      id: 'pt-2',
+      subtype: 'pt_vt',
+      props: {
+        tag: 'PT-2',
+        primary_voltage: 12470,
+        secondary_voltage: 120,
+        accuracy_class: '0.3',
+        burden_va: 50,
+        connection_type: 'wye-grounded',
+        fuse_protection: 'yes',
+        relay_id: 'relay-1'
+      }
+    };
+    const resolved = resolvePtVtForComponent(relay, [relay, pt]);
+    assert.ok(resolved);
+    assert.strictEqual(resolved.voltage_base?.compatible, false);
+  });
+});

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -220,6 +220,84 @@ describe('runValidation - meter CT/PT completeness', () => {
   });
 });
 
+describe('runValidation - PT/VT completeness and compatibility', () => {
+  it('flags PT/VT with missing required fields', () => {
+    const components = [
+      {
+        id: 'pt-1',
+        subtype: 'pt_vt',
+        type: 'vt',
+        props: {
+          tag: '',
+          primary_voltage: 0,
+          secondary_voltage: '',
+          accuracy_class: '',
+          burden_va: '',
+          connection_type: '',
+          fuse_protection: ''
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    assert.ok(issues.some(issue => issue.component === 'pt-1' && issue.message.includes('PT/VT missing/invalid')));
+  });
+
+  it('flags PT/VT with incompatible linked consumer voltage base', () => {
+    const components = [
+      {
+        id: 'meter-pt',
+        type: 'meter',
+        props: { voltage: 480 }
+      },
+      {
+        id: 'pt-2',
+        subtype: 'pt_vt',
+        type: 'vt',
+        props: {
+          tag: 'PT-2',
+          primary_voltage: 12470,
+          secondary_voltage: 120,
+          accuracy_class: '0.3',
+          burden_va: 50,
+          connection_type: 'wye-grounded',
+          fuse_protection: 'yes',
+          meter_id: 'meter-pt'
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    assert.ok(issues.some(issue => issue.component === 'pt-2' && issue.message.includes('incompatible')));
+  });
+
+  it('does not flag PT/VT when linked consumer voltage base is compatible', () => {
+    const components = [
+      {
+        id: 'relay-1',
+        type: 'relay',
+        props: { rated_voltage_kv: 12.47 }
+      },
+      {
+        id: 'pt-3',
+        subtype: 'pt_vt',
+        type: 'vt',
+        props: {
+          tag: 'PT-3',
+          primary_voltage: 12470,
+          secondary_voltage: 120,
+          accuracy_class: '0.3',
+          burden_va: 50,
+          connection_type: 'wye-grounded',
+          fuse_protection: 'yes',
+          relay_id: 'relay-1'
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const ptIssues = issues.filter(issue => issue.component === 'pt-3');
+    assert.deepStrictEqual(ptIssues, []);
+  });
+});
+
 describe('runValidation - battery required attributes', () => {
   it('flags a battery when required fields are missing', () => {
     const components = [

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -1,5 +1,43 @@
 import { resolveComponentLabel } from '../utils/componentLabels.js';
 
+function coerceNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function readField(component, key) {
+  if (!component || typeof component !== 'object') return undefined;
+  if (Object.prototype.hasOwnProperty.call(component, key)) return component[key];
+  if (component.props && typeof component.props === 'object' && Object.prototype.hasOwnProperty.call(component.props, key)) {
+    return component.props[key];
+  }
+  return undefined;
+}
+
+function toVolts(value, keyHint = '') {
+  const num = coerceNumber(value);
+  if (!Number.isFinite(num)) return null;
+  const key = `${keyHint || ''}`.toLowerCase();
+  if (key.includes('_kv') || key.includes('basekv') || key === 'kv') return num * 1000;
+  if (key.includes('nominal_voltage_vdc')) return num;
+  return num <= 100 ? num * 1000 : num;
+}
+
+function resolveComponentVoltageVolts(component) {
+  const keys = ['voltage_v', 'rated_voltage_kv', 'baseKV', 'kV', 'prefault_voltage', 'voltage', 'volts', 'nominal_voltage_vdc'];
+  for (const key of keys) {
+    const volts = toVolts(readField(component, key), key);
+    if (Number.isFinite(volts) && volts > 0) return volts;
+  }
+  return null;
+}
+
+function normalizeIdList(value) {
+  if (Array.isArray(value)) return value.map(v => `${v || ''}`.trim()).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  return value.split(',').map(v => v.trim()).filter(Boolean);
+}
+
 export function runValidation(components = [], studies = {}) {
   const issues = [];
   const componentLookup = new Map(components.map(c => [c.id, c]));
@@ -83,6 +121,61 @@ export function runValidation(components = [], studies = {}) {
         message: `Current transformer missing/invalid attributes: ${missing.join(', ')}.`
       });
     }
+  });
+
+  // PT/VT required field completeness, ratio limits, and downstream voltage-base compatibility
+  components.forEach(c => {
+    const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();
+    const type = `${c?.type ?? ''}`.trim().toLowerCase();
+    const isPtVt = subtype === 'pt_vt' || subtype === 'vt' || type === 'pt_vt' || type === 'vt';
+    if (!isPtVt) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    const primaryVoltage = Number(props.primary_voltage);
+    const secondaryVoltage = Number(props.secondary_voltage);
+    if (!Number.isFinite(primaryVoltage) || primaryVoltage <= 0) missing.push('primary_voltage');
+    if (!Number.isFinite(secondaryVoltage) || secondaryVoltage <= 0) missing.push('secondary_voltage');
+    if (Number.isFinite(primaryVoltage) && Number.isFinite(secondaryVoltage)) {
+      if (primaryVoltage < secondaryVoltage) missing.push('primary_voltage>=secondary_voltage');
+      const ratio = primaryVoltage / Math.max(secondaryVoltage, 1e-9);
+      if (!Number.isFinite(ratio) || ratio < 1 || ratio > 2000) missing.push('ratio_range(1..2000)');
+    }
+    if (!`${props.accuracy_class ?? ''}`.trim()) missing.push('accuracy_class');
+    const burdenVa = Number(props.burden_va);
+    if (!Number.isFinite(burdenVa) || burdenVa <= 0) missing.push('burden_va');
+    if (!`${props.connection_type ?? ''}`.trim()) missing.push('connection_type');
+    if (!`${props.fuse_protection ?? ''}`.trim()) missing.push('fuse_protection');
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `PT/VT missing/invalid attributes: ${missing.join(', ')}.`
+      });
+    }
+
+    const linkedIds = new Set(
+      [
+        `${props.protected_device_id ?? ''}`.trim(),
+        `${props.meter_id ?? ''}`.trim(),
+        `${props.relay_id ?? ''}`.trim(),
+        ...normalizeIdList(props.consumer_ids),
+        ...(Array.isArray(c.connections) ? c.connections.map(conn => `${conn?.target ?? ''}`.trim()) : [])
+      ].filter(Boolean)
+    );
+    if (!linkedIds.size || !Number.isFinite(primaryVoltage) || primaryVoltage <= 0) return;
+    linkedIds.forEach(targetId => {
+      const target = componentLookup.get(targetId);
+      if (!target) return;
+      const consumerVoltage = resolveComponentVoltageVolts(target);
+      if (!Number.isFinite(consumerVoltage) || consumerVoltage <= 0) return;
+      const mismatchRatio = Math.abs(primaryVoltage - consumerVoltage) / Math.max(primaryVoltage, consumerVoltage);
+      if (mismatchRatio > 0.35) {
+        issues.push({
+          component: c.id,
+          message: `PT/VT primary_voltage (${primaryVoltage} V) is incompatible with linked component ${describe(targetId)} voltage base (${consumerVoltage.toFixed(1)} V).`
+        });
+      }
+    });
   });
 
   // Meter ratio completeness for study-enabled metering features


### PR DESCRIPTION
### Motivation
- Provide first-class PT/VT (potential/voltage transformer) support so protection and metering workflows can consume instrument-transformer scaling and linkage metadata from the one-line model.
- Surface required PT/VT fields in the editor and enforce physical/compatibility constraints to prevent silent scaling errors in relay/meter calculations.

### Description
- Added a new normalization/linkage module `analysis/ptVtMetadata.mjs` that resolves PT/VT links (explicit id, reverse links, or direct connection), normalizes properties, computes the primary:secondary ratio, and reports consumer voltage-base compatibility.
- Wire PT/VT into study preprocessing by attaching `pt_vt` (and combined `instrument_transformers`) to short-circuit outputs in `analysis/shortCircuit.mjs` so downstream relay/meter post-processing can use consistent scaling.
- Added PT/VT editor integration and persistence via the existing component property pipeline in `oneline.js` (`ptVtFieldSpecs`, `ensurePtVtFieldsOnComponent`, `ensurePtVtMetadata`) and updated property labels/options in the UI.
- Added `pt_vt` subtype to `componentLibrary.json`/`docs/componentLibrary.json` with symbol and defaults, validation checks in `validation/rules.js` (required fields, ratio direction/range, linked-voltage compatibility), tests (`tests/ptVtMetadata.test.mjs`, updated `tests/validation.test.mjs`), and documentation updates (`docs/components.md`, `docs/ground-fault-protection.md`).

### Testing
- Ran the full test suite with `npm test` which completed successfully (including updated validation tests).
- Built the web assets with `npm run build` which completed successfully.
- Ran the PT/VT unit smoke tests with `node tests/ptVtMetadata.test.mjs` which passed.
- Attempted an automated Playwright screenshot to generate a preview image but the environment lacked Playwright browser binaries (`npx playwright install` required), so the screenshot step failed (no change to code tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0457200883248a61826ad9fb7bbf)