### PR TITLE
Fix CP layout canvas to fill available panel height

### DIFF
--- a/dist/asset-manifest.json
+++ b/dist/asset-manifest.json
@@ -38,7 +38,7 @@
   "seismicwindcombined.js": "seismicwindcombined.35b776d17572.js",
   "spoolsheets.js": "spoolsheets.eb77c427808e.js",
   "structuralcombinations.js": "structuralcombinations.f29b69f59d91.js",
-  "style.css": "style.1a1ef9e72dd9.css",
+  "style.css": "style.13a8a0aeb956.css",
   "submittal.js": "submittal.64ae4a76b021.js",
   "supportspan.js": "supportspan.8eaebf747231.js",
   "transientstability.js": "transientstability.328bb79e9a5e.js",

--- a/dist/style.13a8a0aeb956.css
+++ b/dist/style.13a8a0aeb956.css
@@ -233,6 +233,7 @@
 .cp-layout-canvas {
   border: 1px solid var(--border-color, #7d8790);
   border-radius: 10px;
+  height: 420px;
   min-height: 420px;
   background: color-mix(in srgb, var(--panel-bg, #f8fafc) 94%, #b9d7ff 6%);
   overflow: hidden;

--- a/dist/style.css
+++ b/dist/style.css
@@ -233,6 +233,7 @@
 .cp-layout-canvas {
   border: 1px solid var(--border-color, #7d8790);
   border-radius: 10px;
+  height: 420px;
   min-height: 420px;
   background: color-mix(in srgb, var(--panel-bg, #f8fafc) 94%, #b9d7ff 6%);
   overflow: hidden;

--- a/docs/asset-manifest.json
+++ b/docs/asset-manifest.json
@@ -1,5 +1,5 @@
 {
   "docs.js": "docs.402900d29faa.js",
-  "style.css": "style.1a1ef9e72dd9.css",
+  "style.css": "style.13a8a0aeb956.css",
   "dist/vendor/fast-json-patch.mjs": "fast-json-patch.361648778823.mjs"
 }

--- a/docs/style.13a8a0aeb956.css
+++ b/docs/style.13a8a0aeb956.css
@@ -233,6 +233,7 @@
 .cp-layout-canvas {
   border: 1px solid var(--border-color, #7d8790);
   border-radius: 10px;
+  height: 420px;
   min-height: 420px;
   background: color-mix(in srgb, var(--panel-bg, #f8fafc) 94%, #b9d7ff 6%);
   overflow: hidden;

--- a/docs/style.css
+++ b/docs/style.css
@@ -233,6 +233,7 @@
 .cp-layout-canvas {
   border: 1px solid var(--border-color, #7d8790);
   border-radius: 10px;
+  height: 420px;
   min-height: 420px;
   background: color-mix(in srgb, var(--panel-bg, #f8fafc) 94%, #b9d7ff 6%);
   overflow: hidden;

--- a/style.css
+++ b/style.css
@@ -233,6 +233,7 @@
 .cp-layout-canvas {
   border: 1px solid var(--border-color, #7d8790);
   border-radius: 10px;
+  height: 420px;
   min-height: 420px;
   background: color-mix(in srgb, var(--panel-bg, #f8fafc) 94%, #b9d7ff 6%);
   overflow: hidden;


### PR DESCRIPTION
### Motivation
- The CP layout SVG used `height: 100%` but its container had no explicit height, causing the canvas to render as a shallow strip and crop grid/components at the bottom when zooming.
- Providing a concrete container height lets the embedded SVG expand to the available panel area so zoom and pan behave correctly.

### Description
- Added an explicit `height: 420px` to `.cp-layout-canvas` in `style.css` while retaining `min-height` so the nested SVG can resolve `height: 100%` against a real container height.
- Rebuilt site assets so the distributed CSS and manifests in `dist/` and `docs/` reflect the updated stylesheet and hashed filenames.

### Testing
- Ran `npm run build` and the build completed successfully, producing updated `dist/` and `docs/` artifacts. ✅
- Executed the full test suite via `npm test`; tests were started and a large portion of the suite produced passing output, but the full run did not complete within the interactive session window. ⚠️
- Attempted to capture a preview screenshot with Playwright (headless Chromium) but the environment lacked browser binaries and the attempt failed with a prompt to run `npx playwright install`. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1058d9ba8832490a946a079cc4331)