### PR TITLE
Reduce disruptive leave-page warnings and clarify autosave messaging

### DIFF
--- a/site.js
+++ b/site.js
@@ -312,6 +312,7 @@ function initOperationStatusHost(container){
     indicator.setAttribute('aria-live','polite');
     container.appendChild(indicator);
   }
+  updateLastSavedIndicator();
   return host;
 }
 
@@ -405,7 +406,12 @@ function updateLastSavedIndicator(){
   if(typeof document==='undefined') return;
   const el=document.getElementById('last-saved-indicator');
   if(!el) return;
-  el.textContent=formatLastSaved(lastSavedAt);
+  const savedText=formatLastSaved(lastSavedAt);
+  if(savedText){
+    el.textContent=`${savedText} • Edits auto-save in this browser.`;
+  }else{
+    el.textContent='Edits auto-save in this browser. Use Save Project for a downloadable backup.';
+  }
 }
 
 function recordSave(){
@@ -1661,36 +1667,6 @@ function initWorkflowStepNav(){
 }
 
 globalThis.document?.addEventListener('DOMContentLoaded',initWorkflowStepNav);
-
-// ─── Unsaved-Changes Navigation Warning ────────────────────────────────────
-let _projectDirty=false;
-
-function initUnsavedChangesWarning(){
-  // Track project mutations via onProjectChange; mark clean after saves
-  onProjectChange(()=>{_projectDirty=true;});
-
-  window.addEventListener('beforeunload',e=>{
-    if(!_projectDirty) return;
-    // Modern browsers show their own generic message; the return value triggers the dialog
-    e.preventDefault();
-    e.returnValue='You have unsaved changes. Leave anyway?';
-    return e.returnValue;
-  });
-
-  // Mark clean when the user explicitly saves (listen for our toast signal)
-  // We hook into the existing save infrastructure by watching for markClean calls
-  const origShowToast=globalThis.showOperationToast;
-  if(typeof origShowToast==='function'){
-    globalThis.showOperationToast=(msg,kind)=>{
-      if(kind!=='error'&&(msg.toLowerCase().includes('saved')||msg.toLowerCase().includes('save'))){
-        _projectDirty=false;
-      }
-      return origShowToast(msg,kind);
-    };
-  }
-}
-
-globalThis.document?.addEventListener('DOMContentLoaded',initUnsavedChangesWarning);
 
 function persistConduits(data){
   try{


### PR DESCRIPTION
### Motivation
- Users repeatedly saw the generic browser leave-site dialog ("Changes you made may not be saved.") during normal workflow navigation, which is noisy and unclear about what is actually saved. 
- Provide clear, immediate guidance in the UI about the app's autosave behavior and how to create a downloadable backup.

### Description
- Remove the global `beforeunload` unsaved-changes hook and related ad-hoc dirty tracking in `site.js` so routine page navigation no longer triggers the browser leave prompt. 
- Replace the simple last-saved indicator text with contextual messaging that shows a timestamp when available and otherwise states that edits auto-save in the browser and `Save Project` creates a downloadable backup. 
- Call `updateLastSavedIndicator()` when the settings operation-status host is created so the guidance is visible immediately on page load.

### Testing
- Ran `npm test`, which completed successfully and reported all unit/integration tests passing. 
- Ran `npm run build`, which completed successfully (build emitted non-fatal warnings). 
- Ran focused checks `node tests/autoSaveScheduler.test.mjs && node tests/pageNavigation.test.cjs`, both of which passed. 
- Attempted a Playwright UI screenshot for a preview but it failed because Playwright browser binaries are not installed in this environment (`Executable doesn't exist ... headless_shell`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df890b7ac88324b82278a3c05566d3)