### PR TITLE
Refactor CE/EMF Playwright journeys into shared helpers

### DIFF
--- a/playwright-tests/nextFeatures.helpers.js
+++ b/playwright-tests/nextFeatures.helpers.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { expect } from '@playwright/test';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.join(__dirname, '..');
@@ -148,6 +149,87 @@ export async function fillEmfForm(page, overrides = {}) {
   await page.fill('#tray-width', values.trayWidth);
   await page.fill('#cable-od', values.cableOd);
   await page.fill('#meas-distance', values.measDistance);
+}
+
+export async function setupCEPage(page, fixture = null) {
+  await navigateForE2E(page, 'costestimate.html');
+  if (fixture) {
+    await applyCostEstimatorFixture(page, fixture);
+  }
+}
+
+export async function setupEMFPage(page) {
+  await navigateForE2E(page, 'emf.html');
+}
+
+export async function fillCEInputs(page, overrides = {}) {
+  const values = {
+    contingencyPct: '10',
+    laborCableRate: '68',
+    laborTrayRate: '61',
+    laborConduitRate: '58',
+    fittingPrice: '72',
+    ...overrides,
+  };
+
+  await page.getByLabel('Contingency (%)').fill(values.contingencyPct);
+  const details = page.locator('#price-overrides');
+  if (!(await details.evaluate(el => el.hasAttribute('open')))) {
+    await details.locator('summary').click();
+  }
+  await page.getByLabel('Labor ($/ft, cable)').fill(values.laborCableRate);
+  await page.getByLabel('Labor ($/ft, tray)').fill(values.laborTrayRate);
+  await page.getByLabel('Labor ($/ft, conduit)').fill(values.laborConduitRate);
+  await page.getByLabel('Tray fitting unit price ($)').fill(values.fittingPrice);
+}
+
+export async function runCEEstimate(page) {
+  await page.getByRole('button', { name: 'Generate Estimate' }).click();
+}
+
+export async function runCEXlsxExport(page) {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export XLSX' }).click();
+  return downloadPromise;
+}
+
+export async function assertCESmokeControls(page) {
+  await expect(page.getByRole('heading', { level: 1, name: 'Project Cost Estimator' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Generate Estimate' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Export XLSX' })).toBeVisible();
+}
+
+export async function fillEMFInputs(page, overrides = {}) {
+  const values = {
+    frequency: '60',
+    loadCurrent: '180',
+    nCables: '2',
+    trayWidth: '18',
+    cableOd: '1.2',
+    measDistance: '48',
+    ...overrides,
+  };
+
+  await page.getByLabel('Frequency (Hz)').selectOption(values.frequency);
+  await page.getByLabel('Load Current per Phase (A)').fill(values.loadCurrent);
+  await page.getByLabel('Number of Parallel Cable Sets').fill(values.nCables);
+  await page.getByLabel('Tray Width (in)').fill(values.trayWidth);
+  await page.getByLabel('Cable O.D. (in)').fill(values.cableOd);
+  await page.getByLabel('Measurement Distance from Tray Edge (in)').fill(values.measDistance);
+}
+
+export async function runEMFCalculate(page) {
+  await page.getByRole('button', { name: 'Calculate Field' }).click();
+}
+
+export async function runEMFProfile(page) {
+  await page.getByRole('button', { name: /Field Profile/ }).click();
+}
+
+export async function assertEMFSmokeControls(page) {
+  await expect(page.getByRole('heading', { level: 1, name: /EMF/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Calculate Field' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Field Profile/ })).toBeVisible();
 }
 
 export async function getResultText(page, selector = '#results') {

--- a/playwright-tests/nextFeatures.integration.spec.js
+++ b/playwright-tests/nextFeatures.integration.spec.js
@@ -8,8 +8,14 @@ import {
   COST_ESTIMATOR_FIXTURES,
   COST_ESTIMATOR_CANONICAL_FIXTURE,
   EMF_CANONICAL_FIXTURE,
-  fillCostEstimatorForm,
-  fillEmfForm,
+  setupCEPage,
+  setupEMFPage,
+  fillCEInputs,
+  fillEMFInputs,
+  runCEEstimate,
+  runCEXlsxExport,
+  runEMFCalculate,
+  runEMFProfile,
   getResultText,
   getCostEstimateContingencyAmount,
   getCostEstimateGrandTotal,
@@ -28,41 +34,40 @@ async function assertExportDownload(download, expectedName) {
 }
 
 test.describe('next features integration: cost estimator scenarios and exports', () => {
-  test('integration: cost estimator heading and empty/invalid fixture show deterministic guidance', async ({ page }) => {
-    await navigateForE2E(page, 'costestimate.html');
-    await expect(page.locator('h1')).toHaveText('Project Cost Estimator');
+  test('acceptance CE-02: empty or invalid fixture returns deterministic guidance', async ({ page }) => {
+    await setupCEPage(page);
+    await expect(page.getByRole('heading', { level: 1, name: 'Project Cost Estimator' })).toBeVisible();
 
     await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario);
-    await fillCostEstimatorForm(page, {
+    await fillCEInputs(page, {
       contingencyPct: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.contingencyPct,
       laborCableRate: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.laborCableRate,
       laborTrayRate: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.laborTrayRate,
       laborConduitRate: COST_ESTIMATOR_FIXTURES.emptyInvalidInputScenario.laborConduitRate,
     });
 
-    await page.click('#estimate-btn');
+    await runCEEstimate(page);
 
     const resultsText = await getResultText(page, '#results');
     expect(resultsText).toContain('No project data found');
   });
 
-  test('integration: cost estimator xlsx export is blocked until a scenario is generated', async ({ page }) => {
-    await navigateForE2E(page, 'costestimate.html');
+  test('acceptance CE-03: xlsx export is blocked until a scenario is generated', async ({ page }) => {
+    await setupCEPage(page);
 
-    await page.click('#export-xlsx-btn');
+    await page.getByRole('button', { name: 'Export XLSX' }).click();
 
     const bodyText = await page.locator('body').innerText();
     expect(bodyText).toContain('No Data');
   });
 
-  test('integration: baseline fixture renders detailed line items, totals, and contingency impact', async ({ page }) => {
-    await navigateForE2E(page, 'costestimate.html');
-    await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.baselineProject);
-    await fillCostEstimatorForm(page, {
+  test('acceptance CE-04: baseline fixture renders deterministic summary totals', async ({ page }) => {
+    await setupCEPage(page, COST_ESTIMATOR_FIXTURES.baselineProject);
+    await fillCEInputs(page, {
       contingencyPct: String(COST_ESTIMATOR_CANONICAL_FIXTURE.expected.contingencyPct),
     });
 
-    await page.click('#estimate-btn');
+    await runCEEstimate(page);
 
     const results = page.locator('#results');
     await expect(results.locator('h2')).toHaveText('Cost Summary');
@@ -84,40 +89,36 @@ test.describe('next features integration: cost estimator scenarios and exports',
     await expect(results).toContainText(`$${COST_ESTIMATOR_CANONICAL_FIXTURE.expected.totalRounded.toLocaleString()}`);
   });
 
-  test('integration: cost estimator xlsx export downloads expected file', async ({ page }) => {
-    await navigateForE2E(page, 'costestimate.html');
-    await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.baselineProject);
-    await fillCostEstimatorForm(page, { contingencyPct: '10' });
-    await page.click('#estimate-btn');
+  test('acceptance CE-05: cost estimator xlsx export downloads expected file', async ({ page }) => {
+    await setupCEPage(page, COST_ESTIMATOR_FIXTURES.baselineProject);
+    await fillCEInputs(page, { contingencyPct: '10' });
+    await runCEEstimate(page);
 
-    const downloadPromise = page.waitForEvent('download');
-    await page.click('#export-xlsx-btn');
-    const download = await downloadPromise;
+    const download = await runCEXlsxExport(page);
 
     await assertExportDownload(download, 'cost_estimate.xlsx');
   });
 
-  test('integration: changing contingency and labor inputs predictably increases totals', async ({ page }) => {
-    await navigateForE2E(page, 'costestimate.html');
-    await applyCostEstimatorFixture(page, COST_ESTIMATOR_FIXTURES.baselineProject);
+  test('acceptance CE-06: changing contingency and labor inputs predictably increases totals', async ({ page }) => {
+    await setupCEPage(page, COST_ESTIMATOR_FIXTURES.baselineProject);
 
-    await fillCostEstimatorForm(page, { contingencyPct: '10' });
-    await page.click('#estimate-btn');
+    await fillCEInputs(page, { contingencyPct: '10' });
+    await runCEEstimate(page);
     const baseGrandTotal = await getCostEstimateGrandTotal(page);
     const baseContingencyAmount = await getCostEstimateContingencyAmount(page);
 
-    await fillCostEstimatorForm(page, { contingencyPct: COST_ESTIMATOR_FIXTURES.highContingency.contingencyPct });
-    await page.click('#estimate-btn');
+    await fillCEInputs(page, { contingencyPct: COST_ESTIMATOR_FIXTURES.highContingency.contingencyPct });
+    await runCEEstimate(page);
     const highContingencyGrandTotal = await getCostEstimateGrandTotal(page);
     const highContingencyAmount = await getCostEstimateContingencyAmount(page);
 
-    await fillCostEstimatorForm(page, {
+    await fillCEInputs(page, {
       contingencyPct: COST_ESTIMATOR_FIXTURES.highContingency.contingencyPct,
       laborCableRate: COST_ESTIMATOR_FIXTURES.laborOverrideScenario.laborCableRate,
       laborTrayRate: COST_ESTIMATOR_FIXTURES.laborOverrideScenario.laborTrayRate,
       laborConduitRate: COST_ESTIMATOR_FIXTURES.laborOverrideScenario.laborConduitRate,
     });
-    await page.click('#estimate-btn');
+    await runCEEstimate(page);
     const laborOverrideGrandTotal = await getCostEstimateGrandTotal(page);
 
     expect(baseGrandTotal).not.toBeNull();
@@ -162,10 +163,10 @@ test.describe('next features integration: cost estimator scenarios and exports',
 });
 
 test.describe('next features integration: emf deterministic outputs', () => {
-  test('integration: emf calculation returns deterministic numeric output for fixed 60 Hz and 50 Hz scenarios', async ({ page }) => {
-    await navigateForE2E(page, 'emf.html');
-    await fillEmfForm(page, EMF_CANONICAL_FIXTURE.defaultGeometry);
-    await page.click('#calc-btn');
+  test('acceptance EMF-02: emf calculation returns deterministic numeric output', async ({ page }) => {
+    await setupEMFPage(page);
+    await fillEMFInputs(page, EMF_CANONICAL_FIXTURE.defaultGeometry);
+    await runEMFCalculate(page);
 
     await expect(page.locator('tr:has(th:has-text("Frequency")) td')).toHaveText(
       `${EMF_CANONICAL_FIXTURE.defaultGeometry.frequency} Hz`,
@@ -191,65 +192,65 @@ test.describe('next features integration: emf deterministic outputs', () => {
     await expect(page.locator('#results .status-badge', { hasText: 'PASS' })).toHaveCount(2);
   });
 
-  test('integration: emf ICNIRP compliance status shows PASS and FAIL outcomes for supported scenarios', async ({ page }) => {
-    await navigateForE2E(page, 'emf.html');
+  test('acceptance EMF-03: ICNIRP compliance shows PASS and FAIL outcomes for supported scenarios', async ({ page }) => {
+    await setupEMFPage(page);
 
-    await fillEmfForm(page, { ...EMF_CANONICAL_FIXTURE.defaultGeometry });
-    await page.click('#calc-btn');
+    await fillEMFInputs(page, { ...EMF_CANONICAL_FIXTURE.defaultGeometry });
+    await runEMFCalculate(page);
     await expect(page.locator('#results .status-badge', { hasText: 'PASS' })).toHaveCount(2);
     await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(0);
 
-    await fillEmfForm(page, {
+    await fillEMFInputs(page, {
       ...EMF_CANONICAL_FIXTURE.defaultGeometry,
       loadCurrent: EMF_CANONICAL_FIXTURE.boundaryCurrents.overGeneralPublicBoundary,
     });
-    await page.click('#calc-btn');
+    await runEMFCalculate(page);
     await expect(page.locator('#results .status-badge', { hasText: 'PASS' })).toHaveCount(1);
     await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(1);
 
-    await fillEmfForm(page, {
+    await fillEMFInputs(page, {
       ...EMF_CANONICAL_FIXTURE.defaultGeometry,
       loadCurrent: EMF_CANONICAL_FIXTURE.boundaryCurrents.nearOccupationalBoundary,
     });
-    await page.click('#calc-btn');
+    await runEMFCalculate(page);
     await expect(page.locator('#results .status-badge', { hasText: 'FAIL' })).toHaveCount(2);
   });
 
-  test('integration: emf boundary and error handling uses deterministic UI messaging and defaults', async ({ page }) => {
-    await navigateForE2E(page, 'emf.html');
+  test('acceptance EMF-04: boundary and input errors use deterministic messaging and defaults', async ({ page }) => {
+    await setupEMFPage(page);
 
-    await fillEmfForm(page, { loadCurrent: '0' });
-    await page.click('#calc-btn');
+    await fillEMFInputs(page, { loadCurrent: '0' });
+    await runEMFCalculate(page);
     const inputErrorDialog = page.getByRole('dialog');
     await expect(inputErrorDialog).toContainText('Input Error');
     await expect(inputErrorDialog).toContainText('Load current must be greater than zero.');
     await inputErrorDialog.getByRole('button', { name: 'Close' }).click();
 
-    await fillEmfForm(page, { loadCurrent: '' });
-    await page.click('#calc-btn');
+    await fillEMFInputs(page, { loadCurrent: '' });
+    await runEMFCalculate(page);
     const missingValueDialog = page.getByRole('dialog');
     await expect(missingValueDialog).toContainText('Load current must be greater than zero.');
     await missingValueDialog.getByRole('button', { name: 'Close' }).click();
 
-    await fillEmfForm(page, {
+    await fillEMFInputs(page, {
       loadCurrent: '150',
       nCables: '-3',
       measDistance: '',
     });
-    await page.click('#calc-btn');
+    await runEMFCalculate(page);
     await expect(page.locator('#results .method-note')).toContainText('Configuration: 1 × 3-phase cable set(s)');
     await expect(page.locator('tr:has(th:has-text("Measurement Distance (from tray edge)")) td')).toContainText('36.0 in');
   });
 
-  test('integration: emf profile scenario shows deterministic profile container visibility and chart content', async ({ page }) => {
-    await navigateForE2E(page, 'emf.html');
-    await fillEmfForm(page);
+  test('acceptance EMF-05: profile scenario renders deterministic container visibility and chart points', async ({ page }) => {
+    await setupEMFPage(page);
+    await fillEMFInputs(page);
 
     const chartContainer = page.locator('#profile-container');
     await expect(chartContainer).toBeHidden();
     await expect(chartContainer).toHaveAttribute('hidden', '');
 
-    await page.click('#profile-btn');
+    await runEMFProfile(page);
 
     await expect(chartContainer).toBeVisible();
     await expect(chartContainer).not.toHaveAttribute('hidden');

--- a/playwright-tests/nextFeatures.smoke.spec.js
+++ b/playwright-tests/nextFeatures.smoke.spec.js
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { navigateForE2E } from './nextFeatures.helpers.js';
+import {
+  navigateForE2E,
+  setupCEPage,
+  setupEMFPage,
+  assertCESmokeControls,
+  assertEMFSmokeControls,
+  runCEEstimate,
+} from './nextFeatures.helpers.js';
 
 test.describe('next features smoke: page boot and controls', () => {
   test('smoke: submittal package page loads and core controls are visible', async ({ page }) => {
@@ -18,20 +25,16 @@ test.describe('next features smoke: page boot and controls', () => {
     await expect(page.locator('body')).toBeVisible();
   });
 
-  test('smoke: cost estimator page loads and estimate flow does not crash', async ({ page }) => {
-    await navigateForE2E(page, 'costestimate.html');
-    await expect(page.locator('h1')).toContainText('Cost Estimat');
-    await expect(page.locator('#estimate-btn')).toBeVisible();
-    await expect(page.locator('#export-xlsx-btn')).toBeVisible();
-    await page.click('#estimate-btn');
+  test('smoke CE-01: cost estimator page loads and estimate flow does not crash', async ({ page }) => {
+    await setupCEPage(page);
+    await assertCESmokeControls(page);
+    await runCEEstimate(page);
     await expect(page.locator('#results')).toBeVisible();
   });
 
-  test('smoke: emf page loads and calculate/profile controls are available', async ({ page }) => {
-    await navigateForE2E(page, 'emf.html');
-    await expect(page.locator('h1')).toContainText('EMF');
-    await expect(page.locator('#calc-btn')).toBeVisible();
-    await expect(page.locator('#profile-btn')).toBeVisible();
+  test('smoke EMF-01: emf page loads and calculate/profile controls are available', async ({ page }) => {
+    await setupEMFPage(page);
+    await assertEMFSmokeControls(page);
   });
 
   test('smoke: project report page loads and generate does not crash', async ({ page }) => {


### PR DESCRIPTION
### Motivation
- Reduce brittleness and duplication in CE (Cost Estimator) and EMF Playwright tests by centralizing page setup, form fills, run actions and smoke assertions so tests are robust and lane-friendly.
- Move selectors toward stable role/label locators to make acceptance journeys less sensitive to presentational DOM changes and enable phased (smoke vs acceptance) execution.

### Description
- Added shared helpers in `playwright-tests/nextFeatures.helpers.js` including `setupCEPage`, `setupEMFPage`, `fillCEInputs`, `fillEMFInputs`, `runCEEstimate`, `runCEXlsxExport`, `runEMFCalculate`, `runEMFProfile`, `assertCESmokeControls`, and `assertEMFSmokeControls`, and favored `getByRole`/`getByLabel` locators where practical.
- Updated smoke tests in `playwright-tests/nextFeatures.smoke.spec.js` to reuse helpers and explicitly mark smoke lanes as `CE-01` and `EMF-01`.
- Refactored deterministic integration assertions in `playwright-tests/nextFeatures.integration.spec.js` to use the shared helpers and renamed tests to acceptance journey IDs (`CE-02..CE-06`, `EMF-02..EMF-05`).
- Replaced brittle direct selectors in CE/EMF flows with role/label-driven locators while preserving existing fixtures and result-parsing helpers.

### Testing
- Ran `npm run build` and the build completed successfully.
- Ran `npx playwright test --config playwright.config.cjs --list` to enumerate tests and confirmed the smoke/acceptance tests and new names are present.
- Attempted to run the smoke playwright subset with `npx playwright test --config playwright.config.cjs playwright-tests/nextFeatures.smoke.spec.js --grep "CE-01|EMF-01"` but it failed because Playwright browser executables are not installed in the runner (install with `npx playwright install` to run browser tests).
- Ran `npm test` in this environment; the test run started and many unit tests and build steps executed, but a full end-to-end Playwright execution could not be completed here due to environment/browser limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9798fd148324aea033ef72496b50)