### PR TITLE
Fix service worker path and harden project-display insertion to avoid console errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
     });
     // Register service worker for offline support.
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js').catch(() => { /* non-critical */ });
+      navigator.serviceWorker.register('sw.js').catch(() => { /* non-critical */ });
     }
   </script>
 </body>

--- a/site.js
+++ b/site.js
@@ -523,9 +523,14 @@ async function updateProjectDisplay(snapshot){
         span.style.marginLeft='auto';
         span.style.marginRight='var(--space-4)';
         const currentSettingsBtn=document.getElementById('settings-btn');
-        if(currentSettingsBtn&&currentSettingsBtn.parentNode===nav){
-          nav.insertBefore(span,currentSettingsBtn);
-          currentSettingsBtn.style.marginLeft='0';
+        if(currentSettingsBtn&&currentSettingsBtn.parentElement===nav&&nav.contains(currentSettingsBtn)){
+          try{
+            nav.insertBefore(span,currentSettingsBtn);
+            currentSettingsBtn.style.marginLeft='0';
+          }catch(err){
+            console.warn('project display insert fallback',err);
+            nav.appendChild(span);
+          }
         }else{
           nav.appendChild(span);
         }


### PR DESCRIPTION
### Motivation
- Prevent repeated browser console errors caused by a 404 when registering the service worker and by a runtime `insertBefore` NotFoundError when inserting the project display element.

### Description
- Change service worker registration in `index.html` from `'/sw.js'` to the relative path `'sw.js'` so the script resolves correctly when the app is hosted under a subpath.
- Harden `updateProjectDisplay` in `site.js` to only attempt `insertBefore` when the settings button is actually a child of the nav, and wrap `insertBefore` in a `try/catch` that falls back to `appendChild` on error to avoid throwing during DOM mutations.

### Testing
- Ran the focused unit test `node tests/projectDisplayScheduler.test.mjs`, which passed.
- Ran `npm run build`, which completed successfully (the run produced pre-existing Rollup warnings unrelated to these changes).
- Attempted full `npm test`; the suite started and executed many tests but did not cleanly terminate within the task environment so a complete run could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df83913b648324ac9db5466cc54196)