### PR TITLE
Fix interstitial ground rod rendering in ground grid top view

### DIFF
--- a/src/groundgridPreviewGeometry.js
+++ b/src/groundgridPreviewGeometry.js
@@ -28,6 +28,15 @@ function buildAxisIndices(count, targetSpacing, conductorSpacing) {
   return [...indices].sort((a, b) => a - b);
 }
 
+function buildAllAxisIndices(count) {
+  const lastIndex = Math.max(0, count - 1);
+  const indices = [];
+  for (let index = 0; index <= lastIndex; index += 1) {
+    indices.push(index);
+  }
+  return indices;
+}
+
 export function deriveRodLayout({ hasRods, nx, ny, spacingX, spacingY, rodSpacingX, rodSpacingY }) {
   if (!hasRods) {
     return {
@@ -39,8 +48,19 @@ export function deriveRodLayout({ hasRods, nx, ny, spacingX, spacingY, rodSpacin
     };
   }
 
-  const xIndices = buildAxisIndices(ny, rodSpacingX, spacingX);
-  const yIndices = buildAxisIndices(nx, rodSpacingY, spacingY);
+  const hasInterstitialX = Number.isFinite(rodSpacingX) && rodSpacingX > 0;
+  const hasInterstitialY = Number.isFinite(rodSpacingY) && rodSpacingY > 0;
+
+  const xIndices = hasInterstitialX
+    ? buildAxisIndices(ny, rodSpacingX, spacingX)
+    : hasInterstitialY
+      ? buildAllAxisIndices(ny)
+      : buildAxisIndices(ny, rodSpacingX, spacingX);
+  const yIndices = hasInterstitialY
+    ? buildAxisIndices(nx, rodSpacingY, spacingY)
+    : hasInterstitialX
+      ? buildAllAxisIndices(nx)
+      : buildAxisIndices(nx, rodSpacingY, spacingY);
   const points = [];
   const corners = new Set([
     '0:0',

--- a/tests/groundGridPreviewGeometry.test.mjs
+++ b/tests/groundGridPreviewGeometry.test.mjs
@@ -100,4 +100,21 @@ describe('groundgrid preview geometry helpers', () => {
     assert.strictEqual(normalized.rodLayout.count, 4);
     assert.strictEqual(normalized.rodLayout.intermediateCount, 0);
   });
+
+  it('keeps corner rods and fills the cross-axis when interstitial spacing is set on one axis', () => {
+    const rodLayout = deriveRodLayout({
+      hasRods: true,
+      nx: 6,
+      ny: 6,
+      spacingX: 10,
+      spacingY: 10,
+      rodSpacingX: 20,
+      rodSpacingY: 0,
+    });
+
+    assert.strictEqual(rodLayout.count, 24);
+    assert.strictEqual(rodLayout.intermediateCount, 20);
+    assert.ok(rodLayout.points.some(point => point.xIndex === 2 && point.yIndex === 3));
+    assert.ok(rodLayout.points.some(point => point.xIndex === 4 && point.yIndex === 1));
+  });
 });


### PR DESCRIPTION
### Motivation
- The top-view preview only showed corner/perimeter ground rods when interstitial spacing was specified on one axis, so interior/interstitial rods were not rendered at intersection points as expected.

### Description
- Added a helper `buildAllAxisIndices` and updated `deriveRodLayout` to fill the cross-axis indices when interstitial spacing is set on only one axis so rods appear at interior conductor intersections as well as corners.
- Kept existing behavior for two-axis interstitial spacing and for disabled rods, and preserved axis spacing computation and corner identification.
- Added a regression test in `tests/groundGridPreviewGeometry.test.mjs` verifying that corner rods remain and interior rods are produced when spacing is provided for a single axis.

### Testing
- Ran `node tests/groundGridPreviewGeometry.test.mjs` and the updated preview-geometry tests passed.
- Ran `npm run build` and the project built successfully in this environment.
- Ran the full `npm test` suite; it progressed through many tests but the environment hung at `tests/collaboration.test.mjs` so the full suite was not able to complete here.
- Attempted to capture a screenshot with Playwright (`npx playwright screenshot`) but browser binaries could not be downloaded in this environment (Playwright install failed with 403), so no preview image was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfacb6c4408324a653e30d4a9f318b)