### PR TITLE
Add CP protection criteria checks, inputs, and evidence in results

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -262,6 +262,26 @@ Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
           </div>
         </fieldset>
 
+        <fieldset>
+          <legend><strong>Protection Criteria Evidence Inputs</strong></legend>
+          <div class="field-row">
+            <label for="measured-off-potential">Measured instant-off potential (mV vs CSE)</label>
+            <input type="number" id="measured-off-potential" step="1" value="-900" required>
+          </div>
+          <div class="field-row">
+            <label for="simulated-polarization-shift">Measured/simulated polarization shift (mV)</label>
+            <input type="number" id="simulated-polarization-shift" min="0" step="1" value="120" required>
+          </div>
+          <div class="field-row">
+            <label for="test-point-count">Total test points reviewed</label>
+            <input type="number" id="test-point-count" min="1" step="1" value="8" required>
+          </div>
+          <div class="field-row">
+            <label for="test-point-pass-count">Test points meeting criteria</label>
+            <input type="number" id="test-point-pass-count" min="0" step="1" value="8" required>
+          </div>
+        </fieldset>
+
         <button type="submit" class="primary-btn">Run Analysis</button>
       </form>
 

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -7,6 +7,7 @@ import {
   buildInitialComplianceStatus
 } from './src/studies/cp/standardsProfile.js';
 import { computeDistributionBySegment, parseZoneResistivityValues } from './src/studies/cp/distributionModel.js';
+import { evaluateCriteriaChecks } from './src/studies/cp/criteriaChecks.js';
 
 const SQFT_TO_SQM = 0.09290304;
 const LB_TO_KG = 0.45359237;
