### PR TITLE
Expand dissimilar metals options and dynamically populate selectors

### DIFF
--- a/dissimilarmetals.html
+++ b/dissimilarmetals.html
@@ -79,29 +79,17 @@ Rate ∝ Driving potential × environment severity × area ratio × temperature 
           <legend><strong>Material Pair</strong></legend>
           <div class="field-row">
             <label for="primary-metal">Primary component metal</label>
-            <select id="primary-metal" required>
+            <select id="primary-metal" data-default-value="aluminum" required>
               <option value="aluminum" selected>Aluminum alloy</option>
-              <option value="carbonSteel">Carbon steel</option>
-              <option value="zinc">Zinc / galvanized steel</option>
-              <option value="stainless304Passive">Stainless steel 304 (passive)</option>
-              <option value="stainless316Passive">Stainless steel 316 (passive)</option>
-              <option value="copper">Copper / brass / bronze</option>
-              <option value="titanium">Titanium</option>
             </select>
           </div>
           <div class="field-row">
             <label for="secondary-metal">Connected hardware metal</label>
-            <select id="secondary-metal" required>
+            <select id="secondary-metal" data-default-value="stainless304Passive" required>
               <option value="stainless304Passive" selected>Stainless steel 304 (passive)</option>
-              <option value="stainless316Passive">Stainless steel 316 (passive)</option>
-              <option value="carbonSteel">Carbon steel</option>
-              <option value="zinc">Zinc / galvanized steel</option>
-              <option value="aluminum">Aluminum alloy</option>
-              <option value="copper">Copper / brass / bronze</option>
-              <option value="titanium">Titanium</option>
             </select>
           </div>
-          <p class="field-hint">The tool determines anodic vs cathodic automatically from galvanic potential. The primary component can be either role depending on the selected pair.</p>
+          <p class="field-hint">The tool determines anodic vs cathodic automatically from galvanic potential. The expanded list includes tray/base metals, lug and terminal platings, and common securement hardware alloys.</p>
         </fieldset>
 
         <fieldset>

--- a/dissimilarmetals.js
+++ b/dissimilarmetals.js
@@ -6,15 +6,26 @@ const MM_PER_YEAR_TO_MPY = 39.3701;
 
 const METAL_SERIES = {
   magnesium: { label: 'Magnesium alloy', potentialV: -1.6, family: 'active' },
-  zinc: { label: 'Zinc / galvanized steel', potentialV: -1.03, family: 'active' },
+  zinc: { label: 'Zinc / galvanized steel (hot-dip)', potentialV: -1.03, family: 'active' },
+  zincElectroplate: { label: 'Zinc electroplate (clear/yellow chromate)', potentialV: -0.98, family: 'active' },
   aluminum: { label: 'Aluminum alloy', potentialV: -0.8, family: 'active' },
+  aluminumMetallized: { label: 'Aluminum metallized coating', potentialV: -0.78, family: 'active' },
   carbonSteel: { label: 'Carbon steel', potentialV: -0.6, family: 'active' },
   castIron: { label: 'Cast iron', potentialV: -0.61, family: 'active' },
+  cadmium: { label: 'Cadmium-plated steel', potentialV: -0.75, family: 'active' },
   lead: { label: 'Lead', potentialV: -0.5, family: 'intermediate' },
-  copper: { label: 'Copper / brass / bronze', potentialV: -0.34, family: 'noble' },
+  tin: { label: 'Tin / tin-plated copper', potentialV: -0.49, family: 'intermediate' },
+  stainless410Active: { label: 'Stainless steel 410/430 (active)', potentialV: -0.56, family: 'active' },
   stainlessActive: { label: 'Stainless steel (active)', potentialV: -0.5, family: 'intermediate' },
+  copper: { label: 'Copper', potentialV: -0.34, family: 'noble' },
+  brass: { label: 'Brass', potentialV: -0.36, family: 'noble' },
+  bronze: { label: 'Bronze / silicon bronze', potentialV: -0.33, family: 'noble' },
+  copperNickel: { label: 'Copper-nickel alloy', potentialV: -0.3, family: 'noble' },
+  nickelPlatedCopper: { label: 'Nickel-plated copper lug/barrel', potentialV: -0.22, family: 'noble' },
   stainless304Passive: { label: 'Stainless steel 304 (passive)', potentialV: -0.1, family: 'noble' },
   stainless316Passive: { label: 'Stainless steel 316 (passive)', potentialV: -0.05, family: 'noble' },
+  stainlessDuplexPassive: { label: 'Stainless steel duplex (passive)', potentialV: -0.04, family: 'noble' },
+  nickel200: { label: 'Nickel alloy (Ni 200)', potentialV: -0.18, family: 'noble' },
   titanium: { label: 'Titanium', potentialV: -0.03, family: 'noble' }
 };
 
