### PR TITLE
Add UPS component subtype with validation and study/report support

### DIFF
--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -487,7 +487,46 @@ function isGeneratorDevice(comp) {
   return type.includes('generator') || subtype.includes('generator') || type.includes('source');
 }
 
+function isUpsDevice(comp) {
+  const type = String(comp?.type || '').toLowerCase();
+  const subtype = String(comp?.subtype || '').toLowerCase();
+  return type === 'ups' || subtype === 'ups';
+}
+
+function deriveUpsOperatingProfile(comp) {
+  if (!isUpsDevice(comp)) return null;
+  const props = comp?.props && typeof comp.props === 'object' ? comp.props : {};
+  const mode = String(
+    comp?.operating_mode
+    ?? props.operating_mode
+    ?? 'normal'
+  ).trim().toLowerCase();
+  const ratedKva = toNumber(comp?.rated_kva ?? props.rated_kva ?? comp?.kva ?? props.kva);
+  const pfRaw = toNumber(comp?.pf ?? props.pf ?? comp?.power_factor ?? props.power_factor);
+  const pf = pfRaw > 0 ? Math.min(Math.abs(pfRaw), 1) : 0.9;
+  const efficiencyPct = toNumber(comp?.efficiency_pct ?? props.efficiency_pct, 1);
+  const efficiency = Math.max(0.01, efficiencyPct > 1 ? efficiencyPct / 100 : efficiencyPct);
+  const ratedKw = ratedKva > 0 ? ratedKva * pf : 0;
+  const ratedKvar = ratedKva > 0 ? Math.sqrt(Math.max(0, ratedKva * ratedKva - ratedKw * ratedKw)) : 0;
+  if (!ratedKw && !ratedKvar) return null;
+  if (mode === 'battery') {
+    return {
+      load: null,
+      generation: { kw: ratedKw, kvar: ratedKvar },
+      mode
+    };
+  }
+  const inputKw = ratedKw > 0 ? ratedKw / efficiency : 0;
+  return {
+    load: { kw: inputKw, kvar: ratedKvar },
+    generation: null,
+    mode
+  };
+}
+
 function extractLoadPQ(comp) {
+  const upsProfile = deriveUpsOperatingProfile(comp);
+  if (upsProfile?.load) return upsProfile.load;
   const rawSources = [comp?.load, comp?.props?.load, comp?.parameters?.load];
   const seenRefs = new Set();
   const seenValues = new Set();
@@ -540,6 +579,8 @@ function extractLoadPQ(comp) {
 }
 
 function extractGenerationPQ(comp) {
+  const upsProfile = deriveUpsOperatingProfile(comp);
+  if (upsProfile?.generation) return upsProfile.generation;
   const sources = [comp?.generation, comp?.props?.generation, comp?.parameters?.generation];
   let total = null;
   sources.forEach(src => {

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -124,6 +124,7 @@ const upstreamCandidateTypes = new Set([
   'utility_source',
   'generator',
   'pv_inverter',
+  'ups',
   'mcc',
   'feeder'
 ]);
@@ -155,7 +156,63 @@ function normalizePortIndex(port) {
 }
 
 function isSourceComponent(comp) {
-  return ['utility_source', 'generator', 'pv_inverter'].includes(comp?.type);
+  return ['utility_source', 'generator', 'pv_inverter', 'ups'].includes(comp?.type);
+}
+
+function getUpsStudyMetadata(comp) {
+  if (!comp || typeof comp !== 'object') return null;
+  const type = `${comp.type || ''}`.trim().toLowerCase();
+  const subtype = `${comp.subtype || ''}`.trim().toLowerCase();
+  if (type !== 'ups' && subtype !== 'ups') return null;
+  const readNumber = (key, fallback = null) => {
+    const num = parseNumeric(pickValue(comp, key));
+    return num === null ? fallback : num;
+  };
+  const readString = key => `${pickValue(comp, key) ?? ''}`.trim();
+  return {
+    tag: readString('tag'),
+    topology: readString('topology'),
+    operating_mode: readString('operating_mode') || 'normal',
+    rated_kva: readNumber('rated_kva', readNumber('kva', 0)),
+    input_voltage_kv: readNumber('input_voltage_kv', readNumber('kV', readNumber('baseKV'))),
+    output_voltage_kv: readNumber('output_voltage_kv', readNumber('kV', readNumber('baseKV'))),
+    efficiency_pct: readNumber('efficiency_pct'),
+    battery_runtime_min: readNumber('battery_runtime_min'),
+    battery_dc_v: readNumber('battery_dc_v'),
+    static_bypass_supported: Boolean(pickValue(comp, 'static_bypass_supported')),
+    mode_normal_enabled: Boolean(pickValue(comp, 'mode_normal_enabled')),
+    mode_battery_enabled: Boolean(pickValue(comp, 'mode_battery_enabled')),
+    mode_bypass_enabled: Boolean(pickValue(comp, 'mode_bypass_enabled')),
+    runtime_normal_min: readNumber('runtime_normal_min', 0),
+    runtime_battery_min: readNumber('runtime_battery_min', readNumber('battery_runtime_min', 0)),
+    runtime_bypass_min: readNumber('runtime_bypass_min', 0)
+  };
+}
+
+function resolveUpsForComponent(component, components = [], componentMap = new Map()) {
+  if (!component) return null;
+  const direct = getUpsStudyMetadata(component);
+  if (direct) return direct;
+  const incoming = [];
+  components.forEach(source => {
+    if (!source || !Array.isArray(source.connections)) return;
+    source.connections.forEach(conn => {
+      const target = typeof conn === 'string' ? conn : conn?.target;
+      if (target === component.id) incoming.push(source);
+    });
+  });
+  for (const candidate of incoming) {
+    const metadata = getUpsStudyMetadata(candidate);
+    if (metadata) return metadata;
+  }
+  const connList = Array.isArray(component.connections) ? component.connections : [];
+  for (const conn of connList) {
+    const target = typeof conn === 'string' ? conn : conn?.target;
+    if (!target) continue;
+    const metadata = getUpsStudyMetadata(componentMap.get(target));
+    if (metadata) return metadata;
+  }
+  return null;
 }
 
 function isProtectionComponent(comp) {
@@ -730,6 +787,8 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
         ...(ptVt ? { pt_vt: ptVt } : {})
       };
     }
+    const ups = resolveUpsForComponent(comp, comps, compMap);
+    if (ups) entry.ups = ups;
     results[comp.id] = entry;
   });
 

--- a/componentLibrary.json
+++ b/componentLibrary.json
@@ -1901,10 +1901,25 @@
       "label": "UPS",
       "icon": "icons/components/UPS.svg",
       "props": {
-        "kva": 500,
-        "volts": 480,
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
         "topology": "double_conversion",
-        "battery_kwh": 250,
+        "rated_kva": 500,
+        "input_voltage_kv": 0.48,
+        "output_voltage_kv": 0.48,
+        "efficiency_pct": 96.0,
+        "battery_runtime_min": 15,
+        "battery_dc_v": 480,
+        "static_bypass_supported": true,
+        "operating_mode": "normal",
+        "mode_normal_enabled": true,
+        "mode_battery_enabled": true,
+        "mode_bypass_enabled": true,
+        "runtime_normal_min": 0,
+        "runtime_battery_min": 15,
+        "runtime_bypass_min": 60,
         "baseKV": 0.48,
         "kV": 0.48,
         "voltage": 480,
@@ -1915,8 +1930,19 @@
         "electrode_config": "VCB",
         "mva": 0.5,
         "thevenin_mva": 0.5,
-        "battery_runtime_min": 15
-      }
+        "pf": 0.9,
+        "load": {
+          "kw": 180,
+          "kvar": 87.178
+        },
+        "generation": {
+          "kw": 0,
+          "kvar": 0
+        }
+      },
+      "subtype": "ups",
+      "category": "equipment",
+      "iconIEC": "icons/components/iec/IEC_Generator.svg"
     },
     {
       "type": "battery",

--- a/docs/componentLibrary.json
+++ b/docs/componentLibrary.json
@@ -1901,10 +1901,25 @@
       "label": "UPS",
       "icon": "icons/components/UPS.svg",
       "props": {
-        "kva": 500,
-        "volts": 480,
+        "tag": "",
+        "description": "",
+        "manufacturer": "",
+        "model": "",
         "topology": "double_conversion",
-        "battery_kwh": 250,
+        "rated_kva": 500,
+        "input_voltage_kv": 0.48,
+        "output_voltage_kv": 0.48,
+        "efficiency_pct": 96.0,
+        "battery_runtime_min": 15,
+        "battery_dc_v": 480,
+        "static_bypass_supported": true,
+        "operating_mode": "normal",
+        "mode_normal_enabled": true,
+        "mode_battery_enabled": true,
+        "mode_bypass_enabled": true,
+        "runtime_normal_min": 0,
+        "runtime_battery_min": 15,
+        "runtime_bypass_min": 60,
         "baseKV": 0.48,
         "kV": 0.48,
         "voltage": 480,
@@ -1915,8 +1930,19 @@
         "electrode_config": "VCB",
         "mva": 0.5,
         "thevenin_mva": 0.5,
-        "battery_runtime_min": 15
-      }
+        "pf": 0.9,
+        "load": {
+          "kw": 180,
+          "kvar": 87.178
+        },
+        "generation": {
+          "kw": 0,
+          "kvar": 0
+        }
+      },
+      "subtype": "ups",
+      "category": "equipment",
+      "iconIEC": "icons/components/iec/IEC_Generator.svg"
     },
     {
       "type": "battery",

--- a/docs/components.md
+++ b/docs/components.md
@@ -34,6 +34,14 @@ Each subtype in `componentLibrary.json` may include these properties in its sche
 - Meter fields include `tag`, `description`, `manufacturer`, `model`, `meter_class`, `ct_ratio`, `pt_ratio`, `sample_rate_hz`, and study capability flags (`supports_thd`, `supports_flicker`, `supports_waveform_capture`).
 - Validation enforces both `ct_ratio` and `pt_ratio` when any meter study capability flag is enabled so harmonics/power-quality workflows do not run with incomplete instrument transformer scaling.
 
+## UPS component fields
+
+- The one-line palette includes a dedicated `ups` subtype under **Equipment** with `icons/components/UPS.svg`.
+- Required UPS fields are `tag`, `manufacturer`, `model`, `topology`, `rated_kva`, `input_voltage_kv`, `output_voltage_kv`, `efficiency_pct`, `battery_runtime_min`, `battery_dc_v`, and `static_bypass_supported`.
+- Runtime and operating-mode study/report context fields include `operating_mode` (`normal`, `battery`, `bypass`), mode enable flags (`mode_normal_enabled`, `mode_battery_enabled`, `mode_bypass_enabled`), and mode runtimes (`runtime_normal_min`, `runtime_battery_min`, `runtime_bypass_min`).
+- Validation enforces rating/runtime consistency, including battery runtime coherence (`runtime_battery_min` equals `battery_runtime_min`) and bypass-mode constraints.
+- Load-flow and short-circuit adapters now consume UPS metadata directly so users can model UPS behavior without decomposing the element into separate battery/rectifier/inverter primitives.
+
 
 ## Current transformer (CT) component fields
 

--- a/docs/examples/sample_oneline.json
+++ b/docs/examples/sample_oneline.json
@@ -1,6 +1,9 @@
 {
   "version": 2,
-  "scale": { "unitPerPx": 1, "unit": "in" },
+  "scale": {
+    "unitPerPx": 1,
+    "unit": "in"
+  },
   "templates": [],
   "sheets": [
     {
@@ -16,14 +19,25 @@
           "height": 20,
           "label": "Bus 1",
           "ref": "",
-          "labelOffset": { "x": 0, "y": 0 },
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
           "rotation": 0,
           "flipped": false,
-          "impedance": { "r": 0, "x": 0 },
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
           "rating": null,
           "props": {},
           "connections": [
-            { "target": "n2" }
+            {
+              "target": "n2"
+            },
+            {
+              "target": "n4"
+            }
           ]
         },
         {
@@ -34,14 +48,22 @@
           "y": 60,
           "label": "Panel 1",
           "ref": "",
-          "labelOffset": { "x": 0, "y": 0 },
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
           "rotation": 0,
           "flipped": false,
-          "impedance": { "r": 0, "x": 0 },
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
           "rating": null,
           "props": {},
           "connections": [
-            { "target": "n3" }
+            {
+              "target": "n3"
+            }
           ]
         },
         {
@@ -52,25 +74,97 @@
           "y": 60,
           "label": "Load 1",
           "ref": "",
-          "labelOffset": { "x": 0, "y": 0 },
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
           "rotation": 0,
           "flipped": false,
-          "impedance": { "r": 0, "x": 0 },
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
           "rating": null,
           "props": {
             "watts": 300000,
             "volts": 480,
-            "load": { "kw": 300, "kvar": 0 }
+            "load": {
+              "kw": 300,
+              "kvar": 0
+            }
           },
           "watts": 300000,
           "volts": 480,
-          "load": { "kw": 300, "kvar": 0 },
+          "load": {
+            "kw": 300,
+            "kvar": 0
+          },
           "connections": []
+        },
+        {
+          "id": "n4",
+          "type": "ups",
+          "subtype": "ups",
+          "x": 220,
+          "y": 180,
+          "label": "UPS-1",
+          "ref": "",
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
+          "rotation": 0,
+          "flipped": false,
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
+          "rating": null,
+          "props": {
+            "tag": "UPS-1",
+            "description": "Critical IT UPS",
+            "manufacturer": "ExamplePower",
+            "model": "DP-500",
+            "topology": "double_conversion",
+            "rated_kva": 500,
+            "input_voltage_kv": 0.48,
+            "output_voltage_kv": 0.48,
+            "efficiency_pct": 96.0,
+            "battery_runtime_min": 15,
+            "battery_dc_v": 480,
+            "static_bypass_supported": true,
+            "operating_mode": "battery",
+            "mode_normal_enabled": true,
+            "mode_battery_enabled": true,
+            "mode_bypass_enabled": true,
+            "runtime_normal_min": 0,
+            "runtime_battery_min": 15,
+            "runtime_bypass_min": 60
+          },
+          "connections": [
+            {
+              "target": "n3"
+            }
+          ]
         }
       ],
       "connections": [
-        { "from": "n1", "to": "n2" },
-        { "from": "n2", "to": "n3" }
+        {
+          "from": "n1",
+          "to": "n2"
+        },
+        {
+          "from": "n2",
+          "to": "n3"
+        },
+        {
+          "from": "n1",
+          "to": "n4"
+        },
+        {
+          "from": "n4",
+          "to": "n3"
+        }
       ]
     }
   ]