@@ -35,6 +36,7 @@ export const CP_STANDARD_BASIS = {
     label: 'Adopted standards profile',
     summary: 'Defines target standards references, required deliverables, and mandatory/optional compliance checks.',
     standards: CP_STANDARDS_PROFILE.targetReferences.map((reference) => `${reference.code} (${reference.edition})`),
+    selectedProtectionCriteriaSetId: CP_STANDARDS_PROFILE.selectedProtectionCriteriaSetId,
     requiredChecks: getRequiredComplianceChecks(),
     deliverables: Object.values(CP_STANDARDS_PROFILE.deliverables)
       .filter((deliverable) => deliverable.required)
@@ -128,6 +130,7 @@ export function runCathodicProtectionAnalysis(input) {
     input.designFactor,
     adjustedRequiredCurrentA
   );
+  const criteriaCheckEvidence = evaluateCriteriaChecks(input, CP_STANDARDS_PROFILE);
 
   return {
     ...input,
@@ -150,6 +153,7 @@ export function runCathodicProtectionAnalysis(input) {
     predictedLifeYears: roundTo(predictedLifeYears, 2),
     safetyMarginYears: roundTo(predictedLifeYears - input.targetLifeYears, 2),
     safetyMarginPercent: roundTo(((predictedLifeYears - input.targetLifeYears) / input.targetLifeYears) * 100, 1),
+    criteriaCheckEvidence,
     sensitivity: buildSensitivitySummary({
       input,
       adjustedRequiredCurrentA,
@@ -250,6 +254,22 @@ function validateInputs(input) {
 
   if (input.zoneResistivityInputValid === false) {
     errors.push('zoneResistivityOhmM input must be a comma-separated list of positive numbers.');
+  }
+
+  if (!Number.isFinite(input.measuredInstantOffPotentialMv)) {
+    errors.push('measuredInstantOffPotentialMv must be a finite number.');
+  }
+
+  if (!Number.isFinite(input.simulatedPolarizationShiftMv) || input.simulatedPolarizationShiftMv < 0) {
+    errors.push('simulatedPolarizationShiftMv must be zero or greater.');
+  }
+
+  if (!Number.isInteger(input.testPointCount) || input.testPointCount <= 0) {
+    errors.push('testPointCount must be a positive integer.');
+  }
+
+  if (!Number.isInteger(input.passingTestPointCount) || input.passingTestPointCount < 0 || input.passingTestPointCount > input.testPointCount) {
+    errors.push('passingTestPointCount must be an integer between 0 and testPointCount.');
   }
 
   return errors;
@@ -534,6 +554,10 @@ function readFormInputs() {
     anodeBurialDepthM: isMetric ? anodeBurialDepthInput : anodeBurialDepthInput * FT_TO_M,
     zoneResistivityOhmM: parsedZoneResistivityValues,
     zoneResistivityInputValid,
+    measuredInstantOffPotentialMv: getNumber('measured-off-potential'),
+    simulatedPolarizationShiftMv: getNumber('simulated-polarization-shift'),
+    testPointCount: Math.round(getNumber('test-point-count')),
+    passingTestPointCount: Math.round(getNumber('test-point-pass-count')),
     units: isMetric ? 'metric' : 'imperial'
   };
 }
@@ -544,6 +568,15 @@ function renderResults(result, root) {
   const outputBasis = result.outputBasis || {};
   const sensitivityRows = Array.isArray(result.sensitivity) ? result.sensitivity : [];
   const advisories = buildDesignAdvisories(result, sensitivityRows);
+  const criteriaEvidence = result.criteriaCheckEvidence || {};
+  const criteriaSet = criteriaEvidence.selectedCriteriaSet;
+  const criteriaRows = Array.isArray(criteriaEvidence.criteriaResults) ? criteriaEvidence.criteriaResults : [];
+  const criteriaStatusLabel = criteriaEvidence.overallStatus === 'pass'
+    ? 'Pass'
+    : (criteriaEvidence.overallStatus === 'fail' ? 'Fail' : 'Not run');
+  const criteriaStatusClass = criteriaEvidence.overallStatus === 'pass'
+    ? 'result-badge--pass'
+    : (criteriaEvidence.overallStatus === 'fail' ? 'result-badge--fail' : '');
 
   root.innerHTML = `
     <section class="results-panel" aria-labelledby="cp-results-heading">
@@ -601,8 +634,33 @@ function renderResults(result, root) {
             <tr><td>Anode utilization factor U</td><td>${result.anodeUtilization}</td></tr>
             <tr><td>Design factor F<sub>design</sub></td><td>${result.designFactor}</td></tr>
             <tr><td>Availability factor</td><td>${result.availabilityFactor}</td></tr>
+            <tr><td>Measured instant-off potential</td><td>${result.measuredInstantOffPotentialMv} mV</td></tr>
+            <tr><td>Simulated polarization shift</td><td>${result.simulatedPolarizationShiftMv} mV</td></tr>
+            <tr><td>Test points passing</td><td>${result.passingTestPointCount} / ${result.testPointCount}</td></tr>
           </tbody>
         </table>
+      </div>
+
+      <div class="result-group" aria-label="Protection criteria check evidence">
+        <h3>Protection Criteria Check Evidence</h3>
+        <p class="field-hint">Criteria selected: ${escapeHtml(criteriaSet?.label || 'Not configured')} (${escapeHtml(criteriaSet?.reference || 'No reference')})</p>
+        <p class="field-hint">Data used: instant-off ${result.measuredInstantOffPotentialMv} mV, polarization shift ${result.simulatedPolarizationShiftMv} mV, test points ${result.passingTestPointCount}/${result.testPointCount} passing.</p>
+        <div class="result-badge ${criteriaStatusClass}">${criteriaStatusLabel}: criteria set evaluation</div>
+        <div class="table-wrap">
+          <table class="data-table" aria-label="Protection criteria pass fail table">
+            <thead><tr><th>Criterion</th><th>Requirement</th><th>Observed data</th><th>Status</th></tr></thead>
+            <tbody>
+              ${criteriaRows.map((criterion) => `
+                <tr>
+                  <td>${escapeHtml(criterion.label)}</td>
+                  <td>${escapeHtml(criterion.requirement)}</td>
+                  <td>${escapeHtml(criterion.observedValue)}</td>
+                  <td>${criterion.status === 'pass' ? 'Pass' : 'Fail'}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
       </div>
 
       ${sensitivityRows.length ? `

--- a/src/studies/cp/criteriaChecks.js
+++ b/src/studies/cp/criteriaChecks.js
@@ -1,0 +1,68 @@
+import { getSelectedProtectionCriteriaSet } from './standardsProfile.js';
+
+function toCheckStatus(isPassing) {
+  return isPassing ? 'pass' : 'fail';
+}
+
+export function evaluateCriteriaChecks(input, standardsProfile) {
+  const selectedCriteriaSet = getSelectedProtectionCriteriaSet(standardsProfile);
+  if (!selectedCriteriaSet) {
+    return {
+      selectedCriteriaSet: null,
+      dataUsed: {},
+      criteriaResults: [],
+      overallStatus: 'fail'
+    };
+  }
+
+  const dataUsed = {
+    measuredInstantOffPotentialMv: input.measuredInstantOffPotentialMv,
+    simulatedPolarizationShiftMv: input.simulatedPolarizationShiftMv,
+    testPointCount: input.testPointCount,
+    passingTestPointCount: input.passingTestPointCount
+  };
+
+  const instantOffPass = Number.isFinite(dataUsed.measuredInstantOffPotentialMv) && dataUsed.measuredInstantOffPotentialMv <= -850;
+  const polarizationPass = Number.isFinite(dataUsed.simulatedPolarizationShiftMv) && dataUsed.simulatedPolarizationShiftMv >= 100;
+  const coveragePass = Number.isInteger(dataUsed.testPointCount)
+    && Number.isInteger(dataUsed.passingTestPointCount)
+    && dataUsed.testPointCount > 0
+    && dataUsed.passingTestPointCount === dataUsed.testPointCount;
+
+  const criteriaResults = [
+    {
+      key: 'instantOffPotential',
+      label: 'Instant-off potential criterion',
+      requirement: 'Measured instant-off potential ≤ -850 mV (CSE)',
+      observedValue: `${dataUsed.measuredInstantOffPotentialMv} mV`,
+      status: toCheckStatus(instantOffPass)
+    },
+    {
+      key: 'polarizationShift',
+      label: 'Polarization criterion',
+      requirement: 'Measured/simulated polarization shift ≥ 100 mV',
+      observedValue: `${dataUsed.simulatedPolarizationShiftMv} mV`,
+      status: toCheckStatus(polarizationPass)
+    },
+    {
+      key: 'testPointCoverage',
+      label: 'Test-point coverage criterion',
+      requirement: 'All reported test points satisfy selected criteria',
+      observedValue: `${dataUsed.passingTestPointCount} / ${dataUsed.testPointCount} points pass`,
+      status: toCheckStatus(coveragePass)
+    }
+  ];
+
+  const overallStatus = criteriaResults.every((check) => check.status === 'pass') ? 'pass' : 'fail';
+
+  return {
+    selectedCriteriaSet: {
+      id: selectedCriteriaSet.id,
+      label: selectedCriteriaSet.label,
+      reference: selectedCriteriaSet.reference
+    },
+    dataUsed,
+    criteriaResults,
+    overallStatus
+  };
+}

--- a/src/studies/cp/standardsProfile.js
+++ b/src/studies/cp/standardsProfile.js
@@ -1,12 +1,37 @@
 export const CP_STANDARDS_PROFILE = {
   profileId: 'cp-design-basis-2026',
   organization: 'CableTrayRoute default profile',
+  selectedProtectionCriteriaSetId: 'buried-steel-default',
   targetReferences: [
     { code: 'AMPP SP21424', edition: 'Adopted organizational edition' },
     { code: 'NACE SP0169', edition: 'Latest organization-approved edition' },
     { code: 'ISO 15589-1', edition: 'Latest organization-approved edition' },
     { code: 'DNV-RP-B401', edition: 'Latest organization-approved edition' }
   ],
+  protectionCriteriaSets: {
+    'buried-steel-default': {
+      id: 'buried-steel-default',
+      label: 'Buried steel default criteria',
+      reference: 'NACE SP0169 / ISO 15589-1',
+      criteria: [
+        {
+          key: 'instantOffPotential',
+          label: 'Instant-off potential criterion',
+          requirement: 'Measured instant-off potential ≤ -850 mV (CSE).'
+        },
+        {
+          key: 'polarizationShift',
+          label: 'Polarization criterion',
+          requirement: 'Measured/simulated polarization shift ≥ 100 mV.'
+        },
+        {
+          key: 'testPointCoverage',
+          label: 'Test-point coverage criterion',
+          requirement: 'All reported test points satisfy selected protection criteria.'
+        }
+      ]
+    }
+  },
   checks: {
     currentDensitySelection: {
       key: 'currentDensitySelection',
@@ -77,6 +102,11 @@ export function getRequiredComplianceChecks() {
 
 export function buildInitialComplianceStatus() {
   return Object.fromEntries(getRequiredComplianceChecks().map((checkKey) => [checkKey, 'not-run']));
+}
+
+export function getSelectedProtectionCriteriaSet(profile = CP_STANDARDS_PROFILE) {
+  const selectedId = profile.selectedProtectionCriteriaSetId;
+  return profile.protectionCriteriaSets?.[selectedId] || null;
 }
 
 export function evaluateComplianceChecks(result) {


### PR DESCRIPTION
### Motivation
- Provide a traceable, standards-driven evaluation of cathodic protection acceptance by adding a dedicated criteria evaluator and wiring its evidence into the study output and results UI.
- Capture measured/simulated protection evidence (instant-off potential, polarization shift, and test-point coverage) so commissioning checks can be audited alongside sizing calculations.

### Description
- Add a new evaluator module `src/studies/cp/criteriaChecks.js` that resolves the selected protection-criteria set from the standards profile and returns per-criterion observed data, pass/fail and overall status.
- Extend the CP standards profile in `src/studies/cp/standardsProfile.js` with `protectionCriteriaSets`, a `selectedProtectionCriteriaSetId`, and a `getSelectedProtectionCriteriaSet()` helper.
- Add new input fields to `cathodicprotection.html` for `measured-off-potential`, `simulated-polarization-shift`, `test-point-count`, and `test-point-pass-count` and wire those values into `readFormInputs()`.
- Integrate evaluation into the analysis flow in `cathodicprotection.js` by validating the new inputs, calling `evaluateCriteriaChecks()`, persisting `criteriaCheckEvidence` in the returned/stored study JSON, and extending `renderResults()` to show the selected criteria set, data used, and per-criterion pass/fail outcomes.

### Testing
- Ran `npm run build` and confirmed the project builds successfully in this environment.
- Started the full test suite with `npm test`; the suite ran many tests (log captured) but did not complete within the environment before a hang/timeout occurred, so full automated test completion could not be confirmed here.
- Attempted a Playwright screenshot to produce a preview image, but the environment lacked downloaded Playwright browser binaries, so the screenshot step failed (install required via `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e043f22dc08324be7ce4b8ce74d60e)