### PR TITLE
Add configurable CP coating models and scenario-review sensitivity

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -142,8 +142,32 @@ Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
         <fieldset>
           <legend><strong>Exposure &amp; Current Demand</strong></legend>
           <div class="field-row">
-            <label for="coating-breakdown">Coating breakdown factor (0–1)</label>
+            <label for="coating-model-type">Coating demand model</label>
+            <select id="coating-model-type">
+              <option value="fixed" selected>Fixed factor</option>
+              <option value="degradation-curve">Time-varying degradation curve</option>
+              <option value="segment-condition">Segment-based condition factors</option>
+            </select>
+          </div>
+          <div class="field-row" id="coating-fixed-row">
+            <label for="coating-breakdown">Fixed coating breakdown factor (0–1)</label>
             <input type="number" id="coating-breakdown" min="0" max="1" step="0.01" value="0.20" required>
+          </div>
+          <div class="field-row" data-coating-curve-row hidden>
+            <label for="coating-initial-breakdown">Initial coating breakdown factor (0–1)</label>
+            <input type="number" id="coating-initial-breakdown" min="0" max="1" step="0.01" value="0.12">
+          </div>
+          <div class="field-row" data-coating-curve-row hidden>
+            <label for="coating-eol-breakdown">End-of-life coating breakdown factor (0–1)</label>
+            <input type="number" id="coating-eol-breakdown" min="0" max="1" step="0.01" value="0.35">
+          </div>
+          <div class="field-row" data-coating-curve-row hidden>
+            <label for="coating-degradation-exponent">Degradation curve exponent (&gt;0)</label>
+            <input type="number" id="coating-degradation-exponent" min="0.1" step="0.1" value="1.2">
+          </div>
+          <div class="field-row" id="coating-segment-row" hidden>
+            <label for="segment-condition-factors">Segment condition factors (0–1, comma separated)</label>
+            <input type="text" id="segment-condition-factors" value="0.10, 0.18, 0.32" placeholder="e.g., 0.10, 0.18, 0.32">
           </div>
           <div class="field-row">
             <label for="surface-area-mode">Surface area input method</label>

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -9,6 +9,7 @@ import {
 import { computeDistributionBySegment, parseZoneResistivityValues } from './src/studies/cp/distributionModel.js';
 import { evaluateCriteriaChecks } from './src/studies/cp/criteriaChecks.js';
 import { evaluateInterferenceAssessment, parseMitigationActions } from './src/studies/cp/interferenceAssessment.js';
+import { COATING_MODEL_TYPES, parseConditionFactorValues, resolveCoatingModel } from './src/studies/cp/coatingModel.js';
 
 const SQFT_TO_SQM = 0.09290304;
 const LB_TO_KG = 0.45359237;
@@ -71,7 +72,7 @@ export const CP_STANDARD_BASIS = {
     requiredChecks: ['commissioningChecksDefined', 'monitoringPlanDefined'],
     summary: 'Coating breakdown factor, design factor, and optional temperature correction require project-specific engineering validation.',
     assumptions: [
-      'Coating breakdown factor is selected by expected coating quality, age, and defect distribution.',
+      'Coating demand model is selected by fixed factor, degradation curve, or segment-based condition factors.',
       'Design factor is selected as a reliability margin for uncertainty and lifecycle variability.',
       'Temperature correction is not explicitly modeled in this tool and should be applied by engineering review when needed.'
     ]
@@ -108,8 +109,6 @@ export function runCathodicProtectionAnalysis(input) {
     : lookupCurrentDensity(input.assetType, input.moistureCategory, input.soilResistivityOhmM, input.soilPh, input.pipeMaterial);
 
   const designCurrentDensityAperM2 = designCurrentDensityMaM2 / 1000;
-  const exposedAreaM2 = input.surfaceAreaM2 * input.coatingBreakdownFactor;
-  const areaBasedRequiredCurrentA = calculateRequiredCurrent(exposedAreaM2, designCurrentDensityAperM2);
   const distributionModel = computeDistributionBySegment({
     anodeTypeSystem: input.anodeTypeSystem,
     numberOfAnodes: input.numberOfAnodes,
@@ -119,6 +118,9 @@ export function runCathodicProtectionAnalysis(input) {
     soilResistivityOhmM: input.soilResistivityOhmM,
     zoneResistivityOhmM: input.zoneResistivityOhmM
   });
+  const coatingModel = resolveCoatingModel(input, { segmentCount: distributionModel.segments.length });
+  const exposedAreaM2 = input.surfaceAreaM2 * coatingModel.effectiveFactor;
+  const areaBasedRequiredCurrentA = calculateRequiredCurrent(exposedAreaM2, designCurrentDensityAperM2);
   const distributionAdjustedCurrentA = areaBasedRequiredCurrentA * distributionModel.globalAttenuationFactor;
   const adjustedRequiredCurrentA = distributionAdjustedCurrentA / input.availabilityFactor;
   const designHours = input.targetLifeYears * 8760;
@@ -155,6 +157,8 @@ export function runCathodicProtectionAnalysis(input) {
       safetyMargin: 'Compares predicted life versus target design life using the same protection and anode basis assumptions.'
     },
     designCurrentDensityMaM2: roundTo(designCurrentDensityMaM2, 3),
+    coatingModel,
+    coatingBreakdownFactor: roundTo(coatingModel.effectiveFactor, 4),
     exposedAreaM2: roundTo(exposedAreaM2, 3),
     areaBasedRequiredCurrentA: roundTo(areaBasedRequiredCurrentA, 4),
     distributionAdjustedCurrentA: roundTo(distributionAdjustedCurrentA, 4),
@@ -172,33 +176,80 @@ export function runCathodicProtectionAnalysis(input) {
       input,
       adjustedRequiredCurrentA,
       minimumAnodeMassKg,
-      predictedLifeYears
+      predictedLifeYears,
+      coatingModel,
+      distributionModel
     })
   };
 }
 
-function buildSensitivitySummary({ input, adjustedRequiredCurrentA, minimumAnodeMassKg, predictedLifeYears }) {
+function buildSensitivitySummary({ input, adjustedRequiredCurrentA, minimumAnodeMassKg, predictedLifeYears, coatingModel, distributionModel }) {
+  const uncertainty = coatingModel?.uncertaintyBand || { lowFactor: input.coatingBreakdownFactor, baseFactor: input.coatingBreakdownFactor, highFactor: input.coatingBreakdownFactor };
+  const baseFactor = uncertainty.baseFactor || input.coatingBreakdownFactor;
   const scenarios = [
-    { key: 'base', label: 'Base case', currentMultiplier: 1, requiredMassMultiplier: 1, predictedLifeMultiplier: 1 },
-    { key: 'conservative', label: 'Conservative (+20% demand)', currentMultiplier: 1.2, requiredMassMultiplier: 1.2, predictedLifeMultiplier: 1 / 1.2 },
-    { key: 'optimistic', label: 'Optimistic (-20% demand)', currentMultiplier: 0.8, requiredMassMultiplier: 0.8, predictedLifeMultiplier: 1 / 0.8 }
+    { key: 'low-coating', label: 'Low coating demand band', factor: uncertainty.lowFactor },
+    { key: 'base', label: 'Base case', factor: uncertainty.baseFactor },
+    { key: 'high-coating', label: 'High coating demand band', factor: uncertainty.highFactor }
   ];
+  const segmentDemands = computeWorstCaseSegmentDemand({
+    distributionModel,
+    coatingModel,
+    adjustedRequiredCurrentA,
+    baseFactor
+  });
 
   return scenarios.map((scenario) => {
-    const scenarioCurrentA = adjustedRequiredCurrentA * scenario.currentMultiplier;
-    const scenarioRequiredMassKg = minimumAnodeMassKg * scenario.requiredMassMultiplier;
-    const scenarioPredictedLifeYears = predictedLifeYears * scenario.predictedLifeMultiplier;
+    const currentMultiplier = baseFactor > 0 ? scenario.factor / baseFactor : 1;
+    const scenarioCurrentA = adjustedRequiredCurrentA * currentMultiplier;
+    const scenarioRequiredMassKg = minimumAnodeMassKg * currentMultiplier;
+    const scenarioPredictedLifeYears = predictedLifeYears / currentMultiplier;
     const scenarioSafetyMarginYears = scenarioPredictedLifeYears - input.targetLifeYears;
+    const scenarioWorstCaseSegmentDemandA = segmentDemands.worstCaseSegmentDemandA * currentMultiplier;
+    const approvalStatus = scenarioSafetyMarginYears >= 0 ? 'Approved' : 'Review required';
     return {
       ...scenario,
+      approvalStatus,
+      coatingFactor: roundTo(scenario.factor, 4),
       requiredCurrentA: roundTo(scenarioCurrentA, 4),
       minimumAnodeMassKg: roundTo(scenarioRequiredMassKg, 3),
       minimumAnodeMassLb: roundTo(scenarioRequiredMassKg / LB_TO_KG, 3),
       predictedLifeYears: roundTo(scenarioPredictedLifeYears, 2),
+      worstCaseSegmentDemandA: roundTo(scenarioWorstCaseSegmentDemandA, 4),
+      worstCaseSegmentLabel: segmentDemands.worstCaseSegmentLabel,
       safetyMarginYears: roundTo(scenarioSafetyMarginYears, 2),
       safetyMarginPercent: roundTo((scenarioSafetyMarginYears / input.targetLifeYears) * 100, 1)
     };
   });
+}
+
+function computeWorstCaseSegmentDemand({ distributionModel, coatingModel, adjustedRequiredCurrentA, baseFactor }) {
+  const segments = Array.isArray(distributionModel?.segments) ? distributionModel.segments : [];
+  if (!segments.length) {
+    return { worstCaseSegmentDemandA: adjustedRequiredCurrentA, worstCaseSegmentLabel: 'Segment 1' };
+  }
+
+  const segmentFactors = Array.isArray(coatingModel?.segmentFactors) && coatingModel.segmentFactors.length
+    ? coatingModel.segmentFactors
+    : new Array(segments.length).fill(baseFactor);
+  const averageSegmentFactor = segmentFactors.reduce((sum, factor) => sum + factor, 0) / segmentFactors.length;
+  const worstSegment = segments.reduce((worst, segment, index) => {
+    const factor = segmentFactors[index] ?? averageSegmentFactor;
+    const localDemand = (segment.attenuationFactor ?? 1) * factor;
+    if (!worst || localDemand > worst.localDemand) {
+      return {
+        localDemand,
+        label: `Segment ${segment.segment ?? index + 1}`
+      };
+    }
+    return worst;
+  }, null);
+  const worstCaseSegmentDemandA = averageSegmentFactor > 0
+    ? adjustedRequiredCurrentA * (worstSegment.localDemand / averageSegmentFactor)
+    : adjustedRequiredCurrentA;
+  return {
+    worstCaseSegmentDemandA,
+    worstCaseSegmentLabel: worstSegment?.label || 'Segment 1'
+  };
 }
 
 function validateInputs(input) {
@@ -222,6 +273,30 @@ function validateInputs(input) {
 
   if (!Number.isFinite(input.coatingBreakdownFactor) || input.coatingBreakdownFactor <= 0 || input.coatingBreakdownFactor > 1) {
     errors.push('coatingBreakdownFactor must be between 0 and 1, exclusive of zero.');
+  }
+
+  if (!Object.values(COATING_MODEL_TYPES).includes(input.coatingModelType)) {
+    errors.push('coatingModelType must be fixed, degradation-curve, or segment-condition.');
+  }
+
+  if (input.coatingModelType === COATING_MODEL_TYPES.degradationCurve) {
+    if (!Number.isFinite(input.coatingInitialBreakdownFactor) || input.coatingInitialBreakdownFactor <= 0 || input.coatingInitialBreakdownFactor > 1) {
+      errors.push('coatingInitialBreakdownFactor must be between 0 and 1 for degradation-curve mode.');
+    }
+    if (!Number.isFinite(input.coatingEndOfLifeBreakdownFactor) || input.coatingEndOfLifeBreakdownFactor <= 0 || input.coatingEndOfLifeBreakdownFactor > 1) {
+      errors.push('coatingEndOfLifeBreakdownFactor must be between 0 and 1 for degradation-curve mode.');
+    }
+    if (!Number.isFinite(input.coatingDegradationExponent) || input.coatingDegradationExponent <= 0) {
+      errors.push('coatingDegradationExponent must be greater than zero for degradation-curve mode.');
+    }
+  }
+
+  if (input.coatingModelType === COATING_MODEL_TYPES.segmentCondition) {
+    if (!Array.isArray(input.segmentConditionFactors) || !input.segmentConditionFactors.length) {
+      errors.push('segmentConditionFactors must include at least one factor for segment-condition mode.');
+    } else if (input.segmentConditionFactors.some((value) => !Number.isFinite(value) || value <= 0 || value > 1)) {
+      errors.push('segmentConditionFactors values must be between 0 and 1 for segment-condition mode.');
+    }
   }
 
   if (!Number.isFinite(input.soilPh) || input.soilPh < 0 || input.soilPh > 14) {
@@ -427,6 +502,10 @@ if (typeof document !== 'undefined') {
   const calculatedSurfaceAreaEl = document.getElementById('calculated-surface-area');
   const pipeDimensionsIllustrationEl = document.getElementById('pipe-dimensions-illustration');
   const compliancePanelEl = document.getElementById('cp-compliance-status-content');
+  const coatingModelTypeEl = document.getElementById('coating-model-type');
+  const coatingFixedRow = document.getElementById('coating-fixed-row');
+  const coatingCurveRows = document.querySelectorAll('[data-coating-curve-row]');
+  const coatingSegmentRow = document.getElementById('coating-segment-row');
 
   const saved = normalizeSavedStudy(getStudies().cathodicProtection);
   renderCalculationBasis(basisPanel, CP_STANDARD_BASIS);
@@ -440,6 +519,15 @@ if (typeof document !== 'undefined') {
     if (!input) return;
     const tableDensity = lookupCurrentDensity(input.assetType, input.moistureCategory, input.soilResistivityOhmM, input.soilPh, input.pipeMaterial);
     tableDensityEl.value = roundTo(tableDensity, 3);
+  }
+
+  function refreshCoatingModelInputs() {
+    const modelType = coatingModelTypeEl.value;
+    coatingFixedRow.hidden = modelType !== COATING_MODEL_TYPES.fixed;
+    coatingCurveRows.forEach((row) => {
+      row.hidden = modelType !== COATING_MODEL_TYPES.degradationCurve;
+    });
+    coatingSegmentRow.hidden = modelType !== COATING_MODEL_TYPES.segmentCondition;
   }
 
   function toggleDensityMode() {
@@ -503,13 +591,15 @@ if (typeof document !== 'undefined') {
   }
 
   toggleDensityMode();
+  refreshCoatingModelInputs();
   updatePipeVisibility();
   refreshPipeMaterialHint();
   refreshSurfaceAreaMode();
   refreshTableDensity();
 
-  ['asset-type', 'soil-resistivity', 'soil-ph', 'moisture-category', 'density-method', 'pipe-material', 'surface-area-mode', 'pipe-od', 'pipe-length', 'unit-select'].forEach(id => {
+  ['asset-type', 'soil-resistivity', 'soil-ph', 'moisture-category', 'density-method', 'pipe-material', 'surface-area-mode', 'pipe-od', 'pipe-length', 'unit-select', 'coating-model-type'].forEach(id => {
     document.getElementById(id).addEventListener('input', () => {
+      refreshCoatingModelInputs();
       updatePipeVisibility();
       refreshPipeMaterialHint();
       refreshSurfaceAreaMode();
@@ -517,6 +607,7 @@ if (typeof document !== 'undefined') {
       refreshTableDensity();
     });
     document.getElementById(id).addEventListener('change', () => {
+      refreshCoatingModelInputs();
       updatePipeVisibility();
       refreshPipeMaterialHint();
       refreshSurfaceAreaMode();
@@ -575,7 +666,9 @@ function readFormInputs() {
   const anodeDistanceInput = getNumber('anode-distance-to-structure');
   const anodeBurialDepthInput = getNumber('anode-burial-depth');
   const zoneResistivityRaw = getValue('zone-resistivity-values');
+  const segmentConditionFactorsRaw = getValue('segment-condition-factors');
   const parsedZoneResistivityValues = parseZoneResistivityValues(zoneResistivityRaw);
+  const parsedSegmentConditionFactors = parseConditionFactorValues(segmentConditionFactorsRaw);
   const mitigationActions = parseMitigationActions(getValue('mitigation-actions'));
   const zoneResistivityTokens = String(zoneResistivityRaw ?? '')
     .split(',')
@@ -589,7 +682,13 @@ function readFormInputs() {
     soilResistivityOhmM: getNumber('soil-resistivity'),
     soilPh: getNumber('soil-ph'),
     moistureCategory: getValue('moisture-category'),
+    coatingModelType: getValue('coating-model-type'),
     coatingBreakdownFactor: getNumber('coating-breakdown'),
+    coatingInitialBreakdownFactor: getNumber('coating-initial-breakdown'),
+    coatingEndOfLifeBreakdownFactor: getNumber('coating-eol-breakdown'),
+    coatingDegradationExponent: getNumber('coating-degradation-exponent'),
+    segmentConditionFactors: parsedSegmentConditionFactors,
+    segmentConditionFactorsText: segmentConditionFactorsRaw,
     surfaceAreaM2: isMetric ? surfaceAreaInput : surfaceAreaInput * SQFT_TO_SQM,
     currentDensityMethod: getValue('density-method'),
     surfaceAreaMode,
@@ -697,7 +796,9 @@ function renderResults(result, root) {
             <tr><td>Soil pH</td><td>${result.soilPh}</td></tr>
             <tr><td>Moisture / corrosivity category</td><td>${escapeHtml(result.moistureCategory)}</td></tr>
             <tr><td>Design current density i<sub>d</sub></td><td>${result.designCurrentDensityMaM2} mA/m²</td></tr>
-            <tr><td>Coating breakdown factor</td><td>${result.coatingBreakdownFactor}</td></tr>
+            <tr><td>Coating demand model</td><td>${escapeHtml(result.coatingModel?.label || 'Fixed factor')}</td></tr>
+            <tr><td>Effective coating factor</td><td>${result.coatingBreakdownFactor}</td></tr>
+            <tr><td>Coating uncertainty band</td><td>${roundTo(result.coatingModel?.uncertaintyBand?.lowFactor ?? result.coatingBreakdownFactor, 4)} to ${roundTo(result.coatingModel?.uncertaintyBand?.highFactor ?? result.coatingBreakdownFactor, 4)}</td></tr>
             <tr><td>Exposed area</td><td>${result.exposedAreaM2} m²</td></tr>
             <tr><td>Anode capacity</td><td>${result.anodeCapacityAhPerKg} Ah/kg</td></tr>
             <tr><td>Anode system type</td><td>${escapeHtml(result.anodeTypeSystem)}</td></tr>
@@ -785,7 +886,10 @@ function renderResults(result, root) {
           <thead>
             <tr>
               <th>Scenario</th>
+              <th>Design review</th>
+              <th>Coating factor</th>
               <th>Required current (A)</th>
+              <th>Worst-case segment demand (A)</th>
               <th>Minimum anode mass</th>
               <th>Predicted life (years)</th>
               <th>Safety margin</th>
@@ -795,7 +899,10 @@ function renderResults(result, root) {
             ${sensitivityRows.map((scenario) => `
               <tr>
                 <td>${escapeHtml(scenario.label)}</td>
+                <td>${escapeHtml(scenario.approvalStatus || 'Review required')}</td>
+                <td>${scenario.coatingFactor}</td>
                 <td>${scenario.requiredCurrentA}</td>
+                <td>${scenario.worstCaseSegmentDemandA} (${escapeHtml(scenario.worstCaseSegmentLabel || 'Segment 1')})</td>
                 <td>${scenario.minimumAnodeMassKg} kg (${scenario.minimumAnodeMassLb} lb)</td>
                 <td>${scenario.predictedLifeYears}</td>
                 <td>${scenario.safetyMarginYears} years (${scenario.safetyMarginPercent}%)</td>
@@ -841,7 +948,7 @@ function renderResults(result, root) {
 
 function buildDesignAdvisories(result, sensitivityRows) {
   const notes = [];
-  const conservativeScenario = sensitivityRows.find((scenario) => scenario.key === 'conservative');
+  const conservativeScenario = sensitivityRows.find((scenario) => scenario.key === 'high-coating');
 
   if (result.safetyMarginYears < 0) {
     notes.push('Installed anode mass is below target-life demand; increase installed mass or reduce coating breakdown assumptions.');
@@ -850,7 +957,7 @@ function buildDesignAdvisories(result, sensitivityRows) {
   }
 
   if (conservativeScenario && conservativeScenario.safetyMarginYears < 0) {
-    notes.push('The +20% demand sensitivity case fails target life; add contingency mass or plan earlier replacement intervals.');
+    notes.push('The high coating uncertainty band fails target life; add contingency mass or plan earlier replacement intervals.');
   }
 
   if (result.soilResistivityOhmM < 50 || result.soilPh < 5.5 || result.soilPh > 9) {
@@ -862,7 +969,7 @@ function buildDesignAdvisories(result, sensitivityRows) {
   }
 
   if (result.coatingBreakdownFactor > 0.35) {
-    notes.push('Coating breakdown factor is high; prioritize coating condition assessment/rehabilitation to reduce long-term CP demand.');
+    notes.push('Effective coating demand is high; prioritize coating condition assessment/rehabilitation to reduce long-term CP demand.');
   }
 
   notes.push('For the next iteration, include temperature correction and stray-current interference checks in the final detailed design package.');

--- a/docs/cathodic_protection.md
+++ b/docs/cathodic_protection.md
@@ -13,7 +13,10 @@ This guide documents the engineering basis used by the Cathodic Protection sizin
 | Soil resistivity | ρ | Ω·m | Used for current-density adjustment (`< 50`, `50–200`, `> 200` Ω·m bands). |
 | Soil pH | pH | — | Used to apply an acidic/alkaline adjustment outside nominal neutral range. |
 | Moisture category | — | categorical | `low`, `moderate`, or `high`; selects base current-density table column. |
-| Coating breakdown factor | f<sub>cb</sub> | fraction | `0 < f_cb ≤ 1`; represents exposed steel area fraction. |
+| Coating demand model | — | categorical | `fixed`, `degradation-curve`, or `segment-condition`; selects exposed-area treatment. |
+| Fixed coating factor | f<sub>cb</sub> | fraction | Used in `fixed` mode. |
+| Degradation initial/end factors | f<sub>0</sub>, f<sub>EOL</sub> | fraction | Used in `degradation-curve` mode with exponent shape. |
+| Segment condition factors | f<sub>seg,i</sub> | fraction list | Used in `segment-condition` mode for localized condition variation. |
 | Surface area | A<sub>surf</sub> | m² | Total structure surface area used for CP demand calculation. |
 | Current density mode | — | categorical | `table` (auto-selected) or `manual`. |
 | Manual current density | i<sub>manual</sub> | mA/m² | Used only when mode=`manual`. |
@@ -48,9 +51,11 @@ Then convert mA/m² to A/m²:
 
 i<sub>design,A</sub> = i<sub>design</sub> / 1000
 
-### 2) Exposed area
+### 2) Exposed area (coating models)
 
-A<sub>exposed</sub> = A<sub>surf</sub> × f<sub>cb</sub>
+- **Fixed factor:** `A_exposed = A_surf × f_cb`
+- **Degradation curve:** computes life-averaged factor from `f0`, `fEOL`, and exponent `k`, then applies `A_exposed = A_surf × f_effective`.
+- **Segment condition:** computes segment factors `f_seg,i`, averages to `f_effective`, then applies `A_exposed = A_surf × f_effective`.
 
 ### 3) Required current
 
@@ -79,8 +84,14 @@ L<sub>pred</sub> = (M<sub>inst</sub> × C<sub>a</sub> × u × F<sub>d</sub>) / (
 - Safety margin (years) = `L_pred − L_target`
 - Safety margin (%) = `(L_pred − L_target) / L_target × 100`
 
+### 7) Sensitivity and design-review scenarios
 
-### 7) Measurement correction and criteria normalization
+- Sensitivity now uses coating uncertainty bands (`low`, `base`, `high`) derived from the selected coating model.
+- Scenario table includes per-scenario design-review status (`Approved` or `Review required`) from safety margin outcome.
+- Worst-case segment demand is reported using local segment attenuation and condition factor weighting to expose localized current peaks.
+
+
+### 8) Measurement correction and criteria normalization
 
 Acceptance checks now evaluate **corrected** values and retain raw values in output:
 
@@ -97,7 +108,7 @@ When required metadata is missing (unknown context/location, no compensation val
 - Coating breakdown factor is a dominant uncertainty; select conservatively for life-cycle projections.
 - Temperature correction, current-distribution nonuniformity, shielding, stray-current effects, and attenuation modeling are not explicitly solved in this simplified workflow.
 - pH and resistivity effects are represented via bounded multipliers, not full electrochemical kinetics.
-- Validation requires positive numeric values for major scalar inputs and enforces `0 < coatingBreakdownFactor ≤ 1`, `0 ≤ pH ≤ 14`.
+- Validation requires positive numeric values for major scalar inputs and enforces `0 < coating factor ≤ 1`, `0 ≤ pH ≤ 14`.
 
 ## Standards References
 
@@ -123,4 +134,5 @@ The CP study now includes a standards profile and auditable compliance status mo
 
 - **2026-04-16:** Added measurement metadata inputs (test method/context/reference location), implemented correction-aware criteria normalization, separated raw vs corrected acceptance outputs, and added metadata sufficiency warnings in results.
 - **2026-04-16:** Added standards profile configuration, machine-readable required-check keys in CP basis mapping, compliance status panel, and persisted compliance history snapshots.
+- **2026-04-16:** Replaced single coating factor with selectable coating models (fixed / degradation curve / segment condition), added coating uncertainty sensitivity bands, and surfaced design-review scenario comparison with worst-case segment demand.
 - **2026-04-15:** Initial documentation page added for CP sizing inputs, equations, assumptions/limits, references, and consistency guidance between required-mass and predicted-life relations.

--- a/src/studies/cp/coatingModel.js
+++ b/src/studies/cp/coatingModel.js
@@ -1,0 +1,118 @@
+const MIN_FACTOR = 0.001;
+const MAX_FACTOR = 1;
+
+export const COATING_MODEL_TYPES = {
+  fixed: 'fixed',
+  degradationCurve: 'degradation-curve',
+  segmentCondition: 'segment-condition'
+};
+
+export function parseConditionFactorValues(rawValue) {
+  if (typeof rawValue !== 'string') {
+    return [];
+  }
+
+  return rawValue
+    .split(',')
+    .map((token) => Number.parseFloat(token.trim()))
+    .filter((value) => Number.isFinite(value));
+}
+
+export function resolveCoatingModel(input, context = {}) {
+  const modelType = input.coatingModelType || COATING_MODEL_TYPES.fixed;
+  const segmentCount = Number.isInteger(context.segmentCount) && context.segmentCount > 0 ? context.segmentCount : 1;
+
+  if (modelType === COATING_MODEL_TYPES.degradationCurve) {
+    return buildDegradationCurveModel(input, segmentCount);
+  }
+
+  if (modelType === COATING_MODEL_TYPES.segmentCondition) {
+    return buildSegmentConditionModel(input, segmentCount);
+  }
+
+  return buildFixedFactorModel(input, segmentCount);
+}
+
+function buildFixedFactorModel(input, segmentCount) {
+  const factor = clampFactor(input.coatingBreakdownFactor);
+  const uncertainty = buildSymmetricUncertainty(factor, 0.2);
+  return {
+    modelType: COATING_MODEL_TYPES.fixed,
+    label: 'Fixed factor',
+    effectiveFactor: factor,
+    worstCaseFactor: uncertainty.highFactor,
+    uncertaintyBand: uncertainty,
+    segmentFactors: new Array(segmentCount).fill(factor),
+    curvePoints: []
+  };
+}
+
+function buildDegradationCurveModel(input, segmentCount) {
+  const initialFactor = clampFactor(input.coatingInitialBreakdownFactor);
+  const endOfLifeFactor = clampFactor(input.coatingEndOfLifeBreakdownFactor);
+  const exponent = Number.isFinite(input.coatingDegradationExponent) && input.coatingDegradationExponent > 0
+    ? input.coatingDegradationExponent
+    : 1;
+  const effectiveFactor = clampFactor(initialFactor + ((endOfLifeFactor - initialFactor) / (exponent + 1)));
+
+  return {
+    modelType: COATING_MODEL_TYPES.degradationCurve,
+    label: 'Time-varying degradation curve',
+    effectiveFactor,
+    worstCaseFactor: Math.max(initialFactor, endOfLifeFactor),
+    uncertaintyBand: {
+      lowFactor: Math.min(initialFactor, endOfLifeFactor),
+      baseFactor: effectiveFactor,
+      highFactor: Math.max(initialFactor, endOfLifeFactor)
+    },
+    segmentFactors: new Array(segmentCount).fill(effectiveFactor),
+    curvePoints: [0, 0.25, 0.5, 0.75, 1].map((fraction) => {
+      const factor = clampFactor(initialFactor + ((endOfLifeFactor - initialFactor) * (fraction ** exponent)));
+      return {
+        lifeFraction: fraction,
+        factor
+      };
+    })
+  };
+}
+
+function buildSegmentConditionModel(input, segmentCount) {
+  const parsedFactors = Array.isArray(input.segmentConditionFactors) ? input.segmentConditionFactors : [];
+  const sanitized = parsedFactors.map((value) => clampFactor(value)).filter((value) => Number.isFinite(value));
+  const fallbackFactor = clampFactor(input.coatingBreakdownFactor);
+  const segmentFactors = Array.from({ length: segmentCount }, (_, index) => sanitized[index] ?? fallbackFactor);
+  const sum = segmentFactors.reduce((accumulator, factor) => accumulator + factor, 0);
+  const effectiveFactor = clampFactor(sum / segmentFactors.length);
+  const lowFactor = Math.min(...segmentFactors);
+  const highFactor = Math.max(...segmentFactors);
+
+  return {
+    modelType: COATING_MODEL_TYPES.segmentCondition,
+    label: 'Segment-based condition factors',
+    effectiveFactor,
+    worstCaseFactor: highFactor,
+    uncertaintyBand: {
+      lowFactor,
+      baseFactor: effectiveFactor,
+      highFactor
+    },
+    segmentFactors,
+    curvePoints: []
+  };
+}
+
+function buildSymmetricUncertainty(baseFactor, deltaFraction) {
+  return {
+    lowFactor: clampFactor(baseFactor * (1 - deltaFraction)),
+    baseFactor: clampFactor(baseFactor),
+    highFactor: clampFactor(baseFactor * (1 + deltaFraction))
+  };
+}
+
+function clampFactor(value) {
+  if (!Number.isFinite(value)) {
+    return MIN_FACTOR;
+  }
+
+  return Math.min(MAX_FACTOR, Math.max(MIN_FACTOR, value));
+}


### PR DESCRIPTION
### Motivation

- Replace the single scalar `coatingBreakdownFactor` with selectable coating demand models to better represent uncertainty from coating condition and lifecycle degradation. 
- Expose coating uncertainty into sensitivity workflows and report localized worst-case segment demands so design reviews can see conservative outcomes per scenario. 

### Description

- Added `src/studies/cp/coatingModel.js` implementing three coating strategies (`fixed`, `degradation-curve`, `segment-condition`) that produce `effectiveFactor`, `uncertaintyBand`, `segmentFactors`, and optional `curvePoints`.
- Integrated the coating model into `runCathodicProtectionAnalysis()` so exposed area and required current use the model-derived `effectiveFactor`, and added `coatingModel` metadata to results.
- Extended sensitivity analysis with coating uncertainty bands and a `computeWorstCaseSegmentDemand()` routine, and surfaced per-scenario `approvalStatus`, `coatingFactor`, and worst-case segment demand in the results table.
- Updated UI and input handling: replaced the single coating input in `cathodicprotection.html` with a selectable model and model-specific fields, added parsing/validation in `cathodicprotection.js`, and updated documentation in `docs/cathodic_protection.md`.

### Testing

- Ran the full automated test suite with `npm test` and all tests completed successfully. 
- Built the site with `npm run build` and the bundle completed (Rollup emitted pre-existing warnings about unrelated unresolved/missing exports but the build finished). 
- Per-file syntax checks via `node --check cathodicprotection.js` and `node --check src/studies/cp/coatingModel.js` passed. 
- Preview image/screenshot could not be captured in this environment; the UI changes are present in `cathodicprotection.html` and can be inspected in a browser to confirm the new coating model controls and updated results table.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04e4335508324ab7a62a015064543)