--- a/examples/sample_oneline.json
+++ b/examples/sample_oneline.json
@@ -1,6 +1,9 @@
 {
   "version": 2,
-  "scale": { "unitPerPx": 1, "unit": "in" },
+  "scale": {
+    "unitPerPx": 1,
+    "unit": "in"
+  },
   "templates": [],
   "sheets": [
     {
@@ -16,14 +19,25 @@
           "height": 20,
           "label": "Bus 1",
           "ref": "",
-          "labelOffset": { "x": 0, "y": 0 },
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
           "rotation": 0,
           "flipped": false,
-          "impedance": { "r": 0, "x": 0 },
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
           "rating": null,
           "props": {},
           "connections": [
-            { "target": "n2" }
+            {
+              "target": "n2"
+            },
+            {
+              "target": "n4"
+            }
           ]
         },
         {
@@ -34,14 +48,22 @@
           "y": 60,
           "label": "Panel 1",
           "ref": "",
-          "labelOffset": { "x": 0, "y": 0 },
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
           "rotation": 0,
           "flipped": false,
-          "impedance": { "r": 0, "x": 0 },
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
           "rating": null,
           "props": {},
           "connections": [
-            { "target": "n3" }
+            {
+              "target": "n3"
+            }
           ]
         },
         {
@@ -52,25 +74,97 @@
           "y": 60,
           "label": "Load 1",
           "ref": "",
-          "labelOffset": { "x": 0, "y": 0 },
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
           "rotation": 0,
           "flipped": false,
-          "impedance": { "r": 0, "x": 0 },
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
           "rating": null,
           "props": {
             "watts": 300000,
             "volts": 480,
-            "load": { "kw": 300, "kvar": 0 }
+            "load": {
+              "kw": 300,
+              "kvar": 0
+            }
           },
           "watts": 300000,
           "volts": 480,
-          "load": { "kw": 300, "kvar": 0 },
+          "load": {
+            "kw": 300,
+            "kvar": 0
+          },
           "connections": []
+        },
+        {
+          "id": "n4",
+          "type": "ups",
+          "subtype": "ups",
+          "x": 220,
+          "y": 180,
+          "label": "UPS-1",
+          "ref": "",
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          },
+          "rotation": 0,
+          "flipped": false,
+          "impedance": {
+            "r": 0,
+            "x": 0
+          },
+          "rating": null,
+          "props": {
+            "tag": "UPS-1",
+            "description": "Critical IT UPS",
+            "manufacturer": "ExamplePower",
+            "model": "DP-500",
+            "topology": "double_conversion",
+            "rated_kva": 500,
+            "input_voltage_kv": 0.48,
+            "output_voltage_kv": 0.48,
+            "efficiency_pct": 96.0,
+            "battery_runtime_min": 15,
+            "battery_dc_v": 480,
+            "static_bypass_supported": true,
+            "operating_mode": "battery",
+            "mode_normal_enabled": true,
+            "mode_battery_enabled": true,
+            "mode_bypass_enabled": true,
+            "runtime_normal_min": 0,
+            "runtime_battery_min": 15,
+            "runtime_bypass_min": 60
+          },
+          "connections": [
+            {
+              "target": "n3"
+            }
+          ]
         }
       ],
       "connections": [
-        { "from": "n1", "to": "n2" },
-        { "from": "n2", "to": "n3" }
+        {
+          "from": "n1",
+          "to": "n2"
+        },
+        {
+          "from": "n2",
+          "to": "n3"
+        },
+        {
+          "from": "n1",
+          "to": "n4"
+        },
+        {
+          "from": "n4",
+          "to": "n3"
+        }
       ]
     }
   ]

