### PR TITLE
Add imperial/metric unit toggle to heat trace sizing page

### DIFF
--- a/heattracesizing.html
+++ b/heattracesizing.html
@@ -97,6 +97,19 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
 
       <form id="heat-trace-form" novalidate>
         <fieldset>
+          <legend><strong>Unit System</strong></legend>
+
+          <div class="field-row">
+            <label for="unit-system">Preferred units</label>
+            <select id="unit-system" aria-describedby="unit-system-hint">
+              <option value="imperial" selected>Imperial (°F, ft, in, mph)</option>
+              <option value="metric">Metric (°C, m, mm, km/h)</option>
+            </select>
+            <p id="unit-system-hint" class="field-hint">Switch between imperial and metric entry values. The sizing engine normalizes units internally before calculations.</p>
+          </div>
+        </fieldset>
+
+        <fieldset>
           <legend><strong>Pipe + Insulation Geometry</strong></legend>
 
           <div class="field-row">
@@ -120,7 +133,7 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
           </div>
 
           <div class="field-row">
-            <label for="insulation-thickness-in">
+            <label id="insulation-thickness-label" for="insulation-thickness-in">
               Insulation thickness (in)
               <button type="button" class="helpBtn" aria-label="Help — insulation thickness">?</button>
             </label>
@@ -141,7 +154,7 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
           </div>
 
           <div class="field-row">
-            <label for="line-length-ft">Circuit length (ft)</label>
+            <label id="line-length-label" for="line-length-ft">Circuit length (ft)</label>
             <input type="number" id="line-length-ft" min="1" step="1" value="200" required aria-describedby="line-length-hint">
             <p id="line-length-hint" class="field-hint">Total pipe run length for the heat trace circuit. Include equivalent allowances for valves and fittings where applicable.</p>
           </div>
@@ -180,13 +193,13 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
           </div>
 
           <div class="field-row">
-            <label for="ambient-temp-c">Ambient temperature (&deg;C)</label>
+            <label id="ambient-temp-label" for="ambient-temp-c">Ambient temperature (&deg;C)</label>
             <input type="number" id="ambient-temp-c" min="-60" max="60" step="1" value="-10" required aria-describedby="ambient-temp-hint">
             <p id="ambient-temp-hint" class="field-hint">Use the lowest sustained ambient expected during operation for conservative sizing.</p>
           </div>
 
           <div class="field-row">
-            <label for="wind-speed-mph">Wind speed (mph)</label>
+            <label id="wind-speed-label" for="wind-speed-mph">Wind speed (mph)</label>
             <input type="number" id="wind-speed-mph" min="0" max="100" step="1" value="5" aria-describedby="wind-speed-hint">
             <p id="wind-speed-hint" class="field-hint">Required for exposed outdoor runs. For indoor/sheltered installations, leave at a nominal low value.</p>
           </div>
@@ -196,7 +209,7 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
           <legend><strong>Maintain Temperature Target</strong></legend>
 
           <div class="field-row">
-            <label for="maintain-temp-c">Maintain temperature (&deg;C)</label>
+            <label id="maintain-temp-label" for="maintain-temp-c">Maintain temperature (&deg;C)</label>
             <input type="number" id="maintain-temp-c" min="-20" max="250" step="1" value="40" required aria-describedby="maintain-temp-hint">
             <p id="maintain-temp-hint" class="field-hint">Required process hold temperature at the pipe wall. Must be greater than ambient to compute heat-loss sizing.</p>
           </div>
@@ -218,7 +231,7 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
           </div>
 
           <div class="field-row">
-            <label for="max-circuit-length-ft">Maximum allowable circuit length (ft)</label>
+            <label id="max-circuit-length-label" for="max-circuit-length-ft">Maximum allowable circuit length (ft)</label>
             <input type="number" id="max-circuit-length-ft" min="10" step="10" value="300" aria-describedby="max-circuit-length-hint">
             <p id="max-circuit-length-hint" class="field-hint">Project-specific circuit-length planning limit. Compare with manufacturer cable tables during final design.</p>
           </div>

--- a/heattracesizing.js
+++ b/heattracesizing.js
@@ -11,13 +11,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const form = document.getElementById('heat-trace-form');
   const resultsDiv = document.getElementById('results');
