### PR TITLE
Add Insulation Coordination & BIL/SIL Selection (Gap #87)

### DIFF
--- a/analysis/insulationCoordination.mjs
+++ b/analysis/insulationCoordination.mjs
@@ -1,0 +1,582 @@
+/**
+ * Insulation Coordination — IEC 60071-1/2 / IEEE 1313
+ *
+ * Implements the deterministic and simplified-statistical insulation
+ * coordination procedure for AC systems per:
+ *   IEC 60071-1:2006+AMD1:2010 — Definitions, standard insulation levels (Tables 2 & 3)
+ *   IEC 60071-2:1996+AMD1:2012 — Application guide (atmospheric correction, safety factors)
+ *   IEEE 1313.2-1999 — Guide for the application of insulation coordination
+ *
+ * Procedure summary (IEC 60071-2 §2):
+ *   1. Identify the highest voltage for equipment Um for the system nominal voltage.
+ *   2. Determine representative overvoltages for each stress class
+ *      (temporary/TOV, switching impulse, lightning impulse).
+ *   3. Compute the required coordination withstand voltage:
+ *        Ucw = Urp × Ks × Ka
+ *      where Ks is the safety factor (1.05 statistical / 1.15 deterministic) and
+ *      Ka is the atmospheric correction factor for altitude.
+ *   4. Select the lowest standard insulation level from IEC 60071-1 Table 2/3 with
+ *      BIL (LIWV) ≥ Ucw_LI and PFWV ≥ Ucw_TOV.
+ *   5. Verify protective margins of the surge arrester:
+ *        Mp_LI (%) = (Ucw_LI / Ures_LI − 1) × 100  ≥ 20 %
+ *        Mp_SI (%) = (Ucw_SI / Ures_SI − 1) × 100  ≥ 15 %
+ *   6. (Optional) Estimate statistical risk of failure per IEC 60071-2 Annex A using
+ *      a simplified Gaussian convolution model.
+ *
+ * References:
+ *   IEC 60071-1:2006+AMD1:2010 Table 2 (Range I: 1–245 kV) and Table 3 (Range II: >245 kV)
+ *   IEC 60071-2:1996 §3.3 — Atmospheric correction (Ka)
+ *   IEC 60071-2:1996 Annex A — Statistical risk of failure
+ *   IEEE 1313.2-1999 §6 — Protective margins
+ */
+
+// ---------------------------------------------------------------------------
+// Standard insulation levels — IEC 60071-1 Table 2 (Range I, Um 1–245 kV)
+// Each entry: Um (highest voltage for equipment, kV rms),
+//             liwv (standard lightning impulse withstand voltages, kV peak),
+//             pfwv (standard power-frequency withstand voltages, kV rms).
+// Multiple liwv/pfwv values are the alternative standard levels in ascending order.
+// ---------------------------------------------------------------------------
+export const IEC60071_RANGE_I = [
+  { um: 3.6,  liwv: [20, 40],        pfwv: [10] },
+  { um: 7.2,  liwv: [40, 60],        pfwv: [20] },
+  { um: 12,   liwv: [60, 75, 95],    pfwv: [28] },
+  { um: 17.5, liwv: [75, 95],        pfwv: [38] },
+  { um: 24,   liwv: [95, 125, 145],  pfwv: [50] },
+  { um: 36,   liwv: [145, 170],      pfwv: [70] },
+  { um: 52,   liwv: [250],           pfwv: [95] },
+  { um: 72.5, liwv: [325],           pfwv: [140] },
+  { um: 100,  liwv: [380, 450],      pfwv: [185] },
+  { um: 123,  liwv: [450, 550],      pfwv: [230] },
+  { um: 145,  liwv: [550, 650],      pfwv: [275] },
+  { um: 170,  liwv: [650, 750],      pfwv: [325] },
+  { um: 245,  liwv: [850, 950, 1050], pfwv: [395, 460] },
+];
+
+// IEC 60071-1 Table 3 (Range II, Um > 245 kV).
+// PFWV is not listed separately (SIWV governs for this range).
+// siwv = standard switching impulse withstand voltage (kV peak).
+export const IEC60071_RANGE_II = [
+  { um: 300,  liwv: [850, 950, 1050],           siwv: [750, 850] },
+  { um: 362,  liwv: [950, 1050, 1175],           siwv: [850, 950] },
+  { um: 420,  liwv: [1050, 1175, 1300, 1425],   siwv: [850, 950, 1050] },
+  { um: 550,  liwv: [1175, 1300, 1425, 1550],   siwv: [950, 1050] },
+  { um: 800,  liwv: [1425, 1550, 1800],          siwv: [1050, 1175] },
+  { um: 1200, liwv: [1800, 2100],                siwv: [1300, 1425] },
+];
+
+/** Minimum protective margin for lightning impulse (%) per IEEE 1313.2 §6. */
+export const MIN_PROTECTIVE_MARGIN_LI_PCT = 20;
+
+/** Minimum protective margin for switching impulse (%) per IEEE 1313.2 §6. */
+export const MIN_PROTECTIVE_MARGIN_SI_PCT = 15;
+
+/** Safety factor for deterministic approach (IEC 60071-2 §3.22). */
+export const SAFETY_FACTOR_DETERMINISTIC = 1.15;
+
+/** Safety factor for statistical approach (IEC 60071-2 §3.22). */
+export const SAFETY_FACTOR_STATISTICAL = 1.05;
+
+/**
+ * System temporary overvoltage (TOV) factors by earthing type.
+ * Values represent U_TOV / (Um / √3) — the TOV expressed as a multiple
+ * of the phase-to-earth voltage at Um.
+ * Source: IEC 60071-2 Table 1 (informative indicative values).
+ */
+export const TOV_FACTOR = {
+  solidly_grounded:    1.0,
+  low_resistance:      1.3,
+  high_resistance:     1.73,
+  isolated:            1.73,
+};
+
+function round(v, d = 3) {
+  const p = 10 ** d;
+  return Math.round(v * p) / p;
+}
+
+/**
+ * Look up the standard insulation level row for a given Um value (kV rms).
+ * Returns the exact match or the next higher Um in the combined Range I + II tables.
+ *
+ * @param {number} umKv  Highest voltage for equipment (kV rms)
+ * @returns {{ um: number, liwv: number[], pfwv?: number[], siwv?: number[], rangeII: boolean } | null}
+ */
+export function getStandardLevels(umKv) {
+  if (!Number.isFinite(umKv) || umKv <= 0) throw new Error('umKv must be a positive number');
+
+  const all = [
+    ...IEC60071_RANGE_I.map(e => ({ ...e, rangeII: false })),
+    ...IEC60071_RANGE_II.map(e => ({ ...e, rangeII: true })),
+  ];
+
+  // Exact match first
+  const exact = all.find(e => e.um === umKv);
+  if (exact) return exact;
+
+  // Next higher Um
+  const higher = all.filter(e => e.um > umKv).sort((a, b) => a.um - b.um);
+  return higher.length > 0 ? higher[0] : null;
+}
+
+/**
+ * Compute the atmospheric correction factor Ka for a given altitude.
+ *
+ * Per IEC 60071-2 §3.3 and IEC 60060-1:2010 §4.2:
+ *   Ka = e^(m × H / 8150)
+ *
+ * where H is the altitude above sea level (m) and m is an exponent depending
+ * on the type of discharge path:
+ *   m = 1.0 for self-restoring insulation under lightning impulse (air gaps, surge arresters)
+ *   m = 0.75 for non-self-restoring under power frequency (transformers, GIS)
+ *   m = 0.5 for non-uniform-field short gaps under power frequency
+ *
+ * @param {number} altitudeM   Altitude above sea level (m, ≥ 0)
+ * @param {number} [m=1.0]     Exponent (1.0 for LI air gaps, 0.75 for PF non-SR)
+ * @returns {number} Ka (dimensionless; > 1 for altitudes above sea level)
+ */
+export function atmosphericCorrectionFactor(altitudeM, m = 1.0) {
+  if (!Number.isFinite(altitudeM) || altitudeM < 0) {
+    throw new Error('altitudeM must be a non-negative number');
+  }
+  if (!Number.isFinite(m) || m <= 0) {
+    throw new Error('exponent m must be a positive number');
+  }
+  return round(Math.exp(m * altitudeM / 8150), 4);
+}
+
+/**
+ * Compute the required coordination withstand voltage (Ucw).
+ *
+ *   Ucw = Urp × Ks × Ka  (IEC 60071-2 §3)
+ *
+ * @param {number} representativeKvPeak  Representative overvoltage at the equipment (kV peak)
+ * @param {number} safetyFactor          Ks (1.05 statistical or 1.15 deterministic)
+ * @param {number} ka                    Atmospheric correction factor (from atmosphericCorrectionFactor())
+ * @returns {number} Required coordination withstand voltage (kV peak)
+ */
+export function coordinationWithstandVoltage(representativeKvPeak, safetyFactor, ka) {
+  if (!Number.isFinite(representativeKvPeak) || representativeKvPeak <= 0) {
+    throw new Error('representativeKvPeak must be greater than zero');
+  }
+  if (!Number.isFinite(safetyFactor) || safetyFactor < 1.0) {
+    throw new Error('safetyFactor must be ≥ 1.0');
+  }
+  if (!Number.isFinite(ka) || ka < 1.0) {
+    throw new Error('ka must be ≥ 1.0 (sea level = 1.0)');
+  }
+  return round(representativeKvPeak * safetyFactor * ka, 2);
+}
+
+/**
+ * Compute the protective margin of a surge arrester.
+ *
+ *   Mp (%) = (Ucw / Ures − 1) × 100
+ *
+ * A positive Mp means the insulation withstand exceeds the arrester protective level.
+ * Required margins per IEEE 1313.2 §6:
+ *   Lightning impulse: Mp ≥ 20 %
+ *   Switching impulse: Mp ≥ 15 %
+ *
+ * @param {number} ucwKvPeak      Required coordination withstand voltage (kV peak)
+ * @param {number} arresterResKvPeak  Arrester residual/protective level (kV peak)
+ * @returns {{ marginPct: number, pass: boolean, stressClass: string }}
+ */
+export function protectiveMargin(ucwKvPeak, arresterResKvPeak, stressClass = 'li') {
+  if (!Number.isFinite(ucwKvPeak) || ucwKvPeak <= 0) {
+    throw new Error('ucwKvPeak must be greater than zero');
+  }
+  if (!Number.isFinite(arresterResKvPeak) || arresterResKvPeak <= 0) {
+    throw new Error('arresterResKvPeak must be greater than zero');
+  }
+  const marginPct = round((ucwKvPeak / arresterResKvPeak - 1) * 100, 1);
+  const minMargin = stressClass === 'si' ? MIN_PROTECTIVE_MARGIN_SI_PCT : MIN_PROTECTIVE_MARGIN_LI_PCT;
+  return { marginPct, pass: marginPct >= minMargin, minMarginPct: minMargin };
+}
+
+/**
+ * Determine the minimum surge arrester MCOV (Maximum Continuous Operating Voltage)
+ * for a given system nominal voltage and earthing type.
+ *
+ *   MCOV ≥ Um / √3  (solidly grounded)
+ *   MCOV ≥ Um       (isolated / resistance grounded, per IEC 60099-5 §5.1)
+ *
+ * @param {number} umKv           Highest voltage for equipment (kV rms)
+ * @param {string} groundingType  One of: 'solidly_grounded', 'low_resistance',
+ *                                'high_resistance', 'isolated'
+ * @returns {{ mcovMinKv: number, rationale: string }}
+ */
+export function surgeArresterMcov(umKv, groundingType) {
+  if (!Number.isFinite(umKv) || umKv <= 0) throw new Error('umKv must be greater than zero');
+
+  const earthed = groundingType === 'solidly_grounded' || groundingType === 'low_resistance';
+  const mcovMinKv = earthed
+    ? round(umKv / Math.sqrt(3), 2)
+    : round(umKv, 2);
+  const rationale = earthed
+    ? `Solidly / low-resistance earthed: MCOV ≥ Um / √3 = ${mcovMinKv} kV rms (IEC 60099-5 §5.1)`
+    : `Isolated / high-resistance earthed: MCOV ≥ Um = ${mcovMinKv} kV rms (IEC 60099-5 §5.1)`;
+  return { mcovMinKv, rationale };
+}
+
+/**
+ * Temporary overvoltage (TOV) magnitude at the equipment.
+ *
+ *   U_TOV (kV rms, phase-to-earth) = (Um / √3) × tovFactor
+ *   U_TOV_peak (kV peak) = U_TOV × √2
+ *
+ * @param {number} umKv           Highest voltage for equipment (kV rms)
+ * @param {string} groundingType  Earthing type key (see TOV_FACTOR)
+ * @returns {{ tovKvRms: number, tovKvPeak: number, factor: number }}
+ */
+export function temporaryOvervoltage(umKv, groundingType) {
+  if (!Number.isFinite(umKv) || umKv <= 0) throw new Error('umKv must be greater than zero');
+
+  const factor = TOV_FACTOR[groundingType] ?? TOV_FACTOR.solidly_grounded;
+  const tovKvRms  = round((umKv / Math.sqrt(3)) * factor, 3);
+  const tovKvPeak = round(tovKvRms * Math.sqrt(2), 3);
+  return { tovKvRms, tovKvPeak, factor };
+}
+
+/**
+ * Select the lowest standard BIL (lightning impulse withstand voltage) from the
+ * IEC 60071-1 table for the given Um that satisfies BIL ≥ ucwLiKvPeak.
+ *
+ * @param {number} umKv          Highest voltage for equipment (kV rms)
+ * @param {number} ucwLiKvPeak   Required coordination withstand voltage, lightning (kV peak)
+ * @returns {{ selectedBilKv: number | null, availableBilKv: number[] }}
+ */
+export function selectStandardBil(umKv, ucwLiKvPeak) {
+  const row = getStandardLevels(umKv);
+  if (!row) return { selectedBilKv: null, availableBilKv: [] };
+
+  const suitable = row.liwv.filter(v => v >= ucwLiKvPeak);
+  const selectedBilKv = suitable.length > 0 ? Math.min(...suitable) : null;
+  return { selectedBilKv, availableBilKv: row.liwv };
+}
+
+/**
+ * Estimate statistical risk of failure per IEC 60071-2 Annex A (simplified).
+ *
+ * Uses a Gaussian convolution approximation:
+ *   R ≈ Φ((μs − U50) / √(σs² + σw²))
+ *
+ * where:
+ *   μs  = mean representative overvoltage (kV peak)
+ *   σs  = standard deviation of overvoltage distribution = μs × covStress
+ *   U50 = 50% disruptive-discharge voltage = selected BIL / 1.22 (lightning)
+ *          or selected SIL / 1.06 (switching), since test withstand = U50 × (1 − 1.3 β_w)
+ *   σw  = U50 × covWithstand
+ *   Φ   = standard normal cumulative distribution function
+ *
+ * Typical coefficient of variation values (IEC 60071-2 Annex A):
+ *   Lightning:  covWithstand ≈ 0.03 (self-restoring), 0.06 (non-SR)
+ *   Switching:  covWithstand ≈ 0.06
+ *
+ * @param {object} params
+ * @param {number} params.meanOvervoltageKv     Mean representative overvoltage (kV peak)
+ * @param {number} params.covStress             Coefficient of variation of overvoltage (e.g. 0.20)
+ * @param {number} params.selectedWithstandKv   Selected standard BIL or SIL (kV peak)
+ * @param {number} [params.covWithstand=0.03]   Coefficient of variation of withstand voltage
+ * @param {'li'|'si'} [params.stressClass='li'] 'li' for lightning, 'si' for switching impulse
+ * @returns {{ riskOfFailure: number, riskPerYear: number | null, z: number }}
+ */
+export function statisticalRiskOfFailure({
+  meanOvervoltageKv,
+  covStress,
+  selectedWithstandKv,
+  covWithstand = 0.03,
+  stressClass = 'li',
+}) {
+  if (!Number.isFinite(meanOvervoltageKv) || meanOvervoltageKv <= 0) {
+    throw new Error('meanOvervoltageKv must be greater than zero');
+  }
+  if (!Number.isFinite(covStress) || covStress <= 0 || covStress >= 1) {
+    throw new Error('covStress must be between 0 and 1');
+  }
+  if (!Number.isFinite(selectedWithstandKv) || selectedWithstandKv <= 0) {
+    throw new Error('selectedWithstandKv must be greater than zero');
+  }
+  if (!Number.isFinite(covWithstand) || covWithstand <= 0) {
+    throw new Error('covWithstand must be positive');
+  }
+
+  // Back-calculate U50 from selected standard withstand voltage.
+  // For lightning: BIL = U50 × (1 − 1.28 × β_w)  [IEC 60071-2 Annex A]
+  // For switching: SIL = U50 × (1 − 1.28 × β_w) × truncation factor ≈ U50 × (1 − 1.3 × β_w)
+  const u50 = selectedWithstandKv / (1 - 1.28 * covWithstand);
+
+  const sigmaS = meanOvervoltageKv * covStress;
+  const sigmaW = u50 * covWithstand;
+  const z = (meanOvervoltageKv - u50) / Math.sqrt(sigmaS ** 2 + sigmaW ** 2);
+
+  const riskOfFailure = round(standardNormalCDF(z), 8);
+  return { riskOfFailure, u50: round(u50, 2), z: round(z, 4) };
+}
+
+/**
+ * Standard normal cumulative distribution function Φ(z).
+ * Uses the Abramowitz & Stegun rational approximation (error < 7.5e-8).
+ *
+ * @param {number} z
+ * @returns {number} Φ(z) ∈ (0, 1)
+ */
+function standardNormalCDF(z) {
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const poly =
+    t * (0.319381530 +
+    t * (-0.356563782 +
+    t * (1.781477937 +
+    t * (-1.821255978 +
+    t * 1.330274429))));
+  const p = 1 - (1 / Math.sqrt(2 * Math.PI)) * Math.exp(-0.5 * z * z) * poly;
+  return z >= 0 ? p : 1 - p;
+}
+
+/**
+ * Run a complete insulation coordination study.
+ *
+ * @param {object}   inputs
+ * @param {string}   [inputs.studyLabel]            Descriptive label
+ * @param {number}   inputs.nominalVoltageKv         System nominal voltage kV (L-L rms, e.g. 138)
+ * @param {number}   inputs.umKv                     Highest voltage for equipment (kV rms, from IEC table)
+ * @param {number}   [inputs.altitudeM=0]            Site altitude above sea level (m)
+ * @param {string}   [inputs.groundingType]          'solidly_grounded' | 'low_resistance' |
+ *                                                   'high_resistance' | 'isolated'
+ * @param {string}   [inputs.approach='deterministic'] 'deterministic' | 'statistical'
+ * @param {object}   [inputs.lightningImpulse]       Lightning stress inputs
+ * @param {number}   [inputs.lightningImpulse.representativeKvPeak]  Urp for LI (kV peak, = arrester Ures_LI)
+ * @param {number}   [inputs.lightningImpulse.arresterResidualKvPeak] Surge arrester LI residual voltage (kV peak)
+ * @param {object}   [inputs.switchingImpulse]       Switching stress inputs (Range II or large systems)
+ * @param {number}   [inputs.switchingImpulse.representativeKvPeak]  Urp for SI (kV peak, = arrester Ures_SI)
+ * @param {number}   [inputs.switchingImpulse.arresterResidualKvPeak] Surge arrester SI residual voltage (kV peak)
+ * @param {number}   [inputs.surgeArresterMcovKv]    Surge arrester MCOV (kV rms)
+ * @param {object}   [inputs.statisticalLI]          Statistical parameters for LI risk estimation
+ * @param {number}   [inputs.statisticalLI.meanKvPeak]  Mean LI overvoltage (kV peak)
+ * @param {number}   [inputs.statisticalLI.cov]         Coefficient of variation of LI distribution
+ * @returns {object} Study result
+ */
+export function runInsulationCoordinationStudy(inputs) {
+  validateInputs(inputs);
+
+  const {
+    studyLabel = '',
+    nominalVoltageKv,
+    umKv,
+    altitudeM = 0,
+    groundingType = 'solidly_grounded',
+    approach = 'deterministic',
+    lightningImpulse,
+    switchingImpulse,
+    surgeArresterMcovKv,
+    statisticalLI,
+  } = inputs;
+
+  const warnings = [];
+
+  // 1. Standard levels for this Um
+  const standardRow = getStandardLevels(umKv);
+  if (!standardRow) {
+    throw new Error(`No IEC 60071-1 standard insulation level found for Um = ${umKv} kV. Check IEC 60071-1 Tables 2 and 3.`);
+  }
+  if (standardRow.um !== umKv) {
+    warnings.push(
+      `Um = ${umKv} kV is not a standard value. Using the next higher standard Um = ${standardRow.um} kV.`
+    );
+  }
+
+  // 2. Atmospheric correction factor
+  const ks = approach === 'statistical' ? SAFETY_FACTOR_STATISTICAL : SAFETY_FACTOR_DETERMINISTIC;
+  const kaLI = atmosphericCorrectionFactor(altitudeM, 1.0);
+  const kaPF = atmosphericCorrectionFactor(altitudeM, 0.75);
+
+  // 3. Temporary overvoltage
+  const tov = temporaryOvervoltage(umKv, groundingType);
+  const ucwTovKvPeak = coordinationWithstandVoltage(tov.tovKvPeak, ks, kaPF);
+
+  // 4. MCOV check
+  const mcovReq = surgeArresterMcov(umKv, groundingType);
+  let mcovCheck = null;
+  if (Number.isFinite(surgeArresterMcovKv) && surgeArresterMcovKv > 0) {
+    const mcovPass = surgeArresterMcovKv >= mcovReq.mcovMinKv;
+    mcovCheck = {
+      providedMcovKv: surgeArresterMcovKv,
+      requiredMcovKv: mcovReq.mcovMinKv,
+      pass: mcovPass,
+      rationale: mcovReq.rationale,
+    };
+    if (!mcovPass) {
+      warnings.push(
+        `Surge arrester MCOV (${surgeArresterMcovKv} kV) is less than the required minimum of ${mcovReq.mcovMinKv} kV for a ${groundingType.replace(/_/g, ' ')} system. Select a higher MCOV rating.`
+      );
+    }
+  }
+
+  // 5. Lightning impulse coordination
+  let liResult = null;
+  if (lightningImpulse && Number.isFinite(lightningImpulse.representativeKvPeak)) {
+    const ucwLI = coordinationWithstandVoltage(lightningImpulse.representativeKvPeak, ks, kaLI);
+    const { selectedBilKv, availableBilKv } = selectStandardBil(umKv, ucwLI);
+
+    let liMargin = null;
+    if (Number.isFinite(lightningImpulse.arresterResidualKvPeak)) {
+      liMargin = protectiveMargin(ucwLI, lightningImpulse.arresterResidualKvPeak, 'li');
+      if (!liMargin.pass) {
+        warnings.push(
+          `Lightning impulse protective margin (${liMargin.marginPct}%) is below the required ${MIN_PROTECTIVE_MARGIN_LI_PCT}%. Consider a lower arrester protective level or higher BIL.`
+        );
+      }
+    }
+
+    if (selectedBilKv === null) {
+      warnings.push(
+        `No standard BIL in IEC 60071-1 Table 2/3 for Um = ${standardRow.um} kV satisfies the required Ucw = ${ucwLI} kV. Consider a higher voltage class.`
+      );
+    }
+
+    let liRisk = null;
+    if (selectedBilKv !== null && statisticalLI && Number.isFinite(statisticalLI.meanKvPeak)) {
+      liRisk = statisticalRiskOfFailure({
+        meanOvervoltageKv: statisticalLI.meanKvPeak,
+        covStress: statisticalLI.cov ?? 0.20,
+        selectedWithstandKv: selectedBilKv,
+        covWithstand: 0.03,
+        stressClass: 'li',
+      });
+    }
+
+    liResult = {
+      representativeKvPeak: lightningImpulse.representativeKvPeak,
+      ucwKvPeak: ucwLI,
+      ks,
+      ka: kaLI,
+      selectedBilKv,
+      availableBilKv,
+      protectiveMargin: liMargin,
+      risk: liRisk,
+    };
+  }
+
+  // 6. Switching impulse coordination (primarily Range II, but included for completeness)
+  let siResult = null;
+  if (switchingImpulse && Number.isFinite(switchingImpulse.representativeKvPeak)) {
+    const ucwSI = coordinationWithstandVoltage(switchingImpulse.representativeKvPeak, ks, kaLI);
+
+    let siMargin = null;
+    if (Number.isFinite(switchingImpulse.arresterResidualKvPeak)) {
+      siMargin = protectiveMargin(ucwSI, switchingImpulse.arresterResidualKvPeak, 'si');
+      if (!siMargin.pass) {
+        warnings.push(
+          `Switching impulse protective margin (${siMargin.marginPct}%) is below the required ${MIN_PROTECTIVE_MARGIN_SI_PCT}%. Consider a lower arrester protective level or higher SIL.`
+        );
+      }
+    }
+
+    // For Range II, check against standard siwv if available
+    const availableSiwv = standardRow.siwv ?? [];
+    const suitableSiwv = availableSiwv.filter(v => v >= ucwSI);
+    const selectedSilKv = suitableSiwv.length > 0 ? Math.min(...suitableSiwv) : null;
+
+    if (availableSiwv.length > 0 && selectedSilKv === null) {
+      warnings.push(
+        `No standard SIL in IEC 60071-1 Table 3 for Um = ${standardRow.um} kV satisfies the required Ucw = ${ucwSI} kV.`
+      );
+    }
+
+    siResult = {
+      representativeKvPeak: switchingImpulse.representativeKvPeak,
+      ucwKvPeak: ucwSI,
+      ks,
+      ka: kaLI,
+      selectedSilKv,
+      availableSiwv,
+      protectiveMargin: siMargin,
+    };
+  }
+
+  // 7. Power frequency / TOV check against PFWV
+  let tovResult = null;
+  if (!standardRow.rangeII) {
+    const pfwvOptions = standardRow.pfwv ?? [];
+    const suitablePfwv = pfwvOptions.filter(v => v >= ucwTovKvPeak / Math.sqrt(2)); // peak → rms
+    const selectedPfwvKv = suitablePfwv.length > 0 ? Math.min(...suitablePfwv) : null;
+
+    if (pfwvOptions.length > 0 && selectedPfwvKv === null) {
+      warnings.push(
+        `No standard PFWV in IEC 60071-1 Table 2 for Um = ${standardRow.um} kV satisfies the required Ucw_TOV = ${round(ucwTovKvPeak / Math.sqrt(2), 2)} kV rms.`
+      );
+    }
+
+    tovResult = {
+      groundingType,
+      tovFactor: tov.factor,
+      tovKvRms: tov.tovKvRms,
+      tovKvPeak: tov.tovKvPeak,
+      ucwTovKvPeak,
+      ucwTovKvRms: round(ucwTovKvPeak / Math.sqrt(2), 2),
+      selectedPfwvKv,
+      availablePfwvKv: pfwvOptions,
+    };
+  }
+
+  // Summary
+  const liPass = liResult
+    ? (liResult.selectedBilKv !== null && (liResult.protectiveMargin ? liResult.protectiveMargin.pass : true))
+    : null;
+  const siPass = siResult
+    ? (siResult.selectedSilKv !== null || siResult.availableSiwv.length === 0) &&
+      (siResult.protectiveMargin ? siResult.protectiveMargin.pass : true)
+    : null;
+  const mcovPass = mcovCheck ? mcovCheck.pass : null;
+  const allPassed = [liPass, siPass, mcovPass].every(p => p === null || p === true);
+
+  return {
+    inputs: {
+      studyLabel,
+      nominalVoltageKv,
+      umKv,
+      altitudeM,
+      groundingType,
+      approach,
+      surgeArresterMcovKv: surgeArresterMcovKv ?? null,
+    },
+    standardRow: {
+      um: standardRow.um,
+      liwv: standardRow.liwv,
+      pfwv: standardRow.pfwv ?? null,
+      siwv: standardRow.siwv ?? null,
+      rangeII: standardRow.rangeII,
+    },
+    atmosphericCorrection: { kaLI, kaPF, altitudeM },
+    safetyFactor: ks,
+    approach,
+    mcovCheck,
+    tovResult,
+    liResult,
+    siResult,
+    allPassed,
+    warnings,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validateInputs(inputs) {
+  if (!inputs || typeof inputs !== 'object') {
+    throw new Error('inputs must be an object');
+  }
+  if (!Number.isFinite(inputs.nominalVoltageKv) || inputs.nominalVoltageKv <= 0) {
+    throw new Error('nominalVoltageKv must be greater than zero');
+  }
+  if (!Number.isFinite(inputs.umKv) || inputs.umKv <= 0) {
+    throw new Error('umKv must be greater than zero');
+  }
+  if (inputs.altitudeM != null && (!Number.isFinite(inputs.altitudeM) || inputs.altitudeM < 0)) {
+    throw new Error('altitudeM must be a non-negative number');
+  }
+  if (inputs.groundingType != null && !Object.keys(TOV_FACTOR).includes(inputs.groundingType)) {
+    throw new Error(`groundingType must be one of: ${Object.keys(TOV_FACTOR).join(', ')}`);
+  }
+  if (inputs.approach != null && !['deterministic', 'statistical'].includes(inputs.approach)) {
+    throw new Error("approach must be 'deterministic' or 'statistical'");
+  }
+}

--- a/analysis/reportPackage.mjs
+++ b/analysis/reportPackage.mjs
@@ -39,6 +39,7 @@ export const SECTION_REGISTRY = [
   { key: 'sustainability',  label: 'Sustainability Footprint', group: 'Studies', studyKey: 'sustainabilityFootprint' },
   { key: 'tccSettings',     label: 'TCC Settings Manifest', group: 'Studies', studyKey: 'tcc' },
   { key: 'hazAreaClass',    label: 'Hazardous Area Classification', group: 'Studies', studyKey: 'hazAreaClassification' },
+  { key: 'insulationCoord', label: 'Insulation Coordination (BIL/SIL)', group: 'Studies', studyKey: 'insulationCoordination' },
 ];
 
 /** Lookup a section definition by key. */

--- a/docs/insulation-coordination.md
+++ b/docs/insulation-coordination.md
@@ -1,0 +1,180 @@
+# Insulation Coordination
+
+**Standard:** IEC 60071-1:2006+AMD1:2010 / IEC 60071-2:1996+AMD1:2012 / IEEE 1313.2-1999
+
+**Module:** `analysis/insulationCoordination.mjs`  
+**Study page:** `insulationcoordination.html`  
+**Tests:** `tests/insulationCoordination.test.mjs`
+
+---
+
+## Purpose
+
+Selects the lowest standard Basic Insulation Level (BIL) and Short-time withstand level (SIL) from
+IEC 60071-1 Tables 2 and 3 that satisfies the required coordination withstand voltage at the
+equipment terminals, accounting for altitude, safety factor, and surge arrester protective margins.
+
+---
+
+## Procedure (IEC 60071-2 §2)
+
+### 1. Identify Um
+
+The highest voltage for equipment (Um, kV rms) is the upper limit of the highest voltage in the
+network for which the equipment is designed. Select from IEC 60071-1 Table 2 (Range I: Um ≤ 245 kV)
+or Table 3 (Range II: Um > 245 kV).
+
+### 2. Compute representative overvoltage
+
+For lightning impulse, the representative overvoltage at the equipment is the surge arrester
+lightning impulse residual voltage (protective level) at the maximum discharge current:
+
+- Station class (IEC 60099-4): rated at 10 kA discharge current
+- Intermediate class: rated at 5 kA
+- Distribution class: rated at 1.5 kA
+
+### 3. Atmospheric correction factor Ka (IEC 60071-2 §3.3)
+
+```
+Ka = e^(m × H / 8150)
+```
+
+| Insulation type | m |
+|---|---|
+| Lightning impulse, self-restoring (air gaps, arresters) | 1.0 |
+| Power frequency, non-self-restoring (transformers, GIS) | 0.75 |
+
+At sea level Ka = 1.0. At 1000 m Ka ≈ 1.13 (LI); at 2000 m Ka ≈ 1.28 (LI).
+
+### 4. Coordination withstand voltage (IEC 60071-2 §3.22)
+
+```
+Ucw = Urp × Ks × Ka
+```
+
+| Approach | Safety factor Ks |
+|---|---|
+| Deterministic | 1.15 |
+| Statistical | 1.05 |
+
+### 5. Standard BIL selection
+
+Lowest standard LIWV from IEC 60071-1 Table 2 (Range I) or Table 3 (Range II) such that:
+
+```
+BIL ≥ Ucw_LI
+PFWV ≥ Ucw_TOV / √2  (Range I only)
+```
+
+### 6. Surge arrester protective margin (IEEE 1313.2 §6)
+
+```
+Mp (%) = (Ucw / Ures − 1) × 100
+```
+
+Required minimum margins:
+
+| Stress class | Min Mp |
+|---|---|
+| Lightning impulse | 20% |
+| Switching impulse | 15% |
+
+### 7. Minimum MCOV (IEC 60099-5 §5.1)
+
+| Earthing type | Minimum MCOV |
+|---|---|
+| Solidly / low-resistance earthed | Um / √3 |
+| High-resistance earthed / isolated | Um |
+
+---
+
+## Statistical Risk of Failure (IEC 60071-2 Annex A)
+
+A simplified Gaussian convolution approximates the risk of failure per overvoltage event:
+
+```
+R ≈ Φ((μs − U50) / √(σs² + σw²))
+```
+
+Where:
+- μs = mean of overvoltage distribution (kV peak)
+- σs = μs × CoV_stress
+- U50 = 50% disruptive-discharge voltage ≈ BIL / (1 − 1.28 × CoV_withstand)
+- σw = U50 × CoV_withstand
+- Φ = standard normal CDF
+
+Typical CoV values (IEC 60071-2 Annex A):
+- Lightning, self-restoring: CoV_withstand ≈ 0.03
+- Switching, self-restoring: CoV_withstand ≈ 0.06
+
+**Acceptance target:** R ≤ 10⁻⁴ per event (transmission); R ≤ 10⁻³ (distribution)
+
+---
+
+## Temporary Overvoltage (TOV)
+
+TOV magnitude at the equipment per IEC 60071-2 Table 1:
+
+| Earthing type | TOV factor | U_TOV rms |
+|---|---|---|
+| Solidly earthed | 1.0 × | Um / √3 |
+| Low-resistance earthed | 1.3 × | 1.3 Um / √3 |
+| High-resistance / isolated | 1.73 × | Um (≈ phase-to-phase) |
+
+---
+
+## Standard Insulation Levels — IEC 60071-1 (Selected Range I values)
+
+| Um (kV) | Standard BIL (kV peak) | PFWV (kV rms) |
+|---|---|---|
+| 12 | 60 / 75 / 95 | 28 |
+| 24 | 95 / 125 / 145 | 50 |
+| 36 | 145 / 170 | 70 |
+| 72.5 | 325 | 140 |
+| 123 | 450 / 550 | 230 |
+| 145 | 550 / 650 | 275 |
+| 245 | 850 / 950 / 1050 | 395 / 460 |
+
+---
+
+## API
+
+```js
+import {
+  getStandardLevels,
+  atmosphericCorrectionFactor,
+  coordinationWithstandVoltage,
+  protectiveMargin,
+  surgeArresterMcov,
+  statisticalRiskOfFailure,
+  runInsulationCoordinationStudy,
+} from './analysis/insulationCoordination.mjs';
+
+const result = runInsulationCoordinationStudy({
+  nominalVoltageKv: 138,
+  umKv: 145,
+  altitudeM: 0,
+  groundingType: 'solidly_grounded',
+  approach: 'deterministic',
+  lightningImpulse: {
+    representativeKvPeak: 416,  // arrester Ures at 10 kA
+    arresterResidualKvPeak: 340,
+  },
+  surgeArresterMcovKv: 84,
+});
+
+// result.liResult.selectedBilKv   → 550 (kV)
+// result.liResult.protectiveMargin.marginPct → ~40.7 %
+// result.liResult.protectiveMargin.pass → true
+// result.allPassed → true
+```
+
+---
+
+## References
+
+- IEC 60071-1:2006+AMD1:2010 — Insulation coordination — Part 1: Definitions, principles and rules
+- IEC 60071-2:1996+AMD1:2012 — Insulation coordination — Part 2: Application guide
+- IEEE 1313.2-1999 — Guide for the application of insulation coordination
+- IEC 60099-4:2014 — Metal-oxide surge arresters without gaps for AC systems
+- IEC 60099-5:2013 — Surge arresters — Part 5: Selection and application recommendations

--- a/insulationcoordination.html
+++ b/insulationcoordination.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Insulation coordination study per IEC 60071-1/2 and IEEE 1313. Select standard BIL and SIL levels, verify surge arrester protective margins, and estimate statistical risk of failure for HV equipment." />
+  <title>Insulation Coordination — CableTrayRoute</title>
+  <link rel="icon" href="icons/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="icons/favicon.svg">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Insulation Coordination — CableTrayRoute">
+  <meta property="og:description" content="IEC 60071 / IEEE 1313 insulation coordination: BIL/SIL selection, atmospheric correction, arrester protective margins, and statistical risk of failure.">
+  <meta property="og:image" content="https://cabletrayroute.com/icons/og-preview.png">
+  <meta property="og:site_name" content="CableTrayRoute">
+  <meta property="og:url" content="insulationcoordination.html">
+  <link rel="canonical" href="insulationcoordination.html">
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" href="style.css" />
+  <script type="module" src="dirtyTracker.js"></script>
+  <script type="module" src="dist/insulationcoordination.js" defer></script>
+</head>
+<body class="insulationcoordination-page" data-report-title="Insulation Coordination Study">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="top-nav" aria-label="Primary">
+    <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false" title="Toggle navigation">
+      <img src="icons/toolbar/grid.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+    </button>
+    <div id="nav-links" class="nav-links" role="list">
+      <!-- Populated dynamically by navigation.js -->
+    </div>
+    <button id="settings-btn" class="settings-btn" aria-label="Settings" aria-expanded="false" title="Settings">
+      <img src="icons/toolbar/validate.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+    </button>
+  </nav>
+
+  <div id="settings-menu" class="settings-menu">
+    <label for="theme-select">Theme
+      <select id="theme-select">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="high-contrast">High Contrast</option>
+      </select>
+    </label>
+    <label><input type="checkbox" id="compact-toggle" aria-label="Enable compact table mode"> Compact Mode</label>
+    <button id="help-btn" class="btn" aria-expanded="false" title="Show help">
+      <img src="icons/toolbar/validate.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+      <span>Site Help</span>
+    </button>
+    <button id="new-project-btn" title="Start a new project">
+      <img src="icons/toolbar/copy.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+      <span>New Project</span>
+    </button>
+    <button id="save-project-btn" title="Save current project">
+      <img src="icons/toolbar/export.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+      <span>Save Project</span>
+    </button>
+    <button id="load-project-btn" title="Load an existing project">
+      <img src="icons/toolbar/import.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+      <span>Load Project</span>
+    </button>
+    <button id="export-project-btn" title="Export project data">
+      <img src="icons/toolbar/export.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+      <span>Export Project</span>
+    </button>
+    <button id="import-project-btn" title="Import project data">
+      <img src="icons/toolbar/import.svg" alt="" aria-hidden="true" class="control-icon" loading="lazy" decoding="async">
+      <span>Import Project</span>
+    </button>
+    <input type="file" id="import-project-input" accept=".ctr.json" class="hidden" title="Select project file">
+  </div>
+
+  <div class="container">
+    <main id="main-content" class="main-content">
+      <header class="page-header">
+        <h1>Insulation Coordination</h1>
+        <p class="page-subtitle">IEC 60071-1/2 · IEEE 1313 — BIL/SIL selection, arrester protective margins, statistical risk of failure</p>
+      </header>
+
+      <details class="method-panel">
+        <summary>Method &amp; Assumptions</summary>
+        <p>Insulation coordination selects the lowest <strong>standard insulation level</strong> (BIL and SIL from IEC 60071-1 Tables 2 and 3) that satisfies the required coordination withstand voltage at the equipment location, accounting for altitude, safety factor, and surge arrester protective levels.</p>
+        <p><strong>Step 1 — Required coordination withstand voltage (IEC 60071-2 §3):</strong></p>
+        <pre>Ucw = Urp × Ks × Ka</pre>
+        <p>where Urp = representative overvoltage at the equipment (kV peak), Ks = safety factor (1.15 deterministic / 1.05 statistical), Ka = atmospheric correction factor.</p>
+        <p><strong>Step 2 — Atmospheric correction (IEC 60071-2 §3.3):</strong></p>
+        <pre>Ka = e^(m × H / 8150)</pre>
+        <p>H = altitude (m), m = 1.0 for lightning impulse self-restoring, 0.75 for power frequency non-self-restoring.</p>
+        <p><strong>Step 3 — Standard BIL selection:</strong> Lowest standard LIWV ≥ Ucw from IEC 60071-1 Table 2 (Range I: Um ≤ 245 kV) or Table 3 (Range II: Um &gt; 245 kV).</p>
+        <p><strong>Step 4 — Surge arrester protective margin (IEEE 1313.2 §6):</strong></p>
+        <pre>Mp (%) = (Ucw / Ures − 1) × 100</pre>
+        <p>Required: Mp ≥ 20% for lightning impulse, Mp ≥ 15% for switching impulse.</p>
+        <p><strong>Step 5 — Statistical risk of failure (IEC 60071-2 Annex A, optional):</strong> Simplified Gaussian convolution of the overvoltage stress distribution against the insulation withstand characteristic. Target: R ≤ 10⁻⁴ per event (transmission) or 10⁻³ (distribution).</p>
+      </details>
+
+      <form id="inscoord-form" novalidate>
+
+        <fieldset>
+          <legend><strong>System Data</strong></legend>
+
+          <div class="field-row">
+            <label for="study-label">Study label</label>
+            <input type="text" id="study-label" placeholder="e.g. 138 kV Substation — Lightning Coordination" aria-describedby="study-label-hint">
+            <p id="study-label-hint" class="field-hint">Optional descriptive label for the study.</p>
+          </div>
+
+          <div class="field-row">
+            <label for="nominal-kv">System nominal voltage (kV, L-L)</label>
+            <input type="number" id="nominal-kv" min="1" step="1" value="138" required aria-describedby="nominal-kv-hint">
+            <span class="field-unit">kV</span>
+            <p id="nominal-kv-hint" class="field-hint">System nominal voltage (line-to-line rms). Used for display and TOV calculation reference.</p>
+          </div>
+
+          <div class="field-row">
+            <label for="um-select">Highest voltage for equipment Um (kV)</label>
+            <select id="um-select" required aria-describedby="um-select-hint">
+              <!-- Populated by JS from IEC 60071-1 table -->
+            </select>
+            <p id="um-select-hint" class="field-hint">Select Um from IEC 60071-1. For 138 kV systems use Um = 145 kV; for 230 kV systems use Um = 245 kV.</p>
+          </div>
+
+          <div class="field-row">
+            <label for="altitude-m">Site altitude (m above sea level)</label>
+            <input type="number" id="altitude-m" min="0" max="5000" step="50" value="0" required aria-describedby="altitude-hint">
+            <span class="field-unit">m</span>
+            <p id="altitude-hint" class="field-hint">Altitude correction increases withstand requirements. At sea level Ka = 1.0. At 1000 m Ka ≈ 1.13 (LI).</p>
+          </div>
+
+          <div class="field-row">
+            <label for="grounding-type">System earthing type</label>
+            <select id="grounding-type" aria-describedby="grounding-type-hint">
+              <option value="solidly_grounded">Solidly earthed (TOV factor 1.0×)</option>
+              <option value="low_resistance">Low-resistance earthed (TOV factor 1.3×)</option>
+              <option value="high_resistance">High-resistance earthed (TOV factor 1.73×)</option>
+              <option value="isolated">Isolated / unearthed (TOV factor 1.73×)</option>
+            </select>
+            <p id="grounding-type-hint" class="field-hint">Determines the temporary overvoltage (TOV) magnitude and the minimum surge arrester MCOV requirement.</p>
+          </div>
+
+          <div class="field-row">
+            <label for="approach-select">Coordination approach</label>
+            <select id="approach-select" aria-describedby="approach-hint">
+              <option value="deterministic">Deterministic (Ks = 1.15)</option>
+              <option value="statistical">Statistical (Ks = 1.05, risk estimation enabled)</option>
+            </select>
+            <p id="approach-hint" class="field-hint">Deterministic approach uses a higher safety factor. Statistical approach uses Ks = 1.05 and enables risk-of-failure estimation when stress distribution parameters are entered.</p>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend><strong>Surge Arrester</strong></legend>
+
+          <div class="field-row">
+            <label for="arrester-mcov">Surge arrester MCOV (kV rms)</label>
+            <input type="number" id="arrester-mcov" min="0.1" step="0.1" value="" placeholder="e.g. 84" aria-describedby="mcov-hint">
+            <span class="field-unit">kV rms</span>
+            <p id="mcov-hint" class="field-hint">Maximum Continuous Operating Voltage of the surge arrester. For solidly earthed 145 kV systems: MCOV ≥ 145/√3 ≈ 83.7 kV. Leave blank to skip MCOV check.</p>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend><strong>Lightning Impulse Stress</strong></legend>
+
+          <div class="field-row">
+            <label>
+              <input type="checkbox" id="li-enabled" checked aria-controls="li-fields">
+              Enable lightning impulse coordination
+            </label>
+          </div>
+
+          <div id="li-fields">
+            <div class="field-row">
+              <label for="li-urp">Representative overvoltage Urp (kV peak)</label>
+              <input type="number" id="li-urp" min="1" step="1" value="550" aria-describedby="li-urp-hint">
+              <span class="field-unit">kV peak</span>
+              <p id="li-urp-hint" class="field-hint">Lightning impulse representative overvoltage at the equipment terminals. Typically taken as the arrester lightning impulse residual voltage (protective level) Ures_LI at the maximum discharge current (e.g. 10 kA for station class).</p>
+            </div>
+
+            <div class="field-row">
+              <label for="li-ures">Arrester LI residual voltage Ures (kV peak)</label>
+              <input type="number" id="li-ures" min="1" step="1" value="416" aria-describedby="li-ures-hint">
+              <span class="field-unit">kV peak</span>
+              <p id="li-ures-hint" class="field-hint">Surge arrester lightning impulse protective level at 10 kA (station class) or 5 kA (intermediate class). From manufacturer data sheet. Required to compute protective margin Mp ≥ 20%.</p>
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend><strong>Switching Impulse Stress</strong> <span class="field-hint">(Range II or large systems)</span></legend>
+
+          <div class="field-row">
+            <label>
+              <input type="checkbox" id="si-enabled" aria-controls="si-fields">
+              Enable switching impulse coordination
+            </label>
+          </div>
+
+          <div id="si-fields" hidden>
+            <div class="field-row">
+              <label for="si-urp">Representative overvoltage Urp (kV peak)</label>
+              <input type="number" id="si-urp" min="1" step="1" value="850" aria-describedby="si-urp-hint">
+              <span class="field-unit">kV peak</span>
+              <p id="si-urp-hint" class="field-hint">Switching impulse representative overvoltage at the equipment. Typically the arrester switching impulse residual voltage, or 2.0–2.5 pu of Um peak for unprotected systems.</p>
+            </div>
+
+            <div class="field-row">
+              <label for="si-ures">Arrester SI residual voltage Ures (kV peak)</label>
+              <input type="number" id="si-ures" min="1" step="1" value="" placeholder="e.g. 742" aria-describedby="si-ures-hint">
+              <span class="field-unit">kV peak</span>
+              <p id="si-ures-hint" class="field-hint">Surge arrester switching impulse protective level. From manufacturer data sheet. Used to compute Mp ≥ 15%.</p>
+            </div>
+          </div>
+        </fieldset>
+
+        <div id="statistical-panel" hidden>
+          <fieldset>
+            <legend><strong>Statistical Parameters — Lightning Impulse</strong></legend>
+            <p class="field-hint">Required for statistical risk-of-failure estimation (IEC 60071-2 Annex A).</p>
+
+            <div class="field-row">
+              <label for="stat-li-mean">Mean overvoltage μ (kV peak)</label>
+              <input type="number" id="stat-li-mean" min="1" step="1" value="400" aria-describedby="stat-li-mean-hint">
+              <span class="field-unit">kV peak</span>
+              <p id="stat-li-mean-hint" class="field-hint">Mean of the lightning overvoltage distribution at the equipment location. Obtain from electromagnetic transient simulations or line-arrester data.</p>
+            </div>
+
+            <div class="field-row">
+              <label for="stat-li-cov">Coefficient of variation σ/μ</label>
+              <input type="number" id="stat-li-cov" min="0.01" max="0.99" step="0.01" value="0.20" aria-describedby="stat-li-cov-hint">
+              <p id="stat-li-cov-hint" class="field-hint">Coefficient of variation of the overvoltage distribution. Typical value: 0.15–0.25 for lightning on overhead lines.</p>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="form-actions">
+          <button type="submit" class="btn btn-primary">Run Coordination Study</button>
+        </div>
+      </form>
+
+      <script>
+        // Show/hide SI fields based on checkbox
+        document.addEventListener('DOMContentLoaded', () => {
+          const siCheck = document.getElementById('si-enabled');
+          const siFields = document.getElementById('si-fields');
+          if (siCheck && siFields) {
+            siCheck.addEventListener('change', () => { siFields.hidden = !siCheck.checked; });
+          }
+        });
+      </script>
+
+      <div id="calc-errors" class="result-fail" hidden aria-live="polite"></div>
+
+      <div id="results" aria-live="polite"></div>
+
+      <section class="card">
+        <div id="study-basis-panel"></div>
+      </section>
+
+      <nav class="step-nav" aria-label="Workflow navigation">
+        <a href="differentialprotection.html" class="step-nav-prev">← Differential Protection</a>
+        <a href="voltagestability.html" class="step-nav-next">Voltage Stability →</a>
+      </nav>
+
+    </main>
+  </div>
+
+  <div id="help-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="help-modal-title" hidden>
+    <div class="modal-content">
+      <button id="close-help-btn" class="modal-close" aria-label="Close help">×</button>
+      <h2 id="help-modal-title">Insulation Coordination Help</h2>
+      <p>Insulation coordination selects equipment withstand voltages that are economically and technically justified given the overvoltage stresses and the protection provided by surge arresters.</p>
+      <h3>When to use</h3>
+      <ul>
+        <li>Selecting transformer BIL for a new substation.</li>
+        <li>Verifying that the selected surge arrester provides adequate protection margin for HV cables, GIS, or power transformers.</li>
+        <li>Altitude correction for high-elevation substations (> 1000 m above sea level).</li>
+        <li>Statistical risk assessment for transmission projects requiring NERC or utility-level reliability targets.</li>
+      </ul>
+      <h3>Standard insulation levels (IEC 60071-1)</h3>
+      <ul>
+        <li><strong>Range I (Um ≤ 245 kV):</strong> BIL (LIWV) and PFWV selected from Table 2.</li>
+        <li><strong>Range II (Um &gt; 245 kV):</strong> BIL and SIL (SIWV) selected from Table 3. Switching impulse governs.</li>
+      </ul>
+      <h3>Protective margin requirements (IEEE 1313.2 §6)</h3>
+      <ul>
+        <li>Lightning impulse: Mp ≥ 20% between equipment BIL and arrester LI protective level.</li>
+        <li>Switching impulse: Mp ≥ 15% between equipment SIL and arrester SI protective level.</li>
+      </ul>
+      <h3>Typical BIL values by voltage class</h3>
+      <ul>
+        <li>34.5 kV (Um = 36 kV): 170 kV BIL</li>
+        <li>69 kV (Um = 72.5 kV): 325 kV BIL</li>
+        <li>115 kV (Um = 123 kV): 550 kV BIL</li>
+        <li>138 kV (Um = 145 kV): 650 kV BIL</li>
+        <li>230 kV (Um = 245 kV): 1050 kV BIL</li>
+        <li>345 kV (Um = 362 kV): 1175 kV BIL (Range II)</li>
+        <li>500 kV (Um = 550 kV): 1550 kV BIL (Range II)</li>
+      </ul>
+    </div>
+  </div>
+
+  <footer class="site-footer">
+    <div class="footer-left">
+      <img src="icons/route.svg" alt="CableTrayRoute logo" class="footer-logo" loading="lazy" decoding="async">
+      <span>CableTrayRoute</span>
+    </div>
+    <nav class="footer-links" aria-label="Footer">
+      <a href="docs/index.html">Docs</a>
+      <a href="docs/quickstart.html">Quick Start</a>
+      <a href="index.html">Home</a>
+    </nav>
+  </footer>
+
+</body>
+</html>

--- a/insulationcoordination.js
+++ b/insulationcoordination.js
@@ -1,0 +1,310 @@
+import {
+  runInsulationCoordinationStudy,
+  IEC60071_RANGE_I,
+  IEC60071_RANGE_II,
+  TOV_FACTOR,
+  MIN_PROTECTIVE_MARGIN_LI_PCT,
+  MIN_PROTECTIVE_MARGIN_SI_PCT,
+  SAFETY_FACTOR_DETERMINISTIC,
+  SAFETY_FACTOR_STATISTICAL,
+} from './analysis/insulationCoordination.mjs';
+import { getStudies, setStudies } from './dataStore.mjs';
+import { initStudyApprovalPanel } from './src/components/studyApproval.js';
+import { initStudyBasisPanel } from './src/components/studyBasis.js';
+import { escapeHtml } from './src/htmlUtils.mjs';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSettings();
+  initDarkMode();
+  initCompactMode();
+  initHelpModal('help-btn', 'help-modal', 'close-help-btn');
+  initNavToggle();
+
+  initStudyBasisPanel('insulationCoordination', {
+    standard: 'IEC 60071-1:2006+AMD1:2010 / IEC 60071-2:1996+AMD1:2012 / IEEE 1313.2-1999',
+    clause: 'Deterministic and simplified-statistical coordination procedure (IEC 60071-2 §2)',
+    formulas: [
+      'Ucw = Urp × Ks × Ka — coordination withstand voltage',
+      'Ka = e^(m × H / 8150) — atmospheric correction (IEC 60071-2 §3.3)',
+      'Mp (%) = (Ucw / Ures − 1) × 100 — surge arrester protective margin',
+      'R ≈ Φ((μs − U50) / √(σs² + σw²)) — statistical risk of failure (Gaussian convolution)',
+    ],
+    assumptions: [
+      'Standard insulation levels from IEC 60071-1 Tables 2 (Range I, Um ≤ 245 kV) and 3 (Range II, Um > 245 kV)',
+      'Deterministic safety factor Ks = 1.15; statistical Ks = 1.05',
+      'Lightning Ka uses exponent m = 1.0 (self-restoring air gaps)',
+      'Power-frequency Ka uses exponent m = 0.75 (non-self-restoring insulation)',
+    ],
+    limitations: [
+      'Switching impulse PFWV not separately tabulated for Range II (governed by SIWV)',
+      'Full statistical convolution integral requires site-measured overvoltage distributions',
+      'Transferred overvoltages from transformer coupling not modeled',
+    ],
+    benchmarkId: 'iec60071',
+  });
+  initStudyApprovalPanel('insulationCoordination');
+
+  // Populate Um selector from IEC tables
+  populateUmSelector();
+
+  const form = document.getElementById('inscoord-form');
+  const resultsDiv = document.getElementById('results');
+  const errorsDiv = document.getElementById('calc-errors');
+
+  // Restore from saved state or set defaults
+  const saved = getStudies().insulationCoordination;
+  if (saved) {
+    restoreForm(saved.inputs);
+    renderResults(saved);
+  }
+
+  // Toggle statistical panel visibility
+  document.getElementById('approach-select').addEventListener('change', updateApproachVisibility);
+  updateApproachVisibility();
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    let result;
+    try {
+      result = runInsulationCoordinationStudy(readInputs());
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unable to run insulation coordination study.';
+      errorsDiv.hidden = false;
+      errorsDiv.textContent = msg;
+      showModal('Input Error', `<p>${escapeHtml(msg)}</p>`, 'error');
+      return;
+    }
+    errorsDiv.hidden = true;
+    errorsDiv.textContent = '';
+
+    const studies = getStudies();
+    studies.insulationCoordination = result;
+    setStudies(studies);
+
+    renderResults(result);
+  });
+
+  // -----------------------------------------------------------------------
+  // Populate Um dropdown from IEC 60071-1 standard table
+  // -----------------------------------------------------------------------
+  function populateUmSelector() {
+    const sel = document.getElementById('um-select');
+    if (!sel) return;
+    const all = [
+      ...IEC60071_RANGE_I.map(e => ({ um: e.um, range: 'I' })),
+      ...IEC60071_RANGE_II.map(e => ({ um: e.um, range: 'II' })),
+    ];
+    all.forEach(({ um, range }) => {
+      const opt = document.createElement('option');
+      opt.value = um;
+      opt.textContent = `${um} kV (Range ${range})`;
+      if (um === 145) opt.selected = true;
+      sel.appendChild(opt);
+    });
+  }
+
+  function updateApproachVisibility() {
+    const approach = document.getElementById('approach-select').value;
+    const statPanel = document.getElementById('statistical-panel');
+    if (statPanel) statPanel.hidden = approach !== 'statistical';
+  }
+
+  // -----------------------------------------------------------------------
+  // Form reading
+  // -----------------------------------------------------------------------
+  function readInputs() {
+    const flt = id => parseFloat(document.getElementById(id).value);
+    const str = id => document.getElementById(id).value;
+
+    const hasLI = document.getElementById('li-enabled').checked;
+    const hasSI = document.getElementById('si-enabled').checked;
+    const hasStat = str('approach-select') === 'statistical';
+
+    return {
+      studyLabel: document.getElementById('study-label').value.trim(),
+      nominalVoltageKv: flt('nominal-kv'),
+      umKv: parseFloat(str('um-select')),
+      altitudeM: flt('altitude-m'),
+      groundingType: str('grounding-type'),
+      approach: str('approach-select'),
+
+      lightningImpulse: hasLI ? {
+        representativeKvPeak: flt('li-urp'),
+        arresterResidualKvPeak: flt('li-ures'),
+      } : undefined,
+
+      switchingImpulse: hasSI ? {
+        representativeKvPeak: flt('si-urp'),
+        arresterResidualKvPeak: flt('si-ures'),
+      } : undefined,
+
+      surgeArresterMcovKv: Number.isFinite(flt('arrester-mcov')) ? flt('arrester-mcov') : undefined,
+
+      statisticalLI: (hasStat && hasLI) ? {
+        meanKvPeak: flt('stat-li-mean'),
+        cov: flt('stat-li-cov'),
+      } : undefined,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Form restoration
+  // -----------------------------------------------------------------------
+  function restoreForm(inputs) {
+    if (!inputs) return;
+    const set = (id, v) => { const el = document.getElementById(id); if (el && v != null) el.value = v; };
+    set('study-label', inputs.studyLabel);
+    set('nominal-kv', inputs.nominalVoltageKv);
+    set('altitude-m', inputs.altitudeM);
+    set('arrester-mcov', inputs.surgeArresterMcovKv);
+
+    const umSel = document.getElementById('um-select');
+    if (umSel && inputs.umKv) {
+      const opt = Array.from(umSel.options).find(o => parseFloat(o.value) === inputs.umKv);
+      if (opt) umSel.value = opt.value;
+    }
+
+    const gSel = document.getElementById('grounding-type');
+    if (gSel && inputs.groundingType) gSel.value = inputs.groundingType;
+
+    const aSel = document.getElementById('approach-select');
+    if (aSel && inputs.approach) aSel.value = inputs.approach;
+
+    updateApproachVisibility();
+  }
+
+  // -----------------------------------------------------------------------
+  // Results rendering
+  // -----------------------------------------------------------------------
+  function renderResults(result) {
+    const { standardRow, atmosphericCorrection, safetyFactor, mcovCheck, tovResult, liResult, siResult, allPassed, warnings } = result;
+
+    const ok = v => `<span class="result-ok">${v}</span>`;
+    const fail = v => `<span class="result-fail">${v}</span>`;
+    const warn = v => `<span class="result-warn">${v}</span>`;
+    const badge = pass => pass ? ok('PASS') : fail('FAIL');
+
+    const warningHtml = warnings.length
+      ? `<ul class="drc-findings">${warnings.map(w =>
+          `<li class="drc-finding drc-warn"><span class="drc-msg">${escapeHtml(w)}</span></li>`
+        ).join('')}</ul>`
+      : '<p class="field-hint">No warnings.</p>';
+
+    // Standard insulation level table
+    const bilList = (standardRow.liwv || []).map(v => `${v} kV`).join(' / ');
+    const pfwvList = standardRow.pfwv ? standardRow.pfwv.map(v => `${v} kV rms`).join(' / ') : '—';
+    const siwvList = standardRow.siwv ? standardRow.siwv.map(v => `${v} kV`).join(' / ') : '—';
+
+    // MCOV card
+    const mcovHtml = mcovCheck
+      ? `<div class="result-card">
+           <div class="result-card-label">Arrester MCOV</div>
+           <div class="result-card-value">${mcovCheck.providedMcovKv} kV</div>
+           <div class="result-card-sub">Required ≥ ${mcovCheck.requiredMcovKv} kV — ${badge(mcovCheck.pass)}</div>
+         </div>`
+      : '';
+
+    // LI result card
+    const liHtml = liResult
+      ? `<div class="result-card">
+           <div class="result-card-label">BIL (LI Withstand)</div>
+           <div class="result-card-value ${liResult.selectedBilKv ? '' : 'result-fail'}">${liResult.selectedBilKv ? liResult.selectedBilKv + ' kV' : 'None found'}</div>
+           <div class="result-card-sub">Ucw = ${liResult.ucwKvPeak} kV peak</div>
+           ${liResult.protectiveMargin ? `<div class="result-card-sub">Arrester margin: ${liResult.protectiveMargin.marginPct}% — ${badge(liResult.protectiveMargin.pass)}</div>` : ''}
+         </div>`
+      : '';
+
+    // SI result card
+    const siHtml = siResult
+      ? `<div class="result-card">
+           <div class="result-card-label">SIL (SI Withstand)</div>
+           <div class="result-card-value ${siResult.selectedSilKv ? '' : (siResult.availableSiwv.length ? 'result-fail' : 'result-warn')}">${siResult.selectedSilKv ? siResult.selectedSilKv + ' kV' : siResult.availableSiwv.length ? 'None found' : 'N/A'}</div>
+           <div class="result-card-sub">Ucw = ${siResult.ucwKvPeak} kV peak</div>
+           ${siResult.protectiveMargin ? `<div class="result-card-sub">Arrester margin: ${siResult.protectiveMargin.marginPct}% — ${badge(siResult.protectiveMargin.pass)}</div>` : ''}
+         </div>`
+      : '';
+
+    // TOV result card
+    const tovHtml = tovResult
+      ? `<div class="result-card">
+           <div class="result-card-label">PFWV Required</div>
+           <div class="result-card-value">${tovResult.ucwTovKvRms} kV rms</div>
+           <div class="result-card-sub">TOV = ${tovResult.tovKvRms} kV rms (factor ${tovResult.tovFactor}×)</div>
+           <div class="result-card-sub">Selected PFWV: ${tovResult.selectedPfwvKv ? tovResult.selectedPfwvKv + ' kV rms' : warn('None found')}</div>
+         </div>`
+      : '';
+
+    // Statistical risk
+    const statHtml = liResult && liResult.risk
+      ? `<div class="result-group">
+           <h3>Statistical Risk of Failure (LI)</h3>
+           <div class="result-cards">
+             <div class="result-card">
+               <div class="result-card-label">Risk per Event</div>
+               <div class="result-card-value ${liResult.risk.riskOfFailure < 1e-4 ? 'result-ok' : liResult.risk.riskOfFailure < 1e-3 ? 'result-warn' : 'result-fail'}">${liResult.risk.riskOfFailure.toExponential(2)}</div>
+               <div class="result-card-sub">z = ${liResult.risk.z}, U₅₀ = ${liResult.risk.u50} kV</div>
+             </div>
+           </div>
+           <p class="field-hint">Target per IEC 60071-2 Annex A: risk per overvoltage event ≤ 10⁻⁴ for transmission, ≤ 10⁻³ for distribution.</p>
+         </div>`
+      : '';
+
+    // Ka section
+    const kaHtml = `<div class="result-group">
+      <h3>Atmospheric Correction</h3>
+      <table class="data-table" aria-label="Atmospheric correction factors">
+        <thead><tr><th>Type</th><th>Exponent m</th><th>Ka</th></tr></thead>
+        <tbody>
+          <tr><td>Lightning impulse (self-restoring)</td><td>1.0</td><td>${atmosphericCorrection.kaLI}</td></tr>
+          <tr><td>Power frequency (non-self-restoring)</td><td>0.75</td><td>${atmosphericCorrection.kaPF}</td></tr>
+        </tbody>
+      </table>
+    </div>`;
+
+    resultsDiv.innerHTML = `
+      <section class="results-panel" aria-labelledby="results-heading">
+        <h2 id="results-heading">Insulation Coordination Results</h2>
+
+        <div class="result-group">
+          <h3>Overall Result</h3>
+          <div class="result-cards">
+            <div class="result-card">
+              <div class="result-card-label">Overall Status</div>
+              <div class="result-card-value ${allPassed ? 'result-ok' : 'result-fail'}">${allPassed ? 'PASS' : 'FAIL'}</div>
+              <div class="result-card-sub">${result.approach === 'deterministic' ? 'Deterministic' : 'Statistical'} approach — Ks = ${safetyFactor}</div>
+            </div>
+            ${mcovHtml}
+            ${liHtml}
+            ${siHtml}
+            ${tovHtml}
+          </div>
+        </div>
+
+        <div class="result-group">
+          <h3>IEC 60071-1 Standard Insulation Levels — Um = ${standardRow.um} kV</h3>
+          <table class="data-table" aria-label="Standard insulation levels">
+            <thead>
+              <tr><th>Voltage Class</th><th>Standard BIL / LIWV (kV peak)</th><th>PFWV (kV rms)</th><th>SIWV (kV peak)</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Um = ${standardRow.um} kV (Range ${standardRow.rangeII ? 'II' : 'I'})</td>
+                <td>${bilList}</td>
+                <td>${pfwvList}</td>
+                <td>${siwvList}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        ${kaHtml}
+
+        ${statHtml}
+
+        <div class="result-group">
+          <h3>Warnings</h3>
+          ${warningHtml}
+        </div>
+      </section>`;
+  }
+});

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -80,7 +80,8 @@ const entries = {
   quasidynamic: 'src/quasiDynamic.js',
   bessHazard: 'src/bessHazard.js',
   hazareaclassification: 'src/hazareaclassification.js',
-  admin: 'src/admin.js'
+  admin: 'src/admin.js',
+  insulationcoordination: 'src/insulationcoordination.js'
 };
 
 /**

--- a/site.js
+++ b/site.js
@@ -84,7 +84,7 @@ function applyPageVisualIdentity(){
     {match:/schedule|list/,value:'schedule'},
     {match:/route|ductbank|pullcards|supportspan/,value:'routing'},
     {match:/fill/,value:'capacity'},
-    {match:/arcflash|harmonics|voltageflicker|motorstart|shortcircuit|loadflow|tcc|conduitbend|busdust|besshazard/,value:'analysis'},
+    {match:/arcflash|harmonics|voltageflicker|motorstart|shortcircuit|loadflow|tcc|conduitbend|busdust|besshazard|insulationcoordination/,value:'analysis'},
     {match:/oneline|custom-components/,value:'diagram'},
     {match:/account|login|forgot-password|reset-password/,value:'account'},
     {match:/index/,value:'home'}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -29,6 +29,7 @@
   <url><loc>loadFlow.html</loc><priority>0.5</priority></url>
   <url><loc>quasidynamic.html</loc><priority>0.5</priority></url>
   <url><loc>bessHazard.html</loc><priority>0.5</priority></url>
+  <url><loc>insulationcoordination.html</loc><priority>0.5</priority></url>
   <url><loc>help.html</loc><priority>0.5</priority></url>
   <url><loc>library.html</loc><priority>0.4</priority></url>
   <url><loc>custom-components.html</loc><priority>0.4</priority></url>

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -58,6 +58,7 @@ const NAV_ROUTES = [
   { href: 'equipmentevaluation.html', label: 'Equipment Evaluation', section: 'Studies', group: 'Protection', icon: 'icons/toolbar/validate.svg' },
   { href: 'bessHazard.html', label: 'BESS Hazard / Thermal Runaway', section: 'Studies', group: 'Protection', icon: 'icons/components/Breaker.svg' },
   { href: 'hazareaclassification.html', label: 'Hazardous Area Classification', section: 'Studies', group: 'Protection', icon: 'icons/toolbar/validate.svg' },
+  { href: 'insulationcoordination.html', label: 'Insulation Coordination (BIL/SIL)', section: 'Studies', group: 'Protection', icon: 'icons/toolbar/validate.svg' },
   { href: 'groundgrid.html', label: 'Ground Grid', section: 'Studies', group: 'Grounding', icon: 'icons/toolbar/validate.svg' },
   { href: 'cathodicprotection.html', label: 'Cathodic Protection', section: 'Studies', group: 'Corrosion Control', icon: 'icons/toolbar/validate.svg' },
   { href: 'dissimilarmetals.html', label: 'Dissimilar Metals', section: 'Studies', group: 'Corrosion Control', icon: 'icons/toolbar/validate.svg' },

--- a/src/insulationcoordination.js
+++ b/src/insulationcoordination.js
@@ -1,0 +1,3 @@
+import "./workflowStatus.js";
+import "../site.js";
+import "../insulationcoordination.js";

--- a/src/scenarioComparison.js
+++ b/src/scenarioComparison.js
@@ -29,6 +29,7 @@ const STUDY_DEFINITIONS = [
   { key: 'motorStart',     label: 'Motor Starting',   href: 'motorStart.html' },
   { key: 'reliability',  label: 'Reliability / N-1', href: 'reliability.html' },
   { key: 'contingency',  label: 'N-1 Contingency',   href: 'contingency.html' },
+  { key: 'insulationCoordination', label: 'Insulation Coordination', href: 'insulationcoordination.html' },
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/workflowDashboard.js
+++ b/src/workflowDashboard.js
@@ -26,6 +26,7 @@ const STUDY_DEFINITIONS = [
   { key: 'bessHazard', label: 'BESS Hazard (HMA)', href: 'bessHazard.html' },
   { key: 'reliability',  label: 'Reliability / N-1',    href: 'reliability.html' },
   { key: 'contingency',  label: 'N-1 Contingency',      href: 'contingency.html' },
+  { key: 'insulationCoordination', label: 'Insulation Coordination', href: 'insulationcoordination.html' },
 ];
 
 function getStatusMeta({ complete, label, hint, forStudy = false }) {

--- a/tests/insulationCoordination.test.mjs
+++ b/tests/insulationCoordination.test.mjs
@@ -1,0 +1,393 @@
+import assert from 'node:assert/strict';
+import {
+  getStandardLevels,
+  atmosphericCorrectionFactor,
+  coordinationWithstandVoltage,
+  protectiveMargin,
+  surgeArresterMcov,
+  temporaryOvervoltage,
+  selectStandardBil,
+  statisticalRiskOfFailure,
+  runInsulationCoordinationStudy,
+  IEC60071_RANGE_I,
+  IEC60071_RANGE_II,
+  TOV_FACTOR,
+  MIN_PROTECTIVE_MARGIN_LI_PCT,
+  MIN_PROTECTIVE_MARGIN_SI_PCT,
+  SAFETY_FACTOR_DETERMINISTIC,
+  SAFETY_FACTOR_STATISTICAL,
+} from '../analysis/insulationCoordination.mjs';
+
+// ---------------------------------------------------------------------------
+// Module constants
+// ---------------------------------------------------------------------------
+(function testConstants() {
+  assert.equal(MIN_PROTECTIVE_MARGIN_LI_PCT, 20, 'LI margin requirement is 20%');
+  assert.equal(MIN_PROTECTIVE_MARGIN_SI_PCT, 15, 'SI margin requirement is 15%');
+  assert.equal(SAFETY_FACTOR_DETERMINISTIC, 1.15, 'deterministic Ks = 1.15');
+  assert.equal(SAFETY_FACTOR_STATISTICAL, 1.05, 'statistical Ks = 1.05');
+  assert.ok(IEC60071_RANGE_I.length >= 13, 'Range I has at least 13 entries');
+  assert.ok(IEC60071_RANGE_II.length >= 6, 'Range II has at least 6 entries');
+  assert.ok(Object.keys(TOV_FACTOR).includes('solidly_grounded'), 'TOV_FACTOR has solidly_grounded');
+  assert.ok(Object.keys(TOV_FACTOR).includes('isolated'), 'TOV_FACTOR has isolated');
+  console.log('✓ module constants');
+})();
+
+// ---------------------------------------------------------------------------
+// getStandardLevels — Range I exact matches
+// ---------------------------------------------------------------------------
+(function testGetStandardLevels() {
+  // Um = 145 kV — standard transformer class for 138 kV systems
+  const r145 = getStandardLevels(145);
+  assert.ok(r145, 'finds 145 kV entry');
+  assert.equal(r145.um, 145, 'um = 145');
+  assert.ok(r145.liwv.includes(550), '145 kV has 550 kV BIL option');
+  assert.ok(r145.liwv.includes(650), '145 kV has 650 kV BIL option');
+  assert.ok(r145.pfwv.includes(275), '145 kV has 275 kV PFWV option');
+  assert.equal(r145.rangeII, false, '145 kV is Range I');
+
+  // Um = 245 kV
+  const r245 = getStandardLevels(245);
+  assert.ok(r245.liwv.includes(1050), '245 kV has 1050 kV BIL');
+
+  // Um = 72.5 kV
+  const r72 = getStandardLevels(72.5);
+  assert.equal(r72.liwv[0], 325, '72.5 kV BIL = 325 kV');
+  assert.equal(r72.pfwv[0], 140, '72.5 kV PFWV = 140 kV rms');
+
+  // Range II
+  const r362 = getStandardLevels(362);
+  assert.equal(r362.rangeII, true, '362 kV is Range II');
+  assert.ok(r362.siwv.includes(850), '362 kV has 850 kV SIL');
+
+  // Non-standard Um → next higher
+  const rNext = getStandardLevels(150);
+  assert.equal(rNext.um, 170, 'Um=150 (non-standard) maps to next higher Um=170');
+
+  // Invalid input
+  assert.throws(() => getStandardLevels(-1), /positive/, 'negative Um throws');
+  console.log('✓ getStandardLevels');
+})();
+
+// ---------------------------------------------------------------------------
+// atmosphericCorrectionFactor — IEC 60071-2 §3.3
+// ---------------------------------------------------------------------------
+(function testAtmosphericCorrection() {
+  // Sea level → Ka = 1.0
+  assert.equal(atmosphericCorrectionFactor(0), 1, 'Ka = 1.0 at sea level');
+
+  // 1000 m, m = 1.0 → Ka = e^(1000/8150) ≈ 1.1290
+  const ka1000 = atmosphericCorrectionFactor(1000, 1.0);
+  assert.ok(ka1000 > 1.12 && ka1000 < 1.14, `Ka(1000m) ≈ 1.13, got ${ka1000}`);
+
+  // 2000 m, m = 1.0 → Ka = e^(2000/8150) ≈ 1.2746
+  const ka2000 = atmosphericCorrectionFactor(2000, 1.0);
+  assert.ok(ka2000 > 1.27 && ka2000 < 1.29, `Ka(2000m) ≈ 1.27, got ${ka2000}`);
+
+  // PF exponent m = 0.75
+  const kaPF1000 = atmosphericCorrectionFactor(1000, 0.75);
+  assert.ok(kaPF1000 < ka1000, 'PF Ka < LI Ka at same altitude');
+  assert.ok(kaPF1000 > 1.0, 'PF Ka > 1 at altitude');
+
+  // Invalid inputs
+  assert.throws(() => atmosphericCorrectionFactor(-10), /non-negative/, 'negative altitude throws');
+  assert.throws(() => atmosphericCorrectionFactor(1000, 0), /positive/, 'zero exponent throws');
+  console.log('✓ atmosphericCorrectionFactor');
+})();
+
+// ---------------------------------------------------------------------------
+// coordinationWithstandVoltage — Ucw = Urp × Ks × Ka
+// ---------------------------------------------------------------------------
+(function testCoordinationWithstand() {
+  // Urp = 416 kV, Ks = 1.15, Ka = 1.0 → Ucw = 478.4 kV
+  const ucw = coordinationWithstandVoltage(416, 1.15, 1.0);
+  assert.ok(Math.abs(ucw - 478.4) < 0.1, `Ucw = 478.4 kV, got ${ucw}`);
+
+  // At altitude 1000m, Ka ≈ 1.129 → Ucw should be larger
+  const ka = atmosphericCorrectionFactor(1000);
+  const ucwAlt = coordinationWithstandVoltage(416, 1.15, ka);
+  assert.ok(ucwAlt > ucw, 'altitude increases Ucw');
+
+  // Statistical Ks = 1.05
+  const ucwStat = coordinationWithstandVoltage(416, 1.05, 1.0);
+  assert.ok(ucwStat < ucw, 'statistical Ucw < deterministic Ucw');
+  assert.ok(Math.abs(ucwStat - 436.8) < 0.5, `statistical Ucw ≈ 436.8, got ${ucwStat}`);
+
+  // Invalid inputs
+  assert.throws(() => coordinationWithstandVoltage(0, 1.15, 1.0), /greater than zero/);
+  assert.throws(() => coordinationWithstandVoltage(416, 0.9, 1.0), /≥ 1.0/);
+  assert.throws(() => coordinationWithstandVoltage(416, 1.15, 0.5), /≥ 1.0/);
+  console.log('✓ coordinationWithstandVoltage');
+})();
+
+// ---------------------------------------------------------------------------
+// protectiveMargin — Mp = (Ucw/Ures − 1) × 100
+// ---------------------------------------------------------------------------
+(function testProtectiveMargin() {
+  // Ucw = 478.4, Ures = 416 → Mp = (478.4/416 − 1) × 100 ≈ 14.98% → FAIL (< 20%)
+  const mp1 = protectiveMargin(478.4, 416, 'li');
+  assert.ok(mp1.marginPct > 14 && mp1.marginPct < 16, `Mp ≈ 15%, got ${mp1.marginPct}`);
+  assert.equal(mp1.pass, false, 'margin < 20% → FAIL for LI');
+  assert.equal(mp1.minMarginPct, 20, 'LI min margin = 20%');
+
+  // Ucw = 478.4, Ures = 380 → Mp ≈ 25.9% → PASS (≥ 20%)
+  const mp2 = protectiveMargin(478.4, 380, 'li');
+  assert.ok(mp2.marginPct > 25, `Mp > 25%, got ${mp2.marginPct}`);
+  assert.equal(mp2.pass, true, 'margin ≥ 20% → PASS for LI');
+
+  // Switching impulse — min margin = 15%
+  const mp3 = protectiveMargin(900, 800, 'si');
+  assert.ok(mp3.marginPct > 12 && mp3.marginPct < 13, `SI Mp ≈ 12.5%, got ${mp3.marginPct}`);
+  assert.equal(mp3.pass, false, 'SI margin < 15% → FAIL');
+  assert.equal(mp3.minMarginPct, 15, 'SI min margin = 15%');
+
+  const mp4 = protectiveMargin(900, 750, 'si');
+  assert.equal(mp4.pass, true, 'SI margin ≥ 15% → PASS');
+
+  // Invalid inputs
+  assert.throws(() => protectiveMargin(0, 416, 'li'), /greater than zero/);
+  assert.throws(() => protectiveMargin(478, 0, 'li'), /greater than zero/);
+  console.log('✓ protectiveMargin');
+})();
+
+// ---------------------------------------------------------------------------
+// surgeArresterMcov — minimum MCOV by earthing type
+// ---------------------------------------------------------------------------
+(function testSurgeArresterMcov() {
+  // Solidly earthed: MCOV ≥ Um / √3
+  const m145solid = surgeArresterMcov(145, 'solidly_grounded');
+  assert.ok(Math.abs(m145solid.mcovMinKv - 83.72) < 0.1, `MCOV = 83.7 kV, got ${m145solid.mcovMinKv}`);
+
+  // Isolated: MCOV ≥ Um
+  const m145iso = surgeArresterMcov(145, 'isolated');
+  assert.equal(m145iso.mcovMinKv, 145, 'isolated MCOV = Um = 145 kV');
+
+  // High resistance: same as isolated
+  const m36hr = surgeArresterMcov(36, 'high_resistance');
+  assert.equal(m36hr.mcovMinKv, 36, 'high-R MCOV = Um for Um=36 kV');
+
+  // Low resistance: treated as effectively earthed
+  const m72lr = surgeArresterMcov(72.5, 'low_resistance');
+  assert.ok(m72lr.mcovMinKv < 72.5, 'low-R MCOV < Um');
+
+  // Invalid
+  assert.throws(() => surgeArresterMcov(0, 'solidly_grounded'), /greater than zero/);
+  console.log('✓ surgeArresterMcov');
+})();
+
+// ---------------------------------------------------------------------------
+// temporaryOvervoltage — TOV magnitude by earthing type
+// ---------------------------------------------------------------------------
+(function testTemporaryOvervoltage() {
+  // Solidly earthed (factor 1.0): TOV = Um / √3
+  const tov145 = temporaryOvervoltage(145, 'solidly_grounded');
+  assert.ok(Math.abs(tov145.tovKvRms - 83.72) < 0.1, `TOV rms ≈ 83.7 kV, got ${tov145.tovKvRms}`);
+  assert.equal(tov145.factor, 1.0, 'solidly earthed factor = 1.0');
+
+  // Isolated (factor 1.73): TOV = Um
+  const tov145iso = temporaryOvervoltage(145, 'isolated');
+  assert.ok(tov145iso.tovKvRms > 144 && tov145iso.tovKvRms < 146, `TOV ≈ Um for isolated`);
+  assert.equal(tov145iso.factor, 1.73, 'isolated factor = 1.73');
+
+  // Peak = rms × √2
+  assert.ok(Math.abs(tov145.tovKvPeak - tov145.tovKvRms * Math.sqrt(2)) < 0.01, 'peak = rms × √2');
+
+  // Invalid Um
+  assert.throws(() => temporaryOvervoltage(-1, 'solidly_grounded'), /greater than zero/);
+  console.log('✓ temporaryOvervoltage');
+})();
+
+// ---------------------------------------------------------------------------
+// selectStandardBil — lowest BIL ≥ Ucw from IEC table
+// ---------------------------------------------------------------------------
+(function testSelectStandardBil() {
+  // Um = 145 kV, Ucw = 478.4 → lowest BIL ≥ 478.4 is 550 kV
+  const r = selectStandardBil(145, 478.4);
+  assert.equal(r.selectedBilKv, 550, 'selected BIL = 550 kV');
+  assert.ok(r.availableBilKv.includes(550), 'available includes 550');
+  assert.ok(r.availableBilKv.includes(650), 'available includes 650');
+
+  // Ucw very high → no standard BIL found
+  const rHigh = selectStandardBil(145, 9999);
+  assert.equal(rHigh.selectedBilKv, null, 'no BIL for Ucw=9999 kV');
+
+  // Ucw below lowest BIL → lowest BIL is selected
+  const rLow = selectStandardBil(145, 100);
+  assert.equal(rLow.selectedBilKv, 550, 'lowest BIL selected when Ucw < all options');
+
+  // Range I — Um = 72.5 kV: only one BIL option (325 kV)
+  const r72 = selectStandardBil(72.5, 300);
+  assert.equal(r72.selectedBilKv, 325, '72.5 kV → 325 kV BIL');
+  console.log('✓ selectStandardBil');
+})();
+
+// ---------------------------------------------------------------------------
+// statisticalRiskOfFailure — Gaussian convolution approximation
+// ---------------------------------------------------------------------------
+(function testStatisticalRisk() {
+  // When mean overvoltage << BIL, risk should be very low
+  const lowRisk = statisticalRiskOfFailure({
+    meanOvervoltageKv: 300,
+    covStress: 0.20,
+    selectedWithstandKv: 650,
+    covWithstand: 0.03,
+    stressClass: 'li',
+  });
+  assert.ok(lowRisk.riskOfFailure < 1e-4, `low risk < 1e-4, got ${lowRisk.riskOfFailure}`);
+  assert.ok(Number.isFinite(lowRisk.u50) && lowRisk.u50 > 0, 'u50 is positive finite');
+
+  // When mean ≈ withstand, risk should be higher
+  const highRisk = statisticalRiskOfFailure({
+    meanOvervoltageKv: 600,
+    covStress: 0.15,
+    selectedWithstandKv: 650,
+    covWithstand: 0.03,
+    stressClass: 'li',
+  });
+  assert.ok(highRisk.riskOfFailure > lowRisk.riskOfFailure, 'higher stress → higher risk');
+
+  // Risk is between 0 and 1
+  assert.ok(lowRisk.riskOfFailure >= 0 && lowRisk.riskOfFailure <= 1, 'risk ∈ [0,1]');
+
+  // Invalid inputs
+  assert.throws(() => statisticalRiskOfFailure({
+    meanOvervoltageKv: 0, covStress: 0.2, selectedWithstandKv: 650, covWithstand: 0.03,
+  }), /greater than zero/);
+  assert.throws(() => statisticalRiskOfFailure({
+    meanOvervoltageKv: 300, covStress: 1.5, selectedWithstandKv: 650, covWithstand: 0.03,
+  }), /between 0 and 1/);
+  console.log('✓ statisticalRiskOfFailure');
+})();
+
+// ---------------------------------------------------------------------------
+// runInsulationCoordinationStudy — integration
+// ---------------------------------------------------------------------------
+(function testIntegration() {
+  // Base 138 kV system, deterministic, solidly earthed, LI only
+  const base = {
+    studyLabel: 'Test 138 kV Substation',
+    nominalVoltageKv: 138,
+    umKv: 145,
+    altitudeM: 0,
+    groundingType: 'solidly_grounded',
+    approach: 'deterministic',
+    lightningImpulse: {
+      representativeKvPeak: 416,
+      arresterResidualKvPeak: 340,
+    },
+    surgeArresterMcovKv: 84,
+  };
+
+  const result = runInsulationCoordinationStudy(base);
+
+  // Structure checks
+  assert.ok(result.inputs, 'has inputs');
+  assert.ok(result.standardRow, 'has standardRow');
+  assert.ok(result.atmosphericCorrection, 'has atmosphericCorrection');
+  assert.ok(result.liResult, 'has liResult');
+  assert.ok(result.tovResult, 'has tovResult');
+  assert.ok(Array.isArray(result.warnings), 'has warnings array');
+  assert.ok(typeof result.timestamp === 'string', 'has timestamp');
+
+  // Sea-level Ka = 1.0
+  assert.equal(result.atmosphericCorrection.kaLI, 1, 'Ka = 1.0 at sea level');
+
+  // deterministic Ks = 1.15
+  assert.equal(result.safetyFactor, 1.15, 'Ks = 1.15');
+
+  // BIL selection: Ucw = 416 × 1.15 × 1.0 = 478.4 → BIL = 550 kV
+  assert.equal(result.liResult.ucwKvPeak, 478.4, 'Ucw = 478.4 kV');
+  assert.equal(result.liResult.selectedBilKv, 550, 'selected BIL = 550 kV');
+
+  // Protective margin: (478.4/340 − 1)*100 ≈ 40.7% → PASS
+  assert.ok(result.liResult.protectiveMargin.pass, 'margin PASS with adequate arrester');
+
+  // MCOV check: 84 ≥ 83.7 → PASS
+  assert.ok(result.mcovCheck, 'mcovCheck performed');
+  assert.ok(result.mcovCheck.pass, 'MCOV = 84 kV passes for solidly earthed Um=145');
+
+  // TOV check should be present for Range I
+  assert.ok(result.tovResult, 'TOV result present for Range I');
+  assert.ok(result.tovResult.selectedPfwvKv != null, 'PFWV selected');
+
+  // allPassed
+  assert.equal(result.allPassed, true, 'all checks passed');
+
+  console.log('✓ runInsulationCoordinationStudy — 138 kV base case');
+})();
+
+(function testIntegrationAltitude() {
+  // At 1500 m altitude, Ka is larger, so Ucw is larger
+  const r0 = runInsulationCoordinationStudy({
+    nominalVoltageKv: 138, umKv: 145, altitudeM: 0, groundingType: 'solidly_grounded',
+    approach: 'deterministic',
+    lightningImpulse: { representativeKvPeak: 416, arresterResidualKvPeak: 340 },
+  });
+  const r1500 = runInsulationCoordinationStudy({
+    nominalVoltageKv: 138, umKv: 145, altitudeM: 1500, groundingType: 'solidly_grounded',
+    approach: 'deterministic',
+    lightningImpulse: { representativeKvPeak: 416, arresterResidualKvPeak: 340 },
+  });
+  assert.ok(r1500.liResult.ucwKvPeak > r0.liResult.ucwKvPeak, 'altitude increases Ucw');
+  assert.ok(r1500.atmosphericCorrection.kaLI > 1, 'Ka > 1 at 1500 m');
+  console.log('✓ runInsulationCoordinationStudy — altitude correction');
+})();
+
+(function testIntegrationIsolated() {
+  // Isolated system has higher MCOV requirement
+  const r = runInsulationCoordinationStudy({
+    nominalVoltageKv: 34.5, umKv: 36, altitudeM: 0, groundingType: 'isolated',
+    approach: 'deterministic',
+    lightningImpulse: { representativeKvPeak: 170, arresterResidualKvPeak: 130 },
+    surgeArresterMcovKv: 30,  // Too low for isolated system (needs 36 kV)
+  });
+  assert.equal(r.mcovCheck.pass, false, 'MCOV = 30 kV fails for isolated Um=36 kV system');
+  assert.ok(r.warnings.some(w => w.toLowerCase().includes('mcov')), 'MCOV warning generated');
+  console.log('✓ runInsulationCoordinationStudy — isolated system MCOV check');
+})();
+
+(function testIntegrationStatistical() {
+  // Statistical approach with risk estimation
+  const r = runInsulationCoordinationStudy({
+    nominalVoltageKv: 138, umKv: 145, altitudeM: 0, groundingType: 'solidly_grounded',
+    approach: 'statistical',
+    lightningImpulse: { representativeKvPeak: 416, arresterResidualKvPeak: 340 },
+    statisticalLI: { meanKvPeak: 350, cov: 0.20 },
+  });
+  assert.equal(r.safetyFactor, SAFETY_FACTOR_STATISTICAL, 'statistical Ks = 1.05');
+  assert.ok(r.liResult.risk, 'risk estimate present');
+  assert.ok(r.liResult.risk.riskOfFailure >= 0, 'risk is non-negative');
+  assert.ok(r.liResult.risk.riskOfFailure < 1e-2, 'risk is low for well-coordinated system');
+  console.log('✓ runInsulationCoordinationStudy — statistical approach');
+})();
+
+(function testIntegrationRangeII() {
+  // 345 kV system (Um = 362 kV, Range II) with switching impulse
+  const r = runInsulationCoordinationStudy({
+    nominalVoltageKv: 345, umKv: 362, altitudeM: 0, groundingType: 'solidly_grounded',
+    approach: 'deterministic',
+    lightningImpulse: { representativeKvPeak: 900, arresterResidualKvPeak: 750 },
+    switchingImpulse: { representativeKvPeak: 800, arresterResidualKvPeak: 680 },
+  });
+  assert.equal(r.standardRow.rangeII, true, 'Um=362 kV is Range II');
+  assert.equal(r.tovResult, null, 'no PFWV result for Range II');
+  assert.ok(r.siResult, 'SI result present for Range II');
+  assert.ok(Array.isArray(r.siResult.availableSiwv) && r.siResult.availableSiwv.length > 0, 'Range II has SIWV options');
+  console.log('✓ runInsulationCoordinationStudy — Range II (345 kV)');
+})();
+
+(function testValidationErrors() {
+  // Missing required fields
+  assert.throws(() => runInsulationCoordinationStudy({}), /nominalVoltageKv/);
+  assert.throws(() => runInsulationCoordinationStudy({ nominalVoltageKv: 138 }), /umKv/);
+  assert.throws(() => runInsulationCoordinationStudy({ nominalVoltageKv: 138, umKv: -5 }), /greater than zero/);
+  assert.throws(() => runInsulationCoordinationStudy({
+    nominalVoltageKv: 138, umKv: 145, altitudeM: -100
+  }), /non-negative/);
+  assert.throws(() => runInsulationCoordinationStudy({
+    nominalVoltageKv: 138, umKv: 145, approach: 'invalid'
+  }), /approach/);
+  console.log('✓ validation errors');
+})();
+
+console.log('\nAll insulationCoordination tests passed.');


### PR DESCRIPTION
Implements IEC 60071-1/2 and IEEE 1313.2 insulation coordination study:

- analysis/insulationCoordination.mjs — pure calculation module:
  IEC 60071-1 Tables 2/3 standard insulation levels (Range I ≤ 245 kV, Range II > 245 kV),
  atmospheric correction Ka = e^(m×H/8150) per IEC 60071-2 §3.3,
  coordination withstand voltage Ucw = Urp × Ks × Ka,
  surge arrester protective margin Mp ≥ 20% (LI) / 15% (SI),
  minimum MCOV check per IEC 60099-5 §5.1,
  temporary overvoltage (TOV) calculation by earthing type,
  statistical risk of failure via Gaussian convolution (IEC 60071-2 Annex A)

- insulationcoordination.html / insulationcoordination.js / src/insulationcoordination.js —
  full study page: Um selector from IEC table, earthing type, altitude, deterministic/statistical
  approach toggle, LI/SI/MCOV inputs, results with BIL selection, protective margin, TOV, risk

- tests/insulationCoordination.test.mjs — 15 test groups, all passing

- docs/insulation-coordination.md — technical reference

Integration: navigation.js (Protection group), rollup.config.cjs, sitemap.xml,
workflowDashboard.js, scenarioComparison.js, reportPackage.mjs (SECTION_REGISTRY), site.js

https://claude.ai/code/session_01WSGWRxkrjR9fBEb2L5YdSs