### PR TITLE
Add CP interference assessment with risk-gated compliance

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -282,6 +282,53 @@ Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
           </div>
         </fieldset>
 
+        <fieldset>
+          <legend><strong>Interference Assessment</strong></legend>
+          <div class="field-row">
+            <label for="nearby-foreign-structures">Nearby foreign structures</label>
+            <select id="nearby-foreign-structures" required>
+              <option value="none" selected>None identified</option>
+              <option value="isolated">Isolated crossings / adjacent assets</option>
+              <option value="multiple">Multiple nearby structures</option>
+              <option value="sharedCorridor">Shared corridor / parallel alignment</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="dc-traction-system">DC traction systems</label>
+            <select id="dc-traction-system" required>
+              <option value="none" selected>No known DC traction</option>
+              <option value="regional">Regional traction network</option>
+              <option value="nearby">Nearby traction substation/line</option>
+              <option value="parallelReturn">Parallel return path proximity</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="known-interference-sources">Known interference sources</label>
+            <select id="known-interference-sources" required>
+              <option value="none" selected>No known stray-current issues</option>
+              <option value="possible">Possible historical interference</option>
+              <option value="confirmed">Confirmed interference sources</option>
+              <option value="severe">Severe/active interference records</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="mitigation-profile">Mitigation profile</label>
+            <select id="mitigation-profile" required>
+              <option value="baseline" selected>Baseline</option>
+              <option value="enhanced">Enhanced</option>
+              <option value="critical">Critical</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="mitigation-actions">Mitigation actions (comma/newline separated)</label>
+            <textarea id="mitigation-actions" rows="3" placeholder="e.g., baseline survey, test station checks, bonding review"></textarea>
+          </div>
+          <div class="field-row">
+            <label for="verification-test-date">Verification test date</label>
+            <input type="date" id="verification-test-date">
+          </div>
+        </fieldset>
+
         <button type="submit" class="primary-btn">Run Analysis</button>
       </form>
 

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -8,6 +8,7 @@ import {
 } from './src/studies/cp/standardsProfile.js';
 import { computeDistributionBySegment, parseZoneResistivityValues } from './src/studies/cp/distributionModel.js';
 import { evaluateCriteriaChecks } from './src/studies/cp/criteriaChecks.js';
+import { evaluateInterferenceAssessment, parseMitigationActions } from './src/studies/cp/interferenceAssessment.js';
 
 const SQFT_TO_SQM = 0.09290304;
 const LB_TO_KG = 0.45359237;
@@ -74,6 +75,13 @@ export const CP_STANDARD_BASIS = {
       'Design factor is selected as a reliability margin for uncertainty and lifecycle variability.',
       'Temperature correction is not explicitly modeled in this tool and should be applied by engineering review when needed.'
     ]
+  },
+  interferenceAssessment: {
+    id: 'interference-assessment',
+    label: 'Interference risk assessment and mitigation profile',
+    standards: ['AMPP SP21424', 'NACE SP0169'],
+    requiredChecks: ['interferenceAssessment'],
+    summary: 'Scored risk screening for foreign structures, DC traction systems, and known stray-current sources with profile-specific mitigations.'
   }
 };
 
@@ -131,6 +139,7 @@ export function runCathodicProtectionAnalysis(input) {
     adjustedRequiredCurrentA
   );
   const criteriaCheckEvidence = evaluateCriteriaChecks(input, CP_STANDARDS_PROFILE);
+  const interferenceAssessment = evaluateInterferenceAssessment(input);
 
   return {
     ...input,
@@ -154,6 +163,7 @@ export function runCathodicProtectionAnalysis(input) {
     safetyMarginYears: roundTo(predictedLifeYears - input.targetLifeYears, 2),
     safetyMarginPercent: roundTo(((predictedLifeYears - input.targetLifeYears) / input.targetLifeYears) * 100, 1),
     criteriaCheckEvidence,
+    interferenceAssessment,
     sensitivity: buildSensitivitySummary({
       input,
       adjustedRequiredCurrentA,
@@ -270,6 +280,22 @@ function validateInputs(input) {
 
   if (!Number.isInteger(input.passingTestPointCount) || input.passingTestPointCount < 0 || input.passingTestPointCount > input.testPointCount) {
     errors.push('passingTestPointCount must be an integer between 0 and testPointCount.');
+  }
+
+  if (!['none', 'isolated', 'multiple', 'sharedCorridor'].includes(input.nearbyForeignStructures)) {
+    errors.push('nearbyForeignStructures must be a supported risk value.');
+  }
+
+  if (!['none', 'regional', 'nearby', 'parallelReturn'].includes(input.dcTractionSystem)) {
+    errors.push('dcTractionSystem must be a supported risk value.');
+  }
+
+  if (!['none', 'possible', 'confirmed', 'severe'].includes(input.knownInterferenceSources)) {
+    errors.push('knownInterferenceSources must be a supported risk value.');
+  }
+
+  if (!['baseline', 'enhanced', 'critical'].includes(input.mitigationProfile)) {
+    errors.push('mitigationProfile must be baseline, enhanced, or critical.');
   }
 
   return errors;
@@ -522,6 +548,7 @@ function readFormInputs() {
   const anodeBurialDepthInput = getNumber('anode-burial-depth');
   const zoneResistivityRaw = getValue('zone-resistivity-values');
   const parsedZoneResistivityValues = parseZoneResistivityValues(zoneResistivityRaw);
+  const mitigationActions = parseMitigationActions(getValue('mitigation-actions'));
   const zoneResistivityTokens = String(zoneResistivityRaw ?? '')
     .split(',')
     .map((token) => token.trim())
@@ -558,6 +585,13 @@ function readFormInputs() {
     simulatedPolarizationShiftMv: getNumber('simulated-polarization-shift'),
     testPointCount: Math.round(getNumber('test-point-count')),
     passingTestPointCount: Math.round(getNumber('test-point-pass-count')),
+    nearbyForeignStructures: getValue('nearby-foreign-structures'),
+    dcTractionSystem: getValue('dc-traction-system'),
+    knownInterferenceSources: getValue('known-interference-sources'),
+    mitigationProfile: getValue('mitigation-profile'),
+    mitigationActions,
+    mitigationActionsText: getValue('mitigation-actions'),
+    verificationTestDate: getValue('verification-test-date'),
     units: isMetric ? 'metric' : 'imperial'
   };
 }
@@ -571,6 +605,12 @@ function renderResults(result, root) {
   const criteriaEvidence = result.criteriaCheckEvidence || {};
   const criteriaSet = criteriaEvidence.selectedCriteriaSet;
   const criteriaRows = Array.isArray(criteriaEvidence.criteriaResults) ? criteriaEvidence.criteriaResults : [];
+  const interference = result.interferenceAssessment || {};
+  const riskFactorRows = Array.isArray(interference.riskFactorScores) ? interference.riskFactorScores : [];
+  const riskBadgeClass = interference.riskLevel === 'high'
+    ? 'result-badge--fail'
+    : (interference.riskLevel === 'medium' ? 'result-badge--not-run' : 'result-badge--pass');
+  const unresolvedHighRisk = interference.unresolvedHighRisk === true;
   const criteriaStatusLabel = criteriaEvidence.overallStatus === 'pass'
     ? 'Pass'
     : (criteriaEvidence.overallStatus === 'fail' ? 'Fail' : 'Not run');
@@ -637,6 +677,8 @@ function renderResults(result, root) {
             <tr><td>Measured instant-off potential</td><td>${result.measuredInstantOffPotentialMv} mV</td></tr>
             <tr><td>Simulated polarization shift</td><td>${result.simulatedPolarizationShiftMv} mV</td></tr>
             <tr><td>Test points passing</td><td>${result.passingTestPointCount} / ${result.testPointCount}</td></tr>
+            <tr><td>Interference mitigation actions</td><td>${escapeHtml(result.mitigationActionsText || 'Not provided')}</td></tr>
+            <tr><td>Verification test date</td><td>${escapeHtml(result.verificationTestDate || 'Not scheduled')}</td></tr>
           </tbody>
         </table>
       </div>
@@ -661,6 +703,35 @@ function renderResults(result, root) {
             </tbody>
           </table>
         </div>
+      </div>
+
+      <div class="result-group" aria-label="Interference assessment results">
+        <h3>Interference Assessment</h3>
+        <div class="result-badge ${riskBadgeClass}">
+          ${escapeHtml(String(interference.riskLevel || 'low').toUpperCase())} risk (score: ${Number.isFinite(interference.score) ? interference.score : 0})
+        </div>
+        <p class="field-hint">Mitigation profile: ${escapeHtml(interference.profile?.label || 'Baseline mitigation profile')}</p>
+        <p class="field-hint">Verification test date: ${escapeHtml(interference.verificationTestDate || 'Not scheduled')}</p>
+        ${unresolvedHighRisk ? '<p class="field-hint"><strong>High-risk case remains unresolved and blocks compliant status until missing mitigations and verification are completed.</strong></p>' : ''}
+        <div class="table-wrap">
+          <table class="data-table" aria-label="Interference risk factors">
+            <thead><tr><th>Factor</th><th>Input</th><th>Score</th></tr></thead>
+            <tbody>
+              ${riskFactorRows.map((factor) => `
+                <tr>
+                  <td>${escapeHtml(factor.label)}</td>
+                  <td>${escapeHtml(factor.value)}</td>
+                  <td>${escapeHtml(String(factor.score))}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+        <p class="field-hint">Required mitigations: ${escapeHtml((interference.requiredMitigations || []).join(', ') || 'None')}</p>
+        <p class="field-hint">Implemented mitigations: ${escapeHtml((interference.mitigationActions || []).join(', ') || 'None')}</p>
+        ${(interference.missingMitigations || []).length
+          ? `<p class="field-hint">Missing mitigations: ${escapeHtml(interference.missingMitigations.join(', '))}</p>`
+          : '<p class="field-hint">No missing mitigations for selected profile.</p>'}
       </div>
 
       ${sensitivityRows.length ? `
@@ -774,7 +845,8 @@ function renderCalculationBasis(root, basis) {
     basis.currentDensitySelection,
     basis.polarizationCriteria,
     basis.anodeCapacityUtilization,
-    basis.engineeringJudgmentAssumptions
+    basis.engineeringJudgmentAssumptions,
+    basis.interferenceAssessment
   ].filter(Boolean);
 
   root.innerHTML = `
@@ -817,8 +889,12 @@ function renderComplianceStatusPanel(root, requiredChecks = {}, lastEvaluatedAt 
     fail: 'Fail',
     'not-run': 'Not run'
   };
+  const overallCompliant = rows.every((row) => row.status === 'pass');
+  const overallBadgeClass = overallCompliant ? 'result-badge--pass' : 'result-badge--fail';
+  const overallBadgeText = overallCompliant ? 'Compliant' : 'Not compliant';
 
   root.innerHTML = `
+    <div class="result-badge ${overallBadgeClass}">${overallBadgeText}</div>
     <div class="table-wrap">
       <table class="data-table" aria-label="Cathodic protection required compliance checks">
         <thead><tr><th>Required check</th><th>Status</th></tr></thead>

--- a/src/studies/cp/interferenceAssessment.js
+++ b/src/studies/cp/interferenceAssessment.js
@@ -1,0 +1,109 @@
+const RISK_WEIGHTS = {
+  nearbyForeignStructures: {
+    none: 0,
+    isolated: 2,
+    multiple: 4,
+    sharedCorridor: 6
+  },
+  dcTractionSystem: {
+    none: 0,
+    regional: 3,
+    nearby: 5,
+    parallelReturn: 7
+  },
+  knownInterferenceSources: {
+    none: 0,
+    possible: 2,
+    confirmed: 5,
+    severe: 7
+  }
+};
+
+const MITIGATION_PROFILES = {
+  baseline: {
+    id: 'baseline',
+    label: 'Baseline mitigation profile',
+    requiredMitigations: ['baseline survey', 'test station checks']
+  },
+  enhanced: {
+    id: 'enhanced',
+    label: 'Enhanced mitigation profile',
+    requiredMitigations: ['baseline survey', 'test station checks', 'bonding review', 'drainage design review']
+  },
+  critical: {
+    id: 'critical',
+    label: 'Critical interference mitigation profile',
+    requiredMitigations: ['baseline survey', 'test station checks', 'bonding review', 'drainage design review', 'traction coordination', 'continuous monitoring coupons']
+  }
+};
+
+function normalizeToken(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+export function parseMitigationActions(rawInput) {
+  return String(rawInput || '')
+    .split(/\r?\n|,/)
+    .map((token) => normalizeToken(token))
+    .filter((token) => token.length > 0);
+}
+
+export function evaluateInterferenceAssessment(input) {
+  const nearbyForeignStructures = input.nearbyForeignStructures || 'none';
+  const dcTractionSystem = input.dcTractionSystem || 'none';
+  const knownInterferenceSources = input.knownInterferenceSources || 'none';
+  const mitigationProfileId = input.mitigationProfile || 'baseline';
+  const mitigationProfile = MITIGATION_PROFILES[mitigationProfileId] || MITIGATION_PROFILES.baseline;
+  const mitigationActions = Array.isArray(input.mitigationActions)
+    ? input.mitigationActions.map((action) => normalizeToken(action)).filter((action) => action.length > 0)
+    : [];
+  const verificationTestDate = typeof input.verificationTestDate === 'string'
+    ? input.verificationTestDate
+    : '';
+
+  const riskFactorScores = [
+    {
+      key: 'nearbyForeignStructures',
+      label: 'Nearby foreign structures',
+      value: nearbyForeignStructures,
+      score: RISK_WEIGHTS.nearbyForeignStructures[nearbyForeignStructures] ?? 0
+    },
+    {
+      key: 'dcTractionSystem',
+      label: 'DC traction systems',
+      value: dcTractionSystem,
+      score: RISK_WEIGHTS.dcTractionSystem[dcTractionSystem] ?? 0
+    },
+    {
+      key: 'knownInterferenceSources',
+      label: 'Known interference sources',
+      value: knownInterferenceSources,
+      score: RISK_WEIGHTS.knownInterferenceSources[knownInterferenceSources] ?? 0
+    }
+  ];
+
+  const totalScore = riskFactorScores.reduce((sum, factor) => sum + factor.score, 0);
+  const riskLevel = totalScore >= 13 ? 'high' : (totalScore >= 6 ? 'medium' : 'low');
+  const requiredMitigations = mitigationProfile.requiredMitigations;
+  const missingMitigations = requiredMitigations.filter((requiredAction) => !mitigationActions.includes(requiredAction));
+  const verificationDateValid = /^\d{4}-\d{2}-\d{2}$/.test(verificationTestDate);
+  const unresolvedHighRisk = riskLevel === 'high' && (missingMitigations.length > 0 || !verificationDateValid);
+
+  return {
+    profile: {
+      id: mitigationProfile.id,
+      label: mitigationProfile.label
+    },
+    score: totalScore,
+    riskLevel,
+    riskFactorScores,
+    requiredMitigations,
+    mitigationActions,
+    missingMitigations,
+    verificationTestDate: verificationTestDate || null,
+    verificationDateValid,
+    unresolvedHighRisk
+  };
+}

--- a/src/studies/cp/standardsProfile.js
+++ b/src/studies/cp/standardsProfile.js
@@ -66,8 +66,8 @@ export const CP_STANDARDS_PROFILE = {
     interferenceAssessment: {
       key: 'interferenceAssessment',
       label: 'Interference assessment',
-      required: false,
-      description: 'Optional review for stray-current and foreign structure interference.'
+      required: true,
+      description: 'Stray-current and foreign structure interference risk is assessed and unresolved high-risk cases are mitigated.'
     }
   },
   deliverables: {
@@ -110,13 +110,23 @@ export function getSelectedProtectionCriteriaSet(profile = CP_STANDARDS_PROFILE)
 }
 
 export function evaluateComplianceChecks(result) {
+  const criteriaStatus = result.criteriaCheckEvidence?.overallStatus || 'fail';
+  const interferenceAssessment = result.interferenceAssessment || {};
+  const hasVerificationDate = Boolean(interferenceAssessment.verificationTestDate);
+  const hasMitigationActions = Array.isArray(interferenceAssessment.mitigationActions)
+    && interferenceAssessment.mitigationActions.length > 0;
+  const unresolvedHighRisk = interferenceAssessment.unresolvedHighRisk === true;
+
   const checks = {
     ...buildInitialComplianceStatus(),
     currentDensitySelection: Number.isFinite(result.designCurrentDensityMaM2) && result.designCurrentDensityMaM2 > 0 ? 'pass' : 'fail',
     anodeMassSizing: Number.isFinite(result.minimumAnodeMassKg) && result.minimumAnodeMassKg > 0 ? 'pass' : 'fail',
     targetLifeVerification: Number.isFinite(result.safetyMarginYears)
       ? (result.safetyMarginYears >= 0 ? 'pass' : 'fail')
-      : 'fail'
+      : 'fail',
+    commissioningChecksDefined: criteriaStatus === 'pass' && hasVerificationDate ? 'pass' : 'fail',
+    monitoringPlanDefined: hasMitigationActions ? 'pass' : 'fail',
+    interferenceAssessment: unresolvedHighRisk ? 'fail' : 'pass'
   };
 
   return checks;


### PR DESCRIPTION
### Motivation
- Introduce a stray-current / interference screening to capture risk from nearby foreign structures, DC traction systems, and known interference sources for buried metallic assets. 
- Provide an auditable, scored risk model with profile-driven mitigations so high-risk cases require mitigation and verification before a study is considered compliant.

### Description
- Added a new browser input section in `cathodicprotection.html` to capture `nearbyForeignStructures`, `dcTractionSystem`, `knownInterferenceSources`, `mitigationProfile`, `mitigationActions`, and `verificationTestDate`.
- Implemented `src/studies/cp/interferenceAssessment.js` which parses mitigation actions, scores weighted risk factors, classifies `low`/`medium`/`high`, defines mitigation profiles (`baseline`/`enhanced`/`critical`), and marks unresolved high-risk cases when required mitigations or verification are missing.
- Wired the assessment into analysis and UI by calling `evaluateInterferenceAssessment` from `runCathodicProtectionAnalysis`, storing `interferenceAssessment` in study results, rendering an Interference Assessment block and report fields (mitigations + verification date) in the results view, and parsing mitigation actions via `parseMitigationActions`.
- Updated `src/studies/cp/standardsProfile.js` to require `interferenceAssessment` and extended `evaluateComplianceChecks` so unresolved high-risk interference causes the `interferenceAssessment` required check to `fail` and affects overall compliance panel which now displays a `Compliant` / `Not compliant` badge.

### Testing
- Ran `npm test` and the test suite completed successfully (unit/integration tests passed in the project test run).
- Ran `npm run build` which completed; Rollup emitted existing repository warnings about unresolved/missing exports unrelated to these changes but build finished.
- Attempted to generate a webpage preview with Playwright (`npx playwright screenshot`) but the automated browser download/install failed in this environment; `npx playwright install chromium` returned a network/403 error so no screenshot artifact was produced.
- All automated unit tests exercised by `npm test` passed; UI preview step failed due to Playwright browser availability rather than code errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e049d8ccac8324a48c8686ef0b98d5)