### PR TITLE
docs: expand heat trace dashboard and acceptance guidance

### DIFF
--- a/docs/heat-trace-sizing.md
+++ b/docs/heat-trace-sizing.md
@@ -125,29 +125,58 @@ Preliminary selection would therefore target the next available trace-circuit ca
 - When freeze protection is safety- or production-critical, use a structured margin policy (environment + uncertainty + aging) rather than a single arbitrary adder.
 - Final design should reconcile process maintain temperature, insulation specification, power availability, hazardous area constraints, and manufacturer-specific cable output curves.
 
-## Heat Trace UI result interpretation
+## Heat Trace dashboard sections and interpretation
 
-The Heat Trace Sizing page now surfaces a KPI card grid to make output review faster:
+The Heat Trace Sizing workspace is organized into five dashboard sections so reviewers can move from quick screening to traceable assumptions without leaving the page:
 
-- **Heat loss (base):** Required line loss before applying design safety margin.
-- **Required heat input:** Final demand after safety margin and material correction factors.
-- **Recommended watt density:** Selected standard cable rating with utilization against required output.
-- **Circuit check:** Length compliance against configured maximum circuit length.
+1. **Overview**
+   - High-level KPI cards: base heat loss, required heat input, recommended watt density, and circuit length check.
+   - Current assumptions snapshot for ambient, maintain, insulation, and selected multipliers.
+2. **Heat Loss**
+   - Step-by-step thermal-resistance breakdown (insulation + external film) and resulting base W/ft (or W/m).
+   - Displays which assumptions dominate the loss so users can quickly identify leverage points.
+3. **Circuit Sizing**
+   - Candidate cable density selection versus required demand.
+   - Circuit-length utilization check against configured maximum allowable circuit length.
+4. **Temperature Profile**
+   - Charted maintain-to-ambient gradient view used as a screening visualization for thermal headroom.
+   - Intended to show relative behavior across the configured range; not a transient startup model.
+5. **Sensitivity**
+   - Baseline-delta explorer for insulation thickness, ambient temperature, wind speed, maintain temperature, and safety margin.
+   - Ranks single-change recommendations and exposes quick-apply controls.
 
-The detail section below the KPI grid reports thermal resistance and multipliers used by the model:
+## New analysis outputs
 
-- `insulationKmPerW`, `externalKmPerW`, `totalKmPerW`
-- `environmentMultiplier`, `materialFactor`, `safetyFactor`
+In addition to the required W/ft calculation, the dashboard now exposes screening outputs that support design review discussions:
 
-Warnings are presented as severity-tagged cards (info/warning/error) to improve scanning during design reviews.
+- **Thermal resistance terms:** `insulationKmPerW`, `externalKmPerW`, `totalKmPerW`
+- **Applied multipliers/factors:** `environmentMultiplier`, `materialFactor`, `safetyFactor`
+- **Sizing diagnostics:** cable utilization %, available margin vs recommended cable, and circuit-length pass/fail indicators
+- **Profile context:** plotted maintain/ambient relationship to highlight low-headroom scenarios
 
-## Sensitivity explorer and quick-apply workflow
+These outputs are intentionally transparent so engineering teams can replicate the arithmetic in hand checks and quickly identify whether a change is driven by environment, insulation, or design margin assumptions.
 
-The Overview tab now includes a **Sensitivity Explorer** card for rapid what-if checks against a baseline case:
+## Recommendation insight generation logic
 
-- Sliders are provided for key drivers: insulation thickness, ambient temperature, wind speed, maintain temperature, and design margin.
-- Each slider movement runs a lightweight recalculation and shows the required output delta relative to the saved baseline case.
-- The **Insights** subsection ranks top one-step recommendations that reduce required output.
-- **Quick Apply** buttons write suggested values back into the form controls and refresh the visual workspace so users can continue from the proposed scenario.
+Recommendation insights in the Sensitivity section are generated from one-step perturbation analysis around the saved baseline:
+
+1. Hold all other inputs constant.
+2. Apply a bounded change to one driver (for example, +insulation thickness or -ambient severity).
+3. Recompute required heat input.
+4. Rank actions by absolute reduction in required output and by practical applicability.
+
+**Quick Apply** actions copy the recommended single change back into the active form controls and trigger a full recalculation so users can continue iterative screening from the suggested case.
 
 Use **Use Current Inputs as Baseline** whenever assumptions change materially and you want future deltas to compare against the new operating point.
