### PR TITLE
Add visual Equipment Arrangements tool page with NEC clearance checks

### DIFF
--- a/docs/equipment-arrangements.md
+++ b/docs/equipment-arrangements.md
@@ -1,0 +1,23 @@
+# Equipment Arrangements
+
+The Equipment Arrangements tool (`equipmentarrangements.html`) provides a drag-and-drop layout canvas for planning electrical equipment in rooms.
+
+## What it supports
+
+- Adjustable room width and depth.
+- Exterior wall types for north/south/east/west walls.
+- Interior walls with configurable orientation, position, and length.
+- Equipment placement from **Equipment List** records or a custom entry.
+- Adjustable equipment width/depth, facing direction, and voltage rating.
+- Graphical movement of equipment blocks directly in the canvas.
+
+## NEC workspace highlighting
+
+The tool draws a required working-space zone in front of each equipment item and marks violations in red when:
+
+- The equipment footprint or workspace extends outside the room.
+- Workspace intersects other equipment footprints.
+- Workspace or equipment intersects interior walls.
+- Access clearance is constrained near the room perimeter.
+
+This screen is meant for early layout checks and collaboration during planning.

--- a/equipmentarrangements.html
+++ b/equipmentarrangements.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Graphical equipment room arrangement tool with NEC workspace checks.">
+  <title>Equipment Arrangements — CableTrayRoute</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="icons/favicon.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Equipment Arrangements — CableTrayRoute">
+  <meta property="og:description" content="Lay out equipment rooms visually, move equipment, and flag NEC working-space violations.">
+  <meta property="og:image" content="https://cabletrayroute.com/icons/og-preview.png">
+  <meta property="og:site_name" content="CableTrayRoute">
+  <meta property="og:url" content="equipmentarrangements.html">
+  <link rel="canonical" href="equipmentarrangements.html">
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" href="style.css">
+  <script type="module" src="dist/equipmentarrangements.js" defer></script>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav" aria-label="Primary">
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">
+      <img src="icons/toolbar/grid.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+    </button>
+    <div id="nav-links" class="nav-links" role="list"></div>
+
+    <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">
+      <img src="icons/toolbar/validate.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+    </button>
+  </nav>
+
+  <div id="settings-menu" class="settings-menu">
+    <label for="theme-select">Theme
+      <select id="theme-select">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="high-contrast">High Contrast</option>
+      </select>
+    </label>
+    <label><input type="checkbox" id="compact-toggle" aria-label="Enable compact table mode"> Compact Mode</label>
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">Site Help</button>
+    <button id="new-project-btn" class="btn" title="Start a new project">New Project</button>
+    <button id="save-project-btn" class="btn" title="Save current project">Save Project</button>
+    <button id="load-project-btn" class="btn" title="Load an existing project">Load Project</button>
+    <button id="export-project-btn" class="btn" title="Export project data">Export Project</button>
+    <button id="import-project-btn" class="btn" title="Import project data">Import Project</button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden" title="Select project file">
+  </div>
+
+  <div class="container">
+    <main id="main-content" class="main-content">
+      <header class="page-header">
+        <h1>Equipment Arrangements</h1>
+        <p>Plan equipment-room layouts visually and highlight NEC working-space/access violations in red.</p>
+      </header>
+
+      <section class="card equipment-arrangement-layout">
+        <aside class="equipment-arrangement-sidebar">
+          <h2>Room Setup</h2>
+          <div class="grid-2">
+            <label>Room Width (ft)
+              <input id="room-width" type="number" min="8" max="200" step="0.5" value="30">
+            </label>
+            <label>Room Depth (ft)
+              <input id="room-depth" type="number" min="8" max="200" step="0.5" value="20">
+            </label>
+          </div>
+          <div class="grid-2">
+            <label>North Wall
+              <select id="wall-north"></select>
+            </label>
+            <label>South Wall
+              <select id="wall-south"></select>
+            </label>
+            <label>East Wall
+              <select id="wall-east"></select>
+            </label>
+            <label>West Wall
+              <select id="wall-west"></select>
+            </label>
+          </div>
+          <button id="apply-room" class="btn">Apply Room Changes</button>
+
+          <h2>Interior Walls</h2>
+          <div class="grid-2">
+            <label>Orientation
+              <select id="interior-orientation">
+                <option value="vertical">Vertical</option>
+                <option value="horizontal">Horizontal</option>
+              </select>
+            </label>
+            <label>Wall Type
+              <select id="interior-type"></select>
+            </label>
+            <label>Start X (ft)
+              <input id="interior-x" type="number" min="0" step="0.5" value="10">
+            </label>
+            <label>Start Y (ft)
+              <input id="interior-y" type="number" min="0" step="0.5" value="5">
+            </label>
+            <label>Length (ft)
+              <input id="interior-length" type="number" min="1" step="0.5" value="10">
+            </label>
+          </div>
+          <button id="add-interior-wall" class="btn">Add Interior Wall</button>
+          <div id="interior-wall-list" class="equipment-mini-list"></div>
+
+          <h2>Add Equipment</h2>
+          <div class="grid-2">
+            <label>Source
+              <select id="equipment-source">
+                <option value="equipment-list">Equipment List</option>
+                <option value="custom">Custom</option>
+              </select>
+            </label>
+            <label id="equipment-preset-wrapper">Equipment
+              <select id="equipment-preset"></select>
+            </label>
+            <label id="custom-name-wrapper" class="hidden">Custom Name
+              <input id="custom-name" type="text" placeholder="SWGR-1">
+            </label>
+            <label>Width (ft)
+              <input id="equipment-width" type="number" min="1" max="30" step="0.25" value="4">
+            </label>
+            <label>Depth (ft)
+              <input id="equipment-depth" type="number" min="1" max="30" step="0.25" value="2">
+            </label>
+            <label>Voltage
+              <select id="equipment-voltage"></select>
+            </label>
+            <label>Facing
+              <select id="equipment-facing">
+                <option value="north">North</option>
+                <option value="south" selected>South</option>
+                <option value="east">East</option>
+                <option value="west">West</option>
+              </select>
+            </label>
+          </div>
+          <button id="add-equipment" class="btn primary-btn">Add Equipment to Layout</button>
+          <p class="small-text">Drag equipment blocks inside the drawing area to reposition them.</p>
+
+          <h2>Legend</h2>
+          <ul class="equipment-legend">
+            <li><span class="swatch swatch-equipment"></span>Equipment footprint</li>
+            <li><span class="swatch swatch-clearance"></span>Required NEC workspace</li>
+            <li><span class="swatch swatch-violation"></span>Violation zone</li>
+          </ul>
+          <p id="arrangement-summary" class="equipment-summary" aria-live="polite"></p>
+        </aside>
+
+        <div class="equipment-arrangement-canvas-wrap">
+          <div class="equipment-canvas-toolbar">
+            <button id="zoom-out" class="btn" type="button">−</button>
+            <span id="zoom-label" class="small-text">Scale: 20 px/ft</span>
+            <button id="zoom-in" class="btn" type="button">+</button>
+            <button id="delete-selected-equipment" class="btn" type="button">Delete Selected Equipment</button>
+          </div>
+          <svg id="equipment-arrangement-canvas" viewBox="0 0 1000 700" role="img" aria-label="Equipment room layout canvas"></svg>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="dist/index.js" defer></script>
+  <script type="module" src="dist/projectManager.js"></script>
+</body>
+</html>

