### PR TITLE
Add CP verification plan, checklist fields, and provisional compliance gating

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -1,4 +1,4 @@
-import { getStudies, setStudies } from './dataStore.mjs';
+import { getStudies, getStudyApprovals, setStudies } from './dataStore.mjs';
 import { initStudyApprovalPanel } from './src/components/studyApproval.js';
 import {
   CP_STANDARDS_PROFILE,
@@ -17,6 +17,23 @@ const IN_TO_M = 0.0254;
 const MM_TO_M = 0.001;
 const FT_TO_M = 0.3048;
 const SQM_TO_SQFT = 10.76391041671;
+const COMMISSIONING_CHECKLIST_ITEMS = [
+  {
+    key: 'requiredCommissioningTests',
+    label: 'Required commissioning tests',
+    description: 'Record who completed acceptance criteria tests and where evidence is stored.'
+  },
+  {
+    key: 'monitoringIntervals',
+    label: 'Monitoring intervals',
+    description: 'Record who approved monitoring cadence and reference the schedule evidence.'
+  },
+  {
+    key: 'correctiveActionThresholds',
+    label: 'Trigger thresholds for corrective action',
+    description: 'Record who approved action trigger thresholds and supporting evidence.'
+  }
+];
 
 const TABLE_CURRENT_DENSITY_MA_M2 = {
   pipe: { low: 5, moderate: 10, high: 20 },
@@ -444,21 +461,32 @@ function normalizeSavedStudy(saved) {
   };
 }
 
-function createComplianceRecord(result, previousStudy = null) {
+function createComplianceRecord(result, previousStudy = null, approval = null) {
   const requiredChecks = evaluateComplianceChecks(result);
   const previousRequiredChecks = previousStudy?.compliance?.requiredChecks || {};
+  const commissioningChecklistComplete = isCommissioningChecklistComplete(approval);
   const mergedRequiredChecks = {
     ...buildInitialComplianceStatus(),
     ...previousRequiredChecks,
-    ...requiredChecks
+    ...requiredChecks,
+    commissioningChecksDefined: commissioningChecklistComplete && requiredChecks.commissioningChecksDefined === 'pass'
+      ? 'pass'
+      : 'fail'
   };
   const evaluatedAt = result.timestamp;
+  const failedCheckKeys = Object.keys(mergedRequiredChecks).filter((checkKey) => mergedRequiredChecks[checkKey] !== 'pass');
+  const complianceState = failedCheckKeys.length
+    ? (commissioningChecklistComplete ? 'not-compliant' : 'provisional')
+    : 'compliant';
 
   const compliance = {
     profileId: CP_STANDARDS_PROFILE.profileId,
     requiredChecks: mergedRequiredChecks,
     optionalChecks: previousStudy?.compliance?.optionalChecks || {},
-    lastEvaluatedAt: evaluatedAt
+    lastEvaluatedAt: evaluatedAt,
+    commissioningChecklistComplete,
+    complianceState,
+    failedCheckKeys
   };
 
   const historyEntry = {
@@ -481,7 +509,49 @@ if (typeof document !== 'undefined') {
   initCompactMode();
   initHelpModal('help-btn', 'help-modal', 'close-help-btn');
   initNavToggle();
-  initStudyApprovalPanel('cathodicProtection');
+  initStudyApprovalPanel('cathodicProtection', 'study-review-panel', {
+    checklistItems: COMMISSIONING_CHECKLIST_ITEMS,
+    onSave: (approval) => {
+      const studies = getStudies();
+      const existingStudy = normalizeSavedStudy(studies.cathodicProtection);
+      if (!existingStudy) return;
+      const complianceRecord = createComplianceRecord(existingStudy, existingStudy, approval);
+      studies.cathodicProtection = {
+        ...existingStudy,
+        reportExport: buildReportExportData(existingStudy, approval),
+        compliance: complianceRecord.compliance,
+        complianceHistory: complianceRecord.complianceHistory
+      };
+      setStudies(studies);
+      renderResults(studies.cathodicProtection, resultsDiv);
+      renderComplianceStatusPanel(
+        compliancePanelEl,
+        studies.cathodicProtection.compliance.requiredChecks,
+        studies.cathodicProtection.compliance.lastEvaluatedAt,
+        studies.cathodicProtection.compliance
+      );
+    },
+    onClear: () => {
+      const studies = getStudies();
+      const existingStudy = normalizeSavedStudy(studies.cathodicProtection);
+      if (!existingStudy) return;
+      const complianceRecord = createComplianceRecord(existingStudy, existingStudy, null);
+      studies.cathodicProtection = {
+        ...existingStudy,
+        reportExport: buildReportExportData(existingStudy, null),
+        compliance: complianceRecord.compliance,
+        complianceHistory: complianceRecord.complianceHistory
+      };
+      setStudies(studies);
+      renderResults(studies.cathodicProtection, resultsDiv);
+      renderComplianceStatusPanel(
+        compliancePanelEl,
+        studies.cathodicProtection.compliance.requiredChecks,
+        studies.cathodicProtection.compliance.lastEvaluatedAt,
+        studies.cathodicProtection.compliance
+      );
+    }
+  });
 
   const form = document.getElementById('cp-form');
   const resultsDiv = document.getElementById('results');
@@ -508,9 +578,18 @@ if (typeof document !== 'undefined') {
   const coatingSegmentRow = document.getElementById('coating-segment-row');
 
   const saved = normalizeSavedStudy(getStudies().cathodicProtection);
+  const savedApproval = getStudyApprovals().cathodicProtection || null;
   renderCalculationBasis(basisPanel, CP_STANDARD_BASIS);
-  renderComplianceStatusPanel(compliancePanelEl, saved?.compliance?.requiredChecks, saved?.compliance?.lastEvaluatedAt);
+  renderComplianceStatusPanel(compliancePanelEl, saved?.compliance?.requiredChecks, saved?.compliance?.lastEvaluatedAt, saved?.compliance);
   if (saved) {
+    if (!saved.reportExport) {
+      const studies = getStudies();
+      studies.cathodicProtection = {
+        ...saved,
+        reportExport: buildReportExportData(saved, savedApproval)
+      };
+      setStudies(studies);
+    }
     renderResults(saved, resultsDiv);
   }
 
@@ -627,9 +706,11 @@ if (typeof document !== 'undefined') {
       errorsDiv.textContent = '';
       const studies = getStudies();
       const previousStudy = normalizeSavedStudy(studies.cathodicProtection);
-      const complianceRecord = createComplianceRecord(result, previousStudy);
+      const approval = getStudyApprovals().cathodicProtection || null;
+      const complianceRecord = createComplianceRecord(result, previousStudy, approval);
       studies.cathodicProtection = {
         ...result,
+        reportExport: buildReportExportData(result, approval),
         compliance: complianceRecord.compliance,
         complianceHistory: complianceRecord.complianceHistory
       };
@@ -638,7 +719,8 @@ if (typeof document !== 'undefined') {
       renderComplianceStatusPanel(
         compliancePanelEl,
         studies.cathodicProtection.compliance.requiredChecks,
-        studies.cathodicProtection.compliance.lastEvaluatedAt
+        studies.cathodicProtection.compliance.lastEvaluatedAt,
+        studies.cathodicProtection.compliance
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Invalid cathodic protection inputs.';
@@ -752,10 +834,23 @@ function renderResults(result, root) {
   const criteriaStatusClass = criteriaEvidence.overallStatus === 'pass'
     ? 'result-badge--pass'
     : (criteriaEvidence.overallStatus === 'fail' ? 'result-badge--fail' : '');
+  const reportExport = result.reportExport || buildReportExportData(result, getStudyApprovals().cathodicProtection || null);
+  const verificationPlan = reportExport.verificationPlan || {};
+  const commissioningChecklist = verificationPlan.completionChecklist || {};
+  const complianceState = result.compliance?.complianceState || 'provisional';
+  const complianceBadgeClass = complianceState === 'compliant'
+    ? 'result-badge--pass'
+    : (complianceState === 'provisional' ? 'result-badge--not-run' : 'result-badge--fail');
+  const complianceBadgeText = complianceState === 'compliant'
+    ? 'Compliance status: Compliant'
+    : (complianceState === 'provisional'
+      ? 'Compliance status: Provisional (commissioning evidence pending)'
+      : 'Compliance status: Not compliant');
 
   root.innerHTML = `
     <section class="results-panel" aria-labelledby="cp-results-heading">
       <h2 id="cp-results-heading">Cathodic Protection Sizing Results</h2>
+      <div class="result-badge ${complianceBadgeClass}">${complianceBadgeText}</div>
 
       <div class="result-group">
         <div class="result-row">
@@ -880,6 +975,30 @@ function renderResults(result, root) {
           : '<p class="field-hint">No missing mitigations for selected profile.</p>'}
       </div>
 
+      <div class="result-group" aria-label="Verification and commissioning plan">
+        <h3>Verification and Commissioning Plan</h3>
+        <p class="field-hint">Required commissioning tests: ${escapeHtml((verificationPlan.requiredCommissioningTests || []).join(' | ') || 'Not defined')}</p>
+        <p class="field-hint">Monitoring intervals: ${escapeHtml((verificationPlan.monitoringIntervals || []).join(' | ') || 'Not defined')}</p>
+        <p class="field-hint">Trigger thresholds for corrective action: ${escapeHtml((verificationPlan.correctiveActionThresholds || []).join(' | ') || 'Not defined')}</p>
+        <div class="table-wrap">
+          <table class="data-table" aria-label="Commissioning checklist completion status">
+            <thead><tr><th>Checklist item</th><th>Completed by</th><th>Completed on</th><th>Evidence</th></tr></thead>
+            <tbody>
+              ${COMMISSIONING_CHECKLIST_ITEMS.map((item) => {
+    const completion = commissioningChecklist[item.key] || {};
+    return `
+                <tr>
+                  <td>${escapeHtml(item.label)}</td>
+                  <td>${escapeHtml(completion.completedBy || 'Pending')}</td>
+                  <td>${escapeHtml(completion.completedAt || 'Pending')}</td>
+                  <td>${escapeHtml(completion.evidence || 'Pending')}</td>
+                </tr>`;
+  }).join('')}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       ${sensitivityRows.length ? `
       <div class="table-wrap">
         <table class="data-table" aria-label="Cathodic protection sensitivity table">
@@ -943,6 +1062,7 @@ function renderResults(result, root) {
       </div>` : ''}
 
       <p class="field-hint result-timestamp">Analysis run: ${new Date(result.timestamp).toLocaleString()}</p>
+      <p class="field-hint">Report export package includes JSON and PDF payload sections for design basis and verification plan.</p>
     </section>`;
 }
 
@@ -1023,7 +1143,7 @@ function renderCalculationBasis(root, basis) {
   `;
 }
 
-function renderComplianceStatusPanel(root, requiredChecks = {}, lastEvaluatedAt = null) {
+function renderComplianceStatusPanel(root, requiredChecks = {}, lastEvaluatedAt = null, compliance = {}) {
   if (!root) return;
 
   const rows = getRequiredComplianceChecks().map((checkKey) => {
@@ -1042,8 +1162,15 @@ function renderComplianceStatusPanel(root, requiredChecks = {}, lastEvaluatedAt 
     'not-run': 'Not run'
   };
   const overallCompliant = rows.every((row) => row.status === 'pass');
-  const overallBadgeClass = overallCompliant ? 'result-badge--pass' : 'result-badge--fail';
-  const overallBadgeText = overallCompliant ? 'Compliant' : 'Not compliant';
+  const complianceState = compliance?.complianceState || (overallCompliant ? 'compliant' : 'not-compliant');
+  const overallBadgeClass = complianceState === 'compliant'
+    ? 'result-badge--pass'
+    : (complianceState === 'provisional' ? 'result-badge--not-run' : 'result-badge--fail');
+  const overallBadgeText = complianceState === 'compliant'
+    ? 'Compliant'
+    : (complianceState === 'provisional'
+      ? 'Provisional — awaiting commissioning evidence'
+      : 'Not compliant');
 
   root.innerHTML = `
     <div class="result-badge ${overallBadgeClass}">${overallBadgeText}</div>
@@ -1062,4 +1189,86 @@ function renderComplianceStatusPanel(root, requiredChecks = {}, lastEvaluatedAt 
     </div>
     <p class="field-hint">Last evaluated: ${lastEvaluatedAt ? escapeHtml(new Date(lastEvaluatedAt).toLocaleString()) : 'Not run yet'}</p>
   `;
+}
+
+function normalizeChecklistEntry(entry) {
+  const completedBy = String(entry?.completedBy || '').trim();
+  const completedAt = String(entry?.completedAt || '').trim();
+  const evidence = String(entry?.evidence || '').trim();
+  return { completedBy, completedAt, evidence };
+}
+
+function getCommissioningChecklist(approval = null) {
+  const approvalChecklist = approval?.checklist && typeof approval.checklist === 'object' ? approval.checklist : {};
+  return COMMISSIONING_CHECKLIST_ITEMS.reduce((acc, item) => {
+    acc[item.key] = normalizeChecklistEntry(approvalChecklist[item.key]);
+    return acc;
+  }, {});
+}
+
+function isCommissioningChecklistComplete(approval = null) {
+  const checklist = getCommissioningChecklist(approval);
+  return COMMISSIONING_CHECKLIST_ITEMS.every((item) => {
+    const completion = checklist[item.key];
+    return Boolean(completion.completedBy && completion.completedAt && completion.evidence);
+  });
+}
+
+function buildVerificationPlan(result, approval = null) {
+  const criteriaRows = Array.isArray(result.criteriaCheckEvidence?.criteriaResults)
+    ? result.criteriaCheckEvidence.criteriaResults
+    : [];
+  const interference = result.interferenceAssessment || {};
+  return {
+    requiredCommissioningTests: criteriaRows.map((criterion) => `${criterion.label}: ${criterion.requirement}`),
+    monitoringIntervals: [
+      `Verification test date: ${interference.verificationTestDate || result.verificationTestDate || 'Not scheduled'}`,
+      `Mitigation profile: ${interference.profile?.label || 'Baseline mitigation profile'}`
+    ],
+    correctiveActionThresholds: [
+      'Any failed protection criterion requires corrective action and re-test before final compliance.',
+      'Unresolved high interference risk requires mitigation completion before compliance closure.',
+      'Negative life safety margin requires design update or contingency mass increase.'
+    ],
+    completionChecklist: getCommissioningChecklist(approval),
+    completionStatus: isCommissioningChecklistComplete(approval) ? 'complete' : 'incomplete'
+  };
+}
+
+function buildReportExportData(result, approval = null) {
+  const verificationPlan = buildVerificationPlan(result, approval);
+  return {
+    version: 'cp-report-export-v1',
+    generatedAt: new Date().toISOString(),
+    format: ['json', 'pdf'],
+    designBasis: {
+      standardsProfile: CP_STANDARD_BASIS.standardsProfile,
+      calculationBasis: result.standardsBasis || CP_STANDARD_BASIS,
+      outputBasis: result.outputBasis || {}
+    },
+    verificationPlan,
+    payloads: {
+      json: {
+        sectionOrder: ['designBasis', 'verificationPlan', 'resultsSummary'],
+        data: {
+          designBasis: result.standardsBasis || CP_STANDARD_BASIS,
+          verificationPlan,
+          resultsSummary: {
+            requiredCurrentA: result.requiredCurrentA,
+            minimumAnodeMassKg: result.minimumAnodeMassKg,
+            predictedLifeYears: result.predictedLifeYears,
+            safetyMarginYears: result.safetyMarginYears
+          }
+        }
+      },
+      pdf: {
+        title: 'Cathodic Protection Design Basis + Verification Plan',
+        sections: [
+          { heading: 'Design Basis', contentKey: 'designBasis' },
+          { heading: 'Verification Plan', contentKey: 'verificationPlan' },
+          { heading: 'Sizing Results Summary', contentKey: 'resultsSummary' }
+        ]
+      }
+    }
+  };
 }

--- a/docs/cathodic_protection.md
+++ b/docs/cathodic_protection.md
@@ -129,9 +129,29 @@ The CP study now includes a standards profile and auditable compliance status mo
 - **Mandatory vs optional checks:** Required checks are explicitly keyed and rendered in the **Compliance Status** panel as `pass`, `fail`, or `not-run`.
 - **Required deliverables:** The profile flags required deliverables for design basis, calculations, commissioning checks, and monitoring plan.
 - **Audit trail:** Every run appends a compliance snapshot under study storage (`studyResults.cathodicProtection.complianceHistory`) so historical status changes can be reviewed.
+- **Provisional state handling:** Compliance is marked **provisional** until commissioning checklist evidence is complete for required tests, monitoring intervals, and corrective-action trigger thresholds.
+
+## Verification Plan and Report Export Structure
+
+The results output now includes a dedicated **Verification and Commissioning Plan** section and a persisted export payload:
+
+- **Required commissioning tests:** Derived from the selected protection criteria requirements.
+- **Monitoring intervals:** Derived from verification date scheduling and mitigation profile details.
+- **Corrective-action thresholds:** Explicit trigger statements for failed criteria, unresolved interference risk, or life-margin shortfall.
+- **Completion checklist fields:** Captured through the Study Approval panel with `completedBy`, `completedAt`, and `evidence` for:
+  - required commissioning tests
+  - monitoring intervals
+  - corrective-action trigger thresholds
+
+Study output now stores `studyResults.cathodicProtection.reportExport` with:
+
+- `designBasis` payload (standards profile + calculation basis mapping)
+- `verificationPlan` payload (commissioning tests, monitoring intervals, thresholds, completion state)
+- `payloads.json` and `payloads.pdf` section metadata for downstream exporters.
 
 ## Revision Notes
 
+- **2026-04-16:** Added commissioning-plan results section, checklist completion fields in the Study Approval panel (`who/when/evidence`), provisional compliance gating until evidence completion, and persisted report export payloads for JSON/PDF workflows.
 - **2026-04-16:** Added measurement metadata inputs (test method/context/reference location), implemented correction-aware criteria normalization, separated raw vs corrected acceptance outputs, and added metadata sufficiency warnings in results.
 - **2026-04-16:** Added standards profile configuration, machine-readable required-check keys in CP basis mapping, compliance status panel, and persisted compliance history snapshots.
 - **2026-04-16:** Replaced single coating factor with selectable coating models (fixed / degradation curve / segment condition), added coating uncertainty sensitivity bands, and surfaced design-review scenario comparison with worst-case segment demand.

--- a/src/components/studyApproval.js
+++ b/src/components/studyApproval.js
@@ -68,11 +68,12 @@ export function getApprovalBadgeHTML(approval) {
  * @param {string} studyKey   Storage key for this study (e.g. 'arcFlash').
  * @param {string} [containerId='study-review-panel']  ID of the host element.
  */
-export function initStudyApprovalPanel(studyKey, containerId = 'study-review-panel') {
+export function initStudyApprovalPanel(studyKey, containerId = 'study-review-panel', options = {}) {
   if (typeof document === 'undefined') return;
 
   const container = document.getElementById(containerId);
   if (!container) return;
+  const checklistItems = Array.isArray(options.checklistItems) ? options.checklistItems : [];
 
   // ── Build the panel DOM ───────────────────────────────────────────────────
 
@@ -82,6 +83,28 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
   const dateId    = `${containerId}-date`;
   const noteId    = `${containerId}-note`;
   const badgeId   = `${containerId}-badge`;
+  const checklistHtml = checklistItems.map((item) => {
+    const key = esc(item.key);
+    const label = esc(item.label || item.key);
+    const description = esc(item.description || '');
+    return `
+      <fieldset class="study-review-panel__checklist-item">
+        <legend>${label}</legend>
+        ${description ? `<p class="field-hint">${description}</p>` : ''}
+        <div class="auth-field">
+          <label for="${containerId}-check-${key}-who">Completed by</label>
+          <input id="${containerId}-check-${key}-who" data-check-key="${key}" data-check-field="completedBy" type="text" placeholder="Name or initials">
+        </div>
+        <div class="auth-field">
+          <label for="${containerId}-check-${key}-when">Completed on</label>
+          <input id="${containerId}-check-${key}-when" data-check-key="${key}" data-check-field="completedAt" type="date">
+        </div>
+        <div class="auth-field">
+          <label for="${containerId}-check-${key}-evidence">Evidence reference</label>
+          <input id="${containerId}-check-${key}-evidence" data-check-key="${key}" data-check-field="evidence" type="text" placeholder="Report, photo, ticket, or file ID">
+        </div>
+      </fieldset>`;
+  }).join('');
 
   container.innerHTML = `
     <div class="study-review-panel">
@@ -131,6 +154,12 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
           </span>
         </div>
 
+        ${checklistItems.length ? `
+        <section class="study-review-panel__checklist" aria-label="Commissioning completion checklist">
+          <h3>Commissioning Completion Checklist</h3>
+          ${checklistHtml}
+        </section>` : ''}
+
         <div class="study-review-panel__actions">
           <button type="submit" class="primary-btn">Save Review</button>
           <button type="button" id="${containerId}-clear-btn" class="btn">Clear</button>
@@ -147,6 +176,7 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
   const noteTA     = container.querySelector(`#${noteId}`);
   const badgeEl    = container.querySelector(`#${badgeId}`);
   const clearBtn   = container.querySelector(`#${containerId}-clear-btn`);
+  const checklistInputs = Array.from(container.querySelectorAll('[data-check-key][data-check-field]'));
 
   // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -160,6 +190,9 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
       byInput.value    = '';
       dateInput.value  = TODAY;
       noteTA.value     = '';
+      checklistInputs.forEach((inputEl) => {
+        inputEl.value = '';
+      });
       renderBadge(null);
       return;
     }
@@ -167,6 +200,13 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
     byInput.value   = approval.reviewedBy ?? '';
     dateInput.value = approval.approvedAt ?? TODAY;
     noteTA.value    = approval.note       ?? '';
+    const checklist = approval.checklist && typeof approval.checklist === 'object' ? approval.checklist : {};
+    checklistInputs.forEach((inputEl) => {
+      const checkKey = inputEl.dataset.checkKey;
+      const checkField = inputEl.dataset.checkField;
+      const value = checklist?.[checkKey]?.[checkField] ?? '';
+      inputEl.value = value;
+    });
     renderBadge(approval);
   }
 
@@ -179,18 +219,33 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
 
   form.addEventListener('submit', ev => {
     ev.preventDefault();
+    const checklist = checklistItems.reduce((acc, item) => {
+      const key = item.key;
+      const completedBy = (container.querySelector(`[data-check-key="${key}"][data-check-field="completedBy"]`)?.value || '').trim();
+      const completedAt = (container.querySelector(`[data-check-key="${key}"][data-check-field="completedAt"]`)?.value || '').trim();
+      const evidence = (container.querySelector(`[data-check-key="${key}"][data-check-field="evidence"]`)?.value || '').trim();
+      acc[key] = { completedBy, completedAt, evidence };
+      return acc;
+    }, {});
     const approval = {
       status:     statusSel.value  || 'pending',
       reviewedBy: byInput.value.trim(),
       approvedAt: dateInput.value  || TODAY,
       note:       noteTA.value.trim(),
+      checklist,
     };
     setStudyApproval(studyKey, approval);
     renderBadge(approval);
+    if (typeof options.onSave === 'function') {
+      options.onSave(approval);
+    }
   });
 
   clearBtn.addEventListener('click', () => {
     clearStudyApproval(studyKey);
     populateForm(null);
+    if (typeof options.onClear === 'function') {
+      options.onClear();
+    }
   });
 }


### PR DESCRIPTION
### Motivation

- Capture commissioning requirements (tests, monitoring cadence, corrective-action thresholds) and link completion evidence into the CP study approval flow so compliance can be auditable. 
- Produce an exportable report package (JSON/PDF metadata) that bundles the design basis together with a verification/commissioning plan for downstream exporters.

### Description

- Extend the Study Approval panel (`src/components/studyApproval.js`) to accept configurable `checklistItems` and render per-item `completedBy` / `completedAt` / `evidence` fields, and to invoke optional `onSave`/`onClear` callbacks when the approval is saved or cleared. 
- Add CP-specific commissioning checklist model and wiring in `cathodicprotection.js`, including `COMMISSIONING_CHECKLIST_ITEMS`, helper functions to normalise/validate checklist entries, and a `buildVerificationPlan()` helper. 
- Make compliance evaluation aware of checklist completion by updating `createComplianceRecord()` to set `commissioningChecklistComplete` and a `complianceState` (`provisional` / `compliant` / `not-compliant`) and persist `failedCheckKeys` and `complianceHistory`. 
- Add `buildReportExportData()` to assemble a `reportExport` payload (design basis + verification plan) with `payloads.json`/`payloads.pdf` metadata and persist it to `studyResults.cathodicProtection.reportExport`. 
- Update `renderResults()` in `cathodicprotection.js` to render a new "Verification and Commissioning Plan" section (required tests, monitoring intervals, trigger thresholds) and show checklist completion status and a compliance badge that reflects provisional/compliant/not-compliant state. 
- Document the new provisional state handling and export structure in `docs/cathodic_protection.md`.

### Testing

- Ran unit checks for approval and battery modules: `node tests/studyApproval.test.mjs && node tests/batterySizing.test.mjs` — both succeeded. 
- Executed `npm run build` to regenerate distribution bundles — build completed (rollup warnings unrelated to these changes). 
- Started full test run with `npm test`; the suite executed a large portion but did not complete in this environment before timing out (partial progress observed). 
- Attempted to produce a preview screenshot with Playwright (`npx playwright screenshot`), but the environment lacks browser binaries so the screenshot step failed (Playwright requested `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05079b96083248ba32964b6919732)