### PR TITLE
fix: harden battery results rendering against stored XSS payloads

### DIFF
--- a/battery.js
+++ b/battery.js
@@ -162,24 +162,33 @@ document.addEventListener('DOMContentLoaded', () => {
     const warnings = Array.isArray(r.warnings) ? r.warnings : [];
     const warningsHtml = warnings.length
       ? `<ul class="drc-findings">${warnings.map(w =>
-          `<li class="drc-finding drc-warn"><span class="drc-msg">${w}</span></li>`
+          `<li class="drc-finding drc-warn"><span class="drc-msg">${escHtml(String(w))}</span></li>`
         ).join('')}</ul>`
       : '';
 
     // Runtime curve table rows
-    const runtimeRows = r.runtimeCurvePoints.map(pt => {
-      const highlight = pt.loadFraction === 1.00 ? ' style="font-weight:600"' : '';
+    const runtimePoints = Array.isArray(r.runtimeCurvePoints) ? r.runtimeCurvePoints : [];
+    const runtimeRows = runtimePoints.map(pt => {
+      const loadFraction = Number(pt?.loadFraction);
+      const loadKw = Number(pt?.loadKw);
+      const runtimeHours = Number(pt?.runtimeHours);
+      if (!Number.isFinite(loadFraction) || !Number.isFinite(loadKw) || !Number.isFinite(runtimeHours)) return '';
+      const highlight = loadFraction === 1.00 ? ' style="font-weight:600"' : '';
       return `<tr${highlight}>
-        <td>${Math.round(pt.loadFraction * 100)}%</td>
-        <td>${pt.loadKw.toFixed(1)} kW</td>
-        <td>${pt.runtimeHours.toFixed(2)} h</td>
+        <td>${Math.round(loadFraction * 100)}%</td>
+        <td>${loadKw.toFixed(1)} kW</td>
+        <td>${runtimeHours.toFixed(2)} h</td>
       </tr>`;
     }).join('');
 
     // Bank options tags
-    const bankOptionsHtml = r.bankOptions.map(s =>
-      `<span class="tag${s === r.selectedBankKwh ? ' tag--primary' : ''}">${s} kWh</span>`
-    ).join(' ');
+    const selectedBankKwh = Number(r.selectedBankKwh);
+    const bankOptions = Array.isArray(r.bankOptions) ? r.bankOptions : [];
+    const bankOptionsHtml = bankOptions.map(s => {
+      const bankKwh = Number(s);
+      if (!Number.isFinite(bankKwh)) return '';
+      return `<span class="tag${bankKwh === selectedBankKwh ? ' tag--primary' : ''}">${bankKwh} kWh</span>`;
+    }).join(' ');
 
     // K_temp status colour
     const tempClass = r.kTempFactor < 0.85


### PR DESCRIPTION
### Motivation
- Close a stored DOM XSS sink where persisted `studyResults.batterySizing` fields (warnings, bank options, runtime points) were interpolated into `innerHTML` without sufficient escaping or validation.
- Prevent attacker-controlled project imports from executing script when the Battery / UPS page reads and renders persisted analysis results.

### Description
- Escape persisted warning strings before interpolation by using `escHtml(String(w))` when building the warnings list in `renderResults`.
- Sanitize `runtimeCurvePoints` by coercing each point field via `Number(...)`, skipping entries with non-finite numeric fields, and then rendering safe numeric values into the runtime table rows.
- Sanitize `bankOptions` and `selectedBankKwh` by coercing to numbers and skipping non-finite entries before rendering option tags and computing the selected state.
- Keep existing behavior and layout while adding defensive checks so only well-formed numeric/runtime entries and escaped text are rendered.

### Testing
- Ran the unit test focused on this feature with `npm test -- batterySizing.test.mjs` and the battery sizing tests completed successfully (all assertions passed).
- Built the distribution with `npm run build` and the build completed successfully (dist artifacts created).
- Attempted to capture a preview screenshot using Playwright but the environment lacked browser binaries, so the visual preview capture failed (Playwright reported missing Chromium).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0883f7f06c832480c8c03b2a9d61d4)