### PR TITLE
docs: add heat trace sizing acceptance checklist

### DIFF
--- a/docs/next-features-acceptance.md
+++ b/docs/next-features-acceptance.md
@@ -9,6 +9,17 @@ Source smoke coverage reference: `playwright-tests/nextFeatures.spec.js` under d
 
 ---
 
+## Heat Trace Sizing — Minimum Acceptance Checklist
+
+- [ ] User can select at least **4 pipe materials**.
+- [ ] User can select at least **4 environment classes**.
+- [ ] Output includes required **W/ft** (or **W/m**), **total watts**, and a **recommended cable rating**.
+- [ ] Changing selected material or environment updates the result **deterministically** for the same inputs.
+- [ ] Results persist and reload via `studyResults.heatTraceSizing`.
+- [ ] Heat Trace Sizing appears in top navigation, command palette, and workflow dashboard summaries.
+
+---
+
 ## 1) Primary User Journeys
 
 ### 1.1 Cost Estimator (`costestimate.html`)


### PR DESCRIPTION
### Motivation
- Add a concise acceptance checklist for the new Heat Trace Sizing study so QA/CI can verify required inputs, outputs, persistence, and UI discoverability before feature sign-off.

### Description
- Added a `Heat Trace Sizing — Minimum Acceptance Checklist` to `docs/next-features-acceptance.md` that requires selecting 4+ pipe materials and 4+ environment classes, output of W/ft (or W/m), total watts, recommended cable rating, deterministic updates on input changes, persistence under `studyResults.heatTraceSizing`, and visibility in top navigation, the command palette, and workflow dashboard summaries.

### Testing
- Ran `npm run build`, which completed successfully though Rollup emitted existing warnings, and started `npm test` which began executing but was terminated after the run hung on `tests/collaboration.test.mjs` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd05f2ed883249c0e5486a20e1d41)