### PR TITLE
Add heat trace sizing docs page and navigation links

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -28,6 +28,7 @@ const DOC_NAV = [
       { href: "load_calculation_formulas.html", title: "Load Calculation" },
       { href: "cable_fill_rules.html", title: "Cable Fill Rules" },
       { href: "routing_assumptions.html", title: "Routing Assumptions" },
+      { href: "heat-trace-sizing.md", title: "Heat Trace Sizing" },
     ],
   },
   {
@@ -35,6 +36,7 @@ const DOC_NAV = [
     children: [
       { href: "standards.html", title: "Engineering References" },
       { href: "nec_reference.html", title: "NEC Reference Tables" },
+      { href: "heat-trace-sizing.md", title: "Heat Trace Sizing (IEEE 515 Context)" },
     ],
   },
   {

--- a/docs/heat-trace-sizing.md
+++ b/docs/heat-trace-sizing.md
@@ -1,0 +1,112 @@
+# Heat Trace Sizing
+
+This note summarizes a practical hand-calculation workflow for electric heat tracing of process and utility piping. Use it as a preliminary design aid before final vendor selection and detailed thermal modeling.
+
+## Calculation model and limits
+
+A steady-state line-loss approach is used to estimate required heat output per linear foot of pipe:
+
+\[
+q_{\text{req}} = U_{\text{overall}} \times A_{\text{surface}} \times \Delta T \times M_{\text{env}} \times M_{\text{design}}
+\]
+
+Where:
+
+- \(q_{\text{req}}\): required tracing power (W/ft)
+- \(U_{\text{overall}}\): overall heat-transfer coefficient through insulation and external film
+- \(A_{\text{surface}}\): exposed outer area per foot of run
+- \(\Delta T\): maintain temperature minus minimum ambient design temperature
+- \(M_{\text{env}}\): environment class multiplier
+- \(M_{\text{design}}\): design margin multiplier
+
+Typical scope limits for this simplified method:
+
+- Intended for **steady-state maintain** duty, not rapid warm-up/startup transients.
+- Assumes continuous insulation, nominally dry conditions, and no major thermal bridges except where explicitly added.
+- Requires separate adder allowances for valves, supports, flanges, and instrument stubs.
+- Not a substitute for project-specific code compliance, hazardous area design, or manufacturer trace-circuit limits.
+
+## Pipe material assumptions and correction factors
+
+Pipe wall conductivity has secondary influence compared with insulation, but material assumptions still affect conservatism at high temperature or large diameters.
+
+Use baseline carbon steel line-loss values unless project standards require otherwise, then apply a material correction factor:
+
+| Pipe material | Suggested factor \(F_{\text{mat}}\) | Notes |
+| --- | ---: | --- |
+| Carbon steel | 1.00 | Baseline for most utility/process runs |
+| Stainless steel | 1.02 | Slightly higher conservatism for lower conductivity |
+| Copper | 0.98 | Higher conductivity; may slightly reduce local gradients |
+| Plastic/composite | 1.05-1.15 | Validate temperature limits and support spacing |
+
+Apply as:
+
+\[
+q_{\text{req,mat}} = q_{\text{req}} \times F_{\text{mat}}
+\]
+
+If heat trace is controlled by thermostats or line-sensing controllers, verify both **minimum output at design cold** and **maximum sheath/jacket temperature** at reduced load.
+
+## Environment classes and multipliers
+
+Use environment multipliers to account for exposure severity beyond nominal still-air assumptions.
+
+| Environment class | Description | Multiplier \(M_{\text{env}}\) |
+| --- | --- | ---: |
+| E1 | Indoor, sheltered, no washdown | 1.00 |
+| E2 | Outdoor, low wind, weather-protected | 1.10 |
+| E3 | Outdoor, wind-exposed process areas | 1.20 |
+| E4 | High wind/coastal or frequent wetting | 1.30 |
+| E5 | Severe cyclic wet/freezing service | 1.40 |
+
+Project teams may replace these with corporate or site climatology factors. Keep one documented source of truth for consistency across all line classes.
+
+## Example hand-check calculation
+
+Given:
+
+- 2 in NPS carbon steel pipe, 1 ft calculation length
+- Maintain temperature: 50 °C (122 °F)
+- Minimum ambient: -10 °C (14 °F)
+- Insulated OD area per foot: \(A_{\text{surface}} = 0.86\,\text{ft}^2/\text{ft}\)
+- Overall U-value estimate: \(U_{\text{overall}} = 0.55\,\text{W}/(\text{ft}^2\cdot\!^\circ\text{F})\)
+- Environment class E3: \(M_{\text{env}} = 1.20\)
+- Design margin: \(M_{\text{design}} = 1.15\)
+- Material factor (carbon steel): \(F_{\text{mat}} = 1.00\)
+
+Step 1: Temperature difference
+
+\[
+\Delta T = 122 - 14 = 108\,^\circ\text{F}
+\]
+
+Step 2: Base line loss
+
+\[
+q_{\text{base}} = U \times A \times \Delta T
+= 0.55 \times 0.86 \times 108
+= 51.1\,\text{W/ft}
+\]
+
+Step 3: Apply environment and design margin
+
+\[
+q_{\text{req}} = 51.1 \times 1.20 \times 1.15
+= 70.5\,\text{W/ft}
+\]
+
+Step 4: Apply material factor
+
+\[
+q_{\text{req,mat}} = 70.5 \times 1.00 = 70.5\,\text{W/ft}
+\]
+
+Preliminary selection would therefore target the next available trace-circuit capacity at or above **70.5 W/ft**, then confirm circuit length, breaker sizing, controller strategy, and startup behavior.
+
+## Notes on standards references and design margins
+
+- IEEE 515 is commonly used as a design framework for electrical resistance heat tracing systems, including system architecture, control philosophy, and installation considerations.
+- Treat this document as context support only; always use the latest adopted edition in your jurisdiction or client specification.
+- Typical design margins for early sizing are often 10-25%, depending on data quality, climatic uncertainty, and criticality.
+- When freeze protection is safety- or production-critical, use a structured margin policy (environment + uncertainty + aging) rather than a single arbitrary adder.
+- Final design should reconcile process maintain temperature, insulation specification, power availability, hazardous area constraints, and manufacturer-specific cable output curves.

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,6 +56,7 @@
           <li><a href="load_calculation_formulas.html">Load Calculation</a></li>
           <li><a href="cable_fill_rules.html">Cable Fill Rules</a></li>
           <li><a href="routing_assumptions.html">Routing Assumptions</a></li>
+          <li><a href="heat-trace-sizing.md">Heat Trace Sizing</a></li>
           <li><a href="caching.html">Caching &amp; Invalidation</a></li>
         </ul>
       </section>
@@ -63,6 +64,7 @@
         <h2>Standards</h2>
         <ul class="doc-list">
           <li><a href="standards.html">Engineering References</a></li>
+          <li><a href="heat-trace-sizing.md">Heat Trace Sizing (IEEE 515 Context)</a></li>
         </ul>
       </section>
       <section>


### PR DESCRIPTION
### Motivation
- Provide a discoverable, practical reference for preliminary electric heat-trace sizing (calculation model, material corrections, environment multipliers, worked example, and standards/design-margin context) to support early design checks and documentation consistency.

### Description
- Add `docs/heat-trace-sizing.md` containing the steady-state line-loss sizing model, scope/limits, pipe material correction factors, environment class multipliers, an example hand-check calculation, and notes referencing IEEE 515 and design margins.
- Update `docs/index.html` to surface the new document under both the "Advanced Topics" and "Standards" sections so it is reachable from the docs home page.
- Update `docs/docs.js` (`DOC_NAV`) so the left-side navigation includes the same new entries for the side menu.

### Testing
- Ran `npm test` and observed many tests passing from the long suite before the run stalled/hung in this environment, so the run was interrupted (progress indicates no doc-related failures before interruption).
- Ran `npm run build` which completed successfully (build warnings are unrelated to these documentation-only changes).
- Attempted `npx playwright screenshot` to produce a preview image but it failed because Playwright browser binaries were not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcc53b61c83248953e4893756f503)