### PR TITLE
Fix cathodic protection canvas double-click property selection

### DIFF
--- a/src/cpLayoutCanvas.js
+++ b/src/cpLayoutCanvas.js
@@ -690,7 +690,7 @@ export function initCpLayoutCanvas({
         class="cp-layout-structure-line ${activeSegmentIndex === index ? 'is-hovered' : ''}"
         data-segment-index="${index}"
       />
-      <text x="${(segment.x1 + segment.x2) / 2}" y="${segment.y1 - 14}" class="cp-layout-segment-label" text-anchor="middle">${segment.label}</text>
+      <text x="${(segment.x1 + segment.x2) / 2}" y="${segment.y1 - 14}" class="cp-layout-segment-label" text-anchor="middle" data-segment-index="${index}">${segment.label}</text>
     `).join('');
 
     const anodeMarkup = anodes.map((anode, index) => `
@@ -887,7 +887,11 @@ export function initCpLayoutCanvas({
   }
 
   function selectElementFromTarget(target) {
-    const dragTarget = target.closest('[data-drag-kind]');
+    const normalizedTarget = target instanceof Element ? target : target?.parentElement;
+    if (!normalizedTarget) {
+      return false;
+    }
+    const dragTarget = normalizedTarget.closest('[data-drag-kind]');
     if (dragTarget) {
       const kind = dragTarget.dataset.dragKind;
       const index = Number.parseInt(dragTarget.dataset.index || '-1', 10);
@@ -900,7 +904,7 @@ export function initCpLayoutCanvas({
         return true;
       }
     }
-    const segment = target.closest('[data-segment-index]');
+    const segment = normalizedTarget.closest('[data-segment-index]');
     if (segment) {
       const index = Number.parseInt(segment.dataset.segmentIndex || '-1', 10);
       if (Number.isInteger(index) && index >= 0) {
@@ -909,7 +913,7 @@ export function initCpLayoutCanvas({
         return true;
       }
     }
-    const hotspot = target.closest('[data-hotspot-index]');
+    const hotspot = normalizedTarget.closest('[data-hotspot-index]');
     if (hotspot) {
       const index = Number.parseInt(hotspot.dataset.hotspotIndex || '-1', 10);
       if (Number.isInteger(index) && index >= 0) {


### PR DESCRIPTION
### Motivation

- Double-clicking elements on the cathodic protection layout canvas sometimes failed to open the properties panel because the double-click event target could be a non-`Element` node (e.g. SVG text node) and segment labels were not directly selectable.

### Description

- Added `data-segment-index` to the structure segment `<text>` labels so clicking the label can identify the corresponding segment.
- Normalized the event target in `selectElementFromTarget` so it falls back to a parent `Element` when the direct `target` is not an `Element`, and used that normalized element for `.closest(...)` lookups.
- Changed implementation in `src/cpLayoutCanvas.js` to perform these updates, restoring reliable element selection on canvas double-click and allowing the properties panel to open.

### Testing

- Ran `npm run build`, which completed successfully.
- Executed focused CP tests with `node tests/cathodicProtection.test.mjs && node tests/cp/complianceWorkflow.e2e.test.mjs`, which failed due to existing cathodic protection input-validation errors unrelated to this UI selection fix.
- Started the full test run with `npm test` (long-running); build steps and many unit tests executed during the run prior to CP test failures noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1327135ec8324aff996d7c8b74450)