### PR TITLE
Clarify anodic/cathodic area sizing guidance on dissimilar metals study

### DIFF
--- a/dissimilarmetals.html
+++ b/dissimilarmetals.html
@@ -119,13 +119,14 @@ Rate ∝ Driving potential × environment severity × area ratio × temperature 
             </select>
           </div>
           <div class="field-row">
-            <label for="anode-area">Estimated anodic exposed area (cm²)</label>
+            <label for="anode-area" id="anode-area-label">Estimated anodic exposed area (cm²)</label>
             <input type="number" id="anode-area" min="1" step="1" value="120" required>
           </div>
           <div class="field-row">
-            <label for="cathode-area">Estimated cathodic exposed area (cm²)</label>
+            <label for="cathode-area" id="cathode-area-label">Estimated cathodic exposed area (cm²)</label>
             <input type="number" id="cathode-area" min="1" step="1" value="300" required>
           </div>
+          <p class="field-hint" id="area-role-hint">Enter the exposed area for whichever selected metal is anodic and cathodic. The tool auto-detects role from the selected pair.</p>
           <div class="field-row">
             <label for="temperature-c">Operating temperature (°C)</label>
             <input type="number" id="temperature-c" min="-40" max="120" step="1" value="30" required>

--- a/dissimilarmetals.js
+++ b/dissimilarmetals.js
@@ -141,9 +141,15 @@ if (typeof document !== 'undefined') {
     initStudyApprovalPanel('dissimilarMetals');
 
     const form = document.getElementById('dissimilar-metals-form');
+    const primarySelect = document.getElementById('primary-metal');
+    const secondarySelect = document.getElementById('secondary-metal');
     const resultsEl = document.getElementById('results');
     const errorsEl = document.getElementById('calc-errors');
     const saved = getStudies().dissimilarMetals;
+
+    updateAreaRoleGuidance();
+    primarySelect.addEventListener('change', updateAreaRoleGuidance);
+    secondarySelect.addEventListener('change', updateAreaRoleGuidance);
 
     if (saved) {
       renderResults(saved, resultsEl);
@@ -183,6 +189,36 @@ function readFormInput() {
     corrosionAllowanceMm: getNumber('corrosion-allowance'),
     temperatureC: getNumber('temperature-c')
   };
+}
+
+function updateAreaRoleGuidance() {
+  const primaryKey = document.getElementById('primary-metal')?.value;
+  const secondaryKey = document.getElementById('secondary-metal')?.value;
+  const primary = METAL_SERIES[primaryKey];
+  const secondary = METAL_SERIES[secondaryKey];
+
+  if (!primary || !secondary) {
+    return;
+  }
+
+  const anodicMetal = primary.potentialV <= secondary.potentialV ? primary : secondary;
+  const cathodicMetal = anodicMetal === primary ? secondary : primary;
+  const anodicRole = anodicMetal === primary ? 'Primary component' : 'Connected hardware';
+  const cathodicRole = cathodicMetal === primary ? 'Primary component' : 'Connected hardware';
+
+  const anodeLabel = document.getElementById('anode-area-label');
+  const cathodeLabel = document.getElementById('cathode-area-label');
+  const areaHint = document.getElementById('area-role-hint');
+
+  if (anodeLabel) {
+    anodeLabel.textContent = `Estimated anodic exposed area (cm²) — ${anodicMetal.label} (${anodicRole})`;
+  }
+  if (cathodeLabel) {
+    cathodeLabel.textContent = `Estimated cathodic exposed area (cm²) — ${cathodicMetal.label} (${cathodicRole})`;
+  }
+  if (areaHint) {
+    areaHint.textContent = `For this pair, ${anodicMetal.label} is anodic (corrodes first) and ${cathodicMetal.label} is cathodic. The primary component is currently ${anodicRole.toLowerCase()}.`;
+  }
 }
 
 function renderResults(result, container) {

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -40,7 +40,7 @@
     <p>This sequence builds a project from scratch and produces routed cables ready for export.</p>
     <section>
       <h2>Corrosion Design Check</h2>
-      <p>When your design mixes metals (for example aluminum tray and stainless hardware), run the <a href="../dissimilarmetals.html">Dissimilar Metals Corrosion Reference</a> to estimate galvanic severity by environment and identify mitigation options before finalizing materials. The study output explicitly shows which selected member is anodic (corroding) versus cathodic for that metal pair.</p>
+      <p>When your design mixes metals (for example aluminum tray and stainless hardware), run the <a href="../dissimilarmetals.html">Dissimilar Metals Corrosion Reference</a> to estimate galvanic severity by environment and identify mitigation options before finalizing materials. The study output explicitly shows which selected member is anodic (corroding) versus cathodic for that metal pair, and the anodic/cathodic area input labels update to show which selected metal belongs in each area field.</p>
     </section>
     <section>
       <h2>Working with Cable Typicals</h2>


### PR DESCRIPTION
### Motivation
- Users were unclear which metal corresponds to the anodic/cathodic area input fields when selecting a material pair, causing possible mis-entry of areas.  
- The UI should show which selected metal is anodic/cathodic and whether it is the primary component or connected hardware to reduce ambiguity.  

### Description
- Added explicit IDs to the anodic and cathodic area labels in `dissimilarmetals.html` to allow dynamic updates.  
- Implemented `updateAreaRoleGuidance()` in `dissimilarmetals.js` to determine anodic vs cathodic from the galvanic potentials and update the area labels and helper hint live.  
- Wired guidance to run on initial page load and on changes to either metal selector (`primary-metal` and `secondary-metal`).  
- Updated `docs/tutorial.html` to mention that area labels now indicate which selected metal belongs in each area field.  

### Testing
- Ran `node tests/dissimilarMetals.test.mjs` which passed.  
- Ran `npm run build`; build completed successfully though Rollup emitted unrelated warnings about external/missing exports in other modules.  
- Attempted a Playwright screenshot to produce a preview image but the capture failed because Playwright browser binaries are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e015fdd580832484adbfcc4f098ecf)