### PR TITLE
Add heat-trace component breakdown, circuit utilization, and profile scaffold

### DIFF
--- a/analysis/heatTraceSizing.mjs
+++ b/analysis/heatTraceSizing.mjs
@@ -68,6 +68,8 @@ export const INSULATION_TYPE_K_W_PER_MK = {
 
 const INCH_TO_M = 0.0254;
 const FT_TO_M = 0.3048;
+const DEFAULT_MAX_CIRCUIT_LENGTH_FT = 500;
+const NEAR_LIMIT_UTILIZATION_THRESHOLD = 0.85;
 
 function round(value, digits = 2) {
   const p = 10 ** digits;
@@ -78,6 +80,50 @@ function assertFinitePositive(value, label) {
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error(`${label} must be a finite number greater than zero`);
   }
+}
+
+function assertFiniteComputed(value, label) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${label} must be finite`);
+  }
+}
+
+function classifyCircuitUtilization(utilizationRatio) {
+  assertFiniteComputed(utilizationRatio, 'circuitUtilizationRatio');
+  if (utilizationRatio > 1) return 'overLimit';
+  if (utilizationRatio >= NEAR_LIMIT_UTILIZATION_THRESHOLD) return 'nearLimit';
+  return 'withinLimit';
+}
+
+function generatePipeTempProfile({
+  lineLengthFt,
+  maintainTempC,
+  ambientTempC,
+  circuitUtilizationRatio,
+  points = 11,
+}) {
+  assertFinitePositive(lineLengthFt, 'lineLengthFt');
+  assertFiniteComputed(maintainTempC, 'maintainTempC');
+  assertFiniteComputed(ambientTempC, 'ambientTempC');
+  assertFiniteComputed(circuitUtilizationRatio, 'circuitUtilizationRatio');
+
+  const profile = [];
+  const stepFt = lineLengthFt / (points - 1);
+  const utilizationClamp = Math.max(0, Math.min(circuitUtilizationRatio, 1.25));
+  const expectedTailDropC = (maintainTempC - ambientTempC) * 0.15 * utilizationClamp;
+
+  for (let i = 0; i < points; i += 1) {
+    const distanceFt = stepFt * i;
+    const progress = i / (points - 1);
+    const expectedPipeTempC = maintainTempC - expectedTailDropC * progress;
+
+    profile.push({
+      distanceFt: round(distanceFt, 2),
+      expectedPipeTempC: round(expectedPipeTempC, 2),
+    });
+  }
+
+  return profile;
 }
 
 /** Resolve pipe outside diameter in inches from direct OD or NPS. */
@@ -254,6 +300,11 @@ export function runHeatTraceSizingAnalysis(inputs) {
   const rTotal = rCond + rExt;
 
   const baseLossWPerM = deltaT / rTotal;
+  const conductionLossShare = rCond / rTotal;
+  const externalFilmLossShare = rExt / rTotal;
+  const baseLossConductionComponentWPerM = baseLossWPerM * conductionLossShare;
+  const baseLossExternalFilmComponentWPerM = baseLossWPerM * externalFilmLossShare;
+
   const materialFactor = PIPE_MATERIAL_FACTORS[pipeMaterial];
   const safetyFactor = 1 + safetyMarginPct / 100;
 
@@ -276,6 +327,32 @@ export function runHeatTraceSizingAnalysis(inputs) {
     warnings.push('Required W/ft exceeds available standard ratings. Use multiple runs or engineered solution.');
   }
 
+  const maxCircuitLengthFt = DEFAULT_MAX_CIRCUIT_LENGTH_FT;
+  const circuitUtilizationRatio = lineLengthFt / maxCircuitLengthFt;
+  const circuitLimitStatus = classifyCircuitUtilization(circuitUtilizationRatio);
+  const profile = generatePipeTempProfile({
+    lineLengthFt,
+    maintainTempC,
+    ambientTempC,
+    circuitUtilizationRatio,
+  });
+
+  const baseLossConductionComponentWPerFt = baseLossConductionComponentWPerM * FT_TO_M;
+  const baseLossExternalFilmComponentWPerFt = baseLossExternalFilmComponentWPerM * FT_TO_M;
+
+  assertFiniteComputed(baseLossWPerM, 'baseLossWPerM');
+  assertFiniteComputed(requiredWPerM, 'requiredWPerM');
+  assertFiniteComputed(requiredWPerFt, 'requiredWPerFt');
+  assertFiniteComputed(totalCircuitWatts, 'totalCircuitWatts');
+  assertFiniteComputed(baseLossConductionComponentWPerM, 'baseLossConductionComponentWPerM');
+  assertFiniteComputed(baseLossExternalFilmComponentWPerM, 'baseLossExternalFilmComponentWPerM');
+  assertFiniteComputed(circuitUtilizationRatio, 'circuitUtilizationRatio');
+
+  const unitConsistencyDelta = Math.abs(requiredWPerFt - (requiredWPerM * FT_TO_M));
+  if (unitConsistencyDelta > 1e-8) {
+    throw new Error('Computed power-unit conversion mismatch between W/m and W/ft');
+  }
+
   return {
     ...normalized,
     deltaT,
@@ -289,6 +366,25 @@ export function runHeatTraceSizingAnalysis(inputs) {
       materialFactor,
       safetyFactor: round(safetyFactor, 4),
     },
+    heatLossComponents: {
+      baseLossTotalWPerM: round(baseLossWPerM, 2),
+      baseLossTotalWPerFt: round(baseLossWPerM * FT_TO_M, 2),
+      conductionComponentWPerM: round(baseLossConductionComponentWPerM, 2),
+      conductionComponentWPerFt: round(baseLossConductionComponentWPerFt, 2),
+      externalFilmComponentWPerM: round(baseLossExternalFilmComponentWPerM, 2),
+      externalFilmComponentWPerFt: round(baseLossExternalFilmComponentWPerFt, 2),
+      conductionSharePct: round(conductionLossShare * 100, 2),
+      externalFilmSharePct: round(externalFilmLossShare * 100, 2),
+    },
+    circuit: {
+      maxCircuitLengthFt,
+      utilizationRatio: round(circuitUtilizationRatio, 4),
+      status: circuitLimitStatus,
+    },
+    maxCircuitLengthFt,
+    circuitUtilizationRatio: round(circuitUtilizationRatio, 4),
+    circuitLimitStatus,
+    profile,
     requiredWPerFt: round(requiredWPerFt, 2),
     requiredWPerM: round(requiredWPerM, 2),
     totalCircuitWatts: round(totalCircuitWatts, 1),


### PR DESCRIPTION
### Motivation

- Provide explicit component outputs used by charts so the UI can display conduction vs external-film contributions separately. 
- Surface derived circuit utilization metrics and a simple status classification to help callers flag long/over-limit runs. 
- Provide a small generated `profile` scaffold (distance + expected pipe temperature trend) for front-end plotting and previews. 
- Preserve existing return keys consumed by the current UI and add validation to ensure computed fields are finite and unit-consistent.

### Description

- Added constants `DEFAULT_MAX_CIRCUIT_LENGTH_FT` and `NEAR_LIMIT_UTILIZATION_THRESHOLD` and new helpers `assertFiniteComputed`, `classifyCircuitUtilization`, and `generatePipeTempProfile` to `analysis/heatTraceSizing.mjs`.
- Compute conduction/external-film shares and per-component losses, and expose them as a new `heatLossComponents` object with values in W/m and W/ft plus share percentages.
- Add derived circuit fields (`maxCircuitLengthFt`, `circuitUtilizationRatio`, `circuitLimitStatus`) and a nested `circuit` object, while also leaving the top-level `maxCircuitLengthFt`, `circuitUtilizationRatio`, and `circuitLimitStatus` keys for backward compatibility.
- Emit a generated `profile` array of distance points and `expectedPipeTempC` trend suitable for plotting, and add validation/unit-consistency checks (finite checks and W/m ↔ W/ft conversion delta guard).

### Testing

- Ran `node tests/analysis.test.cjs` which completed successfully. 
- Ran `npm run build` which completed successfully and produced the `dist` bundle. 
- Ran the full `npm test` run in this environment but the job exceeded the time budget and exited with timeout (`EXIT:124`), so the complete suite did not finish here. 
- Performed a smoke import and invocation (`node -e "import('./analysis/heatTraceSizing.mjs').then(m=>{...})"`) which returned the new keys and a `profile` length of `11` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0ecc1a0c8324b5069769688a6123)