### PR TITLE
Fix stored XSS in Differential Protection saved-result rendering

### DIFF
--- a/differentialprotection.js
+++ b/differentialprotection.js
@@ -167,14 +167,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const warningsHtml = r.warnings.length
       ? `<ul class="drc-findings">${r.warnings.map(w =>
-          `<li class="drc-finding drc-warn"><span class="drc-msg">${w}</span></li>`
+          `<li class="drc-finding drc-warn"><span class="drc-msg">${escHtml(String(w ?? ''))}</span></li>`
         ).join('')}</ul>`
       : '';
 
     const tripClass = r.tripResult.trip ? 'status-fail' : 'status-pass';
     const tripLabel = r.tripResult.trip ? '⚡ TRIP' : '✓ NO TRIP';
     const restrainHtml = r.harmonic.restrain
-      ? `<p class="field-hint">${r.harmonic.reason}</p>`
+      ? `<p class="field-hint">${escHtml(String(r.harmonic.reason ?? ''))}</p>`
       : '';
 
     const ctMismatchHtml = !r.ctMismatch.acceptable
@@ -223,7 +223,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <tr><td>I₁ (CT₁ secondary normalised to tap, pu)</td><td>${r.currents.i1Pu.toFixed(4)}</td></tr>
             <tr><td>I₂ (CT₂ secondary normalised to tap, pu)</td><td>${r.currents.i2Pu.toFixed(4)}</td></tr>
             <tr><td>CT₁ / CT₂ nominal tap</td><td>${r.ctMismatch.nominalTap.toFixed(4)}</td></tr>
-            <tr><td>Set tap</td><td>${r.inputs.tapSetting}</td></tr>
+            <tr><td>Set tap</td><td>${escHtml(String(r.inputs.tapSetting ?? ''))}</td></tr>
             <tr><td>CT mismatch</td><td>${r.ctMismatch.mismatchPct.toFixed(2)}%</td></tr>
             <tr><td>2nd harmonic</td><td>${r.harmonic.secondPct.toFixed(1)}%</td></tr>
             <tr><td>5th harmonic</td><td>${r.harmonic.fifthPct.toFixed(1)}%</td></tr>


### PR DESCRIPTION
### Motivation
- Prevent a stored DOM XSS where restored `studyResults.differentialProtection` fields were interpolated into page `innerHTML` without escaping, allowing attacker-controlled markup in `warnings`, `harmonic.reason`, or `inputs.tapSetting` to execute.

### Description
- Escape restored fields in `renderResults` by applying `escHtml(String(...))` to each saved warning, `harmonic.reason`, and the `inputs.tapSetting` value so imported/saved study data is rendered as plain text instead of markup.

### Testing
- Ran `npm test` and `npm run build`, and both completed successfully; an attempt to capture a visual preview via Playwright failed because browser binaries could not be downloaded in this environment (HTTP 403), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08777bf9f48324afb55185a944d366)