### PR TITLE
Add canonical CE and EMF fixtures for next-features Playwright tests

### DIFF
--- a/playwright-tests/nextFeatures.helpers.js
+++ b/playwright-tests/nextFeatures.helpers.js
@@ -6,21 +6,73 @@ const root = path.join(__dirname, '..');
 
 export const pageUrl = file => `file://${path.join(root, file)}?e2e=1&e2e_reset=1`;
 
-export const COST_ESTIMATOR_FIXTURES = {
-  baselineProject: {
+// README(sync): source-of-truth is docs/next-features-acceptance.md lines
+// 94-135 (CE-Normal-01 + CE-Boundary-01/02) and 210-217 (numeric policy).
+export const COST_ESTIMATOR_CANONICAL_FIXTURE = {
+  projectData: {
     cableSchedule: [
-      { cable_tag: 'C-101', conductor_size: '4 AWG', conductors: 3, length_ft: 150 },
+      { cable_tag: 'C-1', conductor_size: '4 AWG', conductors: 3, length_ft: 100 },
+      { cable_tag: 'C-2', conductor_size: '2/0', conductors: 1, length_ft: 250 },
     ],
     traySchedule: [
-      { tray_id: 'T-101', tray_type: 'Ladder', inside_width: '12', length_ft: 120, fitting_count: 2 },
+      { tray_id: 'T-1', tray_type: 'Ladder', inside_width: '12', length_ft: 80, fitting_count: 2 },
     ],
     conduitSchedule: [
-      { conduit_id: 'CD-101', conduit_type: 'EMT', trade_size: '2', length_ft: 80 },
+      { conduit_id: 'CD-1', conduit_type: 'EMT', trade_size: '2', length_ft: 120 },
     ],
     studyResults: {
-      routeResults: [{ cable: 'C-101', total_length: 150 }],
+      routeResults: [
+        { cable: 'C-1', total_length: 100 },
+        { cable: 'C-2', total_length: 250 },
+      ],
     },
   },
+  expected: {
+    cableSubtotal: 2486,
+    traySubtotal: 980,
+    conduitSubtotal: 756,
+    subtotal: 4222,
+    contingencyPct: 15,
+    contingencyAmountRounded: 633,
+    totalRounded: 4855,
+    contingencyFloorPct: 0,
+    contingencyCeilingPct: 100,
+  },
+  tolerances: {
+    internalMathAbs: 0.01,
+    uiWholeDollarsAbs: 0,
+  },
+};
+
+// README(sync): source-of-truth is docs/next-features-acceptance.md lines
+// 158-188 (EMF-Normal-01 + EMF-Boundary-01/02) and 225-233 (numeric policy).
+export const EMF_CANONICAL_FIXTURE = {
+  defaultGeometry: {
+    frequency: '60',
+    loadCurrent: '100',
+    nCables: '1',
+    trayWidth: '12',
+    cableOd: '1.0',
+    measDistance: '36',
+  },
+  boundaryCurrents: {
+    nearGeneralPublicBoundary: '10150',
+    overGeneralPublicBoundary: '10500',
+    nearOccupationalBoundary: '50750',
+  },
+  expected: {
+    normalBrmsMicroTesla: 1.97,
+    normalBpeakMicroTesla: 2.786,
+  },
+  tolerances: {
+    brmsLowCurrentAbs: 0.02,
+    bpeakLowCurrentAbs: 0.03,
+    boundaryMicroTeslaAbs: 1.0,
+  },
+};
+
+export const COST_ESTIMATOR_FIXTURES = {
+  baselineProject: COST_ESTIMATOR_CANONICAL_FIXTURE.projectData,
   highContingency: {
     contingencyPct: '35',
   },

--- a/playwright-tests/nextFeatures.integration.spec.js
+++ b/playwright-tests/nextFeatures.integration.spec.js
@@ -6,6 +6,8 @@ import {
   navigateForE2E,
   applyCostEstimatorFixture,
   COST_ESTIMATOR_FIXTURES,
+  COST_ESTIMATOR_CANONICAL_FIXTURE,
+  EMF_CANONICAL_FIXTURE,
   fillCostEstimatorForm,
   fillEmfForm,
   getResultText,
@@ -56,7 +58,9 @@ test.describe('next features integration: cost estimator scenarios and exports',
   test('integration: baseline fixture renders detailed line items, totals, and contingency impact', async ({ page }) => {
     await navigateForE2E(page, 'costestimate.html');
     await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.baselineProject);
-    await fillCostEstimatorForm(page, { contingencyPct: '10' });
+    await fillCostEstimatorForm(page, {
+      contingencyPct: String(COST_ESTIMATOR_CANONICAL_FIXTURE.expected.contingencyPct),
+    });
 
     await page.click('#estimate-btn');
 
@@ -67,10 +71,17 @@ test.describe('next features integration: cost estimator scenarios and exports',
     await expect(results).toContainText('Cable');
     await expect(results).toContainText('Tray');
     await expect(results).toContainText('Conduit');
-    await expect(results).toContainText('Contingency (10%)');
+    await expect(results).toContainText(`Contingency (${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.contingencyPct}%)`);
     await expect(results).toContainText('Grand Total (incl. contingency)');
-    await expect(results.locator('summary')).toContainText('Line Item Detail (3 items)');
-    await expect(results.locator('table[aria-label="Line item cost detail"] tbody tr')).toHaveCount(3);
+    await expect(results.locator('summary')).toContainText('Line Item Detail (4 items)');
+    await expect(results.locator('table[aria-label="Line item cost detail"] tbody tr')).toHaveCount(4);
+
+    await expect(results).toContainText(`$${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.cableSubtotal.toLocaleString()}`);
+    await expect(results).toContainText(`$${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.traySubtotal.toLocaleString()}`);
+    await expect(results).toContainText(`$${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.conduitSubtotal.toLocaleString()}`);
+    await expect(results).toContainText(`$${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.subtotal.toLocaleString()}`);
+    await expect(results).toContainText(`$${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.contingencyAmountRounded.toLocaleString()}`);
+    await expect(results).toContainText(`$${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.totalRounded.toLocaleString()}`);
   });
 
   test('integration: cost estimator xlsx export downloads expected file', async ({ page }) => {
@@ -153,60 +164,52 @@ test.describe('next features integration: cost estimator scenarios and exports',
 test.describe('next features integration: emf deterministic outputs', () => {
   test('integration: emf calculation returns deterministic numeric output for fixed 60 Hz and 50 Hz scenarios', async ({ page }) => {
     await navigateForE2E(page, 'emf.html');
-    const fixedInputs = {
-      loadCurrent: '150',
-      nCables: '1',
-      trayWidth: '12',
-      cableOd: '1.0',
-      measDistance: '36',
-    };
+    await fillEmfForm(page, EMF_CANONICAL_FIXTURE.defaultGeometry);
+    await page.click('#calc-btn');
 
-    for (const frequency of ['60', '50']) {
-      await fillEmfForm(page, { ...fixedInputs, frequency });
-      await page.click('#calc-btn');
+    await expect(page.locator('tr:has(th:has-text("Frequency")) td')).toHaveText(
+      `${EMF_CANONICAL_FIXTURE.defaultGeometry.frequency} Hz`,
+    );
 
-      await expect(page.locator('tr:has(th:has-text("Frequency")) td')).toHaveText(`${frequency} Hz`);
+    const rmsCell = page.locator('tr:has(th:has-text("RMS Flux Density")) td strong');
+    await expect(rmsCell).toHaveText(/^\d+\.\d{3}\sµT$/);
+    const rms = await getEmfRmsMicroTesla(page);
+    expect(rms).not.toBeNull();
+    expect(Math.abs(rms - EMF_CANONICAL_FIXTURE.expected.normalBrmsMicroTesla)).toBeLessThanOrEqual(
+      EMF_CANONICAL_FIXTURE.tolerances.brmsLowCurrentAbs,
+    );
 
-      const rmsCell = page.locator('tr:has(th:has-text("RMS Flux Density")) td strong');
-      await expect(rmsCell).toHaveText(/^\d+\.\d{3}\sµT$/);
-      const rms = await getEmfRmsMicroTesla(page);
-      expect(rms).not.toBeNull();
-      expect(rms).toBeGreaterThan(20);
-      expect(rms).toBeLessThan(40);
+    const peakText = await page.locator('tr:has(th:has-text("Peak Flux Density")) td strong').innerText();
+    expect(peakText).toMatch(/^\d+\.\d{3}\sµT$/);
+    const peak = Number.parseFloat(peakText.replace(' µT', ''));
+    expect(Math.abs(peak - EMF_CANONICAL_FIXTURE.expected.normalBpeakMicroTesla)).toBeLessThanOrEqual(
+      EMF_CANONICAL_FIXTURE.tolerances.bpeakLowCurrentAbs,
+    );
 
-      const peakText = await page.locator('tr:has(th:has-text("Peak Flux Density")) td strong').innerText();
-      expect(peakText).toMatch(/^\d+\.\d{3}\sµT$/);
-      const peak = Number.parseFloat(peakText.replace(' µT', ''));
-      expect(peak).toBeGreaterThan(40);
-      expect(peak).toBeLessThan(70);
-
-      const resultText = await getResultText(page, '#results');
-      expect(resultText).toContain('ICNIRP 2010 Compliance');
-    }
+    const resultText = await getResultText(page, '#results');
+    expect(resultText).toContain('ICNIRP 2010 Compliance');
+    await expect(page.locator('#results .status-badge', { hasText: 'PASS' })).toHaveCount(2);
   });
 
   test('integration: emf ICNIRP compliance status shows PASS and FAIL outcomes for supported scenarios', async ({ page }) => {
     await navigateForE2E(page, 'emf.html');
 
-    await fillEmfForm(page, {
-      frequency: '60',
-      loadCurrent: '150',
-      nCables: '1',
-      trayWidth: '12',
-      cableOd: '1.0',
-      measDistance: '36',
-    });
+    await fillEmfForm(page, { ...EMF_CANONICAL_FIXTURE.defaultGeometry });
     await page.click('#calc-btn');
     await expect(page.locator('#results .status-badge', { hasText: 'PASS' })).toHaveCount(2);
     await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(0);
 
     await fillEmfForm(page, {
-      frequency: '60',
-      loadCurrent: '5000',
-      nCables: '20',
-      trayWidth: '48',
-      cableOd: '6',
-      measDistance: '0',
+      ...EMF_CANONICAL_FIXTURE.defaultGeometry,
+      loadCurrent: EMF_CANONICAL_FIXTURE.boundaryCurrents.overGeneralPublicBoundary,
+    });
+    await page.click('#calc-btn');
+    await expect(page.locator('#results .status-badge', { hasText: 'PASS' })).toHaveCount(1);
+    await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(1);
+
+    await fillEmfForm(page, {
+      ...EMF_CANONICAL_FIXTURE.defaultGeometry,
+      loadCurrent: EMF_CANONICAL_FIXTURE.boundaryCurrents.nearOccupationalBoundary,
     });
     await page.click('#calc-btn');
     await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(2);


### PR DESCRIPTION
### Motivation
- Provide stable, canonical input fixtures for Cost Estimator and EMF acceptance tests so CI can make deterministic numeric and label assertions per the acceptance spec.
- Encode expected values and tolerances in a shared helper so multiple Playwright scenarios reuse the same authoritative fixtures and remain synchronized with the doc-based source-of-truth.

### Description
- Add `COST_ESTIMATOR_CANONICAL_FIXTURE` to `playwright-tests/nextFeatures.helpers.js` containing the CE project dataset (cables/tray/conduit), explicit expected subtotal/contingency/total constants, and numeric tolerance constants, plus a README sync comment referencing `docs/next-features-acceptance.md` lines.
- Add `EMF_CANONICAL_FIXTURE` to `playwright-tests/nextFeatures.helpers.js` containing default EMF geometry, boundary-current constants for general-public/occupational thresholds, expected B_rms/B_peak values, and tolerance constants, plus a README sync comment referencing the acceptance doc lines.
- Wire `COST_ESTIMATOR_FIXTURES.baselineProject` to the canonical CE fixture and update `playwright-tests/nextFeatures.integration.spec.js` to consume the canonical constants, asserting the documented whole-dollar UI values and EMF values within the specified tolerances, and using the canonical boundary currents for PASS/FAIL transitions.

### Testing
- Ran `npm run build` and build completed successfully.
- Ran `npm test` (full suite invocation was started; many unit tests ran and passed during the session but the full run did not complete within the session constraints before being stopped).
- Ran `npm run e2e:next-features-integration` and Playwright tests failed to launch because browser executables are not installed in this environment (errors indicate `npx playwright install` is required for Firefox/msedge), so E2E assertions that depend on browser execution could not be completed.
- Because Playwright browsers were unavailable, a webpage preview image could not be produced in this run; the fixtures and test wiring are in place and will exercise deterministically once `npx playwright install` (or equivalent CI browser setup) is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9116f2108324a91e231c9c3fd49c)