+  const unitSystemSelect = document.getElementById('unit-system');
+  let activeUnitSystem = unitSystemSelect?.value || 'imperial';
 
   initStudyApprovalPanel('heatTraceSizing');
 
   const saved = getStudies().heatTraceSizing;
   if (saved) {
+    const savedUnitSystem = saved.unitSystem || 'imperial';
+    if (unitSystemSelect) {
+      unitSystemSelect.value = savedUnitSystem;
+      activeUnitSystem = savedUnitSystem;
+    }
+    applyUnitSystem(activeUnitSystem, { convertExistingValues: false });
     renderResults(saved);
+  } else {
+    applyUnitSystem(activeUnitSystem, { convertExistingValues: false });
   }
+
+  unitSystemSelect?.addEventListener('change', () => {
+    const nextUnitSystem = unitSystemSelect.value;
+    if (nextUnitSystem === activeUnitSystem) return;
+    applyUnitSystem(nextUnitSystem, { convertExistingValues: true });
+    activeUnitSystem = nextUnitSystem;
+  });
 
   form.addEventListener('submit', e => {
     e.preventDefault();
@@ -29,6 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
       showModal('Input Error', `<p>${escHtml(err.message)}</p>`, 'error');
       return;
     }
+    result.unitSystem = activeUnitSystem;
 
     const studies = getStudies();
     studies.heatTraceSizing = result;
@@ -41,23 +59,54 @@ document.addEventListener('DOMContentLoaded', () => {
     const get = id => document.getElementById(id);
     const getFloat = id => parseFloat(get(id).value);
 
-    return {
+    const ambientValue = getFloat('ambient-temp-c');
+    const maintainValue = getFloat('maintain-temp-c');
+    const insulationThicknessValue = getFloat('insulation-thickness-in');
+    const lineLengthValue = getFloat('line-length-ft');
+    const windSpeedValue = getFloat('wind-speed-mph') || 0;
+    const maxCircuitLengthValue = getFloat('max-circuit-length-ft') || 0;
+
+    const inputs = {
       pipeNps: get('pipe-nps').value,
-      insulationThicknessIn: getFloat('insulation-thickness-in'),
+      insulationThicknessIn: insulationThicknessValue,
       insulationType: get('insulation-type').value,
-      lineLengthFt: getFloat('line-length-ft'),
+      lineLengthFt: lineLengthValue,
       pipeMaterial: get('pipe-material').value,
       environment: get('environment').value,
-      ambientTempC: getFloat('ambient-temp-c'),
-      maintainTempC: getFloat('maintain-temp-c'),
-      windSpeedMph: getFloat('wind-speed-mph') || 0,
+      ambientTempC: ambientValue,
+      maintainTempC: maintainValue,
+      windSpeedMph: windSpeedValue,
       safetyMarginPct: getFloat('design-margin-pct'),
       voltageV: getFloat('voltage-v') || 0,
-      maxCircuitLengthFt: getFloat('max-circuit-length-ft') || 0,
+      maxCircuitLengthFt: maxCircuitLengthValue,
     };
+
+    if (activeUnitSystem === 'metric') {
+      inputs.insulationThicknessIn = metricToImperial.insulationThicknessIn(insulationThicknessValue);
+      inputs.lineLengthFt = metricToImperial.lineLengthFt(lineLengthValue);
+      inputs.ambientTempC = ambientValue;
+      inputs.maintainTempC = maintainValue;
+      inputs.windSpeedMph = metricToImperial.windSpeedMph(windSpeedValue);
+      inputs.maxCircuitLengthFt = metricToImperial.maxCircuitLengthFt(maxCircuitLengthValue);
+    } else {
+      inputs.ambientTempC = imperialToMetric.ambientTempC(ambientValue);
+      inputs.maintainTempC = imperialToMetric.maintainTempC(maintainValue);
+    }
+
+    return inputs;
   }
 
   function renderResults(result) {
+    const displayDeltaT = result.unitSystem === 'metric'
+      ? `${result.deltaT.toFixed(1)} &deg;C`
+      : `${cToFDelta(result.deltaT).toFixed(1)} &deg;F`;
+    const displayRequiredOutput = result.unitSystem === 'metric'
+      ? `${result.requiredWPerM.toFixed(2)} W/m`
+      : `${result.requiredWPerFt.toFixed(2)} W/ft`;
+    const displaySelectedRating = result.unitSystem === 'metric'
+      ? `${wPerFtToWPerM(result.recommendedCableRatingWPerFt).toFixed(2)} W/m`
+      : `${result.recommendedCableRatingWPerFt} W/ft`;
+
     const warningItems = result.warnings.length
       ? `<ul class="drc-findings">${result.warnings.map((w) =>
           `<li class="drc-finding drc-warn"><span class="drc-msg">${escHtml(w)}</span></li>`
@@ -71,15 +120,15 @@ document.addEventListener('DOMContentLoaded', () => {
         <div class="result-group">
           <div class="result-row">
             <span class="result-label">Temperature differential (ΔT)</span>
-            <span class="result-value">${result.deltaT.toFixed(1)} &deg;C</span>
+            <span class="result-value">${displayDeltaT}</span>
           </div>
           <div class="result-row">
             <span class="result-label">Required heat output</span>
-            <span class="result-value"><strong>${result.requiredWPerFt.toFixed(2)} W/ft</strong></span>
+            <span class="result-value"><strong>${displayRequiredOutput}</strong></span>
           </div>
           <div class="result-row">
             <span class="result-label">Selected standard cable rating</span>
-            <span class="result-value"><strong>${result.recommendedCableRatingWPerFt} W/ft</strong></span>
+            <span class="result-value"><strong>${displaySelectedRating}</strong></span>
           </div>
           <div class="result-row">
             <span class="result-label">Total estimated circuit load</span>
@@ -93,4 +142,189 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
       </section>`;
   }
+
+  function applyUnitSystem(unitSystem, { convertExistingValues = true } = {}) {
+    const fieldConfigs = [
+      {
+        id: 'insulation-thickness-in',
+        labelId: 'insulation-thickness-label',
+        imperialLabel: 'Insulation thickness (in)',
+        metricLabel: 'Insulation thickness (mm)',
+        imperialMin: 0.25,
+        imperialMax: null,
+        imperialStep: 0.25,
+        metricMin: 6.35,
+        metricMax: null,
+        metricStep: 1,
+        toMetric: imperialToMetric.insulationThicknessIn,
+        toImperial: metricToImperial.insulationThicknessIn,
+      },
+      {
+        id: 'line-length-ft',
+        labelId: 'line-length-label',
+        imperialLabel: 'Circuit length (ft)',
+        metricLabel: 'Circuit length (m)',
+        imperialMin: 1,
+        imperialMax: null,
+        imperialStep: 1,
+        metricMin: 0.3,
+        metricMax: null,
+        metricStep: 0.1,
+        toMetric: imperialToMetric.lineLengthFt,
+        toImperial: metricToImperial.lineLengthFt,
+      },
+      {
+        id: 'ambient-temp-c',
+        labelId: 'ambient-temp-label',
+        imperialLabel: 'Ambient temperature (&deg;F)',
+        metricLabel: 'Ambient temperature (&deg;C)',
+        imperialMin: -76,
+        imperialMax: 140,
+        imperialStep: 1,
+        metricMin: -60,
+        metricMax: 60,
+        metricStep: 1,
+        toMetric: imperialToMetric.ambientTempC,
+        toImperial: metricToImperial.ambientTempC,
+      },
+      {
+        id: 'wind-speed-mph',
+        labelId: 'wind-speed-label',
+        imperialLabel: 'Wind speed (mph)',
+        metricLabel: 'Wind speed (km/h)',
+        imperialMin: 0,
+        imperialMax: 100,
+        imperialStep: 1,
+        metricMin: 0,
+        metricMax: 161,
+        metricStep: 1,
+        toMetric: imperialToMetric.windSpeedMph,
+        toImperial: metricToImperial.windSpeedMph,
+      },
+      {
+        id: 'maintain-temp-c',
+        labelId: 'maintain-temp-label',
+        imperialLabel: 'Maintain temperature (&deg;F)',
+        metricLabel: 'Maintain temperature (&deg;C)',
+        imperialMin: -4,
+        imperialMax: 482,
+        imperialStep: 1,
+        metricMin: -20,
+        metricMax: 250,
+        metricStep: 1,
+        toMetric: imperialToMetric.maintainTempC,
+        toImperial: metricToImperial.maintainTempC,
+      },
+      {
+        id: 'max-circuit-length-ft',
+        labelId: 'max-circuit-length-label',
+        imperialLabel: 'Maximum allowable circuit length (ft)',
+        metricLabel: 'Maximum allowable circuit length (m)',
+        imperialMin: 10,
+        imperialMax: null,
+        imperialStep: 10,
+        metricMin: 3,
+        metricMax: null,
+        metricStep: 1,
+        toMetric: imperialToMetric.maxCircuitLengthFt,
+        toImperial: metricToImperial.maxCircuitLengthFt,
+      },
+    ];
+
+    fieldConfigs.forEach(config => {
+      const input = document.getElementById(config.id);
+      const label = document.getElementById(config.labelId);
+      if (!input || !label) return;
+
+      const currentValue = parseFloat(input.value);
+      const convertedValue = convertExistingValues && Number.isFinite(currentValue)
+        ? (unitSystem === 'metric' ? config.toMetric(currentValue) : config.toImperial(currentValue))
+        : currentValue;
+
+      if (unitSystem === 'metric') {
+        setLabelText(label, config.metricLabel);
+        input.min = String(config.metricMin);
+        input.step = String(config.metricStep);
+        if (config.metricMax == null) {
+          input.removeAttribute('max');
+        } else {
+          input.max = String(config.metricMax);
+        }
+      } else {
+        setLabelText(label, config.imperialLabel);
+        input.min = String(config.imperialMin);
+        input.step = String(config.imperialStep);
+        if (config.imperialMax == null) {
+          input.removeAttribute('max');
+        } else {
+          input.max = String(config.imperialMax);
+        }
+      }
+
+      if (convertExistingValues && Number.isFinite(convertedValue)) {
+        input.value = roundForDisplay(convertedValue, config.id);
+      }
+    });
+  }
 });
+
+function roundForDisplay(value, fieldId) {
+  const precisionByField = {
+    'insulation-thickness-in': 1,
+    'line-length-ft': 1,
+    'ambient-temp-c': 0,
+    'wind-speed-mph': 0,
+    'maintain-temp-c': 0,
+    'max-circuit-length-ft': 0,
+  };
+  const decimals = precisionByField[fieldId] ?? 2;
+  return value.toFixed(decimals);
+}
+
+function setLabelText(label, text) {
+  const helpButton = label.querySelector('.helpBtn');
+  if (helpButton) {
+    const existingTextNode = Array.from(label.childNodes).find(node => node.nodeType === Node.TEXT_NODE);
+    if (existingTextNode) {
+      existingTextNode.textContent = `${text} `;
+    } else {
+      label.insertBefore(document.createTextNode(`${text} `), helpButton);
+    }
+    return;
+  }
+  label.innerHTML = text;
+}
+
+function cToF(tempC) {
+  return (tempC * 9 / 5) + 32;
+}
+
+function fToC(tempF) {
+  return (tempF - 32) * 5 / 9;
+}
+
+function cToFDelta(deltaC) {
+  return deltaC * 9 / 5;
+}
+
+function wPerFtToWPerM(wPerFt) {
+  return wPerFt / 0.3048;
+}
+
+const imperialToMetric = {
+  ambientTempC: fToC,
+  maintainTempC: fToC,
+  insulationThicknessIn: inches => inches * 25.4,
+  lineLengthFt: feet => feet * 0.3048,
+  windSpeedMph: mph => mph * 1.60934,
+  maxCircuitLengthFt: feet => feet * 0.3048,
+};
+
+const metricToImperial = {
+  ambientTempC: cToF,
+  maintainTempC: cToF,
+  insulationThicknessIn: mm => mm / 25.4,
+  lineLengthFt: meters => meters / 0.3048,
+  windSpeedMph: kmh => kmh / 1.60934,
+  maxCircuitLengthFt: meters => meters / 0.3048,
+};


### PR DESCRIPTION
### Motivation
- Provide a user-facing unit-system toggle so the heat trace sizing form accepts Imperial (°F, ft, in, mph) or Metric (°C, m, mm, km/h) inputs and allow users to enter Fahrenheit as requested.

### Description
- Added a `Unit System` selector to `heattracesizing.html` and added label anchors for inputs that change with unit system (temperature, length, insulation thickness, wind speed, and max circuit length).
- Implemented unit handling in `heattracesizing.js` including conversion helpers (`cToF`, `fToC`, etc.), `applyUnitSystem()` to update labels/constraints and convert displayed values, and logic in `readInputs()` to normalize values back to the analysis engine’s expected base units before calling `runHeatTraceSizingAnalysis()`.
- Updated result rendering to display ΔT and cable output in the currently selected unit system and persisted the chosen `unitSystem` in saved study results.
- Preserved help-button behavior on labels and maintained numeric step/min constraints when switching systems.

### Testing
- Ran `node tests/heatTraceSizing.test.mjs` and it passed (heat trace sizing unit cases and validation checks succeeded).
- Ran `npm run build` and the site bundle was created successfully.
- Attempted full `npm test` (project-wide); the run hung in long-running collaboration tests in this environment and did not complete here.
- Attempted an automated Playwright screenshot to produce a preview image but the Playwright browser binaries were not installed in this environment, so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78a6b86f483249b2eca44f5db900c)