### PR TITLE
Optimize step overlay rendering with canvas-based approach

### DIFF
--- a/groundgrid.js
+++ b/groundgrid.js
@@ -179,21 +179,25 @@ document.addEventListener('DOMContentLoaded', () => {
     svgEl.appendChild(makeSvg('rect', { x: startX, y: startY, width: drawWidth, height: drawHeight, class: 'grid-outline' }));
 
     if (showStepOverlay) {
-      const rows = 18;
-      const cols = 18;
-      const cellWidth = drawWidth / cols;
-      const cellHeight = drawHeight / rows;
+      const CELLS_PER_MESH = 8;
+      const MIN_RES = 24;
+      const MAX_RES = 120;
+      const cols = Math.max(MIN_RES, Math.min(MAX_RES, (params.ny - 1) * CELLS_PER_MESH));
+      const rows = Math.max(MIN_RES, Math.min(MAX_RES, (params.nx - 1) * CELLS_PER_MESH));
       const safetyRatio = latestAnalysisResult
         ? Math.max(0, latestAnalysisResult.Es / Math.max(latestAnalysisResult.Estep, 1))
         : 0.55;
       const severityScale = Math.max(0.25, Math.min(1.25, safetyRatio));
 
+      const canvas = document.createElement('canvas');
+      canvas.width = cols;
+      canvas.height = rows;
+      const ctx = canvas.getContext('2d');
+
       for (let row = 0; row < rows; row += 1) {
         for (let col = 0; col < cols; col += 1) {
-          const x = startX + (col * cellWidth);
-          const y = startY + (row * cellHeight);
-          const px = x + (cellWidth / 2);
-          const py = y + (cellHeight / 2);
+          const px = startX + ((col + 0.5) * drawWidth / cols);
+          const py = startY + ((row + 0.5) * drawHeight / rows);
           const nearestVerticalDistance = dx > 0
             ? Math.min(...Array.from({ length: params.ny }, (_, i) => Math.abs(px - (startX + (i * dx)))))
             : 0;
@@ -209,16 +213,20 @@ document.addEventListener('DOMContentLoaded', () => {
           const intensity = Math.max(0, Math.min(1, (0.18 + (0.62 * localGradient) + (0.22 * edgeBoost)) * severityScale));
           const hue = Math.max(0, 125 - (intensity * 125));
           const alpha = (0.08 + (intensity * 0.38)) * overlayOpacity;
-          svgEl.appendChild(makeSvg('rect', {
-            x,
-            y,
-            width: cellWidth + 0.4,
-            height: cellHeight + 0.4,
-            class: 'grid-step-overlay',
-            fill: `hsla(${hue}, 86%, 48%, ${alpha.toFixed(3)})`,
-          }));
+          ctx.fillStyle = `hsla(${hue}, 86%, 48%, ${alpha.toFixed(3)})`;
+          ctx.fillRect(col, row, 1, 1);
         }
       }
+
+      svgEl.appendChild(makeSvg('image', {
+        x: startX,
+        y: startY,
+        width: drawWidth,
+        height: drawHeight,
+        href: canvas.toDataURL(),
+        class: 'grid-step-overlay',
+        preserveAspectRatio: 'none',
+      }));
     }
 
     for (let i = 0; i < params.ny; i += 1) {


### PR DESCRIPTION
## Summary
Refactored the step overlay rendering to use canvas-based drawing instead of creating individual SVG rectangles, significantly improving performance for high-resolution grids.

## Key Changes
- **Dynamic grid resolution**: Changed from fixed 18x18 grid to dynamically calculated resolution based on mesh parameters (8 cells per mesh element, clamped between 24-120)
- **Canvas-based rendering**: Replaced individual SVG rect elements with a single canvas element that is converted to a data URL and embedded as an SVG image
- **Simplified coordinate calculations**: Removed intermediate cellWidth/cellHeight variables in favor of direct pixel calculations using drawWidth/drawHeight and grid dimensions
- **Performance improvement**: Reduces DOM operations from potentially thousands of individual elements to a single image element

## Implementation Details
- Grid resolution now scales with `params.nx` and `params.ny` to maintain consistent cell density across different mesh sizes
- Canvas is created at the exact grid resolution (cols × rows) for pixel-perfect rendering
- The canvas is then scaled to fill the entire draw area via SVG image attributes with `preserveAspectRatio: 'none'`
- All intensity, hue, and alpha calculations remain unchanged, ensuring visual consistency

https://claude.ai/code/session_018Y5Mgttzby7E3NwqcApTqB