### PR TITLE
Refine next-features e2e lane scripts and add Week 1 rollout gates

### DIFF
--- a/docs/test-lanes.md
+++ b/docs/test-lanes.md
@@ -54,4 +54,49 @@ Phase-oriented commands:
 - `npm run e2e:next-features-emf`
 - `npm run e2e:next-features-export`
 
-Post-merge policy: monitor flaky tests for one week after each phase and tighten waits/selectors only where instability is observed.
+Current command mappings:
+
+- `npm run e2e:next-features-integration` → full `playwright-tests/nextFeatures.integration.spec.js` lane
+- `npm run e2e:next-features-cost` → deterministic Cost Estimator acceptance set (`AT-CE-01` through `AT-CE-04`)
+- `npm run e2e:next-features-emf` → deterministic EMF acceptance set (`AT-EMF-01` through `AT-EMF-04`)
+- `npm run e2e:next-features-export` → export-specific validations (`AT-CE-04` and submittal XLSX download integration)
+
+## Week 1 rollout gate criteria (required pass conditions)
+
+For the first seven calendar days after rollout, merge gates for next-feature changes are strict:
+
+1. **Lane command pass requirement**
+   - `npm run e2e:next-features-cost` must pass with no test retries consumed.
+   - `npm run e2e:next-features-emf` must pass with no test retries consumed.
+   - `npm run e2e:next-features-export` must pass before merging export-related changes.
+2. **Deterministic acceptance requirement**
+   - Any PR that modifies Cost Estimator logic/fixtures must include a passing CE acceptance lane run in PR evidence.
+   - Any PR that modifies EMF logic/fixtures must include a passing EMF acceptance lane run in PR evidence.
+3. **Baseline lane protection**
+   - `npm run test:critical` and `npm run e2e:critical` remain required and cannot be waived during Week 1.
+
+## PR checklist additions for related changes
+
+Add the following checklist items to PR descriptions when touching Cost Estimator, EMF, or export flows:
+
+- [ ] Deterministic CE acceptance lane passed (`npm run e2e:next-features-cost`) when CE code, fixtures, or selectors changed.
+- [ ] Deterministic EMF acceptance lane passed (`npm run e2e:next-features-emf`) when EMF code, fixtures, or selectors changed.
+- [ ] Export validation lane passed (`npm run e2e:next-features-export`) when CE export or submittal export behavior changed.
+- [ ] Attached CI/local artifact bundle for any retry used (trace, video/screenshot, and stdout log excerpt).
+
+## Week 1 flake triage protocol
+
+During the first week after rollout, use this protocol for any flaky failure in the phased lanes:
+
+1. **Retry policy**
+   - Allow one immediate rerun of the failing lane to classify potential infra/transient instability.
+   - If rerun also fails, mark as probable product or selector instability and block merge until resolved or explicitly waived by maintainers.
+2. **Selector stabilization**
+   - Replace brittle selectors with role/label/test-id anchored locators.
+   - Prefer explicit readiness checks (`toBeVisible`, `toHaveText`, `waitForEvent`) over arbitrary timeouts.
+   - Keep assertion scopes narrow to deterministic UI regions.
+3. **Artifact capture**
+   - Capture and attach the failing run trace, screenshots/video (if available), and terminal output.
+   - Record failure signature, commit SHA, browser/project name, and whether failure reproduced locally.
+4. **Escalation window**
+   - Repeated failures of the same test (2+ times in Week 1) require opening/linked triage issue before additional related merges.

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "e2e:critical": "playwright test --config playwright.config.cjs playwright-tests/workflow.spec.js playwright-tests/oneline.spec.js playwright-tests/nextFeatures.smoke.spec.js --grep \"create DB-01|dirty-state prompts|editing a source voltage|smoke:\"",
     "e2e:full": "playwright test --config playwright.config.cjs",
     "e2e:next-features-integration": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js",
-    "e2e:next-features-cost": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"cost estimator\"",
-    "e2e:next-features-emf": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"emf\"",
-    "e2e:next-features-export": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"xlsx export|export downloads\"",
+    "e2e:next-features-cost": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"AT-CE-0[1-4]\"",
+    "e2e:next-features-emf": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"AT-EMF-0[1-4]\"",
+    "e2e:next-features-export": "playwright test --config playwright.config.cjs playwright-tests/nextFeatures.integration.spec.js --grep \"AT-CE-04|submittal xlsx export downloads expected file\"",
     "audit:components": "node scripts/componentCoverageAudit.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation

- Make the phased Playwright lanes deterministic and better scoped so Cost Estimator, EMF, and export validations can be gated and audited during rollout. 
- Provide clear Week 1 gate criteria and a flake-triage protocol so early rollout instability is triaged consistently. 

### Description

- Update `package.json` Playwright mappings so `e2e:next-features-cost` targets `AT-CE-0[1-4]`, `e2e:next-features-emf` targets `AT-EMF-0[1-4]`, and `e2e:next-features-export` targets export-specific cases (`AT-CE-04` + submittal XLSX). 
- Expand `docs/test-lanes.md` to document the command mappings, add explicit **Week 1 rollout gate criteria** (required pass conditions), add PR checklist items requiring deterministic CE/EMF/export lane evidence, and add a Week 1 flake triage protocol (retry policy, selector stabilization, artifact capture, escalation). 
- Commit message: "Refine next-features e2e lane mappings and Week 1 gates".

### Testing

- Ran `npm run e2e:next-features-integration -- --list` and confirmed the full `nextFeatures.integration.spec.js` lane enumerates all expected tests (20 tests listed across browsers). 
- Ran `npm run e2e:next-features-cost -- --list`, `npm run e2e:next-features-emf -- --list`, and `npm run e2e:next-features-export -- --list` and confirmed each scoped lane enumerates the intended deterministic acceptance tests (cost: 8 tests, emf: 8 tests, export: 4 tests). 
- Ran `npm run build` which succeeded and produced the `dist` artifacts (Rollup warnings were emitted but build exited successfully). 
- Attempted `npm test` (full test run) in this environment and observed the run hang at `node tests/collaboration.test.mjs`; no failing tests were reported before the hang and the process required termination.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfaa3613a88324a1d8c453de1f8a8f)