### PR TITLE
Add heat trace sizing tests and update navigation regression test

### DIFF
--- a/tests/heatTraceSizing.test.mjs
+++ b/tests/heatTraceSizing.test.mjs
@@ -1,0 +1,182 @@
+/**
+ * Tests for analysis/heatTraceSizing.mjs
+ */
+
+import assert from 'assert';
+import {
+  runHeatTraceSizingAnalysis,
+  selectStandardHeatTraceRating,
+} from '../analysis/heatTraceSizing.mjs';
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  \u2713', name);
+  } catch (err) {
+    console.error('  \u2717', name, err.message || err);
+    process.exitCode = 1;
+  }
+}
+
+function approx(actual, expected, tol = 0.02) {
+  const diff = Math.abs(actual - expected);
+  const rel = diff / (Math.abs(expected) || 1);
+  assert.ok(
+    rel <= tol || diff < 0.1,
+    `Expected ~${expected}, got ${actual} (rel error ${(rel * 100).toFixed(2)}%)`
+  );
+}
+
+describe('heat trace sizing representative W/ft cases', () => {
+  it('carbon steel indoor case returns expected required W/ft', () => {
+    const result = runHeatTraceSizingAnalysis({
+      pipeNps: '2',
+      insulationThicknessIn: 1,
+      lineLengthFt: 150,
+      maintainTempC: 60,
+      ambientTempC: 20,
+      pipeMaterial: 'carbonSteel',
+      environment: 'indoor-still',
+      safetyMarginPct: 10,
+    });
+
+    approx(result.requiredWPerFt, 5.07, 0.01);
+    assert.strictEqual(result.recommendedCableRatingWPerFt, 8);
+  });
+
+  it('stainless outdoor windy case returns expected required W/ft', () => {
+    const result = runHeatTraceSizingAnalysis({
+      pipeNps: '2',
+      insulationThicknessIn: 1,
+      lineLengthFt: 150,
+      maintainTempC: 60,
+      ambientTempC: -10,
+      pipeMaterial: 'stainlessSteel',
+      environment: 'outdoor-windy',
+      windSpeedMph: 15,
+      safetyMarginPct: 10,
+    });
+
+    approx(result.requiredWPerFt, 9.52, 0.01);
+    assert.strictEqual(result.recommendedCableRatingWPerFt, 10);
+  });
+
+  it('plastic piping in freezer-like ambient returns expected required W/ft', () => {
+    const result = runHeatTraceSizingAnalysis({
+      pipeNps: '1',
+      insulationThicknessIn: 1.5,
+      lineLengthFt: 200,
+      maintainTempC: 5,
+      ambientTempC: -30,
+      pipeMaterial: 'pvc',
+      environment: 'freezer',
+      safetyMarginPct: 15,
+    });
+
+    approx(result.requiredWPerFt, 2.19, 0.01);
+    assert.strictEqual(result.recommendedCableRatingWPerFt, 3);
+  });
+});
+
+describe('material/environment multipliers influence output directionally', () => {
+  const baseInputs = {
+    pipeNps: '2',
+    insulationThicknessIn: 1,
+    lineLengthFt: 100,
+    maintainTempC: 60,
+    ambientTempC: 0,
+    safetyMarginPct: 10,
+  };
+
+  it('harsher outdoor windy environment increases required W/ft vs indoor still', () => {
+    const indoor = runHeatTraceSizingAnalysis({
+      ...baseInputs,
+      pipeMaterial: 'copper',
+      environment: 'indoor-still',
+      windSpeedMph: 0,
+    });
+    const windy = runHeatTraceSizingAnalysis({
+      ...baseInputs,
+      pipeMaterial: 'copper',
+      environment: 'outdoor-windy',
+      windSpeedMph: 15,
+    });
+
+    assert.ok(windy.requiredWPerFt > indoor.requiredWPerFt,
+      `Expected windy (${windy.requiredWPerFt}) > indoor (${indoor.requiredWPerFt})`);
+  });
+
+  it('higher material factor (carbon steel) increases required W/ft vs pvc', () => {
+    const carbon = runHeatTraceSizingAnalysis({
+      ...baseInputs,
+      pipeMaterial: 'carbonSteel',
+      environment: 'outdoor-sheltered',
+    });
+    const pvc = runHeatTraceSizingAnalysis({
+      ...baseInputs,
+      pipeMaterial: 'pvc',
+      environment: 'outdoor-sheltered',
+    });
+
+    assert.ok(carbon.requiredWPerFt > pvc.requiredWPerFt,
+      `Expected carbon (${carbon.requiredWPerFt}) > pvc (${pvc.requiredWPerFt})`);
+  });
+});
+
+describe('standard cable rating selection', () => {
+  it('rounds up to next standard when between ratings', () => {
+    const rating = selectStandardHeatTraceRating(8.01);
+    assert.strictEqual(rating.selectedWPerFt, 10);
+  });
+
+  it('keeps exact standard value when already on rating', () => {
+    const rating = selectStandardHeatTraceRating(8);
+    assert.strictEqual(rating.selectedWPerFt, 8);
+  });
+});
+
+describe('input validation', () => {
+  it('throws when maintainTempC is not above ambientTempC', () => {
+    assert.throws(
+      () => runHeatTraceSizingAnalysis({
+        pipeNps: '2',
+        insulationThicknessIn: 1,
+        lineLengthFt: 100,
+        maintainTempC: 10,
+        ambientTempC: 10,
+      }),
+      /maintainTempC must be greater than ambientTempC/
+    );
+  });
+
+  it('throws on invalid geometry (non-positive insulation thickness)', () => {
+    assert.throws(
+      () => runHeatTraceSizingAnalysis({
+        pipeNps: '2',
+        insulationThicknessIn: 0,
+        lineLengthFt: 100,
+        maintainTempC: 60,
+        ambientTempC: 0,
+      }),
+      /insulationThicknessIn must be a finite number greater than zero/
+    );
+  });
+
+  it('throws on invalid geometry (unsupported pipeNps)', () => {
+    assert.throws(
+      () => runHeatTraceSizingAnalysis({
+        pipeNps: '14',
+        insulationThicknessIn: 1,
+        lineLengthFt: 100,
+        maintainTempC: 60,
+        ambientTempC: 0,
+      }),
+      /Unsupported pipeNps/
+    );
+  });
+});