--- a/tests/loadflow/sampleOnelineLoadFlow.test.mjs
+++ b/tests/loadflow/sampleOnelineLoadFlow.test.mjs
@@ -61,6 +61,8 @@ describe('Published sample one-line load flow', () => {
     assert(bus.load, 'Bus n1 should aggregate downstream loads');
     assert(Math.abs(bus.load.kw - 300) < 1e-9, 'Aggregated kW should equal 300');
     assert(Math.abs(bus.load.kvar || 0) < 1e-9, 'Aggregated kvar should equal 0');
+    assert(bus.generation, 'Bus n1 should include UPS generation profile from sample UPS battery mode');
+    assert(Math.abs(bus.generation.kw - 450) < 1e-9, 'UPS battery mode generation should equal 500 kVA × 0.9 PF = 450 kW');
 
     const result = runLoadFlow(model, { baseMVA: 100, balanced: true });
     assert.strictEqual(result.buses.length, 1, 'Study should produce a single slack bus');

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -159,5 +159,49 @@ global.localStorage = {
       assert(bus.threePhaseKA > 0.1, 'generator-based fault current should be non-zero');
       assert(bus.threePhaseKA < 1, 'xdpp should limit source current contribution');
     });
+
+    it('includes normalized UPS metadata in short-circuit results', () => {
+      setOneLine({
+        activeSheet: 0,
+        sheets: [{
+          name: 'UPS',
+          components: [
+            {
+              id: 'ups1',
+              type: 'ups',
+              subtype: 'ups',
+              props: {
+                tag: 'UPS-1',
+                topology: 'double_conversion',
+                operating_mode: 'battery',
+                rated_kva: 500,
+                input_voltage_kv: 0.48,
+                output_voltage_kv: 0.48,
+                efficiency_pct: 96,
+                battery_runtime_min: 15,
+                battery_dc_v: 480,
+                static_bypass_supported: true,
+                mode_normal_enabled: true,
+                mode_battery_enabled: true,
+                mode_bypass_enabled: true,
+                runtime_normal_min: 0,
+                runtime_battery_min: 15,
+                runtime_bypass_min: 60
+              },
+              connections: [{ target: 'bus1', sourcePort: 0, targetPort: 0 }]
+            },
+            { id: 'bus1', type: 'bus', subtype: 'Bus' }
+          ]
+        }]
+      });
+      const res = runShortCircuit();
+      const bus = res.bus1;
+      assert(bus, 'bus results should exist');
+      assert(bus.ups, 'UPS metadata should be attached');
+      assert.strictEqual(bus.ups.tag, 'UPS-1');
+      assert.strictEqual(bus.ups.operating_mode, 'battery');
+      assert.strictEqual(bus.ups.rated_kva, 500);
+      assert.strictEqual(bus.ups.runtime_battery_min, 15);
+    });
   });
 })();

