### PR TITLE
Fix coordinate transformation using SVG matrix instead of manual calculation

### DIFF
--- a/equipmentarrangements.js
+++ b/equipmentarrangements.js
@@ -439,11 +439,12 @@ function pickEquipmentAtPoint(xFt, yFt) {
 }
 
 function toFeetCoordinates(event) {
-  const rect = canvas.getBoundingClientRect();
-  const svgX = event.clientX - rect.left;
-  const svgY = event.clientY - rect.top;
-  const xFt = (svgX - 20) / state.scale;
-  const yFt = (svgY - 20) / state.scale;
+  const pt = canvas.createSVGPoint();
+  pt.x = event.clientX;
+  pt.y = event.clientY;
+  const svgPt = pt.matrixTransform(canvas.getScreenCTM().inverse());
+  const xFt = (svgPt.x - 20) / state.scale;
+  const yFt = (svgPt.y - 20) / state.scale;
   return { xFt, yFt };
 }
 


### PR DESCRIPTION
## Summary
Improved the coordinate transformation logic in `toFeetCoordinates()` to use SVG's native matrix transformation API instead of manual bounding rectangle calculations. This provides more accurate coordinate conversion that properly accounts for SVG transformations.

## Key Changes
- Replaced `getBoundingClientRect()` approach with SVG's `createSVGPoint()` and `getScreenCTM()` methods
- Now uses the inverse of the screen coordinate transformation matrix to convert client coordinates to SVG coordinates
- Eliminates manual offset calculations that may not account for all CSS transforms or SVG scaling

## Implementation Details
The new approach leverages the SVG specification's coordinate transformation matrix (CTM) to properly convert from screen space to SVG coordinate space. This is more robust than calculating offsets manually, as it automatically handles any CSS transforms, viewport scaling, or other transformations applied to the canvas element.

https://claude.ai/code/session_017PNHt6csDJmvJkvP6nvcy4