### PR TITLE
Refactor workflow dashboard status badges and accessibility styles

### DIFF
--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -77,27 +77,47 @@
   }
 }
 
-/* ---- Shared icon ---- */
-.dash-icon {
+/* ---- Semantic badges ---- */
+.dash-badge {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 50%;
-  font-size: 0.8rem;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  line-height: 1;
   font-weight: 700;
-  flex-shrink: 0;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  white-space: nowrap;
 }
 
-.dash-icon--complete {
-  background: var(--color-success, #16a34a);
-  color: #fff;
+.dash-badge-icon {
+  font-size: 0.8rem;
 }
 
-.dash-icon--incomplete {
-  background: var(--color-border, #d1d5db);
-  color: var(--color-text-muted, #6b7280);
+.dash-badge--success {
+  background: #dcfce7;
+  color: #14532d;
+  border-color: #86efac;
+}
+
+.dash-badge--warning {
+  background: #fef3c7;
+  color: #7c2d12;
+  border-color: #fbbf24;
+}
+
+.dash-badge--neutral,
+.dash-badge--pending {
+  background: #e5e7eb;
+  color: #111827;
+  border-color: #9ca3af;
+}
+
+.dash-badge--run {
+  background: #dcfce7;
+  color: #14532d;
+  border-color: #86efac;
 }
 
 /* ---- Workflow steps list ---- */
@@ -107,14 +127,15 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.625rem;
 }
 
 .dash-step-card {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  flex-wrap: wrap;
   gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.7rem 0.85rem;
   border-radius: var(--radius, 6px);
   background: var(--color-surface-alt, #f9fafb);
   border: 1px solid var(--color-border, #e5e7eb);
@@ -126,7 +147,8 @@
 
 .dash-step-name {
   font-weight: 600;
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 11rem;
   text-decoration: none;
   color: var(--color-text, inherit);
 }
@@ -135,7 +157,32 @@
   text-decoration: underline;
 }
 
+.dash-step-status-wrap {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.dash-step-status-pill {
+  align-self: center;
+}
+
+.dash-step-hint-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  color: var(--color-accent, #2563eb);
+  border: 1px solid currentColor;
+}
+
 .dash-step-label {
+  width: 100%;
+  padding-left: 0.05rem;
   font-size: 0.8rem;
   color: var(--color-text-muted, #6b7280);
 }
@@ -195,14 +242,14 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.625rem;
 }
 
 .dash-study-item {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.4rem 0.75rem;
+  padding: 0.7rem 0.85rem;
   border-radius: var(--radius, 6px);
   background: var(--color-surface-alt, #f9fafb);
   border: 1px solid var(--color-border, #e5e7eb);
@@ -223,8 +270,18 @@
   color: var(--color-text-muted, #6b7280);
 }
 
-.dash-study-item--run .dash-study-status {
-  color: var(--color-success, #16a34a);
+.dash-study-item .dash-badge {
+  margin-left: auto;
+}
+
+.dash-kpi-value:focus-visible,
+.dash-step-name:focus-visible,
+.dash-stat-value:focus-visible,
+.dash-study-name:focus-visible,
+.dash-badge:focus-visible {
+  outline: 2px solid var(--color-accent, #2563eb);
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 /* ---- Dark mode overrides ---- */
@@ -263,9 +320,28 @@ body.dark-mode .dash-study-name {
   color: var(--color-text, #e2e8f0);
 }
 
-body.dark-mode .dash-icon--incomplete {
-  background: var(--color-border, #334155);
-  color: var(--color-text-muted, #94a3b8);
+body.dark-mode .dash-badge--success,
+body.dark-mode .dash-badge--run {
+  background: #14532d;
+  color: #dcfce7;
+  border-color: #22c55e;
+}
+
+body.dark-mode .dash-badge--warning {
+  background: #7c2d12;
+  color: #ffedd5;
+  border-color: #f59e0b;
+}
+
+body.dark-mode .dash-badge--neutral,
+body.dark-mode .dash-badge--pending {
+  background: #334155;
+  color: #f8fafc;
+  border-color: #64748b;
+}
+
+body.dark-mode .dash-step-hint-icon {
+  color: #93c5fd;
 }
 
 body.theme-high-contrast .dash-kpi-card {

--- a/src/workflowDashboard.js
+++ b/src/workflowDashboard.js
@@ -16,11 +16,35 @@ const STUDY_DEFINITIONS = [
   { key: 'contingency',  label: 'N-1 Contingency',      href: 'contingency.html' },
 ];
 
-function statusIcon(complete) {
+function getStatusMeta({ complete, label, hint, forStudy = false }) {
+  if (complete) {
+    return { text: forStudy ? 'Run' : 'Complete', icon: '✓', variant: 'success' };
+  }
+  const warning = Boolean(hint) && /(needs|require|add|over|warning)/i.test(`${label} ${hint}`);
+  if (warning) {
+    return { text: 'Warning', icon: '⚠', variant: 'warning' };
+  }
+  return { text: forStudy ? 'Pending' : 'Pending', icon: '•', variant: 'neutral' };
+}
+
+function statusBadge({ complete, label, hint, forStudy = false, extraClass = '' }) {
+  const { text, icon, variant } = getStatusMeta({ complete, label, hint, forStudy });
   const span = document.createElement('span');
-  span.className = complete ? 'dash-icon dash-icon--complete' : 'dash-icon dash-icon--incomplete';
-  span.setAttribute('aria-hidden', 'true');
-  span.textContent = complete ? '✓' : '✗';
+  span.className = `dash-badge dash-badge--${variant}${extraClass ? ` ${extraClass}` : ''}`;
+  span.setAttribute('role', 'status');
+  span.setAttribute('aria-label', `Status: ${text}`);
+
+  const iconEl = document.createElement('span');
+  iconEl.className = 'dash-badge-icon';
+  iconEl.setAttribute('aria-hidden', 'true');
+  iconEl.textContent = icon;
+
+  const textEl = document.createElement('span');
+  textEl.className = 'dash-badge-text';
+  textEl.textContent = text;
+
+  span.appendChild(iconEl);
+  span.appendChild(textEl);
   return span;
 }
 
@@ -164,18 +188,34 @@ function renderWorkflowSteps(container) {
     li.className = 'dash-step-card' + (complete ? ' dash-step-card--complete' : '');
     if (hint) li.title = hint;
 
-    const icon = statusIcon(complete);
     const nameEl = document.createElement('a');
     nameEl.href = step.href;
     nameEl.className = 'dash-step-name';
     nameEl.textContent = step.label;
 
+    const statusMeta = getStatusMeta({ complete, label, hint });
+    const statusPill = statusBadge({ complete, label, hint, extraClass: 'dash-step-status-pill' });
+
+    const statusWrap = document.createElement('span');
+    statusWrap.className = 'dash-step-status-wrap';
+    statusWrap.appendChild(statusPill);
+
+    if (hint) {
+      const hintEl = document.createElement('span');
+      hintEl.className = 'dash-step-hint-icon';
+      hintEl.setAttribute('aria-label', `Hint: ${hint}`);
+      hintEl.title = hint;
+      hintEl.textContent = 'ⓘ';
+      statusWrap.appendChild(hintEl);
+    }
+
     const labelEl = document.createElement('span');
     labelEl.className = 'dash-step-label';
     labelEl.textContent = label;
+    labelEl.setAttribute('aria-label', `${statusMeta.text}: ${label}`);
 
-    li.appendChild(icon);
     li.appendChild(nameEl);
+    li.appendChild(statusWrap);
     li.appendChild(labelEl);
     list.appendChild(li);
   });
@@ -242,18 +282,20 @@ function renderStudiesSummary(container) {
     const li = document.createElement('li');
     li.className = 'dash-study-item' + (hasResults ? ' dash-study-item--run' : '');
 
-    const icon = statusIcon(hasResults);
-
     const linkEl = document.createElement('a');
     linkEl.href = href;
     linkEl.className = 'dash-study-name';
     linkEl.textContent = label;
 
-    const statusEl = document.createElement('span');
-    statusEl.className = 'dash-study-status';
-    statusEl.textContent = hasResults ? 'Results saved' : 'Not run';
+    const statusEl = statusBadge({
+      complete: hasResults,
+      label: hasResults ? 'Results saved' : 'Not run',
+      hint: null,
+      forStudy: true,
+      extraClass: hasResults ? 'dash-badge--run' : 'dash-badge--pending'
+    });
+    statusEl.setAttribute('aria-label', hasResults ? 'Status: Run. Results saved.' : 'Status: Pending. Not run.');
 
-    li.appendChild(icon);
     li.appendChild(linkEl);
     li.appendChild(statusEl);
     list.appendChild(li);


### PR DESCRIPTION
### Motivation
- Improve clarity and semantics of status rendering by replacing single-character icons with icon+text badges that convey state to sighted and assistive users.
- Surface status more consistently in workflow step cards and studies list so users can quickly see `Complete` / `Pending` / `Warning` / `Run` states and access optional hint text.
- Provide semantic CSS hooks and keyboard focus affordances so badges remain accessible across color themes and keyboard navigation.

### Description
- Replaced the old `statusIcon()` helper with `getStatusMeta()` and a reusable `statusBadge()` renderer that returns an icon + text badge and sets accessible attributes like `role=status` and `aria-label` (in `src/workflowDashboard.js`).
- Updated workflow step rendering to include a right-aligned status pill and an optional hint icon when `hint` exists, and added explicit ARIA text for the status with `labelEl.setAttribute('aria-label', ...)` (in `src/workflowDashboard.js`).
- Changed studies list items to render explicit badge variants via `statusBadge()` and class tokens `dash-badge--run` / `dash-badge--pending` instead of muted inline status text (in `src/workflowDashboard.js`).
- Extended `src/styles/dashboard.css` with semantic badge classes (`.dash-badge--success`, `.dash-badge--warning`, `.dash-badge--neutral` / `.dash-badge--pending`, `.dash-badge--run`), `.dash-step-status-wrap` and hint icon styles, focus-visible outlines for links and badges, vertical rhythm adjustments for `.dash-step-list` and `.dash-study-list`, and dark-mode badge variants.

### Testing
- Ran `npm run build` which completed successfully, with existing Rollup warnings about unresolved externals unrelated to these changes.
- Ran the full `npm test` suite which executed many tests and reported numerous passing checks, but the run did not complete to the final exit in this environment (it hung/was terminated during collaboration-related tests).
- No new automated tests were added for this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e031f2e6b88324b6730f06ab92f54d)