### PR TITLE
Sync equipment position changes back to preset list

### DIFF
--- a/dist/equipmentarrangements.js
+++ b/dist/equipmentarrangements.js
@@ -7763,11 +7763,13 @@ function addEquipment() {
   const facing = document.getElementById('equipment-facing').value;
 
   let name = 'Equipment';
+  let listTag = null;
   if (source === 'equipment-list') {
     const index = Number.parseInt(presetSelect.value, 10);
     const item = getEquipment()[index];
     if (!item) return;
     name = item.tag || item.description || `Equipment-${state.equipment.length + 1}`;
+    listTag = item.tag || null;
   } else {
     name = customName || `Custom-${state.equipment.length + 1}`;
   }
@@ -7776,8 +7778,11 @@ function addEquipment() {
   const startX = clamp(1 + state.equipment.length * 0.8, 0, Math.max(0, state.room.width - width));
   const startY = clamp(1 + state.equipment.length * 0.6, 0, Math.max(0, state.room.depth - depth));
 
-  state.equipment.push({ id, name, width, depth, voltage, facing, x: startX, y: startY });
+  const newEq = { id, name, width, depth, voltage, facing, x: startX, y: startY };
+  if (listTag) newEq.listTag = listTag;
+  state.equipment.push(newEq);
   state.selectedEquipmentId = id;
+  if (listTag) syncEquipmentPosition(newEq);
   render();
 }
 
@@ -7809,6 +7814,16 @@ function addInteriorWall() {
 
   state.room.interiorWalls.push({ orientation, type, x, y, length: Math.max(1, adjustedLength) });
   render();
+}
+
+function syncEquipmentPosition(eq) {
+  const list = getEquipment();
+  const idx = list.findIndex(item => item.tag === eq.listTag);
+  if (idx === -1) return;
+  updateEquipment(idx, {
+    x: String(Math.round(eq.x * 100) / 100),
+    y: String(Math.round(eq.y * 100) / 100)
+  });
 }
 
 function pickEquipmentAtPoint(xFt, yFt) {
@@ -7877,6 +7892,10 @@ function bindCanvasInteractions() {
       state.wallDraw.current = null;
       render();
       return;
+    }
+    if (state.drag) {
+      const eq = state.equipment.find(item => item.id === state.drag.id);
+      if (eq && eq.listTag) syncEquipmentPosition(eq);
     }
     state.drag = null;
   };

--- a/equipmentarrangements.js
+++ b/equipmentarrangements.js
@@ -365,11 +365,13 @@ function addEquipment() {
   const facing = document.getElementById('equipment-facing').value;
 
   let name = 'Equipment';
+  let listTag = null;
   if (source === 'equipment-list') {
     const index = Number.parseInt(presetSelect.value, 10);
     const item = dataStore.getEquipment()[index];
     if (!item) return;
     name = item.tag || item.description || `Equipment-${state.equipment.length + 1}`;
+    listTag = item.tag || null;
   } else {
     name = customName || `Custom-${state.equipment.length + 1}`;
   }
@@ -378,8 +380,11 @@ function addEquipment() {
   const startX = clamp(1 + state.equipment.length * 0.8, 0, Math.max(0, state.room.width - width));
   const startY = clamp(1 + state.equipment.length * 0.6, 0, Math.max(0, state.room.depth - depth));
 
-  state.equipment.push({ id, name, width, depth, voltage, facing, x: startX, y: startY });
+  const newEq = { id, name, width, depth, voltage, facing, x: startX, y: startY };
+  if (listTag) newEq.listTag = listTag;
+  state.equipment.push(newEq);
   state.selectedEquipmentId = id;
+  if (listTag) syncEquipmentPosition(newEq);
   render();
 }
 
@@ -411,6 +416,16 @@ function addInteriorWall() {
 
   state.room.interiorWalls.push({ orientation, type, x, y, length: Math.max(1, adjustedLength) });
   render();
+}
+
+function syncEquipmentPosition(eq) {
+  const list = dataStore.getEquipment();
+  const idx = list.findIndex(item => item.tag === eq.listTag);
+  if (idx === -1) return;
+  dataStore.updateEquipment(idx, {
+    x: String(Math.round(eq.x * 100) / 100),
+    y: String(Math.round(eq.y * 100) / 100)
+  });
 }
 
 function pickEquipmentAtPoint(xFt, yFt) {
@@ -479,6 +494,10 @@ function bindCanvasInteractions() {
       state.wallDraw.current = null;
       render();
       return;
+    }
+    if (state.drag) {
+      const eq = state.equipment.find(item => item.id === state.drag.id);
+      if (eq && eq.listTag) syncEquipmentPosition(eq);
     }
     state.drag = null;
   };


### PR DESCRIPTION
## Summary
This PR adds functionality to synchronize equipment position changes back to the preset equipment list when equipment is added from or moved on the canvas.

## Key Changes
- **Track preset list origin**: When equipment is added from the preset list, store the `listTag` reference on the equipment object to maintain a link back to the source preset
- **New `syncEquipmentPosition()` function**: Syncs the current position (x, y coordinates) of equipment back to the preset list by finding the matching item by tag and updating it with rounded coordinates
- **Sync on equipment addition**: When equipment is added from the preset list, immediately sync its initial position to the preset
- **Sync on canvas drag**: When equipment is dragged on the canvas and released, if it has a `listTag`, sync the new position back to the preset list

## Implementation Details
- Position values are rounded to 2 decimal places before syncing (`Math.round(eq.x * 100) / 100`)
- The sync only occurs for equipment that originated from the preset list (has a `listTag`)
- Changes are applied to both the source file (`equipmentarrangements.js`) and the compiled distribution file (`dist/equipmentarrangements.js`)
- The implementation uses the existing `updateEquipment()` / `dataStore.updateEquipment()` API to persist changes

https://claude.ai/code/session_01Vq1Azgtp2HF9ic1HTU7zKc