### PR TITLE
Add heat trace sizing analysis module

### DIFF
--- a/analysis/heatTraceSizing.mjs
+++ b/analysis/heatTraceSizing.mjs
@@ -1,0 +1,276 @@
+/**
+ * Electric Heat Trace Sizing
+ *
+ * Simplified sizing workflow for process temperature maintenance and freeze protection:
+ *   1. Validate pipe, thermal, and environment inputs.
+ *   2. Compute insulation conduction resistance (cylindrical wall).
+ *   3. Apply outside-film resistance with environment/wind adjustment.
+ *   4. Apply pipe-material correction factor and design safety margin.
+ *   5. Select nearest standard heat-trace cable rating.
+ */
+
+/** Nominal Pipe Size (NPS) to outside diameter map (inches). */
+export const NPS_TO_OD_IN = {
+  '0.5': 0.84,
+  '0.75': 1.05,
+  '1': 1.315,
+  '1.25': 1.66,
+  '1.5': 1.9,
+  '2': 2.375,
+  '2.5': 2.875,
+  '3': 3.5,
+  '4': 4.5,
+  '5': 5.563,
+  '6': 6.625,
+  '8': 8.625,
+  '10': 10.75,
+  '12': 12.75,
+};
+
+/**
+ * Environment multipliers for external heat transfer.
+ * >1 increases losses (more severe environment), <1 decreases losses.
+ */
+export const ENVIRONMENT_MULTIPLIERS = {
+  'indoor-still': 0.85,
+  'outdoor-sheltered': 1.0,
+  'outdoor-windy': 1.25,
+  'hazardous-area': 1.1,
+  freezer: 1.35,
+};
+
+/** Material correction factors for warm-up / hold behavior. */
+export const PIPE_MATERIAL_FACTORS = {
+  carbonSteel: 1.1,
+  stainlessSteel: 1.05,
+  pvc: 0.9,
+  hdpe: 0.88,
+  copper: 1.0,
+  aluminum: 1.0,
+};
+
+/** Standard self-regulating / constant-watt cable outputs (W/ft at nominal conditions). */
+export const STANDARD_HEAT_TRACE_RATINGS_W_PER_FT = [
+  3, 5, 8, 10, 12, 15, 20, 25, 30, 40, 50,
+];
+
+/** Default thermal conductivity for insulation (W/m-K), typical for mineral wool / foam ranges. */
+export const DEFAULT_INSULATION_K_W_PER_MK = 0.04;
+
+const INCH_TO_M = 0.0254;
+const FT_TO_M = 0.3048;
+
+function round(value, digits = 2) {
+  const p = 10 ** digits;
+  return Math.round(value * p) / p;
+}
+
+function assertFinitePositive(value, label) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a finite number greater than zero`);
+  }
+}
+
+/** Resolve pipe outside diameter in inches from direct OD or NPS. */
+export function resolvePipeOdIn({ pipeOdIn, pipeNps }) {
+  if (pipeOdIn != null) {
+    assertFinitePositive(pipeOdIn, 'pipeOdIn');
+    return pipeOdIn;
+  }
+
+  if (pipeNps == null) {
+    throw new Error('Provide either pipeOdIn or pipeNps');
+  }
+
+  const npsKey = String(pipeNps);
+  const mapped = NPS_TO_OD_IN[npsKey];
+  if (!mapped) {
+    throw new Error(`Unsupported pipeNps "${pipeNps}". Add a valid NPS or pass pipeOdIn directly.`);
+  }
+  return mapped;
+}
+
+/** Validate core input object and return normalized numeric fields. */
+export function validateHeatTraceInputs(inputs) {
+  if (!inputs || typeof inputs !== 'object') {
+    throw new Error('inputs must be an object');
+  }
+
+  const {
+    pipeNps,
+    pipeOdIn,
+    insulationThicknessIn,
+    lineLengthFt,
+    maintainTempC,
+    ambientTempC,
+    windSpeedMph = 0,
+    safetyMarginPct = 10,
+    pipeMaterial = 'carbonSteel',
+    environment = 'outdoor-sheltered',
+    insulationK = DEFAULT_INSULATION_K_W_PER_MK,
+  } = inputs;
+
+  const resolvedPipeOdIn = resolvePipeOdIn({ pipeNps, pipeOdIn });
+
+  assertFinitePositive(insulationThicknessIn, 'insulationThicknessIn');
+  assertFinitePositive(lineLengthFt, 'lineLengthFt');
+  assertFinitePositive(insulationK, 'insulationK');
+
+  if (!Number.isFinite(maintainTempC) || !Number.isFinite(ambientTempC)) {
+    throw new Error('maintainTempC and ambientTempC must be finite numbers');
+  }
+  if (maintainTempC <= ambientTempC) {
+    throw new Error('maintainTempC must be greater than ambientTempC for heat-loss sizing');
+  }
+
+  if (!Number.isFinite(windSpeedMph) || windSpeedMph < 0) {
+    throw new Error('windSpeedMph must be a finite number ≥ 0');
+  }
+  if (!Number.isFinite(safetyMarginPct) || safetyMarginPct < 0 || safetyMarginPct > 100) {
+    throw new Error('safetyMarginPct must be between 0 and 100');
+  }
+
+  if (!ENVIRONMENT_MULTIPLIERS[environment]) {
+    throw new Error(`Unsupported environment "${environment}"`);
+  }
+
+  if (!PIPE_MATERIAL_FACTORS[pipeMaterial]) {
+    throw new Error(`Unsupported pipeMaterial "${pipeMaterial}"`);
+  }
+
+  if (environment === 'outdoor-windy' && windSpeedMph <= 0) {
+    throw new Error('windSpeedMph must be > 0 for outdoor-windy environment');
+  }
+
+  return {
+    pipeNps,
+    pipeOdIn: resolvedPipeOdIn,
+    insulationThicknessIn,
+    lineLengthFt,
+    maintainTempC,
+    ambientTempC,
+    windSpeedMph,
+    safetyMarginPct,
+    pipeMaterial,
+    environment,
+    insulationK,
+  };
+}
+
+/** Cylindrical conduction resistance through insulation for unit length (K·m/W). */
+export function cylindricalInsulationResistance({ pipeOdIn, insulationThicknessIn, insulationK }) {
+  assertFinitePositive(pipeOdIn, 'pipeOdIn');
+  assertFinitePositive(insulationThicknessIn, 'insulationThicknessIn');
+  assertFinitePositive(insulationK, 'insulationK');
+
+  const rInnerM = (pipeOdIn * INCH_TO_M) / 2;
+  const rOuterM = rInnerM + insulationThicknessIn * INCH_TO_M;
+
+  return Math.log(rOuterM / rInnerM) / (2 * Math.PI * insulationK);
+}
+
+/** Approximate external film resistance for unit length (K·m/W). */
+export function externalFilmResistance({ pipeOdIn, insulationThicknessIn, environment, windSpeedMph = 0 }) {
+  assertFinitePositive(pipeOdIn, 'pipeOdIn');
+  assertFinitePositive(insulationThicknessIn, 'insulationThicknessIn');
+
+  const envFactor = ENVIRONMENT_MULTIPLIERS[environment];
+  if (!envFactor) throw new Error(`Unsupported environment "${environment}"`);
+  if (!Number.isFinite(windSpeedMph) || windSpeedMph < 0) throw new Error('windSpeedMph must be ≥ 0');
+
+  const rOuterM = (pipeOdIn * INCH_TO_M) / 2 + insulationThicknessIn * INCH_TO_M;
+  const baseH = 7; // W/m2-K representative natural convection + radiation
+  const windBoost = environment === 'outdoor-windy' ? 0.5 * windSpeedMph : 0;
+  const hEff = Math.max(2, (baseH + windBoost) * envFactor);
+
+  return 1 / (hEff * 2 * Math.PI * rOuterM);
+}
+
+/** Select nearest standard cable rating equal to or above required W/ft. */
+export function selectStandardHeatTraceRating(requiredWPerFt) {
+  assertFinitePositive(requiredWPerFt, 'requiredWPerFt');
+
+  const selected = STANDARD_HEAT_TRACE_RATINGS_W_PER_FT.find(r => r >= requiredWPerFt)
+    ?? STANDARD_HEAT_TRACE_RATINGS_W_PER_FT[STANDARD_HEAT_TRACE_RATINGS_W_PER_FT.length - 1];
+
+  const idx = STANDARD_HEAT_TRACE_RATINGS_W_PER_FT.indexOf(selected);
+  const options = STANDARD_HEAT_TRACE_RATINGS_W_PER_FT.slice(
+    Math.max(0, idx - 1),
+    Math.min(STANDARD_HEAT_TRACE_RATINGS_W_PER_FT.length, idx + 2)
+  );
+
+  return { selectedWPerFt: selected, options };
+}
+
+/**
+ * Run complete heat-trace sizing analysis.
+ *
+ * @param {object} inputs
+ * @returns {object}
+ */
+export function runHeatTraceSizingAnalysis(inputs) {
+  const normalized = validateHeatTraceInputs(inputs);
+  const {
+    pipeOdIn,
+    insulationThicknessIn,
+    lineLengthFt,
+    maintainTempC,
+    ambientTempC,
+    windSpeedMph,
+    safetyMarginPct,
+    pipeMaterial,
+    environment,
+    insulationK,
+  } = normalized;
+
+  const warnings = [];
+  const deltaT = maintainTempC - ambientTempC;
+
+  const rCond = cylindricalInsulationResistance({ pipeOdIn, insulationThicknessIn, insulationK });
+  const rExt = externalFilmResistance({ pipeOdIn, insulationThicknessIn, environment, windSpeedMph });
+  const rTotal = rCond + rExt;
+
+  const baseLossWPerM = deltaT / rTotal;
+  const materialFactor = PIPE_MATERIAL_FACTORS[pipeMaterial];
+  const safetyFactor = 1 + safetyMarginPct / 100;
+
+  const requiredWPerM = baseLossWPerM * materialFactor * safetyFactor;
+  const requiredWPerFt = requiredWPerM * FT_TO_M;
+  const totalCircuitWatts = requiredWPerFt * lineLengthFt;
+
+  const rating = selectStandardHeatTraceRating(requiredWPerFt);
+
+  if (ambientTempC <= -30) {
+    warnings.push('Very low ambient temperature detected (≤ -30 °C). Verify startup and control strategy.');
+  }
+  if (lineLengthFt >= 500) {
+    warnings.push('Long circuit length (≥ 500 ft). Check voltage drop and maximum circuit length limits.');
+  }
+  if (environment === 'outdoor-windy' && windSpeedMph >= 20) {
+    warnings.push('High wind speed input (≥ 20 mph). Confirm wind shielding and trace placement assumptions.');
+  }
+  if (rating.selectedWPerFt < requiredWPerFt) {
+    warnings.push('Required W/ft exceeds available standard ratings. Use multiple runs or engineered solution.');
+  }
+
+  return {
+    ...normalized,
+    deltaT,
+    thermalResistance: {
+      insulationKmPerW: round(rCond, 4),
+      externalKmPerW: round(rExt, 4),
+      totalKmPerW: round(rTotal, 4),
+    },
+    factors: {
+      environmentMultiplier: ENVIRONMENT_MULTIPLIERS[environment],
+      materialFactor,
+      safetyFactor: round(safetyFactor, 4),
+    },
+    requiredWPerFt: round(requiredWPerFt, 2),
+    requiredWPerM: round(requiredWPerM, 2),
+    totalCircuitWatts: round(totalCircuitWatts, 1),
+    recommendedCableRatingWPerFt: rating.selectedWPerFt,
+    recommendedCableOptionsWPerFt: rating.options,
+    warnings,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a standalone, pure-function analysis module for electric heat-trace sizing to support process temperature maintenance and freeze protection workflows. 
- Mirror the style and patterns used by existing analysis modules (e.g. `analysis/generatorSizing.mjs`) so the new logic is easy to test and integrate.

### Description
- Added `analysis/heatTraceSizing.mjs` which exports constants and pure helper functions including `NPS_TO_OD_IN`, `ENVIRONMENT_MULTIPLIERS`, `PIPE_MATERIAL_FACTORS`, `STANDARD_HEAT_TRACE_RATINGS_W_PER_FT`, and `DEFAULT_INSULATION_K_W_PER_MK`.
- Implemented input validation and normalization in `validateHeatTraceInputs` and pipe OD resolution via `resolvePipeOdIn`, covering NPS/OD, insulation thickness, line length, maintain/ambient temperatures, wind speed, safety margin, pipe material, and environment types.
- Implemented thermal model helpers `cylindricalInsulationResistance` and `externalFilmResistance` (with environment/wind adjustment) plus `selectStandardHeatTraceRating` and an orchestrator `runHeatTraceSizingAnalysis(inputs)` that returns required W/ft and W/m, total circuit watts, recommended standard cable rating/options, thermal-resistance breakdown, applied factors, and advisory warnings.
- All functions are pure and suitable for unit tests; the module uses compact, documented approximations appropriate for preliminary sizing and guidance messages for edge cases (very low ambient, long circuits, high wind, rating ceiling).

### Testing
- Ran the full automated suite with `npm test` and observed extensive passing test output in the test log with no failures reported in the visible output.
- Built the project artifacts with `npm run build` which completed successfully; generated build artifacts were not included in the PR (dist/docs were reverted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbb24e3e48324af2003fe8a0578ab)