### PR TITLE
Add pipe-dimensions illustration and sensitivity/advisory reporting to cathodic protection tool

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -158,6 +158,28 @@ Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
             <label for="calculated-surface-area">Calculated total metallic surface area (<span class="unit-label-ft">ft²</span><span class="unit-label-m" hidden>m²</span>)</label>
             <input type="number" id="calculated-surface-area" value="0" readonly>
           </div>
+          <figure id="pipe-dimensions-illustration" class="cp-geometry-illustration" hidden>
+            <svg viewBox="0 0 700 210" role="img" aria-labelledby="pipe-geometry-title pipe-geometry-desc">
+              <title id="pipe-geometry-title">Pipe dimensions input diagram</title>
+              <desc id="pipe-geometry-desc">Diagram showing a pipe with outside diameter and length dimensions used in the surface area calculation.</desc>
+              <defs>
+                <marker id="cp-arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+                  <path d="M0,0 L8,3 L0,6 z" fill="currentColor"></path>
+                </marker>
+              </defs>
+              <rect x="100" y="70" width="470" height="72" rx="22" ry="22" class="cp-geometry-pipe"></rect>
+              <line x1="96" y1="52" x2="574" y2="52" class="cp-geometry-dimension" marker-start="url(#cp-arrow)" marker-end="url(#cp-arrow)"></line>
+              <line x1="100" y1="60" x2="100" y2="70" class="cp-geometry-guide"></line>
+              <line x1="570" y1="60" x2="570" y2="70" class="cp-geometry-guide"></line>
+              <text x="335" y="44" text-anchor="middle" class="cp-geometry-label">Pipe length (L)</text>
+              <line x1="72" y1="70" x2="72" y2="142" class="cp-geometry-dimension" marker-start="url(#cp-arrow)" marker-end="url(#cp-arrow)"></line>
+              <line x1="82" y1="70" x2="100" y2="70" class="cp-geometry-guide"></line>
+              <line x1="82" y1="142" x2="100" y2="142" class="cp-geometry-guide"></line>
+              <text x="64" y="108" text-anchor="end" class="cp-geometry-label">O.D.</text>
+              <text x="336" y="176" text-anchor="middle" class="cp-geometry-note">Area used: A = π × O.D. × L</text>
+            </svg>
+            <figcaption class="field-hint">Use outside diameter and centerline length for the exposed cylindrical surface estimate.</figcaption>
+          </figure>
           <div class="field-row">
             <label for="surface-area">Total metallic surface area (<span class="unit-label-ft">ft²</span><span class="unit-label-m" hidden>m²</span>)</label>
             <input type="number" id="surface-area" min="0.1" step="0.1" value="500" required>

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -115,8 +115,38 @@ export function runCathodicProtectionAnalysis(input) {
     minimumAnodeMassLb: roundTo(minimumAnodeMassKg / LB_TO_KG, 3),
     predictedLifeYears: roundTo(predictedLifeYears, 2),
     safetyMarginYears: roundTo(predictedLifeYears - input.targetLifeYears, 2),
-    safetyMarginPercent: roundTo(((predictedLifeYears - input.targetLifeYears) / input.targetLifeYears) * 100, 1)
+    safetyMarginPercent: roundTo(((predictedLifeYears - input.targetLifeYears) / input.targetLifeYears) * 100, 1),
+    sensitivity: buildSensitivitySummary({
+      input,
+      adjustedRequiredCurrentA,
+      minimumAnodeMassKg,
+      predictedLifeYears
+    })
   };