--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -367,6 +367,87 @@ describe('runValidation - battery required attributes', () => {
   });
 });
 
+describe('runValidation - ups required attributes and consistency checks', () => {
+  it('flags a UPS when required fields and runtime consistency checks fail', () => {
+    const components = [
+      {
+        id: 'ups-1',
+        type: 'ups',
+        subtype: 'ups',
+        props: {
+          tag: '',
+          manufacturer: '',
+          model: '',
+          topology: '',
+          rated_kva: 0,
+          input_voltage_kv: 0,
+          output_voltage_kv: '',
+          efficiency_pct: 120,
+          battery_runtime_min: 10,
+          battery_dc_v: 0,
+          static_bypass_supported: false,
+          operating_mode: 'bypass',
+          mode_normal_enabled: false,
+          mode_battery_enabled: true,
+          mode_bypass_enabled: false,
+          runtime_normal_min: -1,
+          runtime_battery_min: 5,
+          runtime_bypass_min: -2
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const requiredIssue = issues.find(issue => issue.component === 'ups-1' && issue.message.includes('UPS missing/invalid attributes'));
+    const consistencyIssue = issues.find(issue => issue.component === 'ups-1' && issue.message.includes('UPS rating/runtime consistency checks failed'));
+    assert.ok(requiredIssue);
+    assert.ok(requiredIssue.message.includes('tag'));
+    assert.ok(requiredIssue.message.includes('manufacturer'));
+    assert.ok(requiredIssue.message.includes('model'));
+    assert.ok(requiredIssue.message.includes('topology'));
+    assert.ok(requiredIssue.message.includes('rated_kva'));
+    assert.ok(requiredIssue.message.includes('input_voltage_kv'));
+    assert.ok(requiredIssue.message.includes('output_voltage_kv'));
+    assert.ok(requiredIssue.message.includes('efficiency_pct'));
+    assert.ok(requiredIssue.message.includes('battery_dc_v'));
+    assert.ok(requiredIssue.message.includes('runtime_normal_min'));
+    assert.ok(requiredIssue.message.includes('runtime_bypass_min'));
+    assert.ok(consistencyIssue);
+    assert.ok(consistencyIssue.message.includes('runtime_battery_min must match battery_runtime_min'));
+    assert.ok(consistencyIssue.message.includes('operating_mode=bypass requires static_bypass_supported=true'));
+  });
+
+  it('does not flag a UPS with complete and consistent fields', () => {
+    const components = [
+      {
+        id: 'ups-2',
+        type: 'ups',
+        subtype: 'ups',
+        props: {
+          tag: 'UPS-02',
+          manufacturer: 'ExamplePower',
+          model: 'DP-500',
+          topology: 'double_conversion',
+          rated_kva: 500,
+          input_voltage_kv: 0.48,
+          output_voltage_kv: 0.48,
+          efficiency_pct: 96,
+          battery_runtime_min: 15,
+          battery_dc_v: 480,
+          static_bypass_supported: true,
+          operating_mode: 'normal',
+          mode_normal_enabled: true,
+          mode_battery_enabled: true,
+          mode_bypass_enabled: true,
+          runtime_normal_min: 0,
+          runtime_battery_min: 15,
+          runtime_bypass_min: 60
+        }
+      }
+    ];
+    assert.deepStrictEqual(runValidation(components, {}), []);
+  });
+});
+
 describe('runValidation - dc_bus required attributes', () => {
   it('flags a dc_bus when required fields are missing', () => {
     const components = [

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -233,6 +233,80 @@ export function runValidation(components = [], studies = {}) {
     }
   });
 
+  // UPS required field completeness and rating/runtime consistency
+  components.forEach(c => {
+    const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();
+    const type = `${c?.type ?? ''}`.trim().toLowerCase();
+    const isUps = subtype === 'ups' || type === 'ups';
+    if (!isUps) return;
+    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const missing = [];
+    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
+    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${props.model ?? ''}`.trim()) missing.push('model');
+    if (!`${props.topology ?? ''}`.trim()) missing.push('topology');
+    const ratedKva = Number(props.rated_kva);
+    if (!Number.isFinite(ratedKva) || ratedKva <= 0) missing.push('rated_kva');
+    const inputVoltageKv = Number(props.input_voltage_kv);
+    if (!Number.isFinite(inputVoltageKv) || inputVoltageKv <= 0) missing.push('input_voltage_kv');
+    const outputVoltageKv = Number(props.output_voltage_kv);
+    if (!Number.isFinite(outputVoltageKv) || outputVoltageKv <= 0) missing.push('output_voltage_kv');
+    const efficiencyPct = Number(props.efficiency_pct);
+    if (!Number.isFinite(efficiencyPct) || efficiencyPct <= 0 || efficiencyPct > 100) missing.push('efficiency_pct');
+    const batteryRuntimeMin = Number(props.battery_runtime_min);
+    if (!Number.isFinite(batteryRuntimeMin) || batteryRuntimeMin < 0) missing.push('battery_runtime_min');
+    const batteryDcV = Number(props.battery_dc_v);
+    if (!Number.isFinite(batteryDcV) || batteryDcV <= 0) missing.push('battery_dc_v');
+    if (typeof props.static_bypass_supported !== 'boolean') missing.push('static_bypass_supported');
+
+    const operatingMode = `${props.operating_mode ?? ''}`.trim().toLowerCase();
+    const allowedModes = new Set(['normal', 'battery', 'bypass']);
+    if (!allowedModes.has(operatingMode)) missing.push('operating_mode');
+    const runtimeNormalMin = Number(props.runtime_normal_min);
+    const runtimeBatteryMin = Number(props.runtime_battery_min ?? props.battery_runtime_min);
+    const runtimeBypassMin = Number(props.runtime_bypass_min);
+    if (!Number.isFinite(runtimeNormalMin) || runtimeNormalMin < 0) missing.push('runtime_normal_min');
+    if (!Number.isFinite(runtimeBatteryMin) || runtimeBatteryMin < 0) missing.push('runtime_battery_min');
+    if (!Number.isFinite(runtimeBypassMin) || runtimeBypassMin < 0) missing.push('runtime_bypass_min');
+    if (typeof props.mode_normal_enabled !== 'boolean') missing.push('mode_normal_enabled');
+    if (typeof props.mode_battery_enabled !== 'boolean') missing.push('mode_battery_enabled');
+    if (typeof props.mode_bypass_enabled !== 'boolean') missing.push('mode_bypass_enabled');
+
+    const consistency = [];
+    if (Number.isFinite(runtimeBatteryMin) && Number.isFinite(batteryRuntimeMin)
+      && Math.abs(runtimeBatteryMin - batteryRuntimeMin) > 1e-6) {
+      consistency.push('runtime_battery_min must match battery_runtime_min');
+    }
+    if (props.mode_battery_enabled === true && Number.isFinite(runtimeBatteryMin) && runtimeBatteryMin <= 0) {
+      consistency.push('mode_battery_enabled requires runtime_battery_min > 0');
+    }
+    if (operatingMode === 'bypass' && props.static_bypass_supported !== true) {
+      consistency.push('operating_mode=bypass requires static_bypass_supported=true');
+    }
+    if (operatingMode === 'normal' && props.mode_normal_enabled === false) {
+      consistency.push('operating_mode=normal requires mode_normal_enabled=true');
+    }
+    if (operatingMode === 'battery' && props.mode_battery_enabled === false) {
+      consistency.push('operating_mode=battery requires mode_battery_enabled=true');
+    }
+    if (operatingMode === 'bypass' && props.mode_bypass_enabled === false) {
+      consistency.push('operating_mode=bypass requires mode_bypass_enabled=true');
+    }
+
+    if (missing.length) {
+      issues.push({
+        component: c.id,
+        message: `UPS missing/invalid attributes: ${missing.join(', ')}.`
+      });
+    }
+    if (consistency.length) {
+      issues.push({
+        component: c.id,
+        message: `UPS rating/runtime consistency checks failed: ${consistency.join('; ')}.`
+      });
+    }
+  });
+
   // DC bus required field completeness for DC-focused studies
   components.forEach(c => {
     const isDcBus = c?.subtype === 'dc_bus';


### PR DESCRIPTION
### Motivation

- Provide a first-class `ups` equipment subtype so UPS systems can be modeled as single components with nameplate, battery, and operating-mode metadata for one-line diagrams and studies.
- Require key UPS fields (tag, manufacturer, model, topology, rated_kva, input/output voltage, efficiency, battery/runtime and static-bypass capability) so study inputs are complete and consistent.
- Surface runtime and operating-mode context (`normal`/`battery`/`bypass`) so load-flow and short-circuit adapters can consume UPS behavior without requiring manual decomposition into rectifier/inverter/battery primitives.

### Description

- Added a new `ups` subtype entry and defaults into `componentLibrary.json` and `docs/componentLibrary.json`, including icon reference and UPS-specific `props` such as `rated_kva`, `input_voltage_kv`, `output_voltage_kv`, `efficiency_pct`, `battery_runtime_min`, `battery_dc_v`, `static_bypass_supported`, `operating_mode`, mode enable flags, and per-mode runtimes.
- Implemented validation checks in `validation/rules.js` that enforce required UPS fields and rating/runtime consistency rules (battery runtime coherence, bypass-mode constraints, and enabled-mode consistency) and return clear issue messages.
- Extended study adapters so UPS is handled natively: `analysis/loadFlowModel.js` derives an operating profile via `deriveUpsOperatingProfile()` and plugs UPS `load` or `generation` into `extractLoadPQ()`/`extractGenerationPQ()`, and `analysis/shortCircuit.mjs` now normalizes and attaches UPS metadata into short-circuit `entry.ups` for downstream reporting.
- Documentation and examples updated: `docs/components.md` documents UPS fields and behavior, and `docs/examples/sample_oneline.json` and `examples/sample_oneline.json` include a sample UPS wired into the sample one-line to demonstrate battery-mode behavior; tests were added/updated to cover validation, short-circuit metadata propagation, and sample load-flow expectations.

### Testing

- Ran targeted unit tests: `node tests/validation.test.mjs`, `node tests/shortcircuit/shortCircuit.test.cjs`, and `node tests/loadflow/sampleOnelineLoadFlow.test.mjs`, and each of these passed locally in this environment.
- Started the full test suite with `npm test`; the run exercised many suites and showed the new UPS-related tests passing where executed, but the full long-running suite could not be allowed to finish to completion in this environment before termination.
- Built the app with `npm run build`, which completed successfully for the patched sources (build warnings unrelated to the UPS change remained from existing rollup config/external deps).
- Preview image: attempted to capture a screenshot of `oneline.html` via Playwright to provide the requested webpage preview, but browser binaries are not available in this runtime (`Executable doesn't exist … headless_shell`), so a screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df07401db08324b8c8458e7ebea821)