### PR TITLE
Fix stored XSS by validating/recomputing saved cathodic protection studies

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -585,6 +585,12 @@ function normalizeSavedStudy(saved) {
     return null;
   }
 
+  const normalizedInput = normalizeAnalysisInput(saved);
+  if (!normalizedInput) {
+    return null;
+  }
+
+  const recomputed = runCathodicProtectionAnalysis(normalizedInput);
   const compliance = saved.compliance && typeof saved.compliance === 'object'
     ? saved.compliance
     : {
@@ -600,10 +606,24 @@ function normalizeSavedStudy(saved) {
 
   return {
     ...saved,
+    ...recomputed,
+    timestamp: saved.timestamp || recomputed.timestamp,
     timelineState: normalizeTimelineState(saved.timelineState),
     compliance,
     complianceHistory: existingHistory
   };
+}
+
+function normalizeAnalysisInput(candidate) {
+  if (!candidate || typeof candidate !== 'object') {
+    return null;
+  }
+  const normalized = {
+    ...candidate,
+    zoneResistivityOhmM: parseZoneResistivityValues(candidate.zoneResistivityOhmM)
+  };
+  const validationErrors = validateInputs(normalized);
+  return validationErrors.length ? null : normalized;
 }
 
 function normalizeTimelineState(state) {


### PR DESCRIPTION
### Motivation
- Address a stored DOM XSS where persisted `studies.cathodicProtection` objects were rendered as precomputed output without schema validation, allowing attacker-controlled project imports to inject HTML/event handlers into `innerHTML`.
- Ensure imported project `settings.studyResults` entries cannot be trusted as render-ready outputs and must be validated/recomputed before rendering.

### Description
- Added `normalizeAnalysisInput(candidate)` to parse `zoneResistivityOhmM` via `parseZoneResistivityValues` and validate inputs with the existing `validateInputs` routine.
- Updated `normalizeSavedStudy(saved)` to call `normalizeAnalysisInput`, and when valid, recompute study outputs with `runCathodicProtectionAnalysis(normalizedInput)` and merge the recomputed results into the restored study while preserving `timelineState`, `compliance`, and `complianceHistory`.
- The change confines the fix to `cathodicprotection.js` and prevents untrusted persisted output fields from being inserted into the results template.
- No behavioral changes for legitimately saved studies that pass validation; only non-conforming persisted payloads are dropped.

### Testing
- Ran the full test suite with `npm test` and the run completed successfully with tests passing.
- Built the distribution with `npm run build` and the build completed successfully.
- Attempted to generate a page preview via Playwright but the screenshot step failed because Playwright browser binaries are not installed in this environment, so no preview image could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087e05fa588324865b017a3c781367)