### PR TITLE
Fix Revit export to call valid dataStore APIs

### DIFF
--- a/src/racewayschedule.js
+++ b/src/racewayschedule.js
@@ -774,8 +774,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     exportRevitBtn.addEventListener('click', () => {
       const trays = dataStore.getTrays();
       const conduits = dataStore.getConduits();
-      const cables = dataStore.getCableSchedule ? dataStore.getCableSchedule() : [];
-      const projectName = dataStore.getProjectName ? dataStore.getProjectName() : 'CableTrayRoute Export';
+      const cables = dataStore.getCables();
+      const projectName = 'CableTrayRoute Export';
       downloadRevitExport({ trays, conduits, cables, projectName });
     });
   }


### PR DESCRIPTION
### Motivation
- Eliminate Rollup "Missing exports" warnings caused by `racewayschedule.js` referencing non-exported `getCableSchedule` and `getProjectName` symbols and ensure the Revit export handler uses the public data-store API.

### Description
- Updated the Revit export click handler in `src/racewayschedule.js` to call `dataStore.getCables()` and use a stable default project name string instead of probing `getCableSchedule`/`getProjectName`.

### Testing
- Ran `npm test --silent` and `npm run build --silent`, both completed successfully; the build still reports pre-existing unresolved external dependency warnings, but the missing-export warnings from `racewayschedule.js` are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7845376848324944b1bc52ddad711)