--- a/tests/pageNavigation.test.cjs
+++ b/tests/pageNavigation.test.cjs
@@ -16,7 +16,7 @@ function it(name, fn) {
 const root = path.resolve(__dirname, '..');
 
 describe('page navigation', () => {
-  ['library.html', 'account.html'].forEach(file => {
+  ['library.html', 'account.html', 'heattracesizing.html'].forEach(file => {
     const html = fs.readFileSync(path.join(root, file), 'utf8');
     it(`${file} contains top-nav element`, () => {
       assert.ok(
@@ -40,5 +40,10 @@ describe('page navigation', () => {
   it('account.js imports navigation.js', () => {
     const src = fs.readFileSync(path.join(root, 'account.js'), 'utf8');
     assert.ok(src.includes('navigation.js'), 'account.js missing navigation.js import');
+  });
+
+  it('navigation definitions include heat trace sizing route', () => {
+    const src = fs.readFileSync(path.join(root, 'src/components/navigation.js'), 'utf8');
+    assert.ok(src.includes("href: 'heattracesizing.html'"), 'navigation.js missing heattracesizing.html route');
   });
 });


### PR DESCRIPTION
### Motivation
- Provide automated regression coverage for the Heat Trace Sizing analysis to ensure expected W/ft outputs, selection logic, and input validation remain stable.
- Ensure the site navigation surface includes the new Heat Trace Sizing page and that navigation definitions expose the route for UI wiring.

### Description
- Added `tests/heatTraceSizing.test.mjs` which exercises `runHeatTraceSizingAnalysis` and `selectStandardHeatTraceRating` with representative scenarios (carbon steel indoor, stainless outdoor/windy, PVC in freezer), directional checks for environment/material multipliers, standard-rating rounding behavior, and input validation error cases.
- Updated `tests/pageNavigation.test.cjs` to assert that `heattracesizing.html` contains `.top-nav` and `#nav-links` and to verify `src/components/navigation.js` includes the `heattracesizing.html` route.
- Kept test style and assertion patterns consistent with existing lightweight `describe/it` helpers used across the test suite.

### Testing
- Ran `node tests/heatTraceSizing.test.mjs` and it passed all cases.
- Ran `node tests/pageNavigation.test.cjs` and it passed, including the new assertions for `heattracesizing.html` and the navigation definition.
- Ran `npm run build` and the build completed successfully (dist creation warnings present but non-blocking).
- Started the full suite with `npm test`; the run executed many tests successfully but did not complete in this environment due to an existing suite hang (observed during `tests/collaboration.test.mjs`) so the full run was aborted.

(Note: an attempt to capture a webpage preview via Playwright was made, but browser binaries are not available in this environment so a screenshot could not be produced.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc922c0248324a58d29606cd93cfc)