### PR TITLE
Escape CP distribution segment fields to prevent stored XSS

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -1555,10 +1555,10 @@ function renderResults(result, root) {
           <tbody>
             ${result.distributionModel.segments.map((segment) => `
               <tr>
-                <td>${segment.segment}</td>
-                <td>${segment.zoneResistivityOhmM}</td>
-                <td>${segment.effectivenessFactor}</td>
-                <td>${segment.attenuationFactor}</td>
+                <td>${escapeHtml(segment.segment)}</td>
+                <td>${escapeHtml(segment.zoneResistivityOhmM)}</td>
+                <td>${escapeHtml(segment.effectivenessFactor)}</td>
+                <td>${escapeHtml(segment.attenuationFactor)}</td>
               </tr>`).join('')}
           </tbody>
         </table>


### PR DESCRIPTION
### Motivation
- Close a DOM XSS sink where persisted `studyResults` could inject HTML into the CP distribution table rendered via `root.innerHTML` by ensuring attacker-controlled segment fields are not inserted as raw HTML.

### Description
- Escape all segment-derived values in the distribution table inside `renderResults` by wrapping the four interpolated fields with `escapeHtml(...)` in `cathodicprotection.js` (preserves layout and numeric display while inserting values as text).

### Testing
- Ran `npm test` and `npm run build`, both completed successfully.
- Attempted to produce a browser preview screenshot with Playwright, but browser installation failed due to unavailable Chromium download endpoints (could not generate preview in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087ad113a88324b22b197cf2c0a1be)