### PR TITLE
Add CP measurement metadata and correction-aware criteria reporting

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -265,7 +265,52 @@ Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
         <fieldset>
           <legend><strong>Protection Criteria Evidence Inputs</strong></legend>
           <div class="field-row">
-            <label for="measured-off-potential">Measured instant-off potential (mV vs CSE)</label>
+            <label for="test-method">Test method</label>
+            <select id="test-method" required>
+              <option value="instant-off" selected>Instant-off interrupter</option>
+              <option value="on-potential">On-potential with IR correction</option>
+              <option value="coupon">Coupon depolarization</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="measurement-context">Measurement context</label>
+            <select id="measurement-context" required>
+              <option value="native-soil" selected>Native soil (typical route)</option>
+              <option value="casing">Cased crossing / shielding concern</option>
+              <option value="foreign-interference">Foreign structure / interference zone</option>
+              <option value="test-station">Dedicated test station</option>
+              <option value="unknown">Unknown / not documented</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="reference-electrode-location">Reference electrode location</label>
+            <select id="reference-electrode-location" required>
+              <option value="local" selected>Local over structure (close-coupled)</option>
+              <option value="remote">Remote / gradient-influenced</option>
+              <option value="coupon-lead">Coupon lead reference</option>
+              <option value="unknown">Unknown / not documented</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="ir-drop-compensation-method">IR-drop compensation method</label>
+            <select id="ir-drop-compensation-method" required>
+              <option value="instant-off" selected>Instant-off interruption</option>
+              <option value="coupon">Coupon depolarization</option>
+              <option value="calculated">Calculated from current/resistance</option>
+              <option value="none">None</option>
+              <option value="unknown">Unknown</option>
+            </select>
+          </div>
+          <div class="field-row">
+            <label for="measured-ir-drop">Measured/estimated IR-drop magnitude (mV)</label>
+            <input type="number" id="measured-ir-drop" min="0" step="1" value="0">
+          </div>
+          <div class="field-row">
+            <label for="coupon-depolarization">Coupon depolarization shift (mV)</label>
+            <input type="number" id="coupon-depolarization" min="0" step="1" value="0">
+          </div>
+          <div class="field-row">
+            <label for="measured-off-potential">Measured structure potential (mV vs CSE)</label>
             <input type="number" id="measured-off-potential" step="1" value="-900" required>
           </div>
           <div class="field-row">

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -140,6 +140,9 @@ export function runCathodicProtectionAnalysis(input) {
   );
   const criteriaCheckEvidence = evaluateCriteriaChecks(input, CP_STANDARDS_PROFILE);
   const interferenceAssessment = evaluateInterferenceAssessment(input);
