### PR TITLE
Fix stored XSS in heat-trace branch detail panel

### DIFF
--- a/heattracesizing.js
+++ b/heattracesizing.js
@@ -727,9 +727,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function renderDetailItem(label, value) {
+    const safeValue = value == null ? '' : escHtml(String(value));
     return `<article class="heattrace-detail-item">
       <span>${escHtml(label)}</span>
-      <strong>${value}</strong>
+      <strong>${safeValue}</strong>
     </article>`;
   }
 


### PR DESCRIPTION
### Motivation
- The branch detail renderer could insert attacker-controlled HTML from persisted `circuitCase.result` (e.g. `heatTraceCableSelectionNote`) into `innerHTML`, producing a stored DOM XSS when editing saved branches.
- The change aims to neutralize that vector by escaping detail values before interpolation while keeping the visible text behavior intact.

### Description
- Sanitize detail values in `renderDetailItem` by computing `safeValue = value == null ? '' : escHtml(String(value))` and interpolating `safeValue` instead of the raw `value`.
- Change is localized to `heattracesizing.js` (the `renderDetailItem` function) and preserves existing rendering layout and behavior for non-malicious inputs.

### Testing
- Ran the full test suite with `npm test` and the run completed successfully.
- Built the production artifacts with `npm run build` and the build completed successfully.
- Attempted to capture a preview screenshot via Playwright to produce a webpage preview image, but `npx playwright install chromium` failed due to remote download `403 Forbidden`, so an automated preview image could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08755e5b6c8324934f4b14d177455e)