+}
+
+function buildSensitivitySummary({ input, adjustedRequiredCurrentA, minimumAnodeMassKg, predictedLifeYears }) {
+  const scenarios = [
+    { key: 'base', label: 'Base case', currentMultiplier: 1, requiredMassMultiplier: 1, predictedLifeMultiplier: 1 },
+    { key: 'conservative', label: 'Conservative (+20% demand)', currentMultiplier: 1.2, requiredMassMultiplier: 1.2, predictedLifeMultiplier: 1 / 1.2 },
+    { key: 'optimistic', label: 'Optimistic (-20% demand)', currentMultiplier: 0.8, requiredMassMultiplier: 0.8, predictedLifeMultiplier: 1 / 0.8 }
+  ];
+
+  return scenarios.map((scenario) => {
+    const scenarioCurrentA = adjustedRequiredCurrentA * scenario.currentMultiplier;
+    const scenarioRequiredMassKg = minimumAnodeMassKg * scenario.requiredMassMultiplier;
+    const scenarioPredictedLifeYears = predictedLifeYears * scenario.predictedLifeMultiplier;
+    const scenarioSafetyMarginYears = scenarioPredictedLifeYears - input.targetLifeYears;
+    return {
+      ...scenario,
+      requiredCurrentA: roundTo(scenarioCurrentA, 4),
+      minimumAnodeMassKg: roundTo(scenarioRequiredMassKg, 3),
+      minimumAnodeMassLb: roundTo(scenarioRequiredMassKg / LB_TO_KG, 3),
+      predictedLifeYears: roundTo(scenarioPredictedLifeYears, 2),
+      safetyMarginYears: roundTo(scenarioSafetyMarginYears, 2),
+      safetyMarginPercent: roundTo((scenarioSafetyMarginYears / input.targetLifeYears) * 100, 1)
+    };
+  });
 }
 
 function validateInputs(input) {
@@ -210,6 +240,7 @@ if (typeof document !== 'undefined') {
   const pipeLengthRow = document.getElementById('pipe-length-row');
   const calculatedSurfaceAreaRow = document.getElementById('calculated-surface-area-row');
   const calculatedSurfaceAreaEl = document.getElementById('calculated-surface-area');
+  const pipeDimensionsIllustrationEl = document.getElementById('pipe-dimensions-illustration');
 
   const saved = getStudies().cathodicProtection;
   renderCalculationBasis(basisPanel, CP_STANDARD_BASIS);
@@ -265,6 +296,7 @@ if (typeof document !== 'undefined') {
     pipeOdRow.hidden = !usePipeDimensions;
     pipeLengthRow.hidden = !usePipeDimensions;
     calculatedSurfaceAreaRow.hidden = !usePipeDimensions;
+    pipeDimensionsIllustrationEl.hidden = !usePipeDimensions;
     surfaceAreaEl.closest('.field-row').hidden = usePipeDimensions;
 
     if (!usePipeDimensions) {
@@ -369,6 +401,8 @@ function renderResults(result, root) {
   const lifeBadgeClass = result.safetyMarginYears >= 0 ? 'result-badge--pass' : 'result-badge--fail';
   const lifeBadgeIcon = result.safetyMarginYears >= 0 ? '✓' : '✗';
   const outputBasis = result.outputBasis || {};
+  const sensitivityRows = Array.isArray(result.sensitivity) ? result.sensitivity : [];
+  const advisories = buildDesignAdvisories(result, sensitivityRows);
 
   root.innerHTML = `
     <section class="results-panel" aria-labelledby="cp-results-heading">
@@ -421,8 +455,71 @@ function renderResults(result, root) {
         </table>
       </div>
 
+      ${sensitivityRows.length ? `
+      <div class="table-wrap">
+        <table class="data-table" aria-label="Cathodic protection sensitivity table">
+          <thead>
+            <tr>
+              <th>Scenario</th>
+              <th>Required current (A)</th>
+              <th>Minimum anode mass</th>
+              <th>Predicted life (years)</th>
+              <th>Safety margin</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${sensitivityRows.map((scenario) => `
+              <tr>
+                <td>${escapeHtml(scenario.label)}</td>
+                <td>${scenario.requiredCurrentA}</td>
+                <td>${scenario.minimumAnodeMassKg} kg (${scenario.minimumAnodeMassLb} lb)</td>
+                <td>${scenario.predictedLifeYears}</td>
+                <td>${scenario.safetyMarginYears} years (${scenario.safetyMarginPercent}%)</td>
+              </tr>`).join('')}
+          </tbody>
+        </table>
+      </div>` : ''}
+
+      ${advisories.length ? `
+      <div class="result-group" aria-label="Design improvement advisories">
+        <h3>Design Improvement Opportunities</h3>
+        <ul>
+          ${advisories.map((advisory) => `<li>${escapeHtml(advisory)}</li>`).join('')}
+        </ul>
+      </div>` : ''}
+
       <p class="field-hint result-timestamp">Analysis run: ${new Date(result.timestamp).toLocaleString()}</p>
     </section>`;
+}
+
+function buildDesignAdvisories(result, sensitivityRows) {
+  const notes = [];
+  const conservativeScenario = sensitivityRows.find((scenario) => scenario.key === 'conservative');
+
+  if (result.safetyMarginYears < 0) {
+    notes.push('Installed anode mass is below target-life demand; increase installed mass or reduce coating breakdown assumptions.');
+  } else if (result.safetyMarginPercent < 15) {
+    notes.push('Life margin is modest; consider adding design contingency to improve resilience against coating degradation uncertainty.');
+  }
+
+  if (conservativeScenario && conservativeScenario.safetyMarginYears < 0) {
+    notes.push('The +20% demand sensitivity case fails target life; add contingency mass or plan earlier replacement intervals.');
+  }
+
+  if (result.soilResistivityOhmM < 50 || result.soilPh < 5.5 || result.soilPh > 9) {
+    notes.push('Corrosive environment indicators detected (low resistivity or extreme pH); validate with field surveys and commissioning criteria.');
+  }
+
+  if (result.requiredCurrentA > 5) {
+    notes.push('Required CP current is relatively high; evaluate segmenting protected zones to improve control and maintainability.');
+  }
+
+  if (result.coatingBreakdownFactor > 0.35) {
+    notes.push('Coating breakdown factor is high; prioritize coating condition assessment/rehabilitation to reduce long-term CP demand.');
+  }
+
+  notes.push('For the next iteration, include temperature correction and stray-current interference checks in the final detailed design package.');
+  return notes;
 }
 
 function calculatePipeSurfaceAreaFromInputs(isMetric, outsideDiameterInput, lengthInput) {

--- a/style.css
+++ b/style.css
@@ -49,3 +49,37 @@
 .swatch-violation { background:rgba(218,50,50,.85); }
 .equipment-summary { margin-top:.4rem; font-size:.88rem; font-weight:600; }
 @media (max-width:1100px){ .equipment-arrangement-layout{grid-template-columns:1fr;} .equipment-arrangement-sidebar{max-height:none;} #equipment-arrangement-canvas{min-height:56vh;} }
+
+.cp-geometry-illustration {
+  margin: .5rem 0 1rem;
+  padding: .75rem;
+  border: 1px solid var(--border-color, #7d8790);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel-bg, #f8fafc) 92%, transparent);
+}
+.cp-geometry-illustration svg {
+  width: 100%;
+  height: auto;
+  color: var(--text-color, #1f2b3a);
+}
+.cp-geometry-pipe {
+  fill: color-mix(in srgb, var(--accent-color, #2a6fd6) 38%, #ffffff);
+  stroke: color-mix(in srgb, var(--accent-color, #2a6fd6) 80%, #1f2b3a);
+  stroke-width: 2;
+}
+.cp-geometry-dimension {
+  stroke: currentColor;
+  stroke-width: 2;
+}
+.cp-geometry-guide {
+  stroke: currentColor;
+  stroke-width: 1.2;
+  opacity: .75;
+}
+.cp-geometry-label {
+  font-size: 16px;
+  font-weight: 600;
+}
+.cp-geometry-note {
+  font-size: 14px;
+}


### PR DESCRIPTION
### Motivation
- Improve usability for pipe surface-area input by providing a visual guide for outside diameter and length and reduce input mistakes when `surface-area-mode` is `pipe-dimensions`.
- Improve engineering feedback by surfacing a simple sensitivity sweep around CP demand and by providing actionable design advisories to highlight margin or environmental risks.

### Description
- Add an inline SVG illustration (`#pipe-dimensions-illustration`) to `cathodicprotection.html` that explains pipe O.D. and length and a caption recommending using O.D. and centerline length for area estimation.
- Wire the illustration into the UI in `cathodicprotection.js` by showing/hiding `pipeDimensionsIllustrationEl` when `surface-area-mode` is `pipe-dimensions` and reuse pipe surface-area calculations for the display field.
- Add sensitivity analysis generation via `buildSensitivitySummary` and include the `sensitivity` data in the analysis output object returned by `runCathodicProtectionAnalysis` to create conservative/optimistic scenarios.
- Add design advisories via `buildDesignAdvisories` and render both a sensitivity table and an advisory list in `renderResults` when applicable, and add related CSS styles in `style.css` (classes prefixed with `.cp-geometry-`) for the illustration and labels.

### Testing
- Ran the project unit test suite with `npm test` and the linter `npm run lint`, both completed with no failures.
- Performed automated rendering checks by running the app and exercising the `surface-area-mode` `pipe-dimensions` flow to confirm the illustration shows and calculated surface area updates correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01dbc5d64832487579b0af654867a)