### PR TITLE
fix: prevent XSS in IEC 60909 results rendering

### DIFF
--- a/iec60909.js
+++ b/iec60909.js
@@ -63,18 +63,23 @@ function renderResults(res) {
 
   for (const [id, r] of entries) {
     const tr = document.createElement('tr');
-    tr.innerHTML = `
-      <td>${id}</td>
-      <td>${r.prefaultKV}</td>
-      <td>${r.cFactor}</td>
-      <td>${r.kappa}</td>
-      <td>${r.threePhaseKA}</td>
-      <td>${r.lineToGroundKA}</td>
-      <td>${r.lineToLineKA}</td>
-      <td>${r.ip}</td>
-      <td>${r.Ib}</td>
-      <td>${r.Ith}</td>
-    `;
+    const values = [
+      id,
+      r.prefaultKV,
+      r.cFactor,
+      r.kappa,
+      r.threePhaseKA,
+      r.lineToGroundKA,
+      r.lineToLineKA,
+      r.ip,
+      r.Ib,
+      r.Ith,
+    ];
+    values.forEach(value => {
+      const td = document.createElement('td');
+      td.textContent = value == null ? '' : String(value);
+      tr.appendChild(td);
+    });
     tbody.appendChild(tr);
   }
   resultsSection.hidden = false;


### PR DESCRIPTION
### Motivation
- The IEC 60909 study page rendered project-controlled bus/component IDs using `innerHTML`, creating a DOM XSS sink that could execute same-origin script from a malicious project file.
- The intent is to eliminate the XSS vector while preserving the study output and UX.

### Description
- Replaced unsafe `tr.innerHTML` templating in `iec60909.js` with explicit creation of `<td>` elements and assignment via `textContent` so all values (including bus IDs) are rendered as plain text.
- Kept the existing table columns and ordering (bus id, `prefaultKV`, `cFactor`, `kappa`, `threePhaseKA`, `lineToGroundKA`, `lineToLineKA`, `ip`, `Ib`, `Ith`).
- No changes to study logic, storage, or export behavior; the submit handler still runs `runShortCircuit`, stores results in `studies.iec60909`, and calls the renderer.

### Testing
- Ran the full automated test suite with `npm test`, and all tests completed successfully.
- Built the production bundle with `npm run build`, which completed successfully.
- Attempted to capture a webpage preview screenshot via Playwright, but browser binaries could not be downloaded in this environment (Playwright install failed with HTTP 403), so no preview image could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0883d7ec048324a076f38baeb34b8f)