+
+## Scope and final verification
+
+This dashboard is intended for **screening-level design** and option comparison. It does not replace final vendor engineering.
+
+Before procurement or IFC issue, perform vendor/manufacturer verification for:
+
+- cable output curves across expected operating and startup conditions,
+- maximum circuit length and breaker/control compatibility,
+- sheath/jacket temperature limits,
+- hazardous area and installation code compliance,
+- project-specific insulation and weather exposure details.

--- a/docs/next-features-acceptance.md
+++ b/docs/next-features-acceptance.md
@@ -18,6 +18,28 @@ Source smoke coverage reference: `playwright-tests/nextFeatures.spec.js` under d
 - [ ] Results persist and reload via `studyResults.heatTraceSizing`.
 - [ ] Heat Trace Sizing appears in top navigation, command palette, and workflow dashboard summaries.
 
+### Heat Trace dashboard acceptance checks (expanded)
+
+- [ ] **Overview section** renders KPI cards for base heat loss, required heat input, recommended watt density, and circuit check.
+- [ ] **Heat Loss section** renders thermal-resistance outputs (`insulationKmPerW`, `externalKmPerW`, `totalKmPerW`) and applied multipliers.
+- [ ] **Circuit Sizing section** renders utilization/length compliance indicators and recommendation state.
+- [ ] **Temperature Profile section** renders a non-empty chart path after valid calculation inputs.
+- [ ] **Sensitivity section** renders baseline delta values, ranked insights, and Quick Apply controls.
+- [ ] Severity warnings (info/warning/error) appear for undersized cable, circuit-length exceedance, or low thermal headroom conditions.
+- [ ] Unit conversion (Imperial/Metric) keeps KPI values, chart labels, and warning thresholds numerically consistent (within conversion tolerance) when toggling units.
+
+---
+
+## Heat Trace analysis output + recommendations acceptance
+
+The following checks validate the new analysis outputs and recommendation insight workflow:
+
+- [ ] Analysis output panel includes thermal resistance terms, multipliers, and sizing diagnostics after each successful run.
+- [ ] Recommendation insights are derived from baseline one-variable perturbations and are sorted by greatest reduction in required heat input.
+- [ ] Quick Apply updates the associated input control, triggers recalculation, and refreshes KPI + chart outputs without stale values.
+- [ ] Resetting baseline updates subsequent delta computations so insight rankings match the new baseline context.
+- [ ] Documentation and UI language clearly state this tool is for screening-level design and requires final vendor verification before procurement.
+
 ---
 
 ## 1) Primary User Journeys


### PR DESCRIPTION
### Motivation

- Clarify UI layout and reviewer workflow by documenting the new Heat Trace dashboard sections to help users move from screening to traceable assumptions.
- Make new analysis outputs and recommendation logic transparent so engineering reviewers can reproduce arithmetic and trust quick-apply recommendations.
- Strengthen acceptance criteria so CI/QA can assert KPI cards, chart rendering, warning behavior, and unit-conversion consistency for the Heat Trace feature.

### Description

- Updated `docs/heat-trace-sizing.md` to document the five dashboard sections: `Overview`, `Heat Loss`, `Circuit Sizing`, `Temperature Profile`, and `Sensitivity`, and to describe how each section is intended to be used. 
- Added documentation of new analysis outputs including thermal resistance terms (`insulationKmPerW`, `externalKmPerW`, `totalKmPerW`), applied multipliers (`environmentMultiplier`, `materialFactor`, `safetyFactor`), sizing diagnostics, and profile context. 
- Described recommendation insight generation (one-variable baseline perturbation, ranking by reduction in required heat input) and the `Quick Apply` flow that updates inputs and triggers recalculation. 
- Added explicit scope language that the dashboard is for screening-level design and requires final vendor/manufacturer verification before procurement/IFC. 
- Expanded `docs/next-features-acceptance.md` with concrete acceptance checks for dashboard KPI cards, section rendering (including non-empty chart paths), severity warnings, unit-conversion consistency, analysis-output visibility, recommendation ranking behavior, Quick Apply refresh behavior, and baseline reset behavior.

### Testing

- `npm run build` completed successfully and produced the distribution build. 
- `npm test` was started to exercise the test suite, but the run did not complete in this environment (the suite progressed and showed many passing tests before hanging during collaboration-related tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea13ccf6e08324bdc3665cbef5be22)