### PR TITLE
Add cathodic protection unit tests and documentation

### DIFF
--- a/docs/cathodic_protection.md
+++ b/docs/cathodic_protection.md
@@ -1,0 +1,97 @@
+# Cathodic Protection (CP) Sizing — Inputs, Equations, and Limits
+
+**Page:** `cathodicprotection.html`  
+**Module:** `cathodicprotection.js`
+
+This guide documents the engineering basis used by the Cathodic Protection sizing tool for buried metallic structures.
+
+## Inputs and Units
+
+| Input | Symbol | Units | Notes |
+| --- | --- | --- | --- |
+| Asset type | — | categorical | `pipe`, `tank`, or `other`; selects base current-density table row. |
+| Soil resistivity | ρ | Ω·m | Used for current-density adjustment (`< 50`, `50–200`, `> 200` Ω·m bands). |
+| Soil pH | pH | — | Used to apply an acidic/alkaline adjustment outside nominal neutral range. |
+| Moisture category | — | categorical | `low`, `moderate`, or `high`; selects base current-density table column. |
+| Coating breakdown factor | f<sub>cb</sub> | fraction | `0 < f_cb ≤ 1`; represents exposed steel area fraction. |
+| Surface area | A<sub>surf</sub> | m² | Total structure surface area used for CP demand calculation. |
+| Current density mode | — | categorical | `table` (auto-selected) or `manual`. |
+| Manual current density | i<sub>manual</sub> | mA/m² | Used only when mode=`manual`. |
+| Anode capacity | C<sub>a</sub> | Ah/kg | Net ampere-hour capacity basis for selected anode alloy/system. |
+| Anode utilization | u | fraction | Fraction of theoretical anode capacity considered usable. |
+| Design factor | F<sub>d</sub> | fraction | Reliability/engineering margin factor used in mass/life equations. |
+| Availability factor | F<sub>avail</sub> | fraction | System uptime factor; required current is divided by this factor. |
+| Target design life | L<sub>target</sub> | years | Converted internally to hours (`years × 8760`). |
+| Installed anode mass | M<sub>inst</sub> | kg | Used for predicted-life calculation. |
+
+## Equations Used
+
+### 1) Current density selection
+
+When `table` mode is selected, the tool determines:
+
+- A base current density from asset type + moisture category table (mA/m²), then applies:
+  - Resistivity factor = `1.2` for `ρ < 50` Ω·m, `1.0` for `50–200` Ω·m, `0.85` for `ρ > 200` Ω·m.
+  - pH factor = `1.15` for `pH < 5.5` or `pH > 9`, else `1.0`.
+
+
+i<sub>design</sub> = i<sub>base</sub> × F<sub>ρ</sub> × F<sub>pH</sub>
+
+Then convert mA/m² to A/m²:
+
+i<sub>design,A</sub> = i<sub>design</sub> / 1000
+
+### 2) Exposed area
+
+A<sub>exposed</sub> = A<sub>surf</sub> × f<sub>cb</sub>
+
+### 3) Required current
+
+I<sub>req</sub> = A<sub>exposed</sub> × i<sub>design,A</sub>
+
+Availability-adjusted current used for sizing:
+
+I<sub>adj</sub> = I<sub>req</sub> / F<sub>avail</sub>
+
+### 4) Required anode mass for target life
+
+Design hours:
+
+H = L<sub>target</sub> × 8760
+
+Required mass:
+
+M<sub>req</sub> = (I<sub>adj</sub> × H) / (C<sub>a</sub> × u × F<sub>d</sub>)
+
+### 5) Predicted life for installed mass
+
+L<sub>pred</sub> = (M<sub>inst</sub> × C<sub>a</sub> × u × F<sub>d</sub>) / (I<sub>adj</sub> × 8760)
+
+### 6) Safety margin outputs
+
+- Safety margin (years) = `L_pred − L_target`
+- Safety margin (%) = `(L_pred − L_target) / L_target × 100`
+
+## Assumptions and Limits
+
+- Intended for preliminary CP sizing and scoping studies, not detailed final design.
+- Current-density table values are generalized and should be project-calibrated with owner/asset historical data when available.
+- Coating breakdown factor is a dominant uncertainty; select conservatively for life-cycle projections.
+- Temperature correction, current-distribution nonuniformity, shielding, stray-current effects, and attenuation modeling are not explicitly solved in this simplified workflow.
+- pH and resistivity effects are represented via bounded multipliers, not full electrochemical kinetics.
+- Validation requires positive numeric values for major scalar inputs and enforces `0 < coatingBreakdownFactor ≤ 1`, `0 ≤ pH ≤ 14`.
+
+## Standards References
+
+The in-app standards basis references:
+
+- **AMPP SP21424** — current demand selection workflow basis.
+- **NACE SP0169** — external corrosion control and CP criteria basis.
+- **ISO 15589-1** — cathodic protection design basis for buried/immersed pipelines.
+- **DNV-RP-B401** — anode design/capacity and utilization guidance.
+
+> Note: The tool uses these standards as design-basis references for equation form and parameter framing. Project-specific compliance still requires engineering sign-off against the exact edition and jurisdictional requirements.
+
+## Revision Notes
+
+- **2026-04-15:** Initial documentation page added for CP sizing inputs, equations, assumptions/limits, references, and consistency guidance between required-mass and predicted-life relations.

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -29,6 +29,7 @@ const DOC_NAV = [
       { href: "cable_fill_rules.html", title: "Cable Fill Rules" },
       { href: "routing_assumptions.html", title: "Routing Assumptions" },
       { href: "heat-trace-sizing.md", title: "Heat Trace Sizing" },
+      { href: "cathodic_protection.md", title: "Cathodic Protection Sizing" },
     ],
   },
   {
@@ -37,6 +38,7 @@ const DOC_NAV = [
       { href: "standards.html", title: "Engineering References" },
       { href: "nec_reference.html", title: "NEC Reference Tables" },
       { href: "heat-trace-sizing.md", title: "Heat Trace Sizing (IEEE 515 Context)" },
+      { href: "cathodic_protection.md", title: "Cathodic Protection Sizing (AMPP/NACE/ISO Context)" },
     ],
   },
   {

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
           <li><a href="cable_fill_rules.html">Cable Fill Rules</a></li>
           <li><a href="routing_assumptions.html">Routing Assumptions</a></li>
           <li><a href="heat-trace-sizing.md">Heat Trace Sizing</a></li>
+          <li><a href="cathodic_protection.md">Cathodic Protection Sizing</a></li>
           <li><a href="caching.html">Caching &amp; Invalidation</a></li>
         </ul>
       </section>
@@ -65,6 +66,7 @@
         <ul class="doc-list">
           <li><a href="standards.html">Engineering References</a></li>
           <li><a href="heat-trace-sizing.md">Heat Trace Sizing (IEEE 515 Context)</a></li>
+          <li><a href="cathodic_protection.md">Cathodic Protection Sizing (AMPP/NACE/ISO Context)</a></li>
         </ul>
       </section>
       <section>

--- a/tests/cathodicProtection.test.mjs
+++ b/tests/cathodicProtection.test.mjs
@@ -6,14 +6,8 @@ import {
   runCathodicProtectionAnalysis
 } from '../cathodicprotection.js';
 
-(function testPureFormulas() {
-  assert.equal(calculateRequiredCurrent(100, 0.01), 1);
-  assert.equal(calculateRequiredAnodeMass(1, 8760, 780, 0.85, 1.1).toFixed(6), '12.011518');
-  assert.equal(calculatePredictedDesignLife(100, 780, 0.85, 1.1, 1).toFixed(6), '8.325342');
-})();
-
-(function testIntegratedSizing() {
-  const result = runCathodicProtectionAnalysis({
+function baseInput(overrides = {}) {
+  return {
     assetType: 'pipe',
     soilResistivityOhmM: 100,
     soilPh: 7,
@@ -27,12 +21,88 @@ import {
     designFactor: 1.1,
     availabilityFactor: 0.95,
     targetLifeYears: 20,
-    installedMassKg: 200
-  });
+    installedMassKg: 200,
+    ...overrides
+  };
+}
+
+(function testNominalValidCase() {
+  const result = runCathodicProtectionAnalysis(baseInput());
+
+  assert.equal(result.designCurrentDensityMaM2, 10);
+  assert.equal(result.exposedAreaM2, 20);
+  assert.equal(result.requiredCurrentA, 0.2105);
+  assert.equal(result.minimumAnodeMassKg, 50.575);
+  assert.equal(result.predictedLifeYears, 79.09);
+  assert.equal(result.safetyMarginYears, 59.09);
 
   assert.ok(result.requiredCurrentA > 0);
   assert.ok(result.minimumAnodeMassKg > 0);
   assert.ok(result.predictedLifeYears > 0);
+})();
+
+(function testFormulaHelpers() {
+  assert.equal(calculateRequiredCurrent(100, 0.01), 1);
+  assert.equal(calculateRequiredAnodeMass(1, 8760, 780, 0.85, 1.1).toFixed(6), '12.011518');
+  assert.equal(calculatePredictedDesignLife(100, 780, 0.85, 1.1, 1).toFixed(6), '8.325342');
+})();
+
+(function testEdgeCaseVeryLowHighResistivity() {
+  const lowRes = runCathodicProtectionAnalysis(baseInput({ soilResistivityOhmM: 10 }));
+  const highRes = runCathodicProtectionAnalysis(baseInput({ soilResistivityOhmM: 500 }));
+
+  assert.equal(lowRes.designCurrentDensityMaM2, 12, 'low resistivity should increase current density');
+  assert.equal(highRes.designCurrentDensityMaM2, 8.5, 'high resistivity should decrease current density');
+  assert.ok(lowRes.requiredCurrentA > highRes.requiredCurrentA, 'lower resistivity case should require more current');
+})();
+
+(function testEdgeCaseCoatingBreakdownNearBounds() {
+  const almostIntact = runCathodicProtectionAnalysis(baseInput({ coatingBreakdownFactor: 0.001 }));
+  const almostBare = runCathodicProtectionAnalysis(baseInput({ coatingBreakdownFactor: 0.999 }));
+
+  assert.ok(almostIntact.requiredCurrentA > 0, 'near-zero breakdown should still produce finite positive current');
+  assert.ok(almostBare.requiredCurrentA > almostIntact.requiredCurrentA, 'near-one breakdown should require more current');
+})();
+
+(function testValidationErrorsMissingOrNegativeInputs() {
+  assert.throws(
+    () => runCathodicProtectionAnalysis(baseInput({ soilResistivityOhmM: undefined })),
+    /soilResistivityOhmM must be greater than zero/,
+    'missing numeric input should fail validation'
+  );
+
+  assert.throws(
+    () => runCathodicProtectionAnalysis(baseInput({ targetLifeYears: -1 })),
+    /targetLifeYears must be greater than zero/,
+    'negative input should fail validation'
+  );
+
+  assert.throws(
+    () => runCathodicProtectionAnalysis(baseInput({ coatingBreakdownFactor: 0 })),
+    /coatingBreakdownFactor must be between 0 and 1/,
+    'coating breakdown at exactly zero should fail validation'
+  );
+
+  assert.throws(
+    () => runCathodicProtectionAnalysis(baseInput({ coatingBreakdownFactor: 1.2 })),
+    /coatingBreakdownFactor must be between 0 and 1/,
+    'coating breakdown above one should fail validation'
+  );
+})();
+
+(function testRequiredMassAndPredictedLifeConsistency() {
+  const baseline = baseInput({ installedMassKg: 200, targetLifeYears: 20 });
+  const baselineResult = runCathodicProtectionAnalysis(baseline);
+
+  const matchedMassResult = runCathodicProtectionAnalysis(baseInput({
+    installedMassKg: baselineResult.minimumAnodeMassKg,
+    targetLifeYears: baseline.targetLifeYears
+  }));
+
+  assert.ok(
+    Math.abs(matchedMassResult.predictedLifeYears - baseline.targetLifeYears) <= 0.02,
+    `predicted life (${matchedMassResult.predictedLifeYears}) should match target life (${baseline.targetLifeYears}) when installed mass equals required mass`
+  );
 })();
 
 console.log('✓ cathodic protection sizing tests passed');


### PR DESCRIPTION
### Motivation
- Provide unit test coverage for the newly implemented cathodic protection formulas to ensure correctness across nominal, edge, and invalid input conditions.
- Add a user-facing documentation page that records inputs, units, equations, assumptions, and standards references so design intent is discoverable and auditable.

### Description
- Add `tests/cathodicProtection.test.mjs` with focused coverage for a nominal valid case, very low/high soil resistivity edges, coating-breakdown near-boundary behavior, validation error cases for missing/negative/out-of-range inputs, and a consistency check between required anode mass and predicted life when mass is matched.
- Add `docs/cathodic_protection.md` documenting inputs/units, the equations used (current density, exposed area, required current, required anode mass, predicted life, and safety margins), assumptions/limits, standards references, and a revision note.
- Link the new documentation into the docs index/navigation by updating `docs/index.html` and `docs/docs.js` so the CP guide appears alongside other study tools.
- Refactor the test to use a `baseInput()` helper and align expected numeric assertions to match the implemented formula outputs.

### Testing
- Ran the unit test file directly with `node tests/cathodicProtection.test.mjs`, and it completed successfully. 
- Built the browser distribution with `npm run build`, and the build completed successfully. 
- Attempted the full test suite with `npm test`, but the run timed out after the environment's 900s limit while executing the very large test suite; partial logs showed many passing tests prior to the timeout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdf8d1a8c8324b2cd5fc812e5cdbc)