### PR TITLE
Implement Gap #71: Lifecycle Project Model / Digital Twin Governance

### DIFF
--- a/COMPETITOR_FEATURE_ANALYSIS.md
+++ b/COMPETITOR_FEATURE_ANALYSIS.md
@@ -26,7 +26,7 @@ A separate **2026-04-11 extension** to the Cost Estimation module added **custom
 
 A **2026-04-26 website/product competitiveness refresh** compared CableTrayRoute against current positioning and features from ETAP, EasyPower, SKM, Bentley Raceway and Cable Management, MagiCAD/Revit, Eplan Data Portal/eBuild, nVent TraceCalc, Thermon CompuTrace, Chromalox ChromaTrace, SES CDEGS, XGSLab, CYMCAP, Cableizer, and related engineering tools. This revealed **12 additional gaps** (**Gaps #71-#82**) across lifecycle model governance, manufacturer data, heat-trace deliverables, grounding fidelity, cable thermal/pulling workflows, BIM round-trip, field data capture, benchmark/audit confidence, design automation, and public onboarding.
 
-**Current status: 66 of 83 total identified gaps implemented. 1 deferred (native BIM/CAD plugin). Live pricing gap extended with custom CSV pricing book. 16 open gaps remain: advanced power study #65 (OPF) plus website/product competitiveness gaps #71-#82 (excluding #78 now implemented). Gaps #64 (Voltage Stability) and #70 (Voltage Flicker) were implemented and are corrected in the roadmap table below.**
+**Current status: 68 of 83 total identified gaps implemented. 1 deferred (native BIM/CAD plugin). Live pricing gap extended with custom CSV pricing book. 14 open gaps remain: advanced power study #65 (OPF) plus website/product competitiveness gaps #72-#77, #79-#81 (excluding #71, #73, #78, #82 now implemented). Gaps #64 (Voltage Stability) and #70 (Voltage Flicker) were implemented and are corrected in the roadmap table below.**
 
 ---
 
@@ -1236,7 +1236,7 @@ The strongest market pattern is that competing tools sell more than formulas. Th
 - Surface package lineage in `projectreport.html`, exported reports, and study approval banners.
 - Tests: package creation round-trip, immutable snapshot behavior, diff summaries, and report export using the selected package.
 
-**Status:** Not implemented.
+**Status:** ✅ **Implemented 2026-05-02.** `analysis/lifecyclePackage.mjs` — pure computation module with `buildLifecyclePackage(config, projectData)` (deep-clone snapshot of cables, trays, studies, approvals, and one-line component count), `summarizePackage(projectData)` (counts without freezing), and `diffLifecyclePackages(pkgA, pkgB)` (cable/tray/study/approval deltas). `STATUS_OPTIONS` — four valid status labels (Draft, Issued for Review, Approved, Superseded). `dataStore.mjs` — three new exports: `getLifecyclePackages()`, `addLifecyclePackage(pkg)`, `deleteLifecyclePackage(id)`, persisted to `EXTRA_KEYS.lifecyclePackages`. Dashboard: `workflowdashboard.html` gains a "Release Package" panel with revision label, author, status select, notes, and a package history table (rev, date, author, status, cable count, study count, actions); `src/workflowDashboard.js` wires `initReleasePackageForm()` and `renderPackageHistory()`. Report builder: `projectreport.html` gains a "Data Source" dropdown and a lineage banner; `src/projectreport.js` adds `activeLifecyclePkg` state, `renderLifecyclePkgSelector()`, `updateLifecycleBanner()`, and `loadProjectDataWithPackage()` so the selected package snapshot is used as the report source; `?pkg=<id>` URL parameter pre-selects a package when navigating from the dashboard. Tests: `tests/lifecyclePackage.test.mjs` — 25 assertions covering STATUS_OPTIONS, summarizePackage counts, buildLifecyclePackage shape/defaults/deep-copy immutability/JSON round-trip, and diffLifecyclePackages for added/removed/changed cables, trays, studies, approvals, and null snapshot robustness.
 
 ---
 
@@ -1423,7 +1423,7 @@ The strongest market pattern is that competing tools sell more than formulas. Th
 - Pull report snapshots from `studyPackages[]` so results are reproducible after later project edits.
 - Tests: report schema, section ordering, escaped user data, package snapshot selection, and PDF/HTML parity.
 
-**Status:** Individual report exports partially implemented; commercial-grade report package builder not implemented.
+**Status:** ✅ **Implemented.** `analysis/reportPackage.mjs` — `SECTION_REGISTRY` (16 sections across Meta/Construction/Studies groups), `PRESET_CONFIGS` (6 named presets: electrical, construction, heatTrace, grounding, ownerTurnover, bimHandoff), `buildReportPackage(config, sectionData)`, `buildCoverSheet()`, `buildRevisionTable()`, `snapshotPackage()`, `getAvailableSections()`, `sectionToAOA()`. `analysis/projectReport.mjs` — section builders for all study and construction sections plus `renderPackageHTML()`. `src/projectreport.js` — full UI orchestration: section checkboxes, preset buttons, cover sheet form, revision table editor, Generate Preview, Print/PDF, Export XLSX (multi-sheet), Export HTML, Export JSON, Save Snapshot, Load Snapshot. `projectreport.html` — two-column builder layout with sticky config panel. Tests: `tests/reportPackage.test.mjs` — 26 assertions covering all registry, preset, builder, snapshot, and sectionToAOA functions.
 
 ---
 
@@ -1432,9 +1432,9 @@ The strongest market pattern is that competing tools sell more than formulas. Th
 | Priority | # | Gap | Recommended First Slice | Effort | Status |
 |---|---|---|---|---|---|
 | **P1** | 78 | ~~**Calculation Validation, Benchmarks, and Trust Center**~~ | Standards/basis drawers plus public validation page | Medium | ✅ Implemented 2026-04-26 |
-| **P1** | 82 | **Commercial-Grade Report Package Builder** | Structured package builder over existing reports | High | Not implemented |
+| **P1** | 82 | ~~**Commercial-Grade Report Package Builder**~~ | Structured package builder over existing reports | High | ✅ Implemented |
 | **P1** | 73 | ~~**Heat Trace Line List, BOM, and Installation Package**~~ | Product families + BOM/report tabs | Medium | ✅ Implemented 2026-04-30 |
-| **P1** | 71 | **Lifecycle Project Model / Digital Twin Governance** | Named study packages and revision snapshots | High | Not implemented |
+| **P1** | 71 | ~~**Lifecycle Project Model / Digital Twin Governance**~~ | Named study packages and revision snapshots | High | ✅ Implemented 2026-05-02 |
 | **P2** | 79 | **Cross-Study Design Coach** | Shared suggestion engine and dashboard action queue | Medium | Not implemented |
 | **P2** | 81 | **Sample Project Gallery / Guided Demos** | Curated sample JSON projects and launch cards | Low | Not implemented |
 | **P2** | 80 | **Equipment Evaluation / Compliance Inventory** | Join ratings with short-circuit/arc-flash/TCC results | Medium | Not implemented |
@@ -1689,4 +1689,5 @@ Full IEC 60909-0:2016 equivalent voltage source method implemented in `analysis/
 | **P2** | 67 | ~~**Differential Protection (87B/T/G)**~~ | `analysis/differentialProtection.mjs`, `data/protectiveDevices.json` | Medium | ✅ Implemented 2026-04-19 |
 | **P3** | 64 | ~~**Voltage Stability (P-V / Q-V)**~~ | `analysis/voltageStability.mjs` | High | ✅ Implemented 2026-04-20 |
 | **P3** | 65 | **Optimal Power Flow / Economic Dispatch** | `analysis/optimalPowerFlow.mjs` | High | Not implemented |
+
 | **P3** | 70 | ~~**Voltage Flicker (Pst/Plt)**~~ | `analysis/voltageFlicker.mjs` | Medium | ✅ Implemented 2026-04-19 |

--- a/analysis/lifecyclePackage.mjs
+++ b/analysis/lifecyclePackage.mjs
@@ -1,0 +1,237 @@
+/**
+ * Lifecycle Package — immutable project-model snapshots for design governance.
+ *
+ * Pure computation module (no DOM, no dataStore imports) — safe to test in Node.
+ * The page script reads live project data and passes it in.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Valid lifecycle package status labels. */
+export const STATUS_OPTIONS = [
+  'Draft',
+  'Issued for Review',
+  'Approved',
+  'Superseded',
+];
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function uid() {
+  return 'lp-' + Date.now() + '-' + Math.random().toString(36).slice(2, 7);
+}
+
+/**
+ * Deep-clone a value via JSON round-trip so mutations to the original
+ * do not affect the snapshot.
+ */
+function deepClone(value) {
+  if (value === null || value === undefined) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** Count studies that have non-null, non-empty results. */
+function countStudies(studies) {
+  if (!studies || typeof studies !== 'object') return 0;
+  return Object.values(studies).filter(v => {
+    if (v === null || v === undefined) return false;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === 'object') return Object.keys(v).length > 0;
+    return true;
+  }).length;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute summary counts from live project data without freezing a snapshot.
+ *
+ * @param {{ cables?: any[], trays?: any[], studies?: object, oneLine?: object }} projectData
+ * @returns {{ cableCount: number, trayCount: number, studyCount: number, oneLineComponentCount: number }}
+ */
+export function summarizePackage(projectData = {}) {
+  const cables  = Array.isArray(projectData.cables) ? projectData.cables : [];
+  const trays   = Array.isArray(projectData.trays)  ? projectData.trays  : [];
+  const studies = projectData.studies || {};
+  const oneLine = projectData.oneLine || {};
+  const components = Array.isArray(oneLine.components) ? oneLine.components : [];
+
+  return {
+    cableCount:           cables.length,
+    trayCount:            trays.length,
+    studyCount:           countStudies(studies),
+    oneLineComponentCount: components.length,
+  };
+}
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   createdAt: string,
+ *   revisionLabel: string,
+ *   author: string,
+ *   status: string,
+ *   notes: string,
+ *   projectSnapshot: {
+ *     cables: any[],
+ *     trays: any[],
+ *     studies: object,
+ *     approvals: object,
+ *     oneLineComponentCount: number,
+ *   },
+ *   summary: {
+ *     cableCount: number,
+ *     trayCount: number,
+ *     studyCount: number,
+ *     oneLineComponentCount: number,
+ *   },
+ * }} LifecyclePackage
+ */
+
+/**
+ * Build an immutable lifecycle package snapshot from current project data.
+ *
+ * @param {{
+ *   revisionLabel?: string,
+ *   author?: string,
+ *   status?: string,
+ *   notes?: string,
+ * }} config
+ * @param {{
+ *   cables?: any[],
+ *   trays?: any[],
+ *   studies?: object,
+ *   approvals?: object,
+ *   oneLine?: object,
+ * }} projectData
+ * @returns {LifecyclePackage}
+ */
+export function buildLifecyclePackage(config = {}, projectData = {}) {
+  const status = STATUS_OPTIONS.includes(config.status) ? config.status : 'Draft';
+
+  const cables    = deepClone(Array.isArray(projectData.cables) ? projectData.cables : []);
+  const trays     = deepClone(Array.isArray(projectData.trays)  ? projectData.trays  : []);
+  const studies   = deepClone(projectData.studies   || {});
+  const approvals = deepClone(projectData.approvals || {});
+  const oneLine   = projectData.oneLine || {};
+  const components = Array.isArray(oneLine.components) ? oneLine.components : [];
+
+  const summary = {
+    cableCount:            cables.length,
+    trayCount:             trays.length,
+    studyCount:            countStudies(studies),
+    oneLineComponentCount: components.length,
+  };
+
+  return {
+    id:            uid(),
+    createdAt:     nowIso(),
+    revisionLabel: String(config.revisionLabel || 'Rev 0'),
+    author:        String(config.author        || ''),
+    status,
+    notes:         String(config.notes         || ''),
+    projectSnapshot: { cables, trays, studies, approvals, oneLineComponentCount: components.length },
+    summary,
+  };
+}
+
+/**
+ * @typedef {{
+ *   cableChanges:   { added: any[], removed: any[], changed: any[] },
+ *   trayChanges:    { added: any[], removed: any[], changed: any[] },
+ *   studyChanges:   { added: string[], removed: string[] },
+ *   approvalChanges: { key: string, from: string, to: string }[],
+ * }} PackageDiff
+ */
+
+/**
+ * Compute the differences between two lifecycle packages.
+ *
+ * @param {LifecyclePackage} pkgA - older / baseline
+ * @param {LifecyclePackage} pkgB - newer / comparison
+ * @returns {PackageDiff}
+ */
+export function diffLifecyclePackages(pkgA, pkgB) {
+  // ── Cable diff (keyed by id) ──────────────────────────────────────────────
+  const cableChanges = _diffByKey(
+    (pkgA.projectSnapshot || {}).cables || [],
+    (pkgB.projectSnapshot || {}).cables || [],
+  );
+
+  // ── Tray diff (keyed by id) ───────────────────────────────────────────────
+  const trayChanges = _diffByKey(
+    (pkgA.projectSnapshot || {}).trays || [],
+    (pkgB.projectSnapshot || {}).trays || [],
+  );
+
+  // ── Study diff ────────────────────────────────────────────────────────────
+  const studiesA = (pkgA.projectSnapshot || {}).studies || {};
+  const studiesB = (pkgB.projectSnapshot || {}).studies || {};
+  const keysA = new Set(Object.keys(studiesA).filter(k => studiesA[k] != null));
+  const keysB = new Set(Object.keys(studiesB).filter(k => studiesB[k] != null));
+
+  const studyChanges = {
+    added:   [...keysB].filter(k => !keysA.has(k)),
+    removed: [...keysA].filter(k => !keysB.has(k)),
+  };
+
+  // ── Approval diff ─────────────────────────────────────────────────────────
+  const approvalsA = (pkgA.projectSnapshot || {}).approvals || {};
+  const approvalsB = (pkgB.projectSnapshot || {}).approvals || {};
+  const allApprovalKeys = new Set([...Object.keys(approvalsA), ...Object.keys(approvalsB)]);
+  const approvalChanges = [];
+  for (const key of allApprovalKeys) {
+    const statusA = (approvalsA[key] || {}).status || '';
+    const statusB = (approvalsB[key] || {}).status || '';
+    if (statusA !== statusB) {
+      approvalChanges.push({ key, from: statusA, to: statusB });
+    }
+  }
+
+  return { cableChanges, trayChanges, studyChanges, approvalChanges };
+}
+
+// ---------------------------------------------------------------------------
+// Private diff helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two arrays of objects by their `id` field.
+ * Returns { added, removed, changed } where `changed` are items whose
+ * serialised representation differs between A and B.
+ */
+function _diffByKey(arrayA, arrayB) {
+  const mapA = new Map((arrayA || []).map(item => [item.id, item]));
+  const mapB = new Map((arrayB || []).map(item => [item.id, item]));
+
+  const added   = [];
+  const removed = [];
+  const changed = [];
+
+  for (const [id, itemB] of mapB) {
+    if (!mapA.has(id)) {
+      added.push(itemB);
+    } else {
+      const itemA = mapA.get(id);
+      if (JSON.stringify(itemA) !== JSON.stringify(itemB)) {
+        changed.push({ id, from: itemA, to: itemB });
+      }
+    }
+  }
+
+  for (const [id, itemA] of mapA) {
+    if (!mapB.has(id)) removed.push(itemA);
+  }
+
+  return { added, removed, changed };
+}

--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -96,6 +96,7 @@ const EXTRA_KEYS = {
   drcAcceptedFindings: 'drcAcceptedFindings',
   studyApprovals: 'studyApprovals',
   reportSnapshots: 'reportSnapshots',
+  lifecyclePackages: 'lifecyclePackages',
 };
 
 export const STORAGE_KEYS = { ...KEYS, ...EXTRA_KEYS };
@@ -278,6 +279,32 @@ export const deleteReportSnapshot = id => {
   const all = getReportSnapshots();
   delete all[id];
   write(EXTRA_KEYS.reportSnapshots, all);
+};
+
+// ---------------------------------------------------------------------------
+// Lifecycle packages (Gap #71 — project model governance)
+// ---------------------------------------------------------------------------
+
+/** Return all saved lifecycle packages as an array, newest first. */
+export const getLifecyclePackages = () => read(EXTRA_KEYS.lifecyclePackages, []);
+
+/**
+ * Append a lifecycle package to storage.
+ * @param {object} pkg - serializable LifecyclePackage object
+ */
+export const addLifecyclePackage = pkg => {
+  const list = getLifecyclePackages();
+  list.unshift(pkg); // newest first
+  write(EXTRA_KEYS.lifecyclePackages, list);
+};
+
+/**
+ * Delete a lifecycle package by id.
+ * @param {string} id
+ */
+export const deleteLifecyclePackage = id => {
+  const list = getLifecyclePackages().filter(p => p.id !== id);
+  write(EXTRA_KEYS.lifecyclePackages, list);
 };
 
 

--- a/projectreport.html
+++ b/projectreport.html
@@ -205,6 +205,16 @@
         <p>Presets pre-select the sections most commonly required for each deliverable type. Individual sections can always be toggled after applying a preset.</p>
       </details>
 
+      <!-- Lifecycle package source (Gap #71) -->
+      <div class="rpt-source-row" style="display:flex;align-items:center;gap:.75rem;margin-bottom:.75rem;flex-wrap:wrap;">
+        <label for="rpt-lifecycle-pkg-select" style="font-weight:600;white-space:nowrap;">Data Source:</label>
+        <select id="rpt-lifecycle-pkg-select" class="form-control" style="min-width:260px;" aria-label="Select released package as data source">
+          <option value="">— Live project data —</option>
+        </select>
+      </div>
+      <div id="rpt-lifecycle-banner" class="result-info" role="status" aria-live="polite" hidden
+           style="margin-bottom:.75rem;padding:.5rem .75rem;border-radius:4px;font-size:.875rem;"></div>
+
       <!-- Status bar -->
       <div id="report-status" class="report-status" role="status" aria-live="polite"></div>
 

--- a/src/projectreport.js
+++ b/src/projectreport.js
@@ -14,6 +14,7 @@ import {
   getStudies, getStudyApprovals,
   getReportSnapshots, setReportSnapshot, deleteReportSnapshot,
   getDrcAcceptedFindings,
+  getLifecyclePackages,
 } from '../dataStore.mjs';
 import { getProjectState } from '../projectStorage.js';
 import { generateProjectReport } from '../analysis/projectReport.mjs';
@@ -493,10 +494,60 @@ function loadSnapshotIntoUI(snap) {
 let lastPkg = null;
 let lastBaseReport = null;
 
+// ---------------------------------------------------------------------------
+// Lifecycle package source (Gap #71)
+// ---------------------------------------------------------------------------
+
+/** The lifecycle package whose snapshot is used as the report data source, or null for live data. */
+let activeLifecyclePkg = null;
+
+function renderLifecyclePkgSelector() {
+  const select = document.getElementById('rpt-lifecycle-pkg-select');
+  if (!select) return;
+  const packages = getLifecyclePackages();
+  select.innerHTML = '<option value="">— Live project data —</option>';
+  for (const pkg of packages) {
+    const date = pkg.createdAt ? pkg.createdAt.slice(0, 10) : '';
+    const opt = document.createElement('option');
+    opt.value = pkg.id;
+    opt.textContent = `${pkg.revisionLabel} — ${pkg.status} — ${date}`;
+    if (activeLifecyclePkg && activeLifecyclePkg.id === pkg.id) opt.selected = true;
+    select.appendChild(opt);
+  }
+}
+
+function updateLifecycleBanner() {
+  const banner = document.getElementById('rpt-lifecycle-banner');
+  if (!banner) return;
+  if (activeLifecyclePkg) {
+    const date = activeLifecyclePkg.createdAt ? activeLifecyclePkg.createdAt.slice(0, 10) : '';
+    banner.textContent = `Data source: Package "${activeLifecyclePkg.revisionLabel}" — ${activeLifecyclePkg.status} — ${date}`;
+    banner.hidden = false;
+  } else {
+    banner.textContent = '';
+    banner.hidden = true;
+  }
+}
+
+/** Override loadProjectData() with snapshot data when a package is selected. */
+function loadProjectDataWithPackage() {
+  if (!activeLifecyclePkg) return loadProjectData();
+  const snap = activeLifecyclePkg.projectSnapshot || {};
+  return {
+    cables:    Array.isArray(snap.cables)  ? snap.cables  : [],
+    trays:     Array.isArray(snap.trays)   ? snap.trays   : [],
+    conduits:  [],
+    ductbanks: [],
+    studies:   snap.studies   || {},
+    approvals: snap.approvals || {},
+    drcResults: [],
+  };
+}
+
 function generatePreview() {
   try {
     setStatus('Generating…', 'info');
-    const projectData = loadProjectData();
+    const projectData = loadProjectDataWithPackage();
     const config      = buildPackageConfig();
     const pkg         = assemblePackage(config, projectData);
     const baseReport  = buildBaseReport(projectData);
@@ -528,6 +579,36 @@ document.addEventListener('DOMContentLoaded', () => {
   // Set default date
   const dateEl = document.getElementById('rpt-date');
   if (dateEl && !dateEl.value) dateEl.value = new Date().toISOString().slice(0, 10);
+
+  // ── Lifecycle package selector (Gap #71) ──
+  renderLifecyclePkgSelector();
+  updateLifecycleBanner();
+
+  // Pre-select a package if ?pkg=<id> is in the URL
+  const urlPkgId = new URLSearchParams(window.location.search).get('pkg');
+  if (urlPkgId) {
+    const found = getLifecyclePackages().find(p => p.id === urlPkgId);
+    if (found) {
+      activeLifecyclePkg = found;
+      const select = document.getElementById('rpt-lifecycle-pkg-select');
+      if (select) select.value = urlPkgId;
+      updateLifecycleBanner();
+    }
+  }
+
+  document.getElementById('rpt-lifecycle-pkg-select')?.addEventListener('change', e => {
+    const id = e.target.value;
+    if (!id) {
+      activeLifecyclePkg = null;
+    } else {
+      activeLifecyclePkg = getLifecyclePackages().find(p => p.id === id) || null;
+    }
+    updateLifecycleBanner();
+    // Rebuild section availability for the chosen source
+    const pd = loadProjectDataWithPackage();
+    const avail = getAvailableSections({ studies: pd.studies, cables: pd.cables, trays: pd.trays, drcResults: pd.drcResults });
+    buildSectionChecks(avail);
+  });
 
   // Build section checkboxes based on available data
   const projectData = loadProjectData();

--- a/src/workflowDashboard.js
+++ b/src/workflowDashboard.js
@@ -1,6 +1,11 @@
 import { workflowOrder, getStepStatus } from './workflowStatus.js';
-import { getCables, getTrays, getConduits, getDuctbanks, getStudies } from '../dataStore.mjs';
+import {
+  getCables, getTrays, getConduits, getDuctbanks, getStudies,
+  getStudyApprovals, getOneLine,
+  getLifecyclePackages, addLifecyclePackage, deleteLifecyclePackage,
+} from '../dataStore.mjs';
 import { trayFillPercent } from '../analysis/designRuleChecker.mjs';
+import { buildLifecyclePackage, summarizePackage } from '../analysis/lifecyclePackage.mjs';
 import '../site.js';
 
 // Studies tracked in the dashboard with display labels and their storage keys
@@ -357,9 +362,124 @@ function renderStudiesSummary(container) {
   container.appendChild(list);
 }
 
+// ---------------------------------------------------------------------------
+// Release Package panel (Gap #71)
+// ---------------------------------------------------------------------------
+
+function esc(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderPackageHistory(container) {
+  if (!container) return;
+  const packages = getLifecyclePackages();
+  if (!packages.length) {
+    container.innerHTML = '<p class="text-muted">No packages released yet.</p>';
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'data-table pkg-history-table';
+  table.setAttribute('aria-label', 'Released packages');
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>Revision</th>
+        <th>Date</th>
+        <th>Author</th>
+        <th>Status</th>
+        <th>Cables</th>
+        <th>Studies</th>
+        <th>Actions</th>
+      </tr>
+    </thead>`;
+
+  const tbody = document.createElement('tbody');
+  for (const pkg of packages) {
+    const date = pkg.createdAt ? pkg.createdAt.slice(0, 10) : '—';
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${esc(pkg.revisionLabel)}</td>
+      <td>${esc(date)}</td>
+      <td>${esc(pkg.author)}</td>
+      <td><span class="pkg-status-badge pkg-status--${esc(pkg.status.toLowerCase().replace(/ /g, '-'))}">${esc(pkg.status)}</span></td>
+      <td>${esc(pkg.summary?.cableCount ?? 0)}</td>
+      <td>${esc(pkg.summary?.studyCount ?? 0)}</td>
+      <td>
+        <a href="projectreport.html?pkg=${esc(pkg.id)}" class="btn btn-sm">Load in Report Builder</a>
+        <button class="btn btn-sm btn-danger pkg-delete-btn" data-pkg-id="${esc(pkg.id)}" aria-label="Delete package ${esc(pkg.revisionLabel)}">Delete</button>
+      </td>`;
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+
+  container.innerHTML = '';
+  container.appendChild(table);
+
+  container.querySelectorAll('.pkg-delete-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-pkg-id');
+      if (!id) return;
+      if (!window.confirm(`Delete package "${btn.getAttribute('aria-label').replace('Delete package ', '')}"?`)) return;
+      deleteLifecyclePackage(id);
+      renderPackageHistory(container);
+    });
+  });
+}
+
+function initReleasePackageForm() {
+  const form       = document.getElementById('release-pkg-form');
+  const statusEl   = document.getElementById('release-pkg-status');
+  const historyEl  = document.getElementById('pkg-history');
+
+  if (!form) return;
+
+  // Initial render of history
+  renderPackageHistory(historyEl);
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+
+    const revisionLabel = (document.getElementById('pkg-revision')?.value || '').trim() || 'Rev 0';
+    const author        = (document.getElementById('pkg-author')?.value   || '').trim();
+    const status        = document.getElementById('pkg-status')?.value    || 'Draft';
+    const notes         = (document.getElementById('pkg-notes')?.value    || '').trim();
+
+    const projectData = {
+      cables:    getCables(),
+      trays:     getTrays(),
+      studies:   getStudies(),
+      approvals: getStudyApprovals(),
+      oneLine:   getOneLine(),
+    };
+
+    const summary = summarizePackage(projectData);
+    const pkg = buildLifecyclePackage({ revisionLabel, author, status, notes }, projectData);
+
+    addLifecyclePackage(pkg);
+
+    if (statusEl) {
+      statusEl.textContent = `Package "${revisionLabel}" released — ${summary.cableCount} cable(s), ${summary.studyCount} study result(s).`;
+    }
+
+    renderPackageHistory(historyEl);
+
+    // Reset form fields
+    document.getElementById('pkg-revision').value = '';
+    document.getElementById('pkg-author').value   = '';
+    document.getElementById('pkg-notes').value    = '';
+    document.getElementById('pkg-status').value   = 'Draft';
+  });
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   renderKpiStrip(document.getElementById('dashboard-kpi-strip'));
   renderWorkflowSteps(document.getElementById('workflow-step-grid'));
   renderProjectSummary(document.getElementById('project-summary'));
   renderStudiesSummary(document.getElementById('studies-summary'));
+  initReleasePackageForm();
 });

--- a/tests/lifecyclePackage.test.mjs
+++ b/tests/lifecyclePackage.test.mjs
@@ -1,0 +1,234 @@
+/**
+ * Tests for analysis/lifecyclePackage.mjs
+ */
+import assert from 'assert';
+import {
+  STATUS_OPTIONS,
+  summarizePackage,
+  buildLifecyclePackage,
+  diffLifecyclePackages,
+} from '../analysis/lifecyclePackage.mjs';
+
+function describe(name, fn) { console.log(name); fn(); }
+function it(name, fn) {
+  try { fn(); console.log('  ✓', name); }
+  catch (err) { console.error('  ✗', name, err.message || err); process.exitCode = 1; }
+}
+
+// ---------------------------------------------------------------------------
+describe('STATUS_OPTIONS', () => {
+  it('contains exactly 4 entries', () => {
+    assert.strictEqual(STATUS_OPTIONS.length, 4);
+  });
+
+  it('includes Draft, Issued for Review, Approved, Superseded', () => {
+    assert.ok(STATUS_OPTIONS.includes('Draft'));
+    assert.ok(STATUS_OPTIONS.includes('Issued for Review'));
+    assert.ok(STATUS_OPTIONS.includes('Approved'));
+    assert.ok(STATUS_OPTIONS.includes('Superseded'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('summarizePackage', () => {
+  it('returns zero counts for empty input', () => {
+    const s = summarizePackage({});
+    assert.strictEqual(s.cableCount, 0);
+    assert.strictEqual(s.trayCount, 0);
+    assert.strictEqual(s.studyCount, 0);
+    assert.strictEqual(s.oneLineComponentCount, 0);
+  });
+
+  it('counts cables and trays correctly', () => {
+    const s = summarizePackage({ cables: [{id:'C1'},{id:'C2'}], trays: [{id:'T1'}] });
+    assert.strictEqual(s.cableCount, 2);
+    assert.strictEqual(s.trayCount, 1);
+  });
+
+  it('counts only studies with non-null results', () => {
+    const s = summarizePackage({
+      studies: {
+        arcFlash: { bus1: {} },
+        loadFlow: null,
+        harmonics: [],
+        shortCircuit: { ok: true },
+      },
+    });
+    assert.strictEqual(s.studyCount, 2); // arcFlash + shortCircuit
+  });
+
+  it('counts one-line components when present', () => {
+    const s = summarizePackage({ oneLine: { components: [{id:'A'},{id:'B'},{id:'C'}] } });
+    assert.strictEqual(s.oneLineComponentCount, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('buildLifecyclePackage', () => {
+  it('returns correct shape', () => {
+    const pkg = buildLifecyclePackage({ revisionLabel: 'Rev 1', author: 'J. Doe' }, {});
+    assert.ok(typeof pkg.id === 'string' && pkg.id.startsWith('lp-'));
+    assert.ok(typeof pkg.createdAt === 'string');
+    assert.strictEqual(pkg.revisionLabel, 'Rev 1');
+    assert.strictEqual(pkg.author, 'J. Doe');
+    assert.strictEqual(pkg.status, 'Draft');
+    assert.ok(pkg.projectSnapshot);
+    assert.ok(pkg.summary);
+  });
+
+  it('defaults status to Draft for unknown status', () => {
+    const pkg = buildLifecyclePackage({ status: 'Invalid' }, {});
+    assert.strictEqual(pkg.status, 'Draft');
+  });
+
+  it('accepts valid status values', () => {
+    for (const status of STATUS_OPTIONS) {
+      const pkg = buildLifecyclePackage({ status }, {});
+      assert.strictEqual(pkg.status, status);
+    }
+  });
+
+  it('defaults revisionLabel to Rev 0', () => {
+    const pkg = buildLifecyclePackage({}, {});
+    assert.strictEqual(pkg.revisionLabel, 'Rev 0');
+  });
+
+  it('snapshot is a deep copy — mutating source does not affect snapshot', () => {
+    const cables = [{ id: 'C1', tag: 'original' }];
+    const pkg = buildLifecyclePackage({}, { cables });
+    cables[0].tag = 'mutated';
+    assert.strictEqual(pkg.projectSnapshot.cables[0].tag, 'original');
+  });
+
+  it('snapshot cables array is independent of source', () => {
+    const cables = [{ id: 'C1' }];
+    const pkg = buildLifecyclePackage({}, { cables });
+    cables.push({ id: 'C2' });
+    assert.strictEqual(pkg.projectSnapshot.cables.length, 1);
+  });
+
+  it('summary counts match snapshot contents', () => {
+    const projectData = {
+      cables: [{ id: 'C1' }, { id: 'C2' }],
+      trays:  [{ id: 'T1' }],
+      studies: { arcFlash: { b: {} }, loadFlow: null },
+    };
+    const pkg = buildLifecyclePackage({}, projectData);
+    assert.strictEqual(pkg.summary.cableCount, 2);
+    assert.strictEqual(pkg.summary.trayCount, 1);
+    assert.strictEqual(pkg.summary.studyCount, 1); // only arcFlash is non-null
+  });
+
+  it('survives JSON round-trip', () => {
+    const pkg  = buildLifecyclePackage({ revisionLabel: 'Rev 3', author: 'A. Smith', status: 'Approved' }, {
+      cables: [{ id: 'C1' }],
+      studies: { arcFlash: { b: 1 } },
+    });
+    const back = JSON.parse(JSON.stringify(pkg));
+    assert.strictEqual(back.id, pkg.id);
+    assert.strictEqual(back.revisionLabel, pkg.revisionLabel);
+    assert.strictEqual(back.status, pkg.status);
+    assert.strictEqual(back.projectSnapshot.cables[0].id, 'C1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('diffLifecyclePackages', () => {
+  function makePkg(cables = [], trays = [], studies = {}, approvals = {}) {
+    return buildLifecyclePackage({}, { cables, trays, studies, approvals });
+  }
+
+  it('returns empty diff for identical packages', () => {
+    const cables = [{ id: 'C1', tag: 'same' }];
+    const trays  = [{ id: 'T1' }];
+    const pkgA = makePkg(cables, trays);
+    const pkgB = makePkg(cables, trays);
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.cableChanges.added.length, 0);
+    assert.strictEqual(diff.cableChanges.removed.length, 0);
+    assert.strictEqual(diff.cableChanges.changed.length, 0);
+    assert.strictEqual(diff.trayChanges.added.length, 0);
+  });
+
+  it('detects added cables', () => {
+    const pkgA = makePkg([{ id: 'C1' }]);
+    const pkgB = makePkg([{ id: 'C1' }, { id: 'C2' }]);
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.cableChanges.added.length, 1);
+    assert.strictEqual(diff.cableChanges.added[0].id, 'C2');
+  });
+
+  it('detects removed cables', () => {
+    const pkgA = makePkg([{ id: 'C1' }, { id: 'C2' }]);
+    const pkgB = makePkg([{ id: 'C1' }]);
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.cableChanges.removed.length, 1);
+    assert.strictEqual(diff.cableChanges.removed[0].id, 'C2');
+  });
+
+  it('detects changed cables', () => {
+    const pkgA = makePkg([{ id: 'C1', size: '12 AWG' }]);
+    const pkgB = makePkg([{ id: 'C1', size: '10 AWG' }]);
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.cableChanges.changed.length, 1);
+    assert.strictEqual(diff.cableChanges.changed[0].id, 'C1');
+  });
+
+  it('detects added trays', () => {
+    const pkgA = makePkg([], [{ id: 'T1' }]);
+    const pkgB = makePkg([], [{ id: 'T1' }, { id: 'T2' }]);
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.trayChanges.added.length, 1);
+    assert.strictEqual(diff.trayChanges.added[0].id, 'T2');
+  });
+
+  it('detects removed trays', () => {
+    const pkgA = makePkg([], [{ id: 'T1' }, { id: 'T2' }]);
+    const pkgB = makePkg([], [{ id: 'T1' }]);
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.trayChanges.removed.length, 1);
+    assert.strictEqual(diff.trayChanges.removed[0].id, 'T2');
+  });
+
+  it('detects added studies', () => {
+    const pkgA = makePkg([], [], { arcFlash: { b: 1 } });
+    const pkgB = makePkg([], [], { arcFlash: { b: 1 }, loadFlow: { v: 2 } });
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.ok(diff.studyChanges.added.includes('loadFlow'));
+    assert.strictEqual(diff.studyChanges.removed.length, 0);
+  });
+
+  it('detects removed studies', () => {
+    const pkgA = makePkg([], [], { arcFlash: { b: 1 }, loadFlow: { v: 2 } });
+    const pkgB = makePkg([], [], { arcFlash: { b: 1 } });
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.ok(diff.studyChanges.removed.includes('loadFlow'));
+  });
+
+  it('ignores null study values when computing study diff', () => {
+    const pkgA = makePkg([], [], { arcFlash: null });
+    const pkgB = makePkg([], [], { arcFlash: null });
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.studyChanges.added.length, 0);
+    assert.strictEqual(diff.studyChanges.removed.length, 0);
+  });
+
+  it('detects approval status changes', () => {
+    const pkgA = makePkg([], [], {}, { arcFlash: { status: 'Pending' } });
+    const pkgB = makePkg([], [], {}, { arcFlash: { status: 'Approved' } });
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.strictEqual(diff.approvalChanges.length, 1);
+    assert.strictEqual(diff.approvalChanges[0].key, 'arcFlash');
+    assert.strictEqual(diff.approvalChanges[0].from, 'Pending');
+    assert.strictEqual(diff.approvalChanges[0].to, 'Approved');
+  });
+
+  it('handles null/undefined snapshot gracefully', () => {
+    const pkgA = buildLifecyclePackage({}, {});
+    const pkgB = buildLifecyclePackage({}, {});
+    // Corrupt one snapshot to check robustness
+    pkgA.projectSnapshot = undefined;
+    const diff = diffLifecyclePackages(pkgA, pkgB);
+    assert.ok(Array.isArray(diff.cableChanges.added));
+  });
+});

--- a/workflowdashboard.html
+++ b/workflowdashboard.html
@@ -134,6 +134,45 @@
             <p class="text-muted">Loading…</p>
           </div>
         </section>
+
+        <!-- Release Package (Gap #71) -->
+        <section class="card dash-full-width" aria-label="Release package">
+          <h2>Release Package</h2>
+          <p class="text-muted" style="margin-bottom:0.75rem">Freeze the current project state into a named, immutable snapshot for design governance and traceability.</p>
+
+          <form id="release-pkg-form" class="release-pkg-form" aria-label="Release package form" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem 1rem;margin-bottom:1rem;" novalidate>
+            <div>
+              <label for="pkg-revision" class="field-label">Revision Label</label>
+              <input type="text" id="pkg-revision" name="revisionLabel" class="form-control" placeholder="Rev 1" autocomplete="off">
+            </div>
+            <div>
+              <label for="pkg-author" class="field-label">Author / Engineer</label>
+              <input type="text" id="pkg-author" name="author" class="form-control" placeholder="J. Smith, PE" autocomplete="off">
+            </div>
+            <div>
+              <label for="pkg-status" class="field-label">Status</label>
+              <select id="pkg-status" name="status" class="form-control">
+                <option value="Draft">Draft</option>
+                <option value="Issued for Review">Issued for Review</option>
+                <option value="Approved">Approved</option>
+                <option value="Superseded">Superseded</option>
+              </select>
+            </div>
+            <div>
+              <label for="pkg-notes" class="field-label">Notes</label>
+              <input type="text" id="pkg-notes" name="notes" class="form-control" placeholder="e.g. Issued for HAZOP review" autocomplete="off">
+            </div>
+            <div style="grid-column:1/-1;display:flex;align-items:center;gap:.75rem;">
+              <button type="submit" id="release-pkg-btn" class="btn btn-primary">Release Package</button>
+              <span id="release-pkg-status" class="text-muted" aria-live="polite"></span>
+            </div>
+          </form>
+
+          <h3 style="font-size:.9375rem;margin-bottom:.5rem;">Package History</h3>
+          <div id="pkg-history" aria-live="polite">
+            <p class="text-muted">No packages released yet.</p>
+          </div>
+        </section>
       </div>
 
     </main>


### PR DESCRIPTION
Adds an immutable project-model snapshot workflow so engineers can freeze,
label, and trace which model revision produced a given deliverable — closing
the gap with ETAP/EasyPower/SKM governed-model workflows.

New files:
- analysis/lifecyclePackage.mjs — pure computation: buildLifecyclePackage()
  (deep-clone snapshot), diffLifecyclePackages() (cable/tray/study/approval
  deltas), summarizePackage(), STATUS_OPTIONS
- tests/lifecyclePackage.test.mjs — 25 assertions

Modified files:
- dataStore.mjs — getLifecyclePackages / addLifecyclePackage /
  deleteLifecyclePackage persisted to EXTRA_KEYS.lifecyclePackages
- workflowdashboard.html — "Release Package" panel with form + history table
- src/workflowDashboard.js — initReleasePackageForm / renderPackageHistory
- projectreport.html — "Data Source" lifecycle package selector + lineage banner
- src/projectreport.js — activeLifecyclePkg state, loadProjectDataWithPackage(),
  renderLifecyclePkgSelector(), updateLifecycleBanner(); ?pkg= URL param
- COMPETITOR_FEATURE_ANALYSIS.md — mark Gap #71 and Gap #82 implemented
  (68/83 gaps now closed)

https://claude.ai/code/session_01PDAe5CAqz94jCDb6sPqPMR