### PR TITLE
Consider egress doorways when evaluating NEC workspace access in equipment arrangements

### DIFF
--- a/equipmentarrangements.js
+++ b/equipmentarrangements.js
@@ -114,6 +114,32 @@ function interiorWallRect(wall) {
 }
 
 function accessViolation(eq, workspace) {
+  const doorwayAccess = state.room.doorways.some(door => {
+    if (!door.isEgress) return false;
+    const clearance = 0.5;
+    switch (door.wall) {
+      case 'north': {
+        const overlapsX = workspace.x <= door.position + door.width && workspace.x + workspace.w >= door.position;
+        return overlapsX && workspace.y <= clearance;
+      }
+      case 'south': {
+        const overlapsX = workspace.x <= door.position + door.width && workspace.x + workspace.w >= door.position;
+        return overlapsX && workspace.y + workspace.h >= state.room.depth - clearance;
+      }
+      case 'east': {
+        const overlapsY = workspace.y <= door.position + door.width && workspace.y + workspace.h >= door.position;
+        return overlapsY && workspace.x + workspace.w >= state.room.width - clearance;
+      }
+      case 'west': {
+        const overlapsY = workspace.y <= door.position + door.width && workspace.y + workspace.h >= door.position;
+        return overlapsY && workspace.x <= clearance;
+      }
+      default:
+        return false;
+    }
+  });
+  if (doorwayAccess) return false;
+
   const left = workspace.x;
   const right = state.room.width - (workspace.x + workspace.w);
   const top = workspace.y;


### PR DESCRIPTION
### Motivation
- Prevent false NEC workspace/access violation flags when an equipment item's required workspace abuts a doorway that is explicitly marked as a means of egress.

### Description
- Modified `accessViolation` in `equipmentarrangements.js` to check `state.room.doorways` for doorways with `isEgress === true` and test wall-specific overlaps so workspace regions adjacent to a matching egress doorway are treated as valid access and not flagged as violations.
- The new logic handles all four wall orientations (`north`, `south`, `east`, `west`) by checking overlap along the doorway span and a small clearance threshold before falling back to the existing perimeter and nearby-blocker checks.

### Testing
- Ran `npm test --silent`, which reported failures due to a pre-existing metadata issue in `validationBenchmarks.json` (standard `ieee80-advanced-soil` missing `name`), so full test suite could not be validated in this environment.
- Ran `npm run build --silent`, which failed due to a pre-existing Rollup export mismatch in `src/validation.js` (importing `initSettings` from `site.js`), unrelated to this change.
- Attempted to capture a visual preview with Playwright, but browser binaries could not be downloaded in this environment (HTTP 403), so an automated screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023d69ec4c832494b5fa23035d88c5)