### PR TITLE
Add equipment detail modal on canvas double-click

### DIFF
--- a/equipmentarrangements.js
+++ b/equipmentarrangements.js
@@ -1,4 +1,5 @@
 import * as dataStore from './dataStore.mjs';
+import { openModal } from './src/components/modal.js';
 
 const WALL_TYPES = ['Concrete', 'CMU', 'Gypsum', 'Metal', 'Fire Rated', 'Removable Panel'];
 const VOLTAGE_OPTIONS = ['120V', '208V', '480V', '600V', '4.16kV', '13.8kV', '15kV'];
@@ -911,6 +912,87 @@ function toFeetCoordinates(event) {
   return { xFt, yFt };
 }
 
+// ── Equipment detail modal ───────────────────────────────────────────────────
+
+function showEquipmentDetailModal(eq) {
+  const listItem = eq.listTag
+    ? dataStore.getEquipment().find(item => item.tag === eq.listTag) || null
+    : null;
+
+  openModal({
+    title: eq.name,
+    primaryText: 'Close',
+    secondaryText: null,
+    defaultWidth: 'medium',
+    render(body) {
+      body.style.padding = '0';
+
+      const card = document.createElement('div');
+      card.className = 'equipment-detail-card';
+
+      function section(label, value) {
+        if (!value && value !== 0) return;
+        const row = document.createElement('div');
+        row.className = 'equipment-detail-row';
+        const lbl = document.createElement('span');
+        lbl.className = 'equipment-detail-label';
+        lbl.textContent = label;
+        const val = document.createElement('span');
+        val.className = 'equipment-detail-value';
+        val.textContent = String(value);
+        row.appendChild(lbl);
+        row.appendChild(val);
+        card.appendChild(row);
+      }
+
+      // Canvas placement data
+      section('Tag', eq.name);
+      if (listItem) {
+        section('Description', listItem.description);
+        section('Category', listItem.category);
+        section('Sub-Category', listItem.subCategory);
+      }
+      section('Voltage', eq.voltage);
+      if (listItem) {
+        section('Phases', listItem.phases);
+        section('Manufacturer', listItem.manufacturer);
+        section('Model', listItem.model);
+      }
+
+      const divider = document.createElement('hr');
+      divider.className = 'equipment-detail-divider';
+      card.appendChild(divider);
+
+      section('Width', `${eq.width.toFixed(1)} ft`);
+      section('Depth', `${eq.depth.toFixed(1)} ft`);
+      section('Facing', eq.facing.charAt(0).toUpperCase() + eq.facing.slice(1));
+      section('Position', `(${eq.x.toFixed(2)}, ${eq.y.toFixed(2)}) ft`);
+
+      const hasViolation = state.violations.has(eq.id);
+      const statusRow = document.createElement('div');
+      statusRow.className = 'equipment-detail-row';
+      const statusLbl = document.createElement('span');
+      statusLbl.className = 'equipment-detail-label';
+      statusLbl.textContent = 'NEC Status';
+      const statusVal = document.createElement('span');
+      statusVal.className = `equipment-detail-value equipment-detail-status${hasViolation ? ' equipment-detail-status--violation' : ' equipment-detail-status--ok'}`;
+      statusVal.textContent = hasViolation ? 'Violation' : 'Compliant';
+      statusRow.appendChild(statusLbl);
+      statusRow.appendChild(statusVal);
+      card.appendChild(statusRow);
+
+      if (listItem && listItem.notes) {
+        const notesDivider = document.createElement('hr');
+        notesDivider.className = 'equipment-detail-divider';
+        card.appendChild(notesDivider);
+        section('Notes', listItem.notes);
+      }
+
+      body.appendChild(card);
+    }
+  });
+}
+
 // ── Canvas interactions ───────────────────────────────────────────────────────
 
 function bindCanvasInteractions() {
@@ -924,6 +1006,14 @@ function bindCanvasInteractions() {
       render();
     }
     showContextMenu(event.clientX, event.clientY, picked);
+  });
+
+  canvas.addEventListener('dblclick', event => {
+    const { xFt, yFt } = toFeetCoordinates(event);
+    const picked = pickEquipmentAtPoint(xFt, yFt);
+    if (picked) {
+      showEquipmentDetailModal(picked);
+    }
   });
 
   canvas.addEventListener('pointerdown', event => {

--- a/style.css
+++ b/style.css
@@ -59,6 +59,16 @@
 .equipment-gap-label-bg { fill:rgba(255,255,255,.9); stroke:#f97316; stroke-width:1; pointer-events:none; }
 @media (max-width:1100px){ .equipment-arrangement-layout{grid-template-columns:1fr;} .equipment-arrangement-sidebar{max-height:none;} #equipment-arrangement-canvas{min-height:56vh;} }
 
+.equipment-detail-card { display:flex; flex-direction:column; padding:.75rem 1rem; gap:0; }
+.equipment-detail-row { display:grid; grid-template-columns:140px 1fr; gap:.5rem; align-items:baseline; padding:.4rem 0; border-bottom:1px solid var(--border-color,#e5e9f0); }
+.equipment-detail-row:last-child { border-bottom:none; }
+.equipment-detail-label { font-size:.8rem; font-weight:600; color:var(--muted-color,#6b7280); text-transform:uppercase; letter-spacing:.04em; }
+.equipment-detail-value { font-size:.92rem; color:var(--text-color,#1f2b3a); word-break:break-word; }
+.equipment-detail-divider { border:none; border-top:2px solid var(--border-color,#e5e9f0); margin:.25rem 0; }
+.equipment-detail-status { font-weight:700; padding:.15rem .5rem; border-radius:4px; font-size:.82rem; }
+.equipment-detail-status--ok { background:rgba(16,185,129,.12); color:#065f46; }
+.equipment-detail-status--violation { background:rgba(220,38,38,.1); color:#991b1b; }
+
 .cp-geometry-illustration {
   margin: .5rem 0 1rem;
   padding: .75rem;


### PR DESCRIPTION
## Summary
This PR adds a modal dialog that displays detailed information about equipment when users double-click on it in the canvas. The modal shows equipment specifications, placement data, NEC compliance status, and notes.

## Key Changes
- **New modal function**: Added `showEquipmentDetailModal()` to display comprehensive equipment details in a formatted card layout
- **Canvas interaction**: Added double-click event listener to `bindCanvasInteractions()` that triggers the detail modal for picked equipment
- **Modal styling**: Added CSS classes for the equipment detail card layout including:
  - `.equipment-detail-card` - main container with flex layout
  - `.equipment-detail-row` - label/value pairs with grid layout
  - `.equipment-detail-status` - NEC compliance status badge with conditional styling (ok/violation states)
  - `.equipment-detail-divider` - visual separators between sections
- **Modal import**: Added import for `openModal` from the modal component

## Implementation Details
- The modal displays equipment data in two sections separated by a divider:
  - **Equipment specs**: Tag, description, category, voltage, phases, manufacturer, model
  - **Canvas placement**: Width, depth, facing direction, position coordinates, and NEC compliance status
- Equipment notes (if available) are displayed in a separate section below another divider
- The modal uses a "medium" width and only shows a "Close" button
- NEC compliance status is color-coded: green for compliant, red for violations
- The detail modal looks up additional equipment information from the data store using the equipment's `listTag`

https://claude.ai/code/session_01AmbDiBbYV2Y7htHxnHeTKk