### PR TITLE
Fix stored XSS vector in Bus Duct study restore path

### DIFF
--- a/busdust.js
+++ b/busdust.js
@@ -25,8 +25,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const saved = getStudies().busDuctSizing;
   if (saved && saved._inputs) {
     restoreInputs(saved._inputs);
-    renderResults(saved);
-    exportBtn.disabled = false;
+    const restoredResult = runBusDuctStudy(saved._inputs);
+    const studies = getStudies();
+    studies.busDuctSizing = { ...restoredResult, _inputs: saved._inputs };
+    setStudies(studies);
+    renderResults(studies.busDuctSizing);
+    exportBtn.disabled = !restoredResult.valid;
   }
 
   // -------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- The Bus Duct study page restored persisted `busDuctSizing` result objects directly and passed many fields into an `innerHTML` template, allowing stored XSS via crafted imported project settings. 
- The change aims to treat persisted study payloads as untrusted and ensure rendered values originate from the calculation pipeline rather than arbitrary stored objects.

### Description
- On page load the restore flow now reads only `saved._inputs`, recomputes results with `runBusDuctStudy(saved._inputs)`, and replaces the stored study with the recomputed object before rendering. 
- The code writes the recomputed result back via `setStudies(...)` and then calls `renderResults(...)` with the safe, recomputed object. 
- The export button enablement is adjusted to reflect the recomputed `valid` flag (`exportBtn.disabled = !restoredResult.valid`).

### Testing
- Ran `npm test` and the test suite completed successfully. 
- Ran `npm run build` and the project built without errors. 
- Attempted to produce a page preview via Playwright but browser binaries could not be downloaded in this environment (`npx playwright install chromium` failed with 403), so an automated screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0871a30cc083249ce98742761d6765)