### PR TITLE
Fix stored XSS path in insulation coordination restore flow

### DIFF
--- a/insulationcoordination.js
+++ b/insulationcoordination.js
@@ -55,7 +55,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const saved = getStudies().insulationCoordination;
   if (saved) {
     restoreForm(saved.inputs);
-    renderResults(saved);
+    try {
+      const restoredResult = runInsulationCoordinationStudy(readInputs());
+      renderResults(restoredResult);
+    } catch {
+      // Ignore invalid/malformed persisted data and wait for a fresh user submission.
+    }
   }
 
   // Toggle statistical panel visibility


### PR DESCRIPTION
### Motivation
- The insulation coordination page previously restored `studies.insulationCoordination` and passed it directly to `renderResults()`, which built an HTML string and assigned it to `innerHTML`, allowing a malicious imported project to inject executable markup (stored XSS).

### Description
- On page restore only the form inputs are restored via `restoreForm(saved.inputs)` and results are recomputed with `runInsulationCoordinationStudy(readInputs())` before calling `renderResults()` to ensure displayed values come from trusted calculation logic rather than persisted markup.
- A defensive `try/catch` was added around the restore-time recomputation so malformed or attacker-controlled persisted payloads are ignored until a valid user submission overwrites them.

### Testing
- Ran `npm test` and the full test suite completed successfully (all automated tests passed).
- Ran `npm run build` and the project built successfully into `dist`.
- Attempted an automated Playwright screenshot of `insulationcoordination.html`, but browser installation failed in this environment (`npx playwright install chromium` returned HTTP 403), so the visual preview could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08718fe6088324bd887f3347a7b25c)