### PR TITLE
Add Field View explorer tile and preview artwork

### DIFF
--- a/dist/icons/graphics/fieldview-visual.svg
+++ b/dist/icons/graphics/fieldview-visual.svg
@@ -1,0 +1,24 @@
+<svg width="720" height="360" viewBox="0 0 720 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="360" rx="24" fill="url(#bg)"/>
+  <rect x="56" y="58" width="608" height="244" rx="18" fill="#F8FAFC"/>
+  <rect x="84" y="88" width="224" height="184" rx="14" fill="#CCFBF1"/>
+  <rect x="324" y="88" width="312" height="114" rx="14" fill="#DBEAFE"/>
+  <rect x="324" y="216" width="312" height="56" rx="14" fill="#E0F2FE"/>
+  <path d="M106 232L146 186L186 198L222 152L278 174" stroke="#0F766E" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="142" cy="130" r="18" fill="#14B8A6" fill-opacity="0.28"/>
+  <path d="M142 120V140" stroke="#0F766E" stroke-width="6" stroke-linecap="round"/>
+  <path d="M132 130H152" stroke="#0F766E" stroke-width="6" stroke-linecap="round"/>
+  <rect x="348" y="112" width="170" height="16" rx="8" fill="#93C5FD"/>
+  <rect x="348" y="140" width="244" height="16" rx="8" fill="#60A5FA"/>
+  <rect x="348" y="168" width="204" height="16" rx="8" fill="#38BDF8"/>
+  <rect x="350" y="234" width="138" height="20" rx="10" fill="#67E8F9"/>
+  <rect x="500" y="234" width="114" height="20" rx="10" fill="#22D3EE"/>
+  <circle cx="590" cy="116" r="24" fill="#2563EB" fill-opacity="0.16"/>
+  <path d="M578 116L588 126L606 108" stroke="#1D4ED8" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <defs>
+    <linearGradient id="bg" x1="34" y1="22" x2="686" y2="338" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F766E"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/docs/icons/graphics/fieldview-visual.svg
+++ b/docs/icons/graphics/fieldview-visual.svg
@@ -1,0 +1,24 @@
+<svg width="720" height="360" viewBox="0 0 720 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="360" rx="24" fill="url(#bg)"/>
+  <rect x="56" y="58" width="608" height="244" rx="18" fill="#F8FAFC"/>
+  <rect x="84" y="88" width="224" height="184" rx="14" fill="#CCFBF1"/>
+  <rect x="324" y="88" width="312" height="114" rx="14" fill="#DBEAFE"/>
+  <rect x="324" y="216" width="312" height="56" rx="14" fill="#E0F2FE"/>
+  <path d="M106 232L146 186L186 198L222 152L278 174" stroke="#0F766E" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="142" cy="130" r="18" fill="#14B8A6" fill-opacity="0.28"/>
+  <path d="M142 120V140" stroke="#0F766E" stroke-width="6" stroke-linecap="round"/>
+  <path d="M132 130H152" stroke="#0F766E" stroke-width="6" stroke-linecap="round"/>
+  <rect x="348" y="112" width="170" height="16" rx="8" fill="#93C5FD"/>
+  <rect x="348" y="140" width="244" height="16" rx="8" fill="#60A5FA"/>
+  <rect x="348" y="168" width="204" height="16" rx="8" fill="#38BDF8"/>
+  <rect x="350" y="234" width="138" height="20" rx="10" fill="#67E8F9"/>
+  <rect x="500" y="234" width="114" height="20" rx="10" fill="#22D3EE"/>
+  <circle cx="590" cy="116" r="24" fill="#2563EB" fill-opacity="0.16"/>
+  <path d="M578 116L588 126L606 108" stroke="#1D4ED8" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <defs>
+    <linearGradient id="bg" x1="34" y1="22" x2="686" y2="338" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F766E"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/icons/graphics/fieldview-visual.svg
+++ b/icons/graphics/fieldview-visual.svg
@@ -1,0 +1,24 @@
+<svg width="720" height="360" viewBox="0 0 720 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="360" rx="24" fill="url(#bg)"/>
+  <rect x="56" y="58" width="608" height="244" rx="18" fill="#F8FAFC"/>
+  <rect x="84" y="88" width="224" height="184" rx="14" fill="#CCFBF1"/>
+  <rect x="324" y="88" width="312" height="114" rx="14" fill="#DBEAFE"/>
+  <rect x="324" y="216" width="312" height="56" rx="14" fill="#E0F2FE"/>
+  <path d="M106 232L146 186L186 198L222 152L278 174" stroke="#0F766E" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="142" cy="130" r="18" fill="#14B8A6" fill-opacity="0.28"/>
+  <path d="M142 120V140" stroke="#0F766E" stroke-width="6" stroke-linecap="round"/>
+  <path d="M132 130H152" stroke="#0F766E" stroke-width="6" stroke-linecap="round"/>
+  <rect x="348" y="112" width="170" height="16" rx="8" fill="#93C5FD"/>
+  <rect x="348" y="140" width="244" height="16" rx="8" fill="#60A5FA"/>
+  <rect x="348" y="168" width="204" height="16" rx="8" fill="#38BDF8"/>
+  <rect x="350" y="234" width="138" height="20" rx="10" fill="#67E8F9"/>
+  <rect x="500" y="234" width="114" height="20" rx="10" fill="#22D3EE"/>
+  <circle cx="590" cy="116" r="24" fill="#2563EB" fill-opacity="0.16"/>
+  <path d="M578 116L588 126L606 108" stroke="#1D4ED8" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <defs>
+    <linearGradient id="bg" x1="34" y1="22" x2="686" y2="338" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F766E"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/index.html
+++ b/index.html
@@ -185,6 +185,11 @@
             <span class="tool-graphic-title">Electrical Studies</span>
             <span class="tool-graphic-meta">Arc flash, short circuit, harmonics, cathodic protection, motor start, load flow, TCC</span>
           </a>
+          <a href="fieldview.html" class="tool-graphic-card tool-graphic-card--fieldview">
+            <img src="icons/graphics/fieldview-visual.svg" alt="Illustration previewing field snapshots, as-built overlays, and site verification workflows" loading="lazy" decoding="async">
+            <span class="tool-graphic-title">Field View</span>
+            <span class="tool-graphic-meta">Site-ready snapshots, as-built context, and field verification</span>
+          </a>
         </div>
       </section>
       <section class="card">

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -291,6 +291,10 @@ body.dark-mode .quick-launch-meta {
     background: linear-gradient(165deg, color-mix(in srgb, #7c3aed 16%, #ffffff) 0%, var(--color-surface-strong) 72%);
 }
 
+.tool-graphic-card--fieldview {
+    background: linear-gradient(165deg, color-mix(in srgb, #0f766e 18%, #ffffff) 0%, var(--color-surface-strong) 72%);
+}
+
 body.dark-mode .tool-graphic-card {
     border-color: #3a3f46;
     background: #1e2124;
@@ -303,7 +307,8 @@ body.dark-mode .tool-graphic-card img {
 body.dark-mode .tool-graphic-card--schedules,
 body.dark-mode .tool-graphic-card--fill,
 body.dark-mode .tool-graphic-card--routing,
-body.dark-mode .tool-graphic-card--studies {
+body.dark-mode .tool-graphic-card--studies,
+body.dark-mode .tool-graphic-card--fieldview {
     background: linear-gradient(170deg, rgba(37, 99, 235, 0.18) 0%, #1e2124 76%);
 }
 


### PR DESCRIPTION
### Motivation
- Provide a new Visual Tool Explorer card for a Field View workspace so users can open site-ready snapshots, as-built context, and field verification workflows from the homepage.

### Description
- Added a new explorer card anchor to the `.tool-graphics-grid` in `index.html` linking to `fieldview.html` with classes `tool-graphic-card tool-graphic-card--fieldview`, accessible alt text, title, and meta copy.
- Introduced `.tool-graphic-card--fieldview` in `src/styles/homepage.css` with a distinct gradient and included it in the dark-mode grouped selector so it matches existing cards in both themes.
- Added lightweight preview artwork `icons/graphics/fieldview-visual.svg` and mirrored it into `docs/icons/graphics/fieldview-visual.svg` and the build output `dist/icons/graphics/fieldview-visual.svg` via the normal asset copy step.

### Testing
- Ran `npm run build`, which completed and produced the site assets (Rollup emitted existing repo warnings but the build finished).
- Ran `npm test`, which executed the full test suite and reported extensive passing test output in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e036a363f48324985845b1cfddfae3)