+  const measurementMetadataWarnings = Array.isArray(criteriaCheckEvidence?.measurementCorrections?.warnings)
+    ? criteriaCheckEvidence.measurementCorrections.warnings
+    : [];
 
   return {
     ...input,
@@ -163,6 +166,7 @@ export function runCathodicProtectionAnalysis(input) {
     safetyMarginYears: roundTo(predictedLifeYears - input.targetLifeYears, 2),
     safetyMarginPercent: roundTo(((predictedLifeYears - input.targetLifeYears) / input.targetLifeYears) * 100, 1),
     criteriaCheckEvidence,
+    measurementMetadataWarnings,
     interferenceAssessment,
     sensitivity: buildSensitivitySummary({
       input,
@@ -296,6 +300,30 @@ function validateInputs(input) {
 
   if (!['baseline', 'enhanced', 'critical'].includes(input.mitigationProfile)) {
     errors.push('mitigationProfile must be baseline, enhanced, or critical.');
+  }
+
+  if (!['instant-off', 'on-potential', 'coupon'].includes(input.testMethod)) {
+    errors.push('testMethod must be instant-off, on-potential, or coupon.');
+  }
+
+  if (!['native-soil', 'casing', 'foreign-interference', 'test-station', 'unknown'].includes(input.measurementContext)) {
+    errors.push('measurementContext must be a supported option.');
+  }
+
+  if (!['local', 'remote', 'coupon-lead', 'unknown'].includes(input.referenceElectrodeLocation)) {
+    errors.push('referenceElectrodeLocation must be a supported option.');
+  }
+
+  if (!['instant-off', 'coupon', 'calculated', 'none', 'unknown'].includes(input.irDropCompensationMethod)) {
+    errors.push('irDropCompensationMethod must be a supported option.');
+  }
+
+  if (Number.isFinite(input.measuredIrDropMv) && input.measuredIrDropMv < 0) {
+    errors.push('measuredIrDropMv cannot be negative.');
+  }
+
+  if (Number.isFinite(input.couponDepolarizationMv) && input.couponDepolarizationMv < 0) {
+    errors.push('couponDepolarizationMv cannot be negative.');
   }
 
   return errors;
@@ -581,6 +609,12 @@ function readFormInputs() {
     anodeBurialDepthM: isMetric ? anodeBurialDepthInput : anodeBurialDepthInput * FT_TO_M,
     zoneResistivityOhmM: parsedZoneResistivityValues,
     zoneResistivityInputValid,
+    testMethod: getValue('test-method'),
+    measurementContext: getValue('measurement-context'),
+    referenceElectrodeLocation: getValue('reference-electrode-location'),
+    irDropCompensationMethod: getValue('ir-drop-compensation-method'),
+    measuredIrDropMv: getNumber('measured-ir-drop'),
+    couponDepolarizationMv: getNumber('coupon-depolarization'),
     measuredInstantOffPotentialMv: getNumber('measured-off-potential'),
     simulatedPolarizationShiftMv: getNumber('simulated-polarization-shift'),
     testPointCount: Math.round(getNumber('test-point-count')),
@@ -605,6 +639,8 @@ function renderResults(result, root) {
   const criteriaEvidence = result.criteriaCheckEvidence || {};
   const criteriaSet = criteriaEvidence.selectedCriteriaSet;
   const criteriaRows = Array.isArray(criteriaEvidence.criteriaResults) ? criteriaEvidence.criteriaResults : [];
+  const measurementCorrections = criteriaEvidence.measurementCorrections || {};
+  const measurementWarnings = Array.isArray(result.measurementMetadataWarnings) ? result.measurementMetadataWarnings : [];
   const interference = result.interferenceAssessment || {};
   const riskFactorRows = Array.isArray(interference.riskFactorScores) ? interference.riskFactorScores : [];
   const riskBadgeClass = interference.riskLevel === 'high'
@@ -674,8 +710,14 @@ function renderResults(result, root) {
             <tr><td>Anode utilization factor U</td><td>${result.anodeUtilization}</td></tr>
             <tr><td>Design factor F<sub>design</sub></td><td>${result.designFactor}</td></tr>
             <tr><td>Availability factor</td><td>${result.availabilityFactor}</td></tr>
-            <tr><td>Measured instant-off potential</td><td>${result.measuredInstantOffPotentialMv} mV</td></tr>
-            <tr><td>Simulated polarization shift</td><td>${result.simulatedPolarizationShiftMv} mV</td></tr>
+            <tr><td>Test method</td><td>${escapeHtml(result.testMethod || 'instant-off')}</td></tr>
+            <tr><td>Measurement context</td><td>${escapeHtml(result.measurementContext || 'unknown')}</td></tr>
+            <tr><td>Reference electrode location</td><td>${escapeHtml(result.referenceElectrodeLocation || 'unknown')}</td></tr>
+            <tr><td>IR-drop compensation method</td><td>${escapeHtml(result.irDropCompensationMethod || 'unknown')}</td></tr>
+            <tr><td>Measured IR-drop</td><td>${Number.isFinite(result.measuredIrDropMv) ? `${result.measuredIrDropMv} mV` : 'Not provided'}</td></tr>
+            <tr><td>Coupon depolarization</td><td>${Number.isFinite(result.couponDepolarizationMv) ? `${result.couponDepolarizationMv} mV` : 'Not provided'}</td></tr>
+            <tr><td>Measured structure potential</td><td>${result.measuredInstantOffPotentialMv} mV</td></tr>
+            <tr><td>Measured/simulated polarization shift</td><td>${result.simulatedPolarizationShiftMv} mV</td></tr>
             <tr><td>Test points passing</td><td>${result.passingTestPointCount} / ${result.testPointCount}</td></tr>
             <tr><td>Interference mitigation actions</td><td>${escapeHtml(result.mitigationActionsText || 'Not provided')}</td></tr>
             <tr><td>Verification test date</td><td>${escapeHtml(result.verificationTestDate || 'Not scheduled')}</td></tr>
@@ -686,18 +728,21 @@ function renderResults(result, root) {
       <div class="result-group" aria-label="Protection criteria check evidence">
         <h3>Protection Criteria Check Evidence</h3>
         <p class="field-hint">Criteria selected: ${escapeHtml(criteriaSet?.label || 'Not configured')} (${escapeHtml(criteriaSet?.reference || 'No reference')})</p>
-        <p class="field-hint">Data used: instant-off ${result.measuredInstantOffPotentialMv} mV, polarization shift ${result.simulatedPolarizationShiftMv} mV, test points ${result.passingTestPointCount}/${result.testPointCount} passing.</p>
+        <p class="field-hint">Measurement basis: method ${escapeHtml(measurementCorrections.metadata?.testMethod || result.testMethod || 'instant-off')}, context ${escapeHtml(measurementCorrections.metadata?.measurementContext || result.measurementContext || 'unknown')}, reference ${escapeHtml(measurementCorrections.metadata?.referenceElectrodeLocation || result.referenceElectrodeLocation || 'unknown')}.</p>
+        <p class="field-hint">Correction summary: ${escapeHtml(measurementCorrections.correctionSummary || 'No correction summary provided.')}</p>
         <div class="result-badge ${criteriaStatusClass}">${criteriaStatusLabel}: criteria set evaluation</div>
+        ${measurementWarnings.length ? `<p class="field-hint"><strong>Validation warnings:</strong> ${escapeHtml(measurementWarnings.join(' | '))}</p>` : '<p class="field-hint">Validation warnings: none.</p>'}
         <div class="table-wrap">
           <table class="data-table" aria-label="Protection criteria pass fail table">
-            <thead><tr><th>Criterion</th><th>Requirement</th><th>Observed data</th><th>Status</th></tr></thead>
+            <thead><tr><th>Criterion</th><th>Requirement</th><th>Raw value</th><th>Corrected value</th><th>Acceptance decision</th></tr></thead>
             <tbody>
               ${criteriaRows.map((criterion) => `
                 <tr>
                   <td>${escapeHtml(criterion.label)}</td>
                   <td>${escapeHtml(criterion.requirement)}</td>
-                  <td>${escapeHtml(criterion.observedValue)}</td>
-                  <td>${criterion.status === 'pass' ? 'Pass' : 'Fail'}</td>
+                  <td>${escapeHtml(criterion.rawValue || criterion.observedValue || 'n/a')}</td>
+                  <td>${escapeHtml(criterion.correctedValue || criterion.observedValue || 'n/a')}</td>
+                  <td>${escapeHtml(criterion.decision || (criterion.status === 'pass' ? 'Pass' : 'Fail'))}</td>
                 </tr>
               `).join('')}
             </tbody>

--- a/docs/cathodic_protection.md
+++ b/docs/cathodic_protection.md
@@ -24,6 +24,13 @@ This guide documents the engineering basis used by the Cathodic Protection sizin
 | Target design life | L<sub>target</sub> | years | Converted internally to hours (`years × 8760`). |
 | Installed anode mass | M<sub>inst</sub> | kg | Used for predicted-life calculation. |
 
+| Test method | — | categorical | `instant-off`, `on-potential`, or `coupon`; defines correction path for acceptance checks. |
+| Measurement context | — | categorical | Captures environment at test location (`native-soil`, `casing`, `foreign-interference`, etc.). |
+| Reference electrode location | — | categorical | Records whether reference placement is local, remote, coupon lead, or unknown. |
+| IR-drop compensation method | — | categorical | Documents compensation source (`instant-off`, `coupon`, `calculated`, `none`, `unknown`). |
+| Measured IR-drop magnitude | ΔV<sub>IR</sub> | mV | Used to normalize ON-potential readings when provided. |
+| Coupon depolarization shift | ΔV<sub>coupon</sub> | mV | Used for coupon-based normalization and polarization substitution when needed. |
+
 ## Equations Used
 
 ### 1) Current density selection
@@ -72,6 +79,17 @@ L<sub>pred</sub> = (M<sub>inst</sub> × C<sub>a</sub> × u × F<sub>d</sub>) / (
 - Safety margin (years) = `L_pred − L_target`
 - Safety margin (%) = `(L_pred − L_target) / L_target × 100`
 
+
+### 7) Measurement correction and criteria normalization
+
+Acceptance checks now evaluate **corrected** values and retain raw values in output:
+
+- For `on-potential` tests with supplied IR drop: `V_corrected = V_raw + |ΔV_IR|`
+- For `coupon` tests with supplied depolarization: `V_corrected = V_raw + |ΔV_coupon|`
+- For coupon workflows with missing explicit polarization shift, the shift defaults to `|ΔV_coupon|`
+
+When required metadata is missing (unknown context/location, no compensation value for ON/coupon methods, or compensation explicitly set to `none`), the study reports validation warnings so acceptance decisions can be reviewed with caution.
+
 ## Assumptions and Limits
 
 - Intended for preliminary CP sizing and scoping studies, not detailed final design.
@@ -103,5 +121,6 @@ The CP study now includes a standards profile and auditable compliance status mo
 
 ## Revision Notes
 
+- **2026-04-16:** Added measurement metadata inputs (test method/context/reference location), implemented correction-aware criteria normalization, separated raw vs corrected acceptance outputs, and added metadata sufficiency warnings in results.
 - **2026-04-16:** Added standards profile configuration, machine-readable required-check keys in CP basis mapping, compliance status panel, and persisted compliance history snapshots.
 - **2026-04-15:** Initial documentation page added for CP sizing inputs, equations, assumptions/limits, references, and consistency guidance between required-mass and predicted-life relations.

--- a/src/studies/cp/criteriaChecks.js
+++ b/src/studies/cp/criteriaChecks.js
@@ -1,7 +1,12 @@
 import { getSelectedProtectionCriteriaSet } from './standardsProfile.js';
+import { applyMeasurementCorrections } from './measurementCorrections.js';
 
 function toCheckStatus(isPassing) {
   return isPassing ? 'pass' : 'fail';
+}
+
+function toDecisionLabel(status) {
+  return status === 'pass' ? 'Pass' : 'Fail';
 }
 
 export function evaluateCriteriaChecks(input, standardsProfile) {
@@ -9,21 +14,31 @@ export function evaluateCriteriaChecks(input, standardsProfile) {
   if (!selectedCriteriaSet) {
     return {
       selectedCriteriaSet: null,
+      measurementCorrections: null,
       dataUsed: {},
       criteriaResults: [],
       overallStatus: 'fail'
     };
   }
 
+  const measurementCorrections = applyMeasurementCorrections(input);
   const dataUsed = {
     measuredInstantOffPotentialMv: input.measuredInstantOffPotentialMv,
+    correctedInstantOffPotentialMv: measurementCorrections.correctedValues.instantOffPotentialMv,
     simulatedPolarizationShiftMv: input.simulatedPolarizationShiftMv,
+    correctedPolarizationShiftMv: measurementCorrections.correctedValues.polarizationShiftMv,
     testPointCount: input.testPointCount,
-    passingTestPointCount: input.passingTestPointCount
+    passingTestPointCount: input.passingTestPointCount,
+    testMethod: measurementCorrections.metadata.testMethod,
+    measurementContext: measurementCorrections.metadata.measurementContext,
+    referenceElectrodeLocation: measurementCorrections.metadata.referenceElectrodeLocation,
+    irDropCompensationMethod: measurementCorrections.metadata.irDropCompensationMethod
   };
 
-  const instantOffPass = Number.isFinite(dataUsed.measuredInstantOffPotentialMv) && dataUsed.measuredInstantOffPotentialMv <= -850;
-  const polarizationPass = Number.isFinite(dataUsed.simulatedPolarizationShiftMv) && dataUsed.simulatedPolarizationShiftMv >= 100;
+  const instantOffPass = Number.isFinite(dataUsed.correctedInstantOffPotentialMv)
+    && dataUsed.correctedInstantOffPotentialMv <= -850;
+  const polarizationPass = Number.isFinite(dataUsed.correctedPolarizationShiftMv)
+    && dataUsed.correctedPolarizationShiftMv >= 100;
   const coveragePass = Number.isInteger(dataUsed.testPointCount)
     && Number.isInteger(dataUsed.passingTestPointCount)
     && dataUsed.testPointCount > 0
@@ -33,22 +48,28 @@ export function evaluateCriteriaChecks(input, standardsProfile) {
     {
       key: 'instantOffPotential',
       label: 'Instant-off potential criterion',
-      requirement: 'Measured instant-off potential ≤ -850 mV (CSE)',
-      observedValue: `${dataUsed.measuredInstantOffPotentialMv} mV`,
+      requirement: 'Corrected instant-off potential ≤ -850 mV (CSE)',
+      rawValue: `${dataUsed.measuredInstantOffPotentialMv} mV`,
+      correctedValue: `${dataUsed.correctedInstantOffPotentialMv} mV`,
+      decision: toDecisionLabel(toCheckStatus(instantOffPass)),
       status: toCheckStatus(instantOffPass)
     },
     {
       key: 'polarizationShift',
       label: 'Polarization criterion',
-      requirement: 'Measured/simulated polarization shift ≥ 100 mV',
-      observedValue: `${dataUsed.simulatedPolarizationShiftMv} mV`,
+      requirement: 'Corrected polarization shift ≥ 100 mV',
+      rawValue: `${dataUsed.simulatedPolarizationShiftMv} mV`,
+      correctedValue: `${dataUsed.correctedPolarizationShiftMv} mV`,
+      decision: toDecisionLabel(toCheckStatus(polarizationPass)),
       status: toCheckStatus(polarizationPass)
     },
     {
       key: 'testPointCoverage',
       label: 'Test-point coverage criterion',
       requirement: 'All reported test points satisfy selected criteria',
-      observedValue: `${dataUsed.passingTestPointCount} / ${dataUsed.testPointCount} points pass`,
+      rawValue: `${dataUsed.passingTestPointCount} / ${dataUsed.testPointCount} points pass`,
+      correctedValue: `${dataUsed.passingTestPointCount} / ${dataUsed.testPointCount} points pass`,
+      decision: toDecisionLabel(toCheckStatus(coveragePass)),
       status: toCheckStatus(coveragePass)
     }
   ];
@@ -61,6 +82,7 @@ export function evaluateCriteriaChecks(input, standardsProfile) {
       label: selectedCriteriaSet.label,
       reference: selectedCriteriaSet.reference
     },
+    measurementCorrections,
     dataUsed,
     criteriaResults,
     overallStatus

--- a/src/studies/cp/measurementCorrections.js
+++ b/src/studies/cp/measurementCorrections.js
@@ -1,0 +1,96 @@
+function asFiniteNumber(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+function normalizeText(value, fallback = 'unknown') {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const normalized = value.trim();
+  return normalized.length ? normalized : fallback;
+}
+
+function formatPotential(value) {
+  if (!Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return `${value} mV`;
+}
+
+export function applyMeasurementCorrections(input) {
+  const rawInstantOffPotentialMv = asFiniteNumber(input.measuredInstantOffPotentialMv);
+  const rawPolarizationShiftMv = asFiniteNumber(input.simulatedPolarizationShiftMv);
+  const measuredIrDropMv = asFiniteNumber(input.measuredIrDropMv);
+  const couponDepolarizationMv = asFiniteNumber(input.couponDepolarizationMv);
+  const testMethod = normalizeText(input.testMethod, 'instant-off');
+  const measurementContext = normalizeText(input.measurementContext);
+  const referenceElectrodeLocation = normalizeText(input.referenceElectrodeLocation);
+  const irDropCompensationMethod = normalizeText(input.irDropCompensationMethod);
+
+  const warnings = [];
+
+  let correctedInstantOffPotentialMv = rawInstantOffPotentialMv;
+  let correctionSummary = 'No correction applied (instant-off measurement basis).';
+
+  if (testMethod === 'on-potential') {
+    if (Number.isFinite(rawInstantOffPotentialMv) && Number.isFinite(measuredIrDropMv)) {
+      correctedInstantOffPotentialMv = rawInstantOffPotentialMv + Math.abs(measuredIrDropMv);
+      correctionSummary = `IR-drop normalization applied from ON potential using +${Math.abs(measuredIrDropMv)} mV.`;
+    } else {
+      warnings.push('ON-potential method selected without measured IR-drop compensation value; potential is treated as uncorrected.');
+    }
+  }
+
+  if (testMethod === 'coupon') {
+    if (Number.isFinite(rawInstantOffPotentialMv) && Number.isFinite(couponDepolarizationMv)) {
+      correctedInstantOffPotentialMv = rawInstantOffPotentialMv + Math.abs(couponDepolarizationMv);
+      correctionSummary = `Coupon depolarization normalization applied using +${Math.abs(couponDepolarizationMv)} mV.`;
+    } else {
+      warnings.push('Coupon method selected without coupon depolarization data; potential is treated as uncorrected.');
+    }
+  }
+
+  let correctedPolarizationShiftMv = rawPolarizationShiftMv;
+  if (testMethod === 'coupon' && Number.isFinite(couponDepolarizationMv) && !Number.isFinite(rawPolarizationShiftMv)) {
+    correctedPolarizationShiftMv = Math.abs(couponDepolarizationMv);
+  }
+
+  if (measurementContext === 'unknown') {
+    warnings.push('Measurement context was not specified; acceptance confidence is reduced.');
+  }
+
+  if (referenceElectrodeLocation === 'unknown') {
+    warnings.push('Reference electrode location was not provided; gradient-related uncertainty cannot be assessed.');
+  }
+
+  if ((testMethod === 'on-potential' || testMethod === 'coupon') && irDropCompensationMethod === 'none') {
+    warnings.push('Selected test method usually requires IR-drop compensation, but compensation method is set to none.');
+  }
+
+  return {
+    metadata: {
+      testMethod,
+      measurementContext,
+      referenceElectrodeLocation,
+      irDropCompensationMethod
+    },
+    rawValues: {
+      instantOffPotentialMv: rawInstantOffPotentialMv,
+      polarizationShiftMv: rawPolarizationShiftMv,
+      measuredIrDropMv,
+      couponDepolarizationMv
+    },
+    correctedValues: {
+      instantOffPotentialMv: correctedInstantOffPotentialMv,
+      polarizationShiftMv: correctedPolarizationShiftMv
+    },
+    correctionSummary,
+    warnings,
+    formatted: {
+      rawInstantOffPotential: formatPotential(rawInstantOffPotentialMv),
+      correctedInstantOffPotential: formatPotential(correctedInstantOffPotentialMv),
+      rawPolarizationShift: formatPotential(rawPolarizationShiftMv),
+      correctedPolarizationShift: formatPotential(correctedPolarizationShiftMv)
+    }
+  };
+}


### PR DESCRIPTION
### Motivation
- Capture richer cathodic protection (CP) test metadata so acceptance checks can be normalized and reviewed with context-aware confidence.
- Normalize/compensate measured potentials (IR-drop, coupon depolarization) before applying pass/fail rules and report both raw and corrected values for auditability.
- Surface warnings when measurement metadata is insufficient so reviewers can treat automated decisions with appropriate caution.

### Description
- Added new form inputs to `cathodicprotection.html` for `testMethod`, `measurementContext`, `referenceElectrodeLocation`, `irDropCompensationMethod`, `measuredIrDropMv`, and `couponDepolarizationMv` and wired them into the CP input model via `readFormInputs` (fields preserved in the study result object as `testMethod`, `measurementContext`, `referenceElectrodeLocation`, `irDropCompensationMethod`, `measuredIrDropMv`, and `couponDepolarizationMv`).
- Implemented `src/studies/cp/measurementCorrections.js` with `applyMeasurementCorrections(input)` that normalizes raw potentials into corrected values, produces a `correctionSummary`, formatted strings, and a `warnings` array when metadata is missing or inconsistent.
- Updated criteria evaluation in `src/studies/cp/criteriaChecks.js` to import and use `applyMeasurementCorrections`, evaluate pass/fail on corrected values while preserving raw values, and emit per-criterion `rawValue`, `correctedValue`, and `decision` fields along with the `measurementCorrections` object.
- Updated `cathodicprotection.js` to validate the new metadata fields in `validateInputs`, include metadata in `runCathodicProtectionAnalysis` output (`measurementMetadataWarnings` and `criteriaCheckEvidence.measurementCorrections`), and update `renderResults` to clearly show test basis, correction summary, raw vs corrected values, acceptance decision, and any validation warnings.
- Documented the new inputs and normalization rules in `docs/cathodic_protection.md` (added measurement metadata rows and a section describing the correction/normalization rules).

### Testing
- Ran the full test suite with `npm test` (output stream is large and truncated in this environment), and captured output showed many passing tests with no observed failures during the run.
- Built the distribution with `npm run build` and verified success of the build step.
- Performed a module sanity check with `node --input-type=module -e "import('./src/studies/cp/measurementCorrections.js'); import('./src/studies/cp/criteriaChecks.js');"` which completed successfully.
- Attempted to produce a preview screenshot via Playwright but the environment lacks browser binaries (Playwright failed with `Executable doesn't exist ... run npx playwright install`), so a visual preview could not be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04b52bd6c8324803a3a6dc4e6e094)