### PR TITLE
Add KPI strip with workflow, tray fill, and study metrics to dashboard

### DIFF
--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -8,6 +8,66 @@
   gap: var(--space-4, 1rem);
 }
 
+/* ---- KPI strip ---- */
+.dash-kpi-strip {
+  margin-bottom: var(--space-4, 1rem);
+}
+
+.dash-kpi-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: var(--space-3, 0.75rem);
+}
+
+.dash-kpi-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius, 6px);
+  border: 1px solid var(--color-border-strong, #9ca3af);
+  background: var(--color-surface-raised, #eef2ff);
+  color: var(--color-text, #111827);
+}
+
+.dash-kpi-card--warn {
+  background: var(--color-warning-bg, #fffbeb);
+  border-color: var(--color-warning, #d97706);
+}
+
+.dash-kpi-label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--color-text-muted, #374151);
+}
+
+.dash-kpi-value {
+  font-size: clamp(1.7rem, 3.2vw, 2.2rem);
+  line-height: 1.1;
+  font-weight: 800;
+  color: var(--color-accent-strong, #1d4ed8);
+  text-decoration: none;
+}
+
+.dash-kpi-value:hover {
+  text-decoration: underline;
+}
+
+.dash-kpi-helper {
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--color-text-muted, #4b5563);
+}
+
+.dash-kpi-card--warn .dash-kpi-value {
+  color: var(--color-warning, #b45309);
+}
+
 @media (min-width: 768px) {
   .dashboard-grid {
     grid-template-columns: 1fr 1fr;
@@ -175,6 +235,29 @@ body.dark-mode .dash-study-item {
   border-color: var(--color-border, #334155);
 }
 
+body.dark-mode .dash-kpi-card {
+  background: var(--color-surface-raised, #172554);
+  border-color: var(--color-border-strong, #475569);
+}
+
+body.dark-mode .dash-kpi-label,
+body.dark-mode .dash-kpi-helper {
+  color: var(--color-text-muted, #cbd5e1);
+}
+
+body.dark-mode .dash-kpi-value {
+  color: var(--color-accent-strong, #93c5fd);
+}
+
+body.dark-mode .dash-kpi-card--warn {
+  background: #422006;
+  border-color: #a16207;
+}
+
+body.dark-mode .dash-kpi-card--warn .dash-kpi-value {
+  color: #fbbf24;
+}
+
 body.dark-mode .dash-step-name,
 body.dark-mode .dash-study-name {
   color: var(--color-text, #e2e8f0);
@@ -183,4 +266,22 @@ body.dark-mode .dash-study-name {
 body.dark-mode .dash-icon--incomplete {
   background: var(--color-border, #334155);
   color: var(--color-text-muted, #94a3b8);
+}
+
+body.theme-high-contrast .dash-kpi-card {
+  background: #000;
+  border-color: #fff;
+}
+
+body.theme-high-contrast .dash-kpi-label,
+body.theme-high-contrast .dash-kpi-helper {
+  color: #fff;
+}
+
+body.theme-high-contrast .dash-kpi-value {
+  color: #0ff;
+}
+
+body.theme-high-contrast .dash-kpi-card--warn .dash-kpi-value {
+  color: #ff0;
 }

--- a/src/workflowDashboard.js
+++ b/src/workflowDashboard.js
@@ -24,34 +24,127 @@ function statusIcon(complete) {
   return span;
 }
 
-function renderWorkflowSteps(container) {
+function studyHasResults(studyResult) {
+  if (!studyResult) return false;
+  if (Array.isArray(studyResult)) return studyResult.length > 0;
+  if (typeof studyResult === 'object') return Object.keys(studyResult).length > 0;
+  return true;
+}
+
+function getWorkflowMetrics() {
   const steps = workflowOrder.map(step => {
     const { complete, label, hint } = getStepStatus(step.key);
     return { step, complete, label, hint };
   });
+  const completedCount = steps.filter(({ complete }) => complete).length;
+  const workflowCompletionPct = workflowOrder.length
+    ? Math.round((completedCount / workflowOrder.length) * 100)
+    : 0;
+  const nextRequiredStep = steps.find(({ complete }) => !complete) || null;
 
-  const completeCount = steps.filter(s => s.complete).length;
+  return { steps, completedCount, workflowCompletionPct, nextRequiredStep };
+}
+
+function getTrayViolationsCount() {
+  return getTrays().filter(tray => {
+    const pct = trayFillPercent(tray);
+    return pct !== null && pct > 80;
+  }).length;
+}
+
+function getStudiesCompletedCount() {
+  const studies = getStudies();
+  return STUDY_DEFINITIONS.filter(({ key }) => studyHasResults(studies[key])).length;
+}
+
+function renderKpiStrip(container) {
+  if (!container) return;
+
+  const { workflowCompletionPct, nextRequiredStep } = getWorkflowMetrics();
+  const trayViolations = getTrayViolationsCount();
+  const studiesCompletedCount = getStudiesCompletedCount();
+  const totalStudies = STUDY_DEFINITIONS.length;
+
+  const kpis = [
+    {
+      label: 'Workflow complete',
+      value: `${workflowCompletionPct}%`,
+      helper: `${workflowOrder.length} total workflow steps tracked.`,
+      href: '#workflow-progress-text',
+    },
+    {
+      label: 'Next required step',
+      value: nextRequiredStep ? nextRequiredStep.step.label : 'Done',
+      helper: nextRequiredStep ? 'Recommended next action in the workflow.' : 'All required workflow steps are complete.',
+      href: nextRequiredStep ? nextRequiredStep.step.href : 'reporting.html',
+    },
+    {
+      label: 'Tray fill warnings',
+      value: trayViolations,
+      helper: trayViolations > 0 ? 'Trays currently over 80% fill.' : 'No tray fill warnings above 80%.',
+      href: 'cabletrayfill.html',
+      warn: trayViolations > 0,
+    },
+    {
+      label: 'Studies completed',
+      value: studiesCompletedCount,
+      helper: `${studiesCompletedCount} of ${totalStudies} studies have saved results.`,
+      href: 'studiesdashboard.html',
+    },
+  ];
+
+  container.innerHTML = '';
+  const list = document.createElement('ul');
+  list.className = 'dash-kpi-grid';
+  list.setAttribute('role', 'list');
+
+  kpis.forEach(({ label, value, helper, href, warn }) => {
+    const li = document.createElement('li');
+    li.className = 'dash-kpi-card' + (warn ? ' dash-kpi-card--warn' : '');
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'dash-kpi-label';
+    labelEl.textContent = label;
+
+    const valueEl = document.createElement('a');
+    valueEl.href = href;
+    valueEl.className = 'dash-kpi-value';
+    valueEl.textContent = value;
+
+    const helperEl = document.createElement('span');
+    helperEl.className = 'dash-kpi-helper';
+    helperEl.textContent = helper;
+
+    li.appendChild(labelEl);
+    li.appendChild(valueEl);
+    li.appendChild(helperEl);
+    list.appendChild(li);
+  });
+
+  container.appendChild(list);
+}
+
+function renderWorkflowSteps(container) {
+  const { steps, completedCount, workflowCompletionPct, nextRequiredStep } = getWorkflowMetrics();
 
   // Progress bar
   const progressText = document.getElementById('workflow-progress-text');
   if (progressText) {
-    progressText.textContent = `${completeCount} of ${workflowOrder.length} workflow steps complete.`;
+    progressText.textContent = `${completedCount} of ${workflowOrder.length} workflow steps complete.`;
   }
   const progressTrack = document.getElementById('workflow-progress-bar-track');
   const progressFill = document.getElementById('workflow-progress-fill');
   if (progressTrack && progressFill) {
-    const pct = Math.round((completeCount / workflowOrder.length) * 100);
-    progressFill.style.width = `${pct}%`;
-    progressTrack.setAttribute('aria-valuenow', completeCount);
+    progressFill.style.width = `${workflowCompletionPct}%`;
+    progressTrack.setAttribute('aria-valuenow', completedCount);
   }
   const nextStepEl = document.getElementById('workflow-next-step');
   if (nextStepEl) {
-    const next = steps.find(s => !s.complete);
-    if (next) {
+    if (nextRequiredStep) {
       nextStepEl.textContent = 'Next recommended step: ';
       const link = document.createElement('a');
-      link.href = next.step.href;
-      link.textContent = next.step.label;
+      link.href = nextRequiredStep.step.href;
+      link.textContent = nextRequiredStep.step.label;
       nextStepEl.appendChild(link);
     } else {
       nextStepEl.textContent = 'All workflow steps are complete. You are ready to generate reports.';
@@ -97,10 +190,7 @@ function renderProjectSummary(container) {
   const trays = getTrays().length;
   const conduits = getConduits().length;
   const ductbanks = getDuctbanks().length;
-  const trayViolations = getTrays().filter(t => {
-    const pct = trayFillPercent(t);
-    return pct !== null && pct > 80;
-  }).length;
+  const trayViolations = getTrayViolationsCount();
 
   const stats = [
     { label: 'Cables', value: cables, href: 'cableschedule.html' },
@@ -147,11 +237,7 @@ function renderStudiesSummary(container) {
   list.setAttribute('role', 'list');
 
   STUDY_DEFINITIONS.forEach(({ key, label, href }) => {
-    const hasResults = !!(studies[key] && (
-      Array.isArray(studies[key]) ? studies[key].length > 0
-        : typeof studies[key] === 'object' ? Object.keys(studies[key]).length > 0
-        : true
-    ));
+    const hasResults = studyHasResults(studies[key]);
 
     const li = document.createElement('li');
     li.className = 'dash-study-item' + (hasResults ? ' dash-study-item--run' : '');
@@ -177,6 +263,7 @@ function renderStudiesSummary(container) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+  renderKpiStrip(document.getElementById('dashboard-kpi-strip'));
   renderWorkflowSteps(document.getElementById('workflow-step-grid'));
   renderProjectSummary(document.getElementById('project-summary'));
   renderStudiesSummary(document.getElementById('studies-summary'));

--- a/workflowdashboard.html
+++ b/workflowdashboard.html
@@ -93,6 +93,12 @@
         <h1>Project Dashboard</h1>
       </header>
 
+      <section class="dash-kpi-strip" aria-label="Dashboard key metrics">
+        <div id="dashboard-kpi-strip" aria-live="polite">
+          <p class="text-muted">Loading key metrics…</p>
+        </div>
+      </section>
+
       <!-- Progress overview -->
       <section class="card workflow-summary dash-full-width" aria-live="polite" aria-label="Workflow progress overview">
         <h2>Workflow Progress</h2>


### PR DESCRIPTION
### Motivation
- Surface a concise set of high-priority project metrics at the top of the dashboard so users can quickly see workflow completion, next required action, tray fill warnings, and study status.

### Description
- Added a KPI container directly below the page header in `workflowdashboard.html` as `<section class="dash-kpi-strip">` with a live region mount point `#dashboard-kpi-strip`.
- Implemented metric computation and rendering in `src/workflowDashboard.js`, including `getWorkflowMetrics()`, `getTrayViolationsCount()`, `getStudiesCompletedCount()`, a reusable `studyHasResults()` helper, and `renderKpiStrip()` which renders semantic KPI cards with label, prominent value, helper text, links, and warning state.
- Reused tray-fill warning logic (via `getTrayViolationsCount`) in both the KPI strip and the existing project summary to keep behavior consistent.
- Added responsive KPI styles and theme overrides in `src/styles/dashboard.css` using a `repeat(auto-fit, minmax(...))` grid, stronger contrast/background tokens, larger value typography, consistent spacing, and `body.dark-mode` / `body.theme-high-contrast` overrides to match existing token patterns.

### Testing
- Ran the full unit/test suite with `npm test` which completed successfully.
- Ran `npm run build` which completed; the build emitted existing Rollup warnings about unrelated unresolved/missing exports but no errors from the changes in this PR.
- Served the site locally with `python3 -m http.server 4173`; attempted to capture a preview using Playwright (`npx playwright screenshot`), but browser installation/download was blocked (HTTP 403) so an automated screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0308eb1a88324a0b8030b804a24b8)