--- a/equipmentarrangements.js
+++ b/equipmentarrangements.js
@@ -1,0 +1,463 @@
+import * as dataStore from './dataStore.mjs';
+
+const WALL_TYPES = ['Concrete', 'CMU', 'Gypsum', 'Fire Rated', 'Removable Panel'];
+const VOLTAGE_OPTIONS = ['120V', '208V', '480V', '600V', '4.16kV', '13.8kV', '15kV'];
+const DEFAULT_SCALE = 20;
+
+const state = {
+  room: {
+    width: 30,
+    depth: 20,
+    walls: { north: 'Concrete', south: 'Concrete', east: 'CMU', west: 'CMU' },
+    interiorWalls: []
+  },
+  equipment: [],
+  scale: DEFAULT_SCALE,
+  selectedEquipmentId: null,
+  drag: null,
+  violations: new Set()
+};
+
+let canvas;
+let summaryEl;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function parseNumber(input, fallback) {
+  const value = Number.parseFloat(input);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function clearanceDepthFt(voltageText) {
+  const normalized = String(voltageText || '').toLowerCase();
+  const kvMatch = normalized.match(/([\d.]+)\s*k\s*v/);
+  let volts = Number.parseFloat(normalized);
+  if (kvMatch) {
+    volts = Number.parseFloat(kvMatch[1]) * 1000;
+  }
+  if (!Number.isFinite(volts) || volts <= 150) return 3;
+  if (volts <= 600) return 3.5;
+  return 4;
+}
+
+function equipmentRect(eq) {
+  return { x: eq.x, y: eq.y, w: eq.width, h: eq.depth };
+}
+
+function intersects(a, b) {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function insideRoom(rect) {
+  return rect.x >= 0 && rect.y >= 0 && rect.x + rect.w <= state.room.width && rect.y + rect.h <= state.room.depth;
+}
+
+function workspaceRect(eq) {
+  const depth = clearanceDepthFt(eq.voltage);
+  const pad = 0.15;
+  switch (eq.facing) {
+    case 'north':
+      return { x: eq.x - pad, y: eq.y - depth, w: eq.width + pad * 2, h: depth };
+    case 'south':
+      return { x: eq.x - pad, y: eq.y + eq.depth, w: eq.width + pad * 2, h: depth };
+    case 'east':
+      return { x: eq.x + eq.width, y: eq.y - pad, w: depth, h: eq.depth + pad * 2 };
+    case 'west':
+      return { x: eq.x - depth, y: eq.y - pad, w: depth, h: eq.depth + pad * 2 };
+    default:
+      return { x: eq.x - pad, y: eq.y + eq.depth, w: eq.width + pad * 2, h: depth };
+  }
+}
+
+function interiorWallRect(wall) {
+  if (wall.orientation === 'vertical') {
+    return { x: wall.x - 0.1, y: wall.y, w: 0.2, h: wall.length };
+  }
+  return { x: wall.x, y: wall.y - 0.1, w: wall.length, h: 0.2 };
+}
+
+function accessViolation(eq, workspace) {
+  const mainRect = equipmentRect(eq);
+  const left = workspace.x;
+  const right = state.room.width - (workspace.x + workspace.w);
+  const top = workspace.y;
+  const bottom = state.room.depth - (workspace.y + workspace.h);
+  const perimeterAccess = left >= 3 || right >= 3 || top >= 3 || bottom >= 3;
+  if (!perimeterAccess) return true;
+
+  const hasNearbyBlocker = state.equipment.some(other => {
+    if (other.id === eq.id) return false;
+    const otherRect = equipmentRect(other);
+    const near = {
+      x: workspace.x - 1,
+      y: workspace.y - 1,
+      w: workspace.w + 2,
+      h: workspace.h + 2
+    };
+    return intersects(otherRect, near) && !intersects(otherRect, workspace);
+  });
+
+  if (hasNearbyBlocker && !insideRoom(mainRect)) return true;
+  return false;
+}
+
+function evaluateViolations() {
+  const violations = new Set();
+
+  state.equipment.forEach(eq => {
+    const eqRect = equipmentRect(eq);
+    const workspace = workspaceRect(eq);
+
+    if (!insideRoom(eqRect) || !insideRoom(workspace)) {
+      violations.add(eq.id);
+      return;
+    }
+
+    const overlapsEquipment = state.equipment.some(other => {
+      if (other.id === eq.id) return false;
+      return intersects(eqRect, equipmentRect(other)) || intersects(workspace, equipmentRect(other));
+    });
+
+    const overlapsInterior = state.room.interiorWalls.some(wall => {
+      const wallRect = interiorWallRect(wall);
+      return intersects(eqRect, wallRect) || intersects(workspace, wallRect);
+    });
+
+    if (overlapsEquipment || overlapsInterior || accessViolation(eq, workspace)) {
+      violations.add(eq.id);
+    }
+  });
+
+  state.violations = violations;
+}
+
+function populateSelect(selectId, values) {
+  const select = document.getElementById(selectId);
+  if (!select) return;
+  select.innerHTML = '';
+  values.forEach(value => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    select.appendChild(option);
+  });
+}
+
+function populateEquipmentPreset() {
+  const select = document.getElementById('equipment-preset');
+  if (!select) return;
+  const equipment = dataStore.getEquipment();
+  const options = equipment.length
+    ? equipment.map((item, idx) => ({
+        value: String(idx),
+        label: `${item.tag || `Equipment-${idx + 1}`} · ${item.description || 'No description'}`,
+        item
+      }))
+    : [{ value: '-1', label: 'No equipment in Equipment List', item: null }];
+
+  select.innerHTML = '';
+  options.forEach(({ value, label }) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    select.appendChild(option);
+  });
+
+  if (options[0]?.item) {
+    const widthInput = document.getElementById('equipment-width');
+    const depthInput = document.getElementById('equipment-depth');
+    widthInput.value = parseNumber(options[0].item.width, 4);
+    depthInput.value = parseNumber(options[0].item.depth, 2);
+  }
+}
+
+function renderInteriorWallList() {
+  const list = document.getElementById('interior-wall-list');
+  if (!list) return;
+  list.innerHTML = '';
+  if (!state.room.interiorWalls.length) {
+    list.textContent = 'No interior walls added.';
+    return;
+  }
+  state.room.interiorWalls.forEach((wall, index) => {
+    const row = document.createElement('div');
+    row.className = 'equipment-mini-list-row';
+    row.innerHTML = `<span>${wall.orientation} wall · ${wall.type} · (${wall.x.toFixed(1)}, ${wall.y.toFixed(1)}) · ${wall.length.toFixed(1)} ft</span>`;
+    const remove = document.createElement('button');
+    remove.className = 'btn';
+    remove.type = 'button';
+    remove.textContent = 'Remove';
+    remove.addEventListener('click', () => {
+      state.room.interiorWalls.splice(index, 1);
+      render();
+    });
+    row.appendChild(remove);
+    list.appendChild(row);
+  });
+}
+
+function drawRect(rect, className, fillOpacity = 1) {
+  const element = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  element.setAttribute('x', String(rect.x * state.scale));
+  element.setAttribute('y', String(rect.y * state.scale));
+  element.setAttribute('width', String(rect.w * state.scale));
+  element.setAttribute('height', String(rect.h * state.scale));
+  element.setAttribute('class', className);
+  if (fillOpacity !== 1) {
+    element.setAttribute('fill-opacity', String(fillOpacity));
+  }
+  canvas.appendChild(element);
+  return element;
+}
+
+function drawText(text, xFt, yFt, className = 'equipment-room-text') {
+  const element = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  element.setAttribute('x', String(xFt * state.scale));
+  element.setAttribute('y', String(yFt * state.scale));
+  element.setAttribute('class', className);
+  element.textContent = text;
+  canvas.appendChild(element);
+}
+
+function renderRoom() {
+  const roomRect = drawRect({ x: 0, y: 0, w: state.room.width, h: state.room.depth }, 'equipment-room-outer');
+  roomRect.setAttribute('rx', '4');
+  roomRect.setAttribute('ry', '4');
+
+  [['north', 0, 0], ['south', 0, state.room.depth], ['west', 0, 0], ['east', state.room.width, 0]].forEach(([direction, x, y]) => {
+    drawText(`${direction.toUpperCase()} · ${state.room.walls[direction]}`, x + 0.3, y + (direction === 'south' ? -0.3 : 0.8), 'equipment-wall-label');
+  });
+
+  state.room.interiorWalls.forEach(wall => {
+    const rect = interiorWallRect(wall);
+    const element = drawRect(rect, 'equipment-interior-wall');
+    element.setAttribute('data-wall-type', wall.type);
+  });
+}
+
+function renderEquipment() {
+  state.equipment.forEach(eq => {
+    const eqRect = equipmentRect(eq);
+    const workspace = workspaceRect(eq);
+    const hasViolation = state.violations.has(eq.id);
+    drawRect(workspace, hasViolation ? 'equipment-clearance equipment-clearance-danger' : 'equipment-clearance', 0.35);
+
+    const block = drawRect(eqRect, hasViolation ? 'equipment-block equipment-block-danger' : 'equipment-block');
+    block.dataset.id = eq.id;
+    if (state.selectedEquipmentId === eq.id) {
+      block.classList.add('selected');
+    }
+
+    const textX = eq.x + 0.2;
+    const textY = eq.y + 0.7;
+    drawText(`${eq.name} (${eq.voltage})`, textX, textY, 'equipment-block-label');
+    drawText(`${eq.width.toFixed(1)}×${eq.depth.toFixed(1)} ft · facing ${eq.facing}`, textX, textY + 0.6, 'equipment-block-meta');
+  });
+}
+
+function updateSummary() {
+  const total = state.equipment.length;
+  const violations = state.violations.size;
+  if (!summaryEl) return;
+  summaryEl.textContent = violations
+    ? `${violations} of ${total} equipment item${total === 1 ? '' : 's'} has NEC working-space/access violations.`
+    : total
+      ? `No NEC workspace violations detected for ${total} equipment item${total === 1 ? '' : 's'}.`
+      : 'Add equipment to start layout checks.';
+}
+
+function render() {
+  evaluateViolations();
+  renderInteriorWallList();
+
+  canvas.innerHTML = '';
+  const widthPx = state.room.width * state.scale;
+  const heightPx = state.room.depth * state.scale;
+  canvas.setAttribute('viewBox', `0 0 ${Math.max(widthPx + 40, 400)} ${Math.max(heightPx + 40, 300)}`);
+
+  const padGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  padGroup.setAttribute('transform', 'translate(20,20)');
+  canvas.appendChild(padGroup);
+
+  const previousCanvas = canvas;
+  canvas = padGroup;
+  renderRoom();
+  renderEquipment();
+  canvas = previousCanvas;
+
+  const zoomLabel = document.getElementById('zoom-label');
+  if (zoomLabel) zoomLabel.textContent = `Scale: ${state.scale} px/ft`;
+  updateSummary();
+}
+
+function addEquipment() {
+  const source = document.getElementById('equipment-source').value;
+  const presetSelect = document.getElementById('equipment-preset');
+  const customName = document.getElementById('custom-name').value.trim();
+  const width = clamp(parseNumber(document.getElementById('equipment-width').value, 4), 1, 30);
+  const depth = clamp(parseNumber(document.getElementById('equipment-depth').value, 2), 1, 30);
+  const voltage = document.getElementById('equipment-voltage').value;
+  const facing = document.getElementById('equipment-facing').value;
+
+  let name = 'Equipment';
+  if (source === 'equipment-list') {
+    const index = Number.parseInt(presetSelect.value, 10);
+    const item = dataStore.getEquipment()[index];
+    if (!item) return;
+    name = item.tag || item.description || `Equipment-${state.equipment.length + 1}`;
+  } else {
+    name = customName || `Custom-${state.equipment.length + 1}`;
+  }
+
+  const id = `eq-${Date.now()}-${Math.round(Math.random() * 1000)}`;
+  const startX = clamp(1 + state.equipment.length * 0.8, 0, Math.max(0, state.room.width - width));
+  const startY = clamp(1 + state.equipment.length * 0.6, 0, Math.max(0, state.room.depth - depth));
+
+  state.equipment.push({ id, name, width, depth, voltage, facing, x: startX, y: startY });
+  state.selectedEquipmentId = id;
+  render();
+}
+
+function applyRoomChanges() {
+  state.room.width = clamp(parseNumber(document.getElementById('room-width').value, 30), 8, 200);
+  state.room.depth = clamp(parseNumber(document.getElementById('room-depth').value, 20), 8, 200);
+  ['north', 'south', 'east', 'west'].forEach(direction => {
+    state.room.walls[direction] = document.getElementById(`wall-${direction}`).value;
+  });
+
+  state.equipment = state.equipment.map(eq => ({
+    ...eq,
+    x: clamp(eq.x, 0, Math.max(0, state.room.width - eq.width)),
+    y: clamp(eq.y, 0, Math.max(0, state.room.depth - eq.depth))
+  }));
+  render();
+}
+
+function addInteriorWall() {
+  const orientation = document.getElementById('interior-orientation').value;
+  const type = document.getElementById('interior-type').value;
+  const x = clamp(parseNumber(document.getElementById('interior-x').value, 0), 0, state.room.width);
+  const y = clamp(parseNumber(document.getElementById('interior-y').value, 0), 0, state.room.depth);
+  const length = clamp(parseNumber(document.getElementById('interior-length').value, 5), 1, 100);
+
+  const adjustedLength = orientation === 'vertical'
+    ? Math.min(length, state.room.depth - y)
+    : Math.min(length, state.room.width - x);
+
+  state.room.interiorWalls.push({ orientation, type, x, y, length: Math.max(1, adjustedLength) });
+  render();
+}
+
+function pickEquipmentAtPoint(xFt, yFt) {
+  for (let i = state.equipment.length - 1; i >= 0; i -= 1) {
+    const eq = state.equipment[i];
+    if (xFt >= eq.x && xFt <= eq.x + eq.width && yFt >= eq.y && yFt <= eq.y + eq.depth) {
+      return eq;
+    }
+  }
+  return null;
+}
+
+function toFeetCoordinates(event) {
+  const rect = canvas.getBoundingClientRect();
+  const svgX = event.clientX - rect.left;
+  const svgY = event.clientY - rect.top;
+  const xFt = (svgX - 20) / state.scale;
+  const yFt = (svgY - 20) / state.scale;
+  return { xFt, yFt };
+}
+
+function bindCanvasInteractions() {
+  canvas.addEventListener('pointerdown', event => {
+    const { xFt, yFt } = toFeetCoordinates(event);
+    const picked = pickEquipmentAtPoint(xFt, yFt);
+    state.selectedEquipmentId = picked ? picked.id : null;
+    if (picked) {
+      state.drag = {
+        id: picked.id,
+        offsetX: xFt - picked.x,
+        offsetY: yFt - picked.y
+      };
+      canvas.setPointerCapture(event.pointerId);
+    }
+    render();
+  });
+
+  canvas.addEventListener('pointermove', event => {
+    if (!state.drag) return;
+    const { xFt, yFt } = toFeetCoordinates(event);
+    const eq = state.equipment.find(item => item.id === state.drag.id);
+    if (!eq) return;
+    eq.x = clamp(xFt - state.drag.offsetX, 0, Math.max(0, state.room.width - eq.width));
+    eq.y = clamp(yFt - state.drag.offsetY, 0, Math.max(0, state.room.depth - eq.depth));
+    render();
+  });
+
+  const release = () => {
+    state.drag = null;
+  };
+  canvas.addEventListener('pointerup', release);
+  canvas.addEventListener('pointercancel', release);
+}
+
+function bindUI() {
+  document.getElementById('apply-room').addEventListener('click', applyRoomChanges);
+  document.getElementById('add-equipment').addEventListener('click', addEquipment);
+  document.getElementById('add-interior-wall').addEventListener('click', addInteriorWall);
+
+  document.getElementById('zoom-in').addEventListener('click', () => {
+    state.scale = clamp(state.scale + 2, 8, 45);
+    render();
+  });
+
+  document.getElementById('zoom-out').addEventListener('click', () => {
+    state.scale = clamp(state.scale - 2, 8, 45);
+    render();
+  });
+
+  document.getElementById('delete-selected-equipment').addEventListener('click', () => {
+    if (!state.selectedEquipmentId) return;
+    state.equipment = state.equipment.filter(eq => eq.id !== state.selectedEquipmentId);
+    state.selectedEquipmentId = null;
+    render();
+  });
+
+  document.getElementById('equipment-source').addEventListener('change', event => {
+    const isCustom = event.target.value === 'custom';
+    document.getElementById('equipment-preset-wrapper').classList.toggle('hidden', isCustom);
+    document.getElementById('custom-name-wrapper').classList.toggle('hidden', !isCustom);
+  });
+
+  document.getElementById('equipment-preset').addEventListener('change', event => {
+    const index = Number.parseInt(event.target.value, 10);
+    const item = dataStore.getEquipment()[index];
+    if (!item) return;
+    document.getElementById('equipment-width').value = parseNumber(item.width, 4);
+    document.getElementById('equipment-depth').value = parseNumber(item.depth, 2);
+    if (item.voltage) {
+      const voltage = String(item.voltage).toUpperCase();
+      const select = document.getElementById('equipment-voltage');
+      const matching = Array.from(select.options).find(opt => opt.value.toUpperCase() === voltage);
+      if (matching) select.value = matching.value;
+    }
+  });
+}
+
+function initialize() {
+  canvas = document.getElementById('equipment-arrangement-canvas');
+  summaryEl = document.getElementById('arrangement-summary');
+  if (!canvas) return;
+
+  ['wall-north', 'wall-south', 'wall-east', 'wall-west', 'interior-type'].forEach(id => populateSelect(id, WALL_TYPES));
+  populateSelect('equipment-voltage', VOLTAGE_OPTIONS);
+  populateEquipmentPreset();
+  bindUI();
+  bindCanvasInteractions();
+  render();
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initialize);
+}

