### PR TITLE
Fix coordinate transformation using SVG matrix instead of manual calculation

### DIFF
--- a/dist/equipmentarrangements.js
+++ b/dist/equipmentarrangements.js
@@ -7837,11 +7837,12 @@ function pickEquipmentAtPoint(xFt, yFt) {
 }
 
 function toFeetCoordinates(event) {
-  const rect = canvas.getBoundingClientRect();
-  const svgX = event.clientX - rect.left;
-  const svgY = event.clientY - rect.top;
-  const xFt = (svgX - 20) / state.scale;
-  const yFt = (svgY - 20) / state.scale;
+  const pt = canvas.createSVGPoint();
+  pt.x = event.clientX;
+  pt.y = event.clientY;
+  const svgPt = pt.matrixTransform(canvas.getScreenCTM().inverse());
+  const xFt = (svgPt.x - 20) / state.scale;
+  const yFt = (svgPt.y - 20) / state.scale;
   return { xFt, yFt };
 }
 


### PR DESCRIPTION
## Summary
Improved the coordinate transformation logic in `toFeetCoordinates()` to use SVG's native matrix transformation API instead of manual bounding rectangle calculations. This provides more accurate coordinate conversion that properly accounts for SVG transformations.

## Key Changes
- Replaced `getBoundingClientRect()` based coordinate calculation with SVG's `createSVGPoint()` and `matrixTransform()` API
- Now uses the canvas's screen CTM (Current Transformation Matrix) and its inverse to properly transform client coordinates to SVG coordinates
- This approach automatically handles any SVG scaling, rotation, or other transformations applied to the canvas element

## Implementation Details
The new implementation:
1. Creates an SVG point with the client mouse coordinates
2. Applies the inverse of the canvas's screen transformation matrix to convert from screen space to SVG space
3. Uses the transformed coordinates for the feet calculation, maintaining the same offset logic (20 pixels) and scale factor

This is a more robust solution that leverages SVG's built-in transformation capabilities rather than relying on manual DOM measurements.

https://claude.ai/code/session_01NJ7n5RyWRL9H72A7s5pcT2