### PR TITLE
Add Heat Trace Sizing to navigation, command palette, and dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
           </a>
           <a class="quick-launch-item" href="shortCircuit.html">
             <span class="quick-launch-title">Run Studies</span>
-            <span class="quick-launch-meta">Short circuit, arc flash, harmonics</span>
+            <span class="quick-launch-meta">Short circuit, arc flash, harmonics, heat trace</span>
           </a>
         </div>
       </section>

--- a/src/components/commandPalette.js
+++ b/src/components/commandPalette.js
@@ -29,6 +29,7 @@ const ACTIONS = [
   { id: "workflow:trayfill", label: "Go to Tray Fill", keywords: ["navigation", "fill", "capacity"], href: "cabletrayfill.html" },
   { id: "workflow:conduitfill", label: "Go to Conduit Fill", keywords: ["navigation", "fill", "nec"], href: "conduitfill.html" },
   { id: "workflow:route", label: "Go to Optimal Route", keywords: ["navigation", "routing", "dijkstra", "pathfinding"], href: "optimalRoute.html" },
+  { id: "workflow:heattrace", label: "Go to Heat Trace Sizing", keywords: ["navigation", "heat", "trace", "pipe"], href: "heattracesizing.html" },
   { id: "workflow:drc", label: "Go to Design Rule Checker", keywords: ["navigation", "drc", "nec", "validation", "fill", "segregation", "ampacity"], href: "designrulechecker.html" },
   { id: "workflow:oneline", label: "Go to One-Line Diagram", keywords: ["navigation", "diagram", "schematic"], href: "oneline.html" },
   { id: "workflow:panel", label: "Go to Panel Schedule", keywords: ["navigation", "panel", "branch"], href: "panelschedule.html" },

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -41,6 +41,7 @@ const NAV_ROUTES = [
   { href: 'arcFlash.html', label: 'Arc Flash', section: 'Studies', group: 'Protection', icon: 'icons/toolbar/connect.svg' },
   { href: 'groundgrid.html', label: 'Ground Grid', section: 'Studies', group: 'Grounding', icon: 'icons/toolbar/validate.svg' },
   { href: 'autosize.html', label: 'Auto-Size', section: 'Studies', group: 'Cable', icon: 'icons/toolbar/grid-size.svg' },
+  { href: 'heattracesizing.html', label: 'Heat Trace Sizing', section: 'Studies', group: 'Equipment Sizing', icon: 'icons/toolbar/grid-size.svg' },
   { href: 'reliability.html', label: 'Reliability', section: 'Studies', group: 'Power System', icon: 'icons/toolbar/validate.svg' },
   { href: 'emf.html', label: 'EMF Analysis', section: 'Studies', group: 'Power System', icon: 'icons/toolbar/connect.svg' },
   { href: 'transientstability.html', label: 'Transient Stability', section: 'Studies', group: 'Power System', icon: 'icons/toolbar/validate.svg' },

--- a/src/workflowDashboard.js
+++ b/src/workflowDashboard.js
@@ -10,6 +10,7 @@ const STUDY_DEFINITIONS = [
   { key: 'loadFlow',     label: 'Load Flow',            href: 'loadFlow.html' },
   { key: 'harmonics',    label: 'Harmonics',            href: 'harmonics.html' },
   { key: 'motorStart',   label: 'Motor Starting',       href: 'motorStart.html' },
+  { key: 'heatTraceSizing', label: 'Heat Trace Sizing', href: 'heattracesizing.html' },
   { key: 'reliability',  label: 'Reliability / N-1',    href: 'reliability.html' },
   { key: 'contingency',  label: 'N-1 Contingency',      href: 'contingency.html' },
 ];


### PR DESCRIPTION
### Motivation
- Surface the new Heat Trace Sizing study in the app navigation and discovery areas so users can find and run it alongside other equipment-sizing tools.
- Make the page reachable via the command palette to improve keyboard-driven navigation.

### Description
- Added a `NAV_ROUTES` entry for `heattracesizing.html` under `Studies → Equipment Sizing` in `src/components/navigation.js`.
- Added a command palette action `{ id: "workflow:heattrace", label: "Go to Heat Trace Sizing" }` with keywords `heat`, `trace`, and `pipe` in `src/components/commandPalette.js` that navigates to `heattracesizing.html`.
- Added `{ key: 'heatTraceSizing', label: 'Heat Trace Sizing', href: 'heattracesizing.html' }` to `STUDY_DEFINITIONS` in `src/workflowDashboard.js` so the dashboard tracks the study.
- Updated the home page quick-launch metadata in `index.html` to mention heat trace discovery; no change was needed to `rollup.config.cjs` because the `heattracesizing` entry already existed.

### Testing
- Ran `npm test`, which executed the full test suite and completed successfully.
- Ran `npm run build`, which completed and produced bundles but emitted Rollup warnings about unresolved/missing exports and external deps; build exit was successful.
- Attempted to capture a page preview with Playwright (`npx playwright screenshot ...`) but this failed because the Playwright browser binary could not be downloaded in this environment (Playwright install returned a 403), so no preview image was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc3f80f788324a6f9a8fa8cf563d4)