### PR TITLE
Add missing escHtml helper to Heat Trace Sizing page

### DIFF
--- a/heattracesizing.js
+++ b/heattracesizing.js
@@ -311,6 +311,16 @@ function wPerFtToWPerM(wPerFt) {
   return wPerFt / 0.3048;
 }
 
+function escHtml(str) {
+  return String(str ?? '').replace(/[&<>"']/g, ch => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[ch]));
+}
+
 const imperialToMetric = {
   ambientTempC: fToC,
   maintainTempC: fToC,


### PR DESCRIPTION
### Motivation
- Fix the `ReferenceError: escHtml is not defined` that prevented the Heat Trace Sizing page from rendering warnings and modal error text by providing a local HTML-escaping helper.

### Description
- Add a small `escHtml` function to `heattracesizing.js` and use it to sanitize warning and error strings before inserting them into the DOM to avoid runtime exceptions.

### Testing
- Ran `npm test` and all automated tests passed.
- Ran `npm run build` and the project built successfully.
- Attempted to capture a Playwright screenshot for a preview, but the environment lacked Playwright browser binaries so the screenshot step could not run (`Executable doesn't exist ... headless_shell`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e790ca11cc83249a7fb097b99107d4)