### PR TITLE
Add CP standards profile and auditable compliance tracking

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -93,6 +93,12 @@ Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
         <div id="calculation-basis-content"></div>
       </section>
 
+      <section class="card" aria-labelledby="cp-compliance-status-heading">
+        <h2 id="cp-compliance-status-heading">Compliance Status</h2>
+        <p class="field-hint">Required checks are tracked as pass, fail, or not run and persisted with study results for audit history.</p>
+        <div id="cp-compliance-status-content"></div>
+      </section>
+
       <form id="cp-form" novalidate>
         <fieldset>
           <legend><strong>Asset &amp; Environment Inputs</strong></legend>

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -1,5 +1,11 @@
 import { getStudies, setStudies } from './dataStore.mjs';
 import { initStudyApprovalPanel } from './src/components/studyApproval.js';
+import {
+  CP_STANDARDS_PROFILE,
+  evaluateComplianceChecks,
+  getRequiredComplianceChecks,
+  buildInitialComplianceStatus
+} from './src/studies/cp/standardsProfile.js';
 
 const SQFT_TO_SQM = 0.09290304;
 const LB_TO_KG = 0.45359237;
@@ -23,28 +29,42 @@ const PIPE_MATERIAL_FACTORS = {
 };
 
 export const CP_STANDARD_BASIS = {
+  standardsProfile: {
+    id: 'cp-standards-profile',
+    label: 'Adopted standards profile',
+    summary: 'Defines target standards references, required deliverables, and mandatory/optional compliance checks.',
+    standards: CP_STANDARDS_PROFILE.targetReferences.map((reference) => `${reference.code} (${reference.edition})`),
+    requiredChecks: getRequiredComplianceChecks(),
+    deliverables: Object.values(CP_STANDARDS_PROFILE.deliverables)
+      .filter((deliverable) => deliverable.required)
+      .map((deliverable) => deliverable.key)
+  },
   currentDensitySelection: {
     id: 'current-density-selection',
     label: 'Current density selection ranges',
     standards: ['AMPP SP21424', 'NACE SP0169'],
+    requiredChecks: ['currentDensitySelection'],
     summary: 'Table-range style current demand selection by structure condition and environment severity.'
   },
   polarizationCriteria: {
     id: 'polarization-criteria',
     label: 'Polarization / protection criteria assumptions',
     standards: ['NACE SP0169', 'ISO 15589-1'],
+    requiredChecks: ['commissioningChecksDefined', 'monitoringPlanDefined'],
     summary: 'Protection assumptions align with conventional on/off potential and polarization criteria used for buried steel CP design.'
   },
   anodeCapacityUtilization: {
     id: 'anode-capacity-utilization',
     label: 'Anode capacity and utilization values',
     standards: ['DNV-RP-B401', 'ISO 15589-1'],
+    requiredChecks: ['anodeMassSizing', 'targetLifeVerification'],
     summary: 'Galvanic anode ampere-hour capacity and utilization factors follow published anode design guidance.'
   },
   engineeringJudgmentAssumptions: {
     id: 'engineering-judgment',
     label: 'Engineering judgment assumptions',
     standards: ['Project-specific engineering judgment'],
+    requiredChecks: ['commissioningChecksDefined', 'monitoringPlanDefined'],
     summary: 'Coating breakdown factor, design factor, and optional temperature correction require project-specific engineering validation.',
     assumptions: [
       'Coating breakdown factor is selected by expected coating quality, age, and defect distribution.',
@@ -214,6 +234,61 @@ function roundTo(value, decimals) {
   return Math.round(value * p) / p;
 }
 
+function normalizeSavedStudy(saved) {
+  if (!saved || typeof saved !== 'object') {
+    return null;
+  }
+
+  const compliance = saved.compliance && typeof saved.compliance === 'object'
+    ? saved.compliance
+    : {
+      profileId: CP_STANDARDS_PROFILE.profileId,
+      requiredChecks: buildInitialComplianceStatus(),
+      optionalChecks: {},
+      lastEvaluatedAt: null
+    };
+
+  const existingHistory = Array.isArray(saved.complianceHistory)
+    ? saved.complianceHistory
+    : [];
+
+  return {
+    ...saved,
+    compliance,
+    complianceHistory: existingHistory
+  };
+}
+
+function createComplianceRecord(result, previousStudy = null) {
+  const requiredChecks = evaluateComplianceChecks(result);
+  const previousRequiredChecks = previousStudy?.compliance?.requiredChecks || {};
+  const mergedRequiredChecks = {
+    ...buildInitialComplianceStatus(),
+    ...previousRequiredChecks,
+    ...requiredChecks
+  };
+  const evaluatedAt = result.timestamp;
+
+  const compliance = {
+    profileId: CP_STANDARDS_PROFILE.profileId,
+    requiredChecks: mergedRequiredChecks,
+    optionalChecks: previousStudy?.compliance?.optionalChecks || {},
+    lastEvaluatedAt: evaluatedAt
+  };
+
+  const historyEntry = {
+    evaluatedAt,
+    requiredChecks: mergedRequiredChecks
+  };
+
+  const complianceHistory = [
+    ...(Array.isArray(previousStudy?.complianceHistory) ? previousStudy.complianceHistory : []),
+    historyEntry
+  ];
+
+  return { compliance, complianceHistory };
+}
+
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
   initSettings();
@@ -241,9 +316,11 @@ if (typeof document !== 'undefined') {
   const calculatedSurfaceAreaRow = document.getElementById('calculated-surface-area-row');
   const calculatedSurfaceAreaEl = document.getElementById('calculated-surface-area');
   const pipeDimensionsIllustrationEl = document.getElementById('pipe-dimensions-illustration');
+  const compliancePanelEl = document.getElementById('cp-compliance-status-content');
 
-  const saved = getStudies().cathodicProtection;
+  const saved = normalizeSavedStudy(getStudies().cathodicProtection);
   renderCalculationBasis(basisPanel, CP_STANDARD_BASIS);
+  renderComplianceStatusPanel(compliancePanelEl, saved?.compliance?.requiredChecks, saved?.compliance?.lastEvaluatedAt);
   if (saved) {
     renderResults(saved, resultsDiv);
   }
@@ -348,9 +425,20 @@ if (typeof document !== 'undefined') {
       errorsDiv.hidden = true;
       errorsDiv.textContent = '';
       const studies = getStudies();
-      studies.cathodicProtection = result;
+      const previousStudy = normalizeSavedStudy(studies.cathodicProtection);
+      const complianceRecord = createComplianceRecord(result, previousStudy);
+      studies.cathodicProtection = {
+        ...result,
+        compliance: complianceRecord.compliance,
+        complianceHistory: complianceRecord.complianceHistory
+      };
       setStudies(studies);
-      renderResults(result, resultsDiv);
+      renderResults(studies.cathodicProtection, resultsDiv);
+      renderComplianceStatusPanel(
+        compliancePanelEl,
+        studies.cathodicProtection.compliance.requiredChecks,
+        studies.cathodicProtection.compliance.lastEvaluatedAt
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Invalid cathodic protection inputs.';
       errorsDiv.hidden = false;
@@ -539,6 +627,7 @@ function renderCalculationBasis(root, basis) {
   if (!root || !basis) return;
 
   const sections = [
+    basis.standardsProfile,
     basis.currentDensitySelection,
     basis.polarizationCriteria,
     basis.anodeCapacityUtilization,
@@ -552,11 +641,54 @@ function renderCalculationBasis(root, basis) {
           <strong>${escapeHtml(section.label)}:</strong>
           <span>${escapeHtml(section.summary)}</span>
           <div class="field-hint">Standards: ${escapeHtml(section.standards.join(', '))}</div>
+          ${Array.isArray(section.requiredChecks) && section.requiredChecks.length
+            ? `<div class="field-hint">Required checks: ${escapeHtml(section.requiredChecks.join(', '))}</div>`
+            : ''}
+          ${Array.isArray(section.deliverables) && section.deliverables.length
+            ? `<div class="field-hint">Required deliverables: ${escapeHtml(section.deliverables.join(', '))}</div>`
+            : ''}
           ${Array.isArray(section.assumptions) && section.assumptions.length
             ? `<ul>${section.assumptions.map((assumption) => `<li>${escapeHtml(assumption)}</li>`).join('')}</ul>`
             : ''}
         </li>
       `).join('')}
     </ul>
+  `;
+}
+
+function renderComplianceStatusPanel(root, requiredChecks = {}, lastEvaluatedAt = null) {
+  if (!root) return;
+
+  const rows = getRequiredComplianceChecks().map((checkKey) => {
+    const check = CP_STANDARDS_PROFILE.checks[checkKey];
+    const status = requiredChecks[checkKey] || 'not-run';
+    return {
+      key: checkKey,
+      label: check?.label || checkKey,
+      status
+    };
+  });
+
+  const statusLabels = {
+    pass: 'Pass',
+    fail: 'Fail',
+    'not-run': 'Not run'
+  };
+
+  root.innerHTML = `
+    <div class="table-wrap">
+      <table class="data-table" aria-label="Cathodic protection required compliance checks">
+        <thead><tr><th>Required check</th><th>Status</th></tr></thead>
+        <tbody>
+          ${rows.map((row) => `
+            <tr>
+              <td>${escapeHtml(row.label)} <span class="field-hint">(${escapeHtml(row.key)})</span></td>
+              <td><span class="result-badge result-badge--${escapeHtml(row.status)}">${escapeHtml(statusLabels[row.status] || 'Not run')}</span></td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    </div>
+    <p class="field-hint">Last evaluated: ${lastEvaluatedAt ? escapeHtml(new Date(lastEvaluatedAt).toLocaleString()) : 'Not run yet'}</p>
   `;
 }

--- a/docs/cathodic_protection.md
+++ b/docs/cathodic_protection.md
@@ -92,6 +92,16 @@ The in-app standards basis references:
 
 > Note: The tool uses these standards as design-basis references for equation form and parameter framing. Project-specific compliance still requires engineering sign-off against the exact edition and jurisdictional requirements.
 
+## Compliance Tracking
+
+The CP study now includes a standards profile and auditable compliance status model:
+
+- **Target references:** A machine-readable profile records the adopted standards set (AMPP/NACE/ISO/DNV references and organization-selected editions).
+- **Mandatory vs optional checks:** Required checks are explicitly keyed and rendered in the **Compliance Status** panel as `pass`, `fail`, or `not-run`.
+- **Required deliverables:** The profile flags required deliverables for design basis, calculations, commissioning checks, and monitoring plan.
+- **Audit trail:** Every run appends a compliance snapshot under study storage (`studyResults.cathodicProtection.complianceHistory`) so historical status changes can be reviewed.
+
 ## Revision Notes
 
+- **2026-04-16:** Added standards profile configuration, machine-readable required-check keys in CP basis mapping, compliance status panel, and persisted compliance history snapshots.
 - **2026-04-15:** Initial documentation page added for CP sizing inputs, equations, assumptions/limits, references, and consistency guidance between required-mass and predicted-life relations.

--- a/src/studies/cp/standardsProfile.js
+++ b/src/studies/cp/standardsProfile.js
@@ -1,0 +1,93 @@
+export const CP_STANDARDS_PROFILE = {
+  profileId: 'cp-design-basis-2026',
+  organization: 'CableTrayRoute default profile',
+  targetReferences: [
+    { code: 'AMPP SP21424', edition: 'Adopted organizational edition' },
+    { code: 'NACE SP0169', edition: 'Latest organization-approved edition' },
+    { code: 'ISO 15589-1', edition: 'Latest organization-approved edition' },
+    { code: 'DNV-RP-B401', edition: 'Latest organization-approved edition' }
+  ],
+  checks: {
+    currentDensitySelection: {
+      key: 'currentDensitySelection',
+      label: 'Current density basis selected',
+      required: true,
+      description: 'Validate that table/manual current density basis is documented and finite.'
+    },
+    anodeMassSizing: {
+      key: 'anodeMassSizing',
+      label: 'Anode mass sizing equation verification',
+      required: true,
+      description: 'Required mass is calculated from approved anode capacity/utilization inputs.'
+    },
+    targetLifeVerification: {
+      key: 'targetLifeVerification',
+      label: 'Target life verification',
+      required: true,
+      description: 'Installed mass life check confirms whether the selected target life is met.'
+    },
+    commissioningChecksDefined: {
+      key: 'commissioningChecksDefined',
+      label: 'Commissioning checks defined',
+      required: true,
+      description: 'Project package includes polarization and acceptance checks for commissioning.'
+    },
+    monitoringPlanDefined: {
+      key: 'monitoringPlanDefined',
+      label: 'Monitoring plan defined',
+      required: true,
+      description: 'Long-term monitoring and inspection cadence is documented for auditing.'
+    },
+    interferenceAssessment: {
+      key: 'interferenceAssessment',
+      label: 'Interference assessment',
+      required: false,
+      description: 'Optional review for stray-current and foreign structure interference.'
+    }
+  },
+  deliverables: {
+    designBasis: {
+      key: 'designBasis',
+      label: 'Design basis memorandum',
+      required: true
+    },
+    calculations: {
+      key: 'calculations',
+      label: 'Sizing calculations package',
+      required: true
+    },
+    commissioningChecks: {
+      key: 'commissioningChecks',
+      label: 'Commissioning and acceptance checks',
+      required: true
+    },
+    monitoringPlan: {
+      key: 'monitoringPlan',
+      label: 'Monitoring and survey plan',
+      required: true
+    }
+  }
+};
+
+export function getRequiredComplianceChecks() {
+  return Object.values(CP_STANDARDS_PROFILE.checks)
+    .filter((check) => check.required)
+    .map((check) => check.key);
+}
+
+export function buildInitialComplianceStatus() {
+  return Object.fromEntries(getRequiredComplianceChecks().map((checkKey) => [checkKey, 'not-run']));
+}
+
+export function evaluateComplianceChecks(result) {
+  const checks = {
+    ...buildInitialComplianceStatus(),
+    currentDensitySelection: Number.isFinite(result.designCurrentDensityMaM2) && result.designCurrentDensityMaM2 > 0 ? 'pass' : 'fail',
+    anodeMassSizing: Number.isFinite(result.minimumAnodeMassKg) && result.minimumAnodeMassKg > 0 ? 'pass' : 'fail',
+    targetLifeVerification: Number.isFinite(result.safetyMarginYears)
+      ? (result.safetyMarginYears >= 0 ? 'pass' : 'fail')
+      : 'fail'
+  };
+
+  return checks;
+}

--- a/style.css
+++ b/style.css
@@ -83,3 +83,26 @@
 .cp-geometry-note {
   font-size: 14px;
 }
+
+.result-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  border-radius: 999px;
+  padding: .2rem .65rem;
+  font-size: .85rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.result-badge--pass {
+  background: color-mix(in srgb, #22c55e 20%, transparent);
+  border-color: color-mix(in srgb, #22c55e 45%, transparent);
+}
+.result-badge--fail {
+  background: color-mix(in srgb, #ef4444 18%, transparent);
+  border-color: color-mix(in srgb, #ef4444 45%, transparent);
+}
+.result-badge--not-run {
+  background: color-mix(in srgb, #64748b 20%, transparent);
+  border-color: color-mix(in srgb, #64748b 45%, transparent);
+}

--- a/tests/cathodicProtection.test.mjs
+++ b/tests/cathodicProtection.test.mjs
@@ -9,6 +9,7 @@ import {
 function baseInput(overrides = {}) {
   return {
     assetType: 'pipe',
+    pipeMaterial: 'carbon-steel',
     soilResistivityOhmM: 100,
     soilPh: 7,
     moistureCategory: 'moderate',


### PR DESCRIPTION
### Motivation
- Provide a machine-readable standards profile for Cathodic Protection that records adopted target references, required vs optional checks, and required deliverables for traceable design basis.
- Make compliance checks machine-tractable in the CP calculation basis and surface a simple pass/fail/not-run status for mandatory checks so projects can be audited.
- Persist compliance evaluation snapshots with study results so historical compliance status can be reviewed over time.

### Description
- Added a new standards profile module at `src/studies/cp/standardsProfile.js` that declares `targetReferences`, `checks` (with required/optional flags), `deliverables`, and helper functions `getRequiredComplianceChecks`, `buildInitialComplianceStatus`, and `evaluateComplianceChecks`.
- Extended `CP_STANDARD_BASIS` in `cathodicprotection.js` to include a `standardsProfile` section and added `requiredChecks` keys to the existing basis entries, plus wiring to evaluate and persist compliance state via `evaluateComplianceChecks` and helper functions (`normalizeSavedStudy`, `createComplianceRecord`).
- Added a compliance status panel to the UI (`cathodicprotection.html`) and rendering logic `renderComplianceStatusPanel` in `cathodicprotection.js` to show pass/fail/not-run for each required check and a last-evaluated timestamp.
- Persisted compliance results and an audit trail under study storage (`studyResults.cathodicProtection.compliance` and `complianceHistory`), added badge styles in `style.css`, updated `docs/cathodic_protection.md`, and adjusted the CP unit test fixture in `tests/cathodicProtection.test.mjs`.

### Testing
- Ran the CP unit test with `node tests/cathodicProtection.test.mjs`, which passed (`✓ cathodic protection sizing tests passed`).
- Built the distribution with `npm run build`, which completed successfully and emitted updated `dist` artifacts.
- Started the full test runner with `npm test`; the suite progressed and many tests passed but the full run did not complete in this environment before the process was terminated (partial run observed). 
- Attempted a Playwright page screenshot (`npx playwright screenshot ...`) and `npx playwright install chromium` to generate a preview image, but browser download failed with HTTP 403 so an automated preview image could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03d4ce7548324baab4dc94771ed54)