### PR TITLE
Improve heat trace sizing for high wind and add insulation type selection

### DIFF
--- a/analysis/heatTraceSizing.mjs
+++ b/analysis/heatTraceSizing.mjs
@@ -57,6 +57,15 @@ export const STANDARD_HEAT_TRACE_RATINGS_W_PER_FT = [
 /** Default thermal conductivity for insulation (W/m-K), typical for mineral wool / foam ranges. */
 export const DEFAULT_INSULATION_K_W_PER_MK = 0.04;
 
+/** Representative insulation thermal conductivity values (W/m-K). Lower values reduce heat dissipation. */
+export const INSULATION_TYPE_K_W_PER_MK = {
+  mineralWool: 0.04,
+  closedCellFoam: 0.028,
+  fiberglass: 0.042,
+  calciumSilicate: 0.06,
+  aerogelBlanket: 0.021,
+};
+
 const INCH_TO_M = 0.0254;
 const FT_TO_M = 0.3048;
 
@@ -107,14 +116,20 @@ export function validateHeatTraceInputs(inputs) {
     safetyMarginPct = 10,
     pipeMaterial = 'carbonSteel',
     environment = 'outdoor-sheltered',
-    insulationK = DEFAULT_INSULATION_K_W_PER_MK,
+    insulationType = 'mineralWool',
+    insulationK,
   } = inputs;
 
   const resolvedPipeOdIn = resolvePipeOdIn({ pipeNps, pipeOdIn });
 
   assertFinitePositive(insulationThicknessIn, 'insulationThicknessIn');
   assertFinitePositive(lineLengthFt, 'lineLengthFt');
-  assertFinitePositive(insulationK, 'insulationK');
+  if (!Object.prototype.hasOwnProperty.call(INSULATION_TYPE_K_W_PER_MK, insulationType)) {
+    throw new Error(`Unsupported insulationType "${insulationType}"`);
+  }
+
+  const resolvedInsulationK = insulationK ?? INSULATION_TYPE_K_W_PER_MK[insulationType] ?? DEFAULT_INSULATION_K_W_PER_MK;
+  assertFinitePositive(resolvedInsulationK, 'insulationK');
 
   if (!Number.isFinite(maintainTempC) || !Number.isFinite(ambientTempC)) {
     throw new Error('maintainTempC and ambientTempC must be finite numbers');
@@ -130,11 +145,11 @@ export function validateHeatTraceInputs(inputs) {
     throw new Error('safetyMarginPct must be between 0 and 100');
   }
 
-  if (!ENVIRONMENT_MULTIPLIERS[environment]) {
+  if (!Object.prototype.hasOwnProperty.call(ENVIRONMENT_MULTIPLIERS, environment)) {
     throw new Error(`Unsupported environment "${environment}"`);
   }
 
-  if (!PIPE_MATERIAL_FACTORS[pipeMaterial]) {
+  if (!Object.prototype.hasOwnProperty.call(PIPE_MATERIAL_FACTORS, pipeMaterial)) {
     throw new Error(`Unsupported pipeMaterial "${pipeMaterial}"`);
   }
 
@@ -153,7 +168,8 @@ export function validateHeatTraceInputs(inputs) {
     safetyMarginPct,
     pipeMaterial,
     environment,
-    insulationK,
+    insulationType,
+    insulationK: resolvedInsulationK,
   };
 }
 
@@ -180,7 +196,14 @@ export function externalFilmResistance({ pipeOdIn, insulationThicknessIn, enviro
 
   const rOuterM = (pipeOdIn * INCH_TO_M) / 2 + insulationThicknessIn * INCH_TO_M;
   const baseH = 7; // W/m2-K representative natural convection + radiation
-  const windBoost = environment === 'outdoor-windy' ? 0.5 * windSpeedMph : 0;
+  let windBoost = 0;
+  if (environment === 'outdoor-windy') {
+    windBoost = 0.5 * windSpeedMph;
+  } else if (environment === 'outdoor-sheltered') {
+    windBoost = 0.2 * windSpeedMph;
+  } else if (environment === 'hazardous-area') {
+    windBoost = 0.15 * windSpeedMph;
+  }
   const hEff = Math.max(2, (baseH + windBoost) * envFactor);
 
   return 1 / (hEff * 2 * Math.PI * rOuterM);

--- a/docs/heat-trace-sizing.md
+++ b/docs/heat-trace-sizing.md
@@ -47,6 +47,20 @@ q_{\text{req,mat}} = q_{\text{req}} \times F_{\text{mat}}
 
 If heat trace is controlled by thermostats or line-sensing controllers, verify both **minimum output at design cold** and **maximum sheath/jacket temperature** at reduced load.
 
+## Insulation type assumptions
+
+Insulation thermal conductivity is a first-order driver of line losses. The calculator supports common insulation materials with representative conductivity values:
+
+| Insulation type | Conductivity \(k\) (W/m·K) | Practical note |
+| --- | ---: | --- |
+| Closed cell foam | 0.028 | Lower heat dissipation; common for freeze protection and moisture resistance |
+| Mineral wool | 0.040 | Common process piping baseline; good high-temperature performance |
+| Fiberglass | 0.042 | Similar to mineral wool for many preliminary studies |
+| Calcium silicate | 0.060 | Higher conductivity; often used where compressive strength is needed |
+| Aerogel blanket | 0.021 | Premium low-loss insulation for constrained space/high performance |
+
+These are screening-level values. Use project or manufacturer data sheets for final design and hot-service verification.
+
 ## Environment classes and multipliers
 
 Use environment multipliers to account for exposure severity beyond nominal still-air assumptions.
@@ -59,7 +73,7 @@ Use environment multipliers to account for exposure severity beyond nominal stil
 | E4 | High wind/coastal or frequent wetting | 1.30 |
 | E5 | Severe cyclic wet/freezing service | 1.40 |
 
-Project teams may replace these with corporate or site climatology factors. Keep one documented source of truth for consistency across all line classes.
+Project teams may replace these with corporate or site climatology factors. Keep one documented source of truth for consistency across all line classes. For outdoor runs, include measured or design wind speed (including values above 20 mph) to avoid understating convective losses.
 
 ## Example hand-check calculation
 

--- a/heattracesizing.html
+++ b/heattracesizing.html
@@ -129,6 +129,18 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
           </div>
 
           <div class="field-row">
+            <label for="insulation-type">Insulation type</label>
+            <select id="insulation-type" aria-describedby="insulation-type-hint">
+              <option value="mineralWool" selected>Mineral Wool</option>
+              <option value="closedCellFoam">Closed Cell Foam</option>
+              <option value="fiberglass">Fiberglass</option>
+              <option value="calciumSilicate">Calcium Silicate</option>
+              <option value="aerogelBlanket">Aerogel Blanket</option>
+            </select>
+            <p id="insulation-type-hint" class="field-hint">Insulation material changes thermal conductivity and heat loss. Closed cell foam usually reduces heat dissipation compared with mineral wool.</p>
+          </div>
+
+          <div class="field-row">
             <label for="line-length-ft">Circuit length (ft)</label>
             <input type="number" id="line-length-ft" min="1" step="1" value="200" required aria-describedby="line-length-hint">
             <p id="line-length-hint" class="field-hint">Total pipe run length for the heat trace circuit. Include equivalent allowances for valves and fittings where applicable.</p>

--- a/heattracesizing.js
+++ b/heattracesizing.js
@@ -44,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return {
       pipeNps: get('pipe-nps').value,
       insulationThicknessIn: getFloat('insulation-thickness-in'),
+      insulationType: get('insulation-type').value,
       lineLengthFt: getFloat('line-length-ft'),
       pipeMaterial: get('pipe-material').value,
       environment: get('environment').value,


### PR DESCRIPTION
### Motivation

- Fix the heat-trace Run Analysis so high wind inputs (≥ 20 mph) influence convective loss and make insulation selection explicit in the sizing model.
- Provide a simple UI control for common insulation materials because insulation thermal conductivity materially changes required W/ft.

### Description

- Added an `Insulation type` selector to the Heat Trace Sizing form with options for `mineralWool`, `closedCellFoam`, `fiberglass`, `calciumSilicate`, and `aerogelBlanket` (`heattracesizing.html`).
- Wired the selected `insulationType` into the form payload (`heattracesizing.js`) so the analysis receives the chosen material.
- Introduced `INSULATION_TYPE_K_W_PER_MK` and logic to resolve/validate `insulationType` (and an optional override `insulationK`) in the analysis, and used the resolved conductivity in `cylindricalInsulationResistance` (`analysis/heatTraceSizing.mjs`).
- Improved external-film/wind treatment so `windSpeedMph` contributes to `windBoost` across outdoor/special environments (not only when environment is `outdoor-windy`), and hardened environment/material key lookups and validation; updated docs to describe insulation assumptions (`docs/heat-trace-sizing.md`).

### Testing

- Built the site with `npm run build` and the build completed successfully.
- Started the test runner with `npm test`, which executed many test suites and showed substantial green results before runtime limits prevented a full run to completion.
- Attempted to capture a page preview with Playwright, but `npx playwright install chromium` failed due to network/permission errors (403 from Playwright CDN) which prevented automated screenshot generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7876cb8cc8324b80dd4d44bc2ea2b)