@@ -147,6 +158,7 @@ if (typeof document !== 'undefined') {
     const errorsEl = document.getElementById('calc-errors');
     const saved = getStudies().dissimilarMetals;
 
+    populateMetalSelects(primarySelect, secondarySelect);
     updateAreaRoleGuidance();
     primarySelect.addEventListener('change', updateAreaRoleGuidance);
     secondarySelect.addEventListener('change', updateAreaRoleGuidance);
@@ -173,6 +185,28 @@ if (typeof document !== 'undefined') {
       }
     });
   });
+}
+
+function populateMetalSelects(primarySelect, secondarySelect) {
+  if (!primarySelect || !secondarySelect) {
+    return;
+  }
+
+  const defaultPrimary = primarySelect.dataset.defaultValue || 'aluminum';
+  const defaultSecondary = secondarySelect.dataset.defaultValue || 'stainless304Passive';
+  const metalEntries = Object.entries(METAL_SERIES)
+    .sort(([, a], [, b]) => a.potentialV - b.potentialV);
+
+  const buildOptions = (selectedValue) => metalEntries.map(([key, metal]) => {
+    const selected = key === selectedValue ? ' selected' : '';
+    return `<option value="${key}"${selected}>${metal.label}</option>`;
+  }).join('');
+
+  const selectedPrimary = METAL_SERIES[primarySelect.value] ? primarySelect.value : defaultPrimary;
+  const selectedSecondary = METAL_SERIES[secondarySelect.value] ? secondarySelect.value : defaultSecondary;
+
+  primarySelect.innerHTML = buildOptions(selectedPrimary);
+  secondarySelect.innerHTML = buildOptions(selectedSecondary);
 }
 
 function readFormInput() {


### PR DESCRIPTION
### Motivation
- Provide a more comprehensive list of metals and common platings/finishes used in electrical installations (tray metals, terminations, lugs, and hardware) so galvanic-corrosion assessments can include realistic hardware and termination materials.

### Description
- Expanded the `METAL_SERIES` map in `dissimilarmetals.js` with additional entries (electroplated zinc, cadmium-plated steel, tin/tin-plated copper, brass, bronze, copper-nickel, nickel-plated copper, extra stainless variants, nickel alloy, and related entries) and adjusted some labels/potentials.
- Added `populateMetalSelects(primarySelect, secondarySelect)` to dynamically build and sort `<option>` lists from `METAL_SERIES` by galvanic potential, and wired it to run on DOMContentLoaded so the UI reflects the canonical list.
- Updated `dissimilarmetals.html` to use `data-default-value` on the two metal `<select>`s and revised the field hint to explain the expanded coverage, removing duplicated hardcoded option lists.

### Testing
- `node tests/dissimilarMetals.test.mjs` was executed and passed.
- `npm run build` completed successfully and produced updated distribution artifacts.
- An attempt to run the full test suite via `npm test` was started and the suite progressed extensively but could not be completed in this environment (the run stalls/blocks around collaboration tests), so full-suite completion is not confirmed here.
- An attempt to produce a webpage preview screenshot with Playwright failed because the environment is missing the Playwright browser binaries (`npx playwright install` would be required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e024a1ceb88324ab49e250767bb32c)