--- a/style.css
+++ b/style.css
@@ -22,3 +22,30 @@
 @import "./src/styles/dashboard.css";
 @import "./src/styles/scenarioComparison.css";
 @import "./src/styles/groundgrid.css";
+
+.equipment-arrangement-layout { display:grid; grid-template-columns:minmax(280px,380px) 1fr; gap:1rem; }
+.equipment-arrangement-sidebar { display:flex; flex-direction:column; gap:.75rem; max-height:78vh; overflow:auto; padding-right:.4rem; }
+.equipment-arrangement-sidebar .grid-2 { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.5rem; }
+.equipment-arrangement-sidebar label { display:flex; flex-direction:column; gap:.25rem; font-size:.86rem; }
+.equipment-arrangement-canvas-wrap { display:flex; flex-direction:column; gap:.5rem; }
+.equipment-canvas-toolbar { display:flex; gap:.5rem; align-items:center; flex-wrap:wrap; }
+#equipment-arrangement-canvas { width:100%; min-height:70vh; border:1px solid var(--border-color,#7d8790); border-radius:10px; background:linear-gradient(180deg,rgba(140,165,188,.15),rgba(27,32,43,.05)); }
+.equipment-room-outer { fill:rgba(33,43,58,.08); stroke:rgba(66,78,98,.95); stroke-width:2; }
+.equipment-wall-label,.equipment-room-text { font-size:12px; fill:var(--text-color,#1f2b3a); }
+.equipment-interior-wall { fill:rgba(56,63,74,.85); }
+.equipment-clearance { fill:rgba(255,213,110,.8); stroke:rgba(200,142,32,.95); stroke-dasharray:4 4; }
+.equipment-clearance-danger { fill:rgba(245,91,91,.35); stroke:rgba(213,32,32,.95); }
+.equipment-block { fill:rgba(38,122,207,.82); stroke:rgba(14,67,122,.95); stroke-width:1.5; cursor:move; }
+.equipment-block.selected { stroke:#fde047; stroke-width:2.5; }
+.equipment-block-danger { fill:rgba(218,50,50,.85); stroke:rgba(125,15,15,.95); }
+.equipment-block-label,.equipment-block-meta { font-size:11px; fill:#fff; pointer-events:none; }
+.equipment-mini-list { display:flex; flex-direction:column; gap:.4rem; font-size:.82rem; }
+.equipment-mini-list-row { display:flex; justify-content:space-between; gap:.5rem; align-items:center; }
+.equipment-legend { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.3rem; font-size:.83rem; }
+.equipment-legend li { display:inline-flex; align-items:center; gap:.4rem; }
+.swatch { display:inline-block; width:14px; height:14px; border-radius:3px; }
+.swatch-equipment { background:rgba(38,122,207,.85); }
+.swatch-clearance { background:rgba(255,213,110,.85); }
+.swatch-violation { background:rgba(218,50,50,.85); }
+.equipment-summary { margin-top:.4rem; font-size:.88rem; font-weight:600; }
+@media (max-width:1100px){ .equipment-arrangement-layout{grid-template-columns:1fr;} .equipment-arrangement-sidebar{max-height:none;} #equipment-arrangement-canvas{min-height:56vh;} }


### PR DESCRIPTION
## Summary
- add a new `equipmentarrangements.html` tool page with a full graphical interface for room/equipment layout planning
- add `equipmentarrangements.js` with interactive SVG-based placement:
  - adjustable room width/depth
  - configurable exterior wall types
  - add/remove interior walls
  - add equipment from Equipment List records or custom entries
  - adjustable equipment size, facing direction, and voltage rating
  - drag-and-drop equipment movement on canvas
  - NEC-style workspace depth checks by voltage and red violation highlighting for workspace/access conflicts
- add scoped styling in `style.css` for the new tool workspace, legends, and canvas visuals
- add `docs/equipment-arrangements.md` describing capabilities and violation behavior

## Validation
- `node --check equipmentarrangements.js`
- `node --check site.js`
- attempted browser screenshot generation with Playwright, but no browser binary available in this environment and install attempts were blocked (403)
- previously ran `npm run build` successfully (with pre-existing unresolved dependency/missing export warnings unrelated to this change)
- previously started `npm test`; suite progressed substantially but stalled during `tests/collaboration.test.mjs` and had to be terminated

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff94eaa24832491a884b46fdea25d)