### PR TITLE
Add cathodic protection sizing page and analysis module

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Cathodic protection preliminary sizing for buried metallic structures. Estimate required current, anode mass, and design life." />
+  <title>Cathodic Protection Sizing — CableTrayRoute</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="icons/favicon.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Cathodic Protection Sizing — CableTrayRoute">
+  <meta property="og:description" content="Cathodic protection sizing for buried structures using current density and anode utilization methods.">
+  <meta property="og:image" content="https://cabletrayroute.com/icons/og-preview.png">
+  <meta property="og:site_name" content="CableTrayRoute">
+  <meta property="og:url" content="cathodicprotection.html">
+  <link rel="canonical" href="cathodicprotection.html">
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" href="style.css" />
+  <script type="module" src="dirtyTracker.js"></script>
+  <script type="module" src="dist/cathodicprotection.js" defer></script>
+</head>
+<body class="cathodicprotection-page" data-report-title="Cathodic Protection Sizing">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav" aria-label="Primary">
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">
+      <img src="icons/toolbar/grid.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+    </button>
+    <div id="nav-links" class="nav-links" role="list"></div>
+    <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">
+      <img src="icons/toolbar/validate.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+    </button>
+  </nav>
+
+  <div id="settings-menu" class="settings-menu">
+    <label for="theme-select">Theme
+      <select id="theme-select">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="high-contrast">High Contrast</option>
+      </select>
+    </label>
+    <label><input type="checkbox" id="compact-toggle" aria-label="Enable compact table mode"> Compact Mode</label>
+    <label for="unit-select">Units
+      <select id="unit-select">
+        <option value="imperial">Imperial (ft, in)</option>
+        <option value="metric">Metric (m, mm)</option>
+      </select>
+    </label>
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">
+      <img src="icons/toolbar/validate.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+      <span>Site Help</span>
+    </button>
+    <button id="new-project-btn" title="Start a new project"><img src="icons/toolbar/copy.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async"><span>New Project</span></button>
+    <button id="save-project-btn" title="Save current project"><img src="icons/toolbar/export.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async"><span>Save Project</span></button>
+    <button id="load-project-btn" title="Load an existing project"><img src="icons/toolbar/import.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async"><span>Load Project</span></button>
+    <button id="export-project-btn" title="Export project data"><img src="icons/toolbar/export.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async"><span>Export Project</span></button>
+    <button id="import-project-btn" title="Import project data"><img src="icons/toolbar/import.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async"><span>Import Project</span></button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden" title="Select project file">
+  </div>
+
+  <div class="container">
+    <main id="main-content" class="main-content">
+      <header class="page-header">
+        <h1>Cathodic Protection (CP) Sizing</h1>
+      </header>
+
+      <details class="method-panel" open>
+        <summary>Method, Formulas, and Standards Mapping</summary>
+        <p>This page provides preliminary impressed-current or galvanic CP sizing for buried assets.
+        Inputs and formulas are aligned with common practice from <strong>NACE SP0169 / AMPP SP21424</strong>,
+        <strong>ISO 15589-1</strong>, and <strong>DNV-RP-B401</strong> style current-demand and anode-consumption methods.</p>
+        <pre>I_req = A_exposed × i_d
+W_req = (I_req × t_design_hours) / (Q_anode × U × F_design)
+Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
+        <table class="data-table" aria-label="Standards reference mapping">
+          <thead><tr><th>Tool Input / Formula</th><th>Reference Guidance</th></tr></thead>
+          <tbody>
+            <tr><td>Asset type, coating condition, environment severity</td><td>NACE/AMPP CP design workflow and ISO 15589-1 design basis definition.</td></tr>
+            <tr><td>Design current density i<sub>d</sub> selection</td><td>Table-based current-density selection per environment and coating quality guidance (NACE/AMPP, DNV-RP-B401).</td></tr>
+            <tr><td>I<sub>req</sub> = A<sub>exposed</sub> × i<sub>d</sub></td><td>Standard CP current-demand relation for exposed steel area.</td></tr>
+            <tr><td>Anode capacity Q and utilization U</td><td>Anode consumption calculations per galvanic anode design standards (DNV-RP-B401 / ISO 15589-1).</td></tr>
+            <tr><td>Design factor F<sub>design</sub> and availability factor</td><td>Engineering margin and uptime allowance consistent with CP design reliability practice.</td></tr>
+            <tr><td>Life prediction from installed mass</td><td>Service-life check from available ampere-hour capacity divided by demand current.</td></tr>
+          </tbody>
+        </table>
+      </details>
+
+      <form id="cp-form" novalidate>
+        <fieldset>
+          <legend><strong>Asset &amp; Environment Inputs</strong></legend>
+          <div class="field-row">
+            <label for="asset-type">Asset type</label>
+            <select id="asset-type" required>
+              <option value="pipe">Pipe</option>
+              <option value="tank">Tank</option>
+              <option value="other">Other buried structure</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="soil-resistivity">Soil resistivity (Ω·m)</label>
+            <input type="number" id="soil-resistivity" min="0.1" step="0.1" value="100" required>
+          </div>
+          <div class="field-row">
+            <label for="soil-ph">Soil pH</label>
+            <input type="number" id="soil-ph" min="0" max="14" step="0.1" value="7.0" required>
+          </div>
+          <div class="field-row">
+            <label for="moisture-category">Moisture / corrosivity category</label>
+            <select id="moisture-category" required>
+              <option value="low">Low / dry</option>
+              <option value="moderate" selected>Moderate</option>
+              <option value="high">High / aggressive</option>
+            </select>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend><strong>Exposure &amp; Current Demand</strong></legend>
+          <div class="field-row">
+            <label for="coating-breakdown">Coating breakdown factor (0–1)</label>
+            <input type="number" id="coating-breakdown" min="0" max="1" step="0.01" value="0.20" required>
+          </div>
+          <div class="field-row">
+            <label for="surface-area">Total metallic surface area (<span class="unit-label-ft">ft²</span><span class="unit-label-m" hidden>m²</span>)</label>
+            <input type="number" id="surface-area" min="0.1" step="0.1" value="500" required>
+          </div>
+          <div class="field-row">
+            <label for="density-method">Current density selection method</label>
+            <select id="density-method" required>
+              <option value="table" selected>Standard table (recommended)</option>
+              <option value="manual">Manual entry</option>
+            </select>
+          </div>
+          <div class="field-row" id="manual-density-row" hidden>
+            <label for="manual-density">Manual design current density i<sub>d</sub> (mA/m²)</label>
+            <input type="number" id="manual-density" min="0.001" step="0.001" value="10">
+          </div>
+          <div class="field-row">
+            <label for="table-density">Table-based design current density i<sub>d</sub> (mA/m²)</label>
+            <input type="number" id="table-density" value="10" readonly>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend><strong>Anode &amp; Design Factors</strong></legend>
+          <div class="field-row">
+            <label for="anode-capacity">Anode capacity Q<sub>anode</sub> (Ah/kg)</label>
+            <input type="number" id="anode-capacity" min="1" step="1" value="780" required>
+          </div>
+          <div class="field-row">
+            <label for="anode-utilization">Anode utilization factor U (0–1)</label>
+            <input type="number" id="anode-utilization" min="0.01" max="1" step="0.01" value="0.85" required>
+          </div>
+          <div class="field-row">
+            <label for="design-factor">Design factor F<sub>design</sub> (&gt;0)</label>
+            <input type="number" id="design-factor" min="0.01" step="0.01" value="1.10" required>
+          </div>
+          <div class="field-row">
+            <label for="availability-factor">Availability factor (0–1)</label>
+            <input type="number" id="availability-factor" min="0.01" max="1" step="0.01" value="0.95" required>
+          </div>
+          <div class="field-row">
+            <label for="design-life-years">Target design life (years)</label>
+            <input type="number" id="design-life-years" min="0.1" step="0.1" value="20" required>
+          </div>
+          <div class="field-row">
+            <label for="installed-mass">Installed anode mass (<span class="unit-label-ft">lb</span><span class="unit-label-m" hidden>kg</span>)</label>
+            <input type="number" id="installed-mass" min="0.1" step="0.1" value="500" required>
+          </div>
+        </fieldset>
+
+        <button type="submit" class="primary-btn">Run Analysis</button>
+      </form>
+
+      <div id="cp-errors" class="alert-error" hidden role="alert"></div>
+      <div id="results" role="region" aria-live="polite" aria-label="Cathodic protection sizing results"></div>
+
+      <section class="card" aria-labelledby="study-review-panel-heading"><div id="study-review-panel"></div></section>
+
+      <nav class="step-nav" aria-label="Workflow navigation">
+        <a href="groundgrid.html" class="step-nav-prev">&#8592; Ground Grid</a>
+        <a href="battery.html" class="step-nav-next">Battery / UPS Sizing &#8594;</a>
+      </nav>
+    </main>
+  </div>
+
+  <div id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="help-title">
+    <div class="modal-content">
+      <button id="close-help-btn" class="close-btn" aria-label="Close Help">&times;</button>
+      <h2 id="help-title">Cathodic Protection Sizing Help</h2>
+      <p>Enter environment, coating, and anode design parameters. The tool calculates required CP current,
+      minimum anode mass for target life, and predicted life from installed anode mass.</p>
+    </div>
+  </div>
+
+  <script type="module" src="dist/projectManager.js"></script>
+</body>
+</html>

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -1,0 +1,283 @@
+import { getStudies, setStudies } from './dataStore.mjs';
+import { initStudyApprovalPanel } from './src/components/studyApproval.js';
+
+const SQFT_TO_SQM = 0.09290304;
+const LB_TO_KG = 0.45359237;
+
+const TABLE_CURRENT_DENSITY_MA_M2 = {
+  pipe: { low: 5, moderate: 10, high: 20 },
+  tank: { low: 8, moderate: 15, high: 25 },
+  other: { low: 6, moderate: 12, high: 22 }
+};
+
+export function calculateRequiredCurrent(areaExposedM2, currentDensityAperM2) {
+  return areaExposedM2 * currentDensityAperM2;
+}
+
+export function calculateRequiredAnodeMass(requiredCurrentA, designHours, anodeCapacityAhPerKg, utilizationFactor, designFactor) {
+  return (requiredCurrentA * designHours) / (anodeCapacityAhPerKg * utilizationFactor * designFactor);
+}
+
+export function calculatePredictedDesignLife(installedMassKg, anodeCapacityAhPerKg, utilizationFactor, designFactor, requiredCurrentA) {
+  return (installedMassKg * anodeCapacityAhPerKg * utilizationFactor * designFactor) / (requiredCurrentA * 8760);
+}
+
+export function runCathodicProtectionAnalysis(input) {
+  const validationErrors = validateInputs(input);
+  if (validationErrors.length) {
+    throw new Error(validationErrors.join(' '));
+  }
+
+  const designCurrentDensityMaM2 = input.currentDensityMethod === 'manual'
+    ? input.manualCurrentDensityMaM2
+    : lookupCurrentDensity(input.assetType, input.moistureCategory, input.soilResistivityOhmM, input.soilPh);
+
+  const designCurrentDensityAperM2 = designCurrentDensityMaM2 / 1000;
+  const exposedAreaM2 = input.surfaceAreaM2 * input.coatingBreakdownFactor;
+  const requiredCurrentA = calculateRequiredCurrent(exposedAreaM2, designCurrentDensityAperM2);
+  const adjustedRequiredCurrentA = requiredCurrentA / input.availabilityFactor;
+  const designHours = input.targetLifeYears * 8760;
+
+  const minimumAnodeMassKg = calculateRequiredAnodeMass(
+    adjustedRequiredCurrentA,
+    designHours,
+    input.anodeCapacityAhPerKg,
+    input.anodeUtilization,
+    input.designFactor
+  );
+
+  const predictedLifeYears = calculatePredictedDesignLife(
+    input.installedMassKg,
+    input.anodeCapacityAhPerKg,
+    input.anodeUtilization,
+    input.designFactor,
+    adjustedRequiredCurrentA
+  );
+
+  return {
+    ...input,
+    timestamp: new Date().toISOString(),
+    designCurrentDensityMaM2: roundTo(designCurrentDensityMaM2, 3),
+    exposedAreaM2: roundTo(exposedAreaM2, 3),
+    requiredCurrentA: roundTo(adjustedRequiredCurrentA, 4),
+    minimumAnodeMassKg: roundTo(minimumAnodeMassKg, 3),
+    minimumAnodeMassLb: roundTo(minimumAnodeMassKg / LB_TO_KG, 3),
+    predictedLifeYears: roundTo(predictedLifeYears, 2),
+    safetyMarginYears: roundTo(predictedLifeYears - input.targetLifeYears, 2),
+    safetyMarginPercent: roundTo(((predictedLifeYears - input.targetLifeYears) / input.targetLifeYears) * 100, 1)
+  };
+}
+
+function validateInputs(input) {
+  const errors = [];
+  const positiveChecks = [
+    ['soilResistivityOhmM', input.soilResistivityOhmM],
+    ['surfaceAreaM2', input.surfaceAreaM2],
+    ['anodeCapacityAhPerKg', input.anodeCapacityAhPerKg],
+    ['targetLifeYears', input.targetLifeYears],
+    ['installedMassKg', input.installedMassKg],
+    ['designFactor', input.designFactor],
+    ['availabilityFactor', input.availabilityFactor],
+    ['anodeUtilization', input.anodeUtilization]
+  ];
+
+  positiveChecks.forEach(([name, value]) => {
+    if (!Number.isFinite(value) || value <= 0) {
+      errors.push(`${name} must be greater than zero.`);
+    }
+  });
+
+  if (!Number.isFinite(input.coatingBreakdownFactor) || input.coatingBreakdownFactor <= 0 || input.coatingBreakdownFactor > 1) {
+    errors.push('coatingBreakdownFactor must be between 0 and 1, exclusive of zero.');
+  }
+
+  if (!Number.isFinite(input.soilPh) || input.soilPh < 0 || input.soilPh > 14) {
+    errors.push('soilPh must be between 0 and 14.');
+  }
+
+  if (!['pipe', 'tank', 'other'].includes(input.assetType)) {
+    errors.push('assetType must be pipe, tank, or other.');
+  }
+
+  if (!['low', 'moderate', 'high'].includes(input.moistureCategory)) {
+    errors.push('moistureCategory must be low, moderate, or high.');
+  }
+
+  if (!['table', 'manual'].includes(input.currentDensityMethod)) {
+    errors.push('currentDensityMethod must be table or manual.');
+  }
+
+  if (input.currentDensityMethod === 'manual' && (!Number.isFinite(input.manualCurrentDensityMaM2) || input.manualCurrentDensityMaM2 <= 0)) {
+    errors.push('manualCurrentDensityMaM2 must be greater than zero when manual mode is selected.');
+  }
+
+  return errors;
+}
+
+function lookupCurrentDensity(assetType, moistureCategory, soilResistivityOhmM, soilPh) {
+  const base = TABLE_CURRENT_DENSITY_MA_M2[assetType]?.[moistureCategory] ?? 10;
+  const resistivityFactor = soilResistivityOhmM < 50 ? 1.2 : (soilResistivityOhmM > 200 ? 0.85 : 1.0);
+  const phFactor = soilPh < 5.5 || soilPh > 9 ? 1.15 : 1.0;
+  return base * resistivityFactor * phFactor;
+}
+
+function roundTo(value, decimals) {
+  const p = 10 ** decimals;
+  return Math.round(value * p) / p;
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+  initSettings();
+  initDarkMode();
+  initCompactMode();
+  initHelpModal('help-btn', 'help-modal', 'close-help-btn');
+  initNavToggle();
+  initStudyApprovalPanel('cathodicProtection');
+
+  const form = document.getElementById('cp-form');
+  const resultsDiv = document.getElementById('results');
+  const errorsDiv = document.getElementById('cp-errors');
+  const densityMethodEl = document.getElementById('density-method');
+  const manualRow = document.getElementById('manual-density-row');
+  const tableDensityEl = document.getElementById('table-density');
+
+  const saved = getStudies().cathodicProtection;
+  if (saved) {
+    renderResults(saved, resultsDiv);
+  }
+
+  function refreshTableDensity() {
+    const input = readFormInputs();
+    if (!input) return;
+    const tableDensity = lookupCurrentDensity(input.assetType, input.moistureCategory, input.soilResistivityOhmM, input.soilPh);
+    tableDensityEl.value = roundTo(tableDensity, 3);
+  }
+
+  function toggleDensityMode() {
+    const manual = densityMethodEl.value === 'manual';
+    manualRow.hidden = !manual;
+    tableDensityEl.closest('.field-row').hidden = manual;
+  }
+
+  toggleDensityMode();
+  refreshTableDensity();
+
+  ['asset-type', 'soil-resistivity', 'soil-ph', 'moisture-category', 'density-method'].forEach(id => {
+    document.getElementById(id).addEventListener('input', () => {
+      toggleDensityMode();
+      refreshTableDensity();
+    });
+    document.getElementById(id).addEventListener('change', () => {
+      toggleDensityMode();
+      refreshTableDensity();
+    });
+  });
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const input = readFormInputs();
+    if (!input) return;
+
+    try {
+      const result = runCathodicProtectionAnalysis(input);
+      errorsDiv.hidden = true;
+      errorsDiv.textContent = '';
+      const studies = getStudies();
+      studies.cathodicProtection = result;
+      setStudies(studies);
+      renderResults(result, resultsDiv);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid cathodic protection inputs.';
+      errorsDiv.hidden = false;
+      errorsDiv.innerHTML = `<strong>Input validation error:</strong> ${escapeHtml(message)}`;
+      showModal('Input Error', `<p>${escapeHtml(message)}</p>`, 'error');
+    }
+  });
+  });
+}
+
+function readFormInputs() {
+  const getValue = id => document.getElementById(id).value;
+  const getNumber = id => Number.parseFloat(getValue(id));
+  const isMetric = document.getElementById('unit-select')?.value === 'metric';
+
+  const surfaceAreaInput = getNumber('surface-area');
+  const installedMassInput = getNumber('installed-mass');
+
+  return {
+    assetType: getValue('asset-type'),
+    soilResistivityOhmM: getNumber('soil-resistivity'),
+    soilPh: getNumber('soil-ph'),
+    moistureCategory: getValue('moisture-category'),
+    coatingBreakdownFactor: getNumber('coating-breakdown'),
+    surfaceAreaM2: isMetric ? surfaceAreaInput : surfaceAreaInput * SQFT_TO_SQM,
+    currentDensityMethod: getValue('density-method'),
+    manualCurrentDensityMaM2: getNumber('manual-density'),
+    anodeCapacityAhPerKg: getNumber('anode-capacity'),
+    anodeUtilization: getNumber('anode-utilization'),
+    designFactor: getNumber('design-factor'),
+    availabilityFactor: getNumber('availability-factor'),
+    targetLifeYears: getNumber('design-life-years'),
+    installedMassKg: isMetric ? installedMassInput : installedMassInput * LB_TO_KG,
+    units: isMetric ? 'metric' : 'imperial'
+  };
+}
+
+function renderResults(result, root) {
+  const lifeBadgeClass = result.safetyMarginYears >= 0 ? 'result-badge--pass' : 'result-badge--fail';
+  const lifeBadgeIcon = result.safetyMarginYears >= 0 ? '✓' : '✗';
+
+  root.innerHTML = `
+    <section class="results-panel" aria-labelledby="cp-results-heading">
+      <h2 id="cp-results-heading">Cathodic Protection Sizing Results</h2>
+
+      <div class="result-group">
+        <div class="result-row">
+          <span class="result-label">Required CP current</span>
+          <span class="result-value">${result.requiredCurrentA} A</span>
+        </div>
+        <p class="field-hint result-formula">I<sub>req</sub> = A<sub>exposed</sub> × i<sub>d</sub> = ${result.exposedAreaM2} × ${(result.designCurrentDensityMaM2 / 1000).toFixed(4)} = ${result.requiredCurrentA} A</p>
+      </div>
+
+      <div class="result-group">
+        <div class="result-row">
+          <span class="result-label">Minimum anode mass</span>
+          <span class="result-value">${result.minimumAnodeMassKg} kg (${result.minimumAnodeMassLb} lb)</span>
+        </div>
+      </div>
+
+      <div class="result-group">
+        <div class="result-row">
+          <span class="result-label">Predicted design life from installed mass</span>
+          <span class="result-value">${result.predictedLifeYears} years</span>
+        </div>
+        <div class="result-badge ${lifeBadgeClass}">${lifeBadgeIcon} Safety margin: ${result.safetyMarginYears} years (${result.safetyMarginPercent}%) vs target ${result.targetLifeYears} years</div>
+      </div>
+
+      <div class="table-wrap">
+        <table class="data-table" aria-label="Cathodic protection summary table">
+          <thead><tr><th>Parameter</th><th>Value</th></tr></thead>
+          <tbody>
+            <tr><td>Asset type</td><td>${escapeHtml(result.assetType)}</td></tr>
+            <tr><td>Soil resistivity</td><td>${result.soilResistivityOhmM} Ω·m</td></tr>
+            <tr><td>Soil pH</td><td>${result.soilPh}</td></tr>
+            <tr><td>Moisture / corrosivity category</td><td>${escapeHtml(result.moistureCategory)}</td></tr>
+            <tr><td>Design current density i<sub>d</sub></td><td>${result.designCurrentDensityMaM2} mA/m²</td></tr>
+            <tr><td>Coating breakdown factor</td><td>${result.coatingBreakdownFactor}</td></tr>
+            <tr><td>Exposed area</td><td>${result.exposedAreaM2} m²</td></tr>
+            <tr><td>Anode capacity</td><td>${result.anodeCapacityAhPerKg} Ah/kg</td></tr>
+            <tr><td>Anode utilization factor U</td><td>${result.anodeUtilization}</td></tr>
+            <tr><td>Design factor F<sub>design</sub></td><td>${result.designFactor}</td></tr>
+            <tr><td>Availability factor</td><td>${result.availabilityFactor}</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="field-hint result-timestamp">Analysis run: ${new Date(result.timestamp).toLocaleString()}</p>
+    </section>`;
+}
+
+function escapeHtml(text) {
+  return String(text).replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char]));
+}

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -36,6 +36,7 @@ const entries = {
   intlCableSize: 'src/intlCableSize.js',
   groundgrid: 'src/groundgrid.js',
   capacitorbank: 'src/capacitorbank.js',
+  cathodicprotection: 'src/cathodicprotection.js',
   battery: 'src/battery.js',
   generatorsizing: 'src/generatorsizing.js',
   heattracesizing: 'src/heattracesizing.js',

--- a/src/cathodicprotection.js
+++ b/src/cathodicprotection.js
@@ -1,0 +1,3 @@
+import "./workflowStatus.js";
+import "../site.js";
+import "../cathodicprotection.js";

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -40,6 +40,7 @@ const NAV_ROUTES = [
   { href: 'shortCircuit.html', label: 'Short Circuit', section: 'Studies', group: 'Protection', icon: 'icons/components/Breaker.svg' },
   { href: 'arcFlash.html', label: 'Arc Flash', section: 'Studies', group: 'Protection', icon: 'icons/toolbar/connect.svg' },
   { href: 'groundgrid.html', label: 'Ground Grid', section: 'Studies', group: 'Grounding', icon: 'icons/toolbar/validate.svg' },
+  { href: 'cathodicprotection.html', label: 'Cathodic Protection', section: 'Studies', group: 'Grounding', icon: 'icons/toolbar/validate.svg' },
   { href: 'autosize.html', label: 'Auto-Size', section: 'Studies', group: 'Cable', icon: 'icons/toolbar/grid-size.svg' },
   { href: 'heattracesizing.html', label: 'Heat Trace Sizing', section: 'Studies', group: 'Equipment Sizing', icon: 'icons/toolbar/grid-size.svg' },
   { href: 'reliability.html', label: 'Reliability', section: 'Studies', group: 'Power System', icon: 'icons/toolbar/validate.svg' },

--- a/tests/cathodicProtection.test.mjs
+++ b/tests/cathodicProtection.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import {
+  calculateRequiredCurrent,
+  calculateRequiredAnodeMass,
+  calculatePredictedDesignLife,
+  runCathodicProtectionAnalysis
+} from '../cathodicprotection.js';
+
+(function testPureFormulas() {
+  assert.equal(calculateRequiredCurrent(100, 0.01), 1);
+  assert.equal(calculateRequiredAnodeMass(1, 8760, 780, 0.85, 1.1).toFixed(6), '12.011518');
+  assert.equal(calculatePredictedDesignLife(100, 780, 0.85, 1.1, 1).toFixed(6), '8.325342');
+})();
+
+(function testIntegratedSizing() {
+  const result = runCathodicProtectionAnalysis({
+    assetType: 'pipe',
+    soilResistivityOhmM: 100,
+    soilPh: 7,
+    moistureCategory: 'moderate',
+    coatingBreakdownFactor: 0.2,
+    surfaceAreaM2: 100,
+    currentDensityMethod: 'table',
+    manualCurrentDensityMaM2: 0,
+    anodeCapacityAhPerKg: 780,
+    anodeUtilization: 0.85,
+    designFactor: 1.1,
+    availabilityFactor: 0.95,
+    targetLifeYears: 20,
+    installedMassKg: 200
+  });
+
+  assert.ok(result.requiredCurrentA > 0);
+  assert.ok(result.minimumAnodeMassKg > 0);
+  assert.ok(result.predictedLifeYears > 0);
+})();
+
+console.log('✓ cathodic protection sizing tests passed');


### PR DESCRIPTION
### Motivation
- Provide a new preliminary Cathodic Protection (CP) sizing study page to estimate required CP current, minimum anode mass, and predicted service life for buried metallic assets.
- Expose the core CP formulas as pure functions so sizing logic can be unit-tested and reused by other tooling or pages.
- Keep the new study consistent with the existing study pages (e.g. `groundgrid.html`, `capacitorbank.html`) and wire it into site navigation and the build pipeline.

### Description
- Added a new page `cathodicprotection.html` following the project study page pattern, including settings/nav/help scaffolding, method & standards panel, grouped input fieldsets, result region, and workflow navigation.
- Implemented `cathodicprotection.js` which exports pure calculation functions `calculateRequiredCurrent`, `calculateRequiredAnodeMass`, and `calculatePredictedDesignLife`, plus an integration entry `runCathodicProtectionAnalysis` that applies validation, table/manual current-density selection, availability/design factor adjustments, and prepares result objects for rendering.
- Added a lightweight browser-entry module `src/cathodicprotection.js` and registered the page in `src/components/navigation.js` and `rollup.config.cjs` so the page builds and appears in navigation.
- Added defensive validation for invalid/zero/negative inputs with user-visible error messaging and modal reporting, plus a standards-reference panel mapping inputs/formulas to NACE/ISO/DNV-style guidance.
- Added unit tests `tests/cathodicProtection.test.mjs` exercising the pure functions and an integrated sizing scenario, and added minimal UI glue in `cathodicprotection.js` to render results and persist to the studies store.

### Testing
- Ran `npm run build`; build completed successfully (Rollup emitted standard non-blocking warnings unrelated to this change). ✅
- Executed the focused unit/integration check with `node tests/cathodicProtection.test.mjs`, and the test file passed. ✅
- Attempted `npm test` (full project suite); in this environment the long-running full suite could not be completed within the session (observed many passing tests before the run was stopped / timed out). ⚠️
- Attempted to produce a browser preview via Playwright screenshot, but `npx playwright install` failed due to Playwright CDN download `403 Forbidden` in this environment, so a screenshot could not be generated. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd337f88883249c7a07c7403edf2a)