### PR TITLE
Add unit system toggle UI and fix surface layer thickness units

### DIFF
--- a/groundgrid.html
+++ b/groundgrid.html
@@ -121,6 +121,14 @@
 
       <form id="ground-grid-form" novalidate>
 
+        <div class="field-row">
+          <span class="cp-mode-switch__label">Unit System</span>
+          <div class="cp-mode-switch" role="group" aria-label="Unit system">
+            <button type="button" class="cp-mode-switch__button is-active" data-unit="imperial">Imperial (ft, in)</button>
+            <button type="button" class="cp-mode-switch__button" data-unit="metric">Metric (m, mm)</button>
+          </div>
+        </div>
+
         <!-- Soil Parameters -->
         <fieldset>
           <legend><strong>Soil Parameters</strong></legend>
@@ -311,12 +319,12 @@
 
           <div class="field-row">
             <label for="surface-hs">
-              h<sub>s</sub> — Surface layer thickness (<span class="unit-label-ft">ft</span><span class="unit-label-m" hidden>m</span>, 0 = none)
+              h<sub>s</sub> — Surface layer thickness (<span class="unit-label-ft">in</span><span class="unit-label-m" hidden>m</span>, 0 = none)
             </label>
             <input type="number" id="surface-hs" min="0" step="0.01"
                    value="0" aria-describedby="surface-hs-hint">
             <p id="surface-hs-hint" class="field-hint">
-              Thickness of the surface material. Typical crushed stone layer: 0.1–0.2 m (4–6 in).
+              Thickness of the surface material. Typical crushed stone layer: 4–6 in (0.1–0.2 m).
             </p>
           </div>
         </fieldset>

--- a/groundgrid.js
+++ b/groundgrid.js
@@ -37,6 +37,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return sel ? sel.value : 'imperial';
   }
 
+  function updateUnitLabels(imperial) {
+    document.querySelectorAll('.unit-label-ft').forEach(el => { el.hidden = !imperial; });
+    document.querySelectorAll('.unit-label-m').forEach(el => { el.hidden = imperial; });
+  }
+
   function renderResult(label, value, unit, safe) {
     const row = document.createElement('div');
     row.className = 'result-row' + (safe === true ? ' result-safe' : safe === false ? ' result-fail' : '');
@@ -68,18 +73,20 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function getPreviewParams() {
-    const unit = getUnits() === 'imperial' ? 'ft' : 'm';
+    const imperial = getUnits() === 'imperial';
+    const unit = imperial ? 'ft' : 'm';
     const gridLxInput = getNum('grid-lx');
     const gridLyInput = getNum('grid-ly');
     const burialDepthInput = getNum('burial-depth');
-    const hsInput = getNum('surface-hs') || 0;
+    const hsRaw = getNum('surface-hs') || 0;
+    const hsInput = imperial ? hsRaw / 12 : hsRaw; // convert in→ft so hs is same unit as burialDepth
     const conductorInput = getNum('conductor-diameter');
     const nxInput = getInt('nx');
     const nyInput = getInt('ny');
     const hasRods = document.getElementById('has-rods').checked;
     const rodSpacingXInput = getNum('rod-spacing-x');
     const rodSpacingYInput = getNum('rod-spacing-y');
-    const diameterUnit = unit === 'ft' ? 'in' : 'mm';
+    const diameterUnit = imperial ? 'in' : 'mm';
 
     const normalized = normalizePreviewGeometry({
       gridLxInput,
@@ -94,7 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
       rodSpacingYInput,
     });
 
-    return { unit, diameterUnit, hasRods, ...normalized };
+    return { unit, diameterUnit, hasRods, ...normalized, hsDisplay: hsRaw, hsDisplayUnit: imperial ? 'in' : 'm' };
   }
 
   function setRodSpacingVisibility() {
@@ -312,7 +319,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     drawDimension(svgEl, left - 24, gradeY, left - 24, conductorY, `h = ${formatDim(params.burialDepth, params.unit)}`, -10);
     if (params.hs > 0) {
-      drawDimension(svgEl, right + 20, gradeY, right + 20, surfaceBottom, `hs = ${formatDim(params.hs, params.unit)}`, -10);
+      drawDimension(svgEl, right + 20, gradeY, right + 20, surfaceBottom, `hs = ${formatDim(params.hsDisplay, params.hsDisplayUnit)}`, -10);
     }
 
     const gradeLabel = makeSvg('text', { x: left + 4, y: gradeY - 8, class: 'grid-legend-text' });
@@ -347,7 +354,7 @@ document.addEventListener('DOMContentLoaded', () => {
       + `${params.nx} horizontal runs • ${params.ny} vertical runs • `
       + `Spacing: ${params.spacingX.toFixed(1)} ${params.unit} (x), ${params.spacingY.toFixed(1)} ${params.unit} (y)`
       + ` • h: ${params.burialDepth.toFixed(2)} ${params.unit}`
-      + (params.hs > 0 ? ` • hs: ${params.hs.toFixed(2)} ${params.unit}` : '')
+      + (params.hs > 0 ? ` • hs: ${params.hsDisplay.toFixed(2)} ${params.hsDisplayUnit}` : '')
       + (params.hasRods ? ` • Ground rods: ${params.rodLayout.count} (${params.rodLayout.intermediateCount} intermediate)` : '')
       + (params.hasRods && params.rodLayout.axisSpacingX > 0 ? ` • Rod spacing x ≈ ${params.rodLayout.axisSpacingX.toFixed(1)} ${params.unit}` : '')
       + (params.hasRods && params.rodLayout.axisSpacingY > 0 ? ` • Rod spacing y ≈ ${params.rodLayout.axisSpacingY.toFixed(1)} ${params.unit}` : '');
@@ -386,7 +393,7 @@ document.addEventListener('DOMContentLoaded', () => {
       h = ftToM(getNum('burial-depth'));
       d = inToM(getNum('conductor-diameter'));
       rhoS = getNum('surface-rho') || 0;
-      hs = ftToM(getNum('surface-hs') || 0);
+      hs = inToM(getNum('surface-hs') || 0);
     } else {
       gridLx = getNum('grid-lx');
       gridLy = getNum('grid-ly');
@@ -550,11 +557,26 @@ document.addEventListener('DOMContentLoaded', () => {
     hasRodsCheckbox.addEventListener('change', handleFormStateChange);
   }
 
+  function onUnitChange() {
+    const imperial = getUnits() === 'imperial';
+    updateUnitLabels(imperial);
+    document.querySelectorAll('[data-unit]').forEach(btn => {
+      btn.classList.toggle('is-active', btn.dataset.unit === (imperial ? 'imperial' : 'metric'));
+    });
+    renderGridPreview();
+  }
+
+  document.querySelectorAll('[data-unit]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const unitSel = document.getElementById('unit-select');
+      if (unitSel) unitSel.value = btn.dataset.unit;
+      onUnitChange();
+    });
+  });
+
   const unitSelect = document.getElementById('unit-select');
   if (unitSelect) {
-    unitSelect.addEventListener('change', () => {
-      renderGridPreview();
-    });
+    unitSelect.addEventListener('change', onUnitChange);
   }
 
   ['show-step-overlay', 'step-overlay-opacity'].forEach(id => {
@@ -567,4 +589,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   renderGridPreview();
   setRodSpacingVisibility();
+
+  const initialImperial = getUnits() === 'imperial';
+  updateUnitLabels(initialImperial);
+  document.querySelectorAll('[data-unit]').forEach(btn => {
+    btn.classList.toggle('is-active', btn.dataset.unit === (initialImperial ? 'imperial' : 'metric'));
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds a visual unit system toggle button to the UI and fixes the handling of surface layer thickness (hs) to use inches in imperial mode instead of feet, ensuring consistent unit representation across the application.

## Key Changes

- **Added unit system toggle buttons**: Implemented a new button group UI component (`cp-mode-switch`) that allows users to switch between Imperial and Metric unit systems, replacing the hidden select dropdown as the primary interaction method.

- **Fixed surface layer thickness units**: Changed `surface-hs` input to use inches (in) in imperial mode instead of feet, with corresponding conversion logic in `getPreviewParams()` to normalize it to feet for internal calculations (matching `burialDepth` units).

- **Implemented `updateUnitLabels()` function**: New function to toggle visibility of unit labels (`.unit-label-ft` and `.unit-label-m`) based on the selected unit system.

- **Created `onUnitChange()` handler**: Centralized unit change logic that updates unit labels, toggles active state on unit buttons, and re-renders the grid preview.

- **Updated unit button event listeners**: Added click handlers to unit toggle buttons that update the hidden select element and trigger the unit change handler.

- **Fixed hs conversion in metric mode**: Changed line 396 from `ftToM()` to `inToM()` to correctly convert inches to meters for the surface layer thickness calculation.

- **Added display unit tracking**: Extended `getPreviewParams()` return value to include `hsDisplay` and `hsDisplayUnit` to preserve the original input value and its unit for display purposes, separate from the normalized internal calculation.

- **Updated preview labels**: Modified dimension and summary text generation to use `hsDisplay` and `hsDisplayUnit` instead of the normalized `hs` value, ensuring the displayed value matches user input.

- **Initialized unit state on page load**: Added initialization code to set the correct active button state and unit label visibility when the page first loads.

## Notable Implementation Details

- The surface layer thickness is now stored in inches (imperial) or meters (metric) in the input, but internally normalized to feet or meters respectively for calculations, maintaining consistency with burial depth units.
- Unit toggle buttons are synchronized with the hidden select element to maintain backward compatibility.
- The `hsDisplay` and `hsDisplayUnit` approach allows the preview to show the exact user input while calculations use normalized values.

https://claude.ai/code/session_01DWntVKdjKEnDz2sCFwgG5i