### PR TITLE
fix: harden relay settings export against injection

### DIFF
--- a/reports/relaySettingsExport.mjs
+++ b/reports/relaySettingsExport.mjs
@@ -25,7 +25,17 @@ export const MANIFEST_HEADERS = [
 export function resolveSettings(entry = {}) {
   const base = entry.baseDevice?.settings || {};
   const overrides = entry.overrideSource || {};
-  return { ...base, ...overrides };
+  const merged = { ...base };
+  for (const key of Object.keys(base)) {
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      merged[key] = overrides[key];
+    }
+  }
+  return merged;
+}
+
+function sanitizeInlineValue(value) {
+  return String(value).replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
 }
 
 /**
@@ -88,8 +98,8 @@ export function formatSEL(entry = {}) {
   const ts = new Date().toISOString();
   const lines = [
     `; SEL Relay Settings File`,
-    `; Device  : ${dev.name || entry.name || 'Unknown'} (${dev.id || ''})`,
-    `; Vendor  : ${dev.vendor || 'SEL'}`,
+    `; Device  : ${sanitizeInlineValue(dev.name || entry.name || 'Unknown')} (${sanitizeInlineValue(dev.id || '')})`,
+    `; Vendor  : ${sanitizeInlineValue(dev.vendor || 'SEL')}`,
     `; Generated: ${ts}`,
     `;`,
   ];
@@ -98,13 +108,13 @@ export function formatSEL(entry = {}) {
 
   if (subtype === 'relay_87') {
     lines.push(`[DIFFERENTIAL]`);
-    if (s.slope1 !== undefined)                    lines.push(`SLP1=${s.slope1}`);
-    if (s.slope2 !== undefined)                    lines.push(`SLP2=${s.slope2}`);
-    if (s.minPickupPu !== undefined)               lines.push(`O87P=${s.minPickupPu}`);
-    if (s.breakpointPu !== undefined)              lines.push(`IRS1=${s.breakpointPu}`);
-    if (s.tapSetting !== undefined)                lines.push(`TAP1=${s.tapSetting}`);
-    if (s.secondHarmonicThresholdPct !== undefined) lines.push(`PCT2=${s.secondHarmonicThresholdPct}`);
-    if (s.fifthHarmonicThresholdPct !== undefined)  lines.push(`PCT5=${s.fifthHarmonicThresholdPct}`);
+    if (s.slope1 !== undefined)                    lines.push(`SLP1=${sanitizeInlineValue(s.slope1)}`);
+    if (s.slope2 !== undefined)                    lines.push(`SLP2=${sanitizeInlineValue(s.slope2)}`);
+    if (s.minPickupPu !== undefined)               lines.push(`O87P=${sanitizeInlineValue(s.minPickupPu)}`);
+    if (s.breakpointPu !== undefined)              lines.push(`IRS1=${sanitizeInlineValue(s.breakpointPu)}`);
+    if (s.tapSetting !== undefined)                lines.push(`TAP1=${sanitizeInlineValue(s.tapSetting)}`);
+    if (s.secondHarmonicThresholdPct !== undefined) lines.push(`PCT2=${sanitizeInlineValue(s.secondHarmonicThresholdPct)}`);
+    if (s.fifthHarmonicThresholdPct !== undefined)  lines.push(`PCT5=${sanitizeInlineValue(s.fifthHarmonicThresholdPct)}`);
   } else {
     const pickup   = s.longTimePickup  ?? s.pickup;
     const tms      = s.tms ?? s.longTimeDelay ?? s.time;
@@ -114,12 +124,12 @@ export function formatSEL(entry = {}) {
     const curve    = SEL_CURVE_MAP[s.curveProfile ?? s.curveFamily] ?? 'U1';
 
     lines.push(`[OVERCURRENT]`);
-    if (instPkup !== undefined) lines.push(`50P1P=${instPkup}`);
-    if (pickup    !== undefined) lines.push(`51P1P=${pickup}`);
-    if (tms       !== undefined) lines.push(`51P1TD=${tms}`);
+    if (instPkup !== undefined) lines.push(`50P1P=${sanitizeInlineValue(instPkup)}`);
+    if (pickup    !== undefined) lines.push(`51P1P=${sanitizeInlineValue(pickup)}`);
+    if (tms       !== undefined) lines.push(`51P1TD=${sanitizeInlineValue(tms)}`);
     lines.push(`51P1C=${curve}`);
-    if (stPickup  !== undefined) lines.push(`51P1SP=${stPickup}`);
-    if (stDelay   !== undefined) lines.push(`51P1SD=${stDelay}`);
+    if (stPickup  !== undefined) lines.push(`51P1SP=${sanitizeInlineValue(stPickup)}`);
+    if (stDelay   !== undefined) lines.push(`51P1SD=${sanitizeInlineValue(stDelay)}`);
   }
 
   lines.push('');
@@ -153,8 +163,8 @@ export function formatGEURS(entry = {}) {
   const ts = new Date().toISOString();
   const lines = [
     `# GE EnerVista Settings File`,
-    `# Device  : ${dev.name || entry.name || 'Unknown'} (${dev.id || ''})`,
-    `# Vendor  : ${dev.vendor || 'GE'}`,
+    `# Device  : ${sanitizeInlineValue(dev.name || entry.name || 'Unknown')} (${sanitizeInlineValue(dev.id || '')})`,
+    `# Vendor  : ${sanitizeInlineValue(dev.vendor || 'GE')}`,
     `# Generated: ${ts}`,
     `#`,
   ];
@@ -163,13 +173,13 @@ export function formatGEURS(entry = {}) {
 
   if (subtype === 'relay_87') {
     lines.push(`# Differential protection`);
-    if (s.slope1 !== undefined)                    lines.push(`DIFF_SLOPE1=${s.slope1}`);
-    if (s.slope2 !== undefined)                    lines.push(`DIFF_SLOPE2=${s.slope2}`);
-    if (s.minPickupPu !== undefined)               lines.push(`DIFF_PICKUP=${s.minPickupPu}`);
-    if (s.breakpointPu !== undefined)              lines.push(`DIFF_BREAKPOINT=${s.breakpointPu}`);
-    if (s.tapSetting !== undefined)                lines.push(`TAP_W1=${s.tapSetting}`);
-    if (s.secondHarmonicThresholdPct !== undefined) lines.push(`PCT2H=${s.secondHarmonicThresholdPct}`);
-    if (s.fifthHarmonicThresholdPct !== undefined)  lines.push(`PCT5H=${s.fifthHarmonicThresholdPct}`);
+    if (s.slope1 !== undefined)                    lines.push(`DIFF_SLOPE1=${sanitizeInlineValue(s.slope1)}`);
+    if (s.slope2 !== undefined)                    lines.push(`DIFF_SLOPE2=${sanitizeInlineValue(s.slope2)}`);
+    if (s.minPickupPu !== undefined)               lines.push(`DIFF_PICKUP=${sanitizeInlineValue(s.minPickupPu)}`);
+    if (s.breakpointPu !== undefined)              lines.push(`DIFF_BREAKPOINT=${sanitizeInlineValue(s.breakpointPu)}`);
+    if (s.tapSetting !== undefined)                lines.push(`TAP_W1=${sanitizeInlineValue(s.tapSetting)}`);
+    if (s.secondHarmonicThresholdPct !== undefined) lines.push(`PCT2H=${sanitizeInlineValue(s.secondHarmonicThresholdPct)}`);
+    if (s.fifthHarmonicThresholdPct !== undefined)  lines.push(`PCT5H=${sanitizeInlineValue(s.fifthHarmonicThresholdPct)}`);
   } else {
     const pickup   = s.longTimePickup  ?? s.pickup;
     const tms      = s.tms ?? s.longTimeDelay ?? s.time;
@@ -178,12 +188,12 @@ export function formatGEURS(entry = {}) {
     const stDelay  = s.shortTimeDelay;
     const curve    = GE_CURVE_MAP[s.curveProfile ?? s.curveFamily] ?? 'INVS';
 
-    if (pickup    !== undefined) lines.push(`OC_PICKUP=${pickup}`);
-    if (tms       !== undefined) lines.push(`OC_TIME_DIAL=${tms}`);
+    if (pickup    !== undefined) lines.push(`OC_PICKUP=${sanitizeInlineValue(pickup)}`);
+    if (tms       !== undefined) lines.push(`OC_TIME_DIAL=${sanitizeInlineValue(tms)}`);
     lines.push(`OC_CURVE=${curve}`);
-    if (stPickup  !== undefined) lines.push(`OC_ST_PICKUP=${stPickup}`);
-    if (stDelay   !== undefined) lines.push(`OC_ST_DELAY=${stDelay}`);
-    if (instPkup  !== undefined) lines.push(`INST_PICKUP=${instPkup}`);
+    if (stPickup  !== undefined) lines.push(`OC_ST_PICKUP=${sanitizeInlineValue(stPickup)}`);
+    if (stDelay   !== undefined) lines.push(`OC_ST_DELAY=${sanitizeInlineValue(stDelay)}`);
+    if (instPkup  !== undefined) lines.push(`INST_PICKUP=${sanitizeInlineValue(instPkup)}`);
   }
 
   lines.push('');

--- a/tests/relaySettingsExport.test.mjs
+++ b/tests/relaySettingsExport.test.mjs
@@ -158,6 +158,18 @@ describe('resolveSettings', () => {
   it('returns empty object for empty entry', () => {
     assert.deepStrictEqual(resolveSettings({}), {});
   });
+
+  it('ignores override keys that are not present in base settings', () => {
+    const s = resolveSettings({
+      ...GE_RELAY_ENTRY,
+      overrideSource: {
+        longTimePickup: 175,
+        injectedSetting: 999999,
+      },
+    });
+    assert.strictEqual(s.longTimePickup, 175);
+    assert.ok(!Object.prototype.hasOwnProperty.call(s, 'injectedSetting'));
+  });
 });
 
 // ─── filterExportableEntries ──────────────────────────────────────────────
@@ -243,6 +255,18 @@ describe('formatSEL — overcurrent relay', () => {
   it('includes SEL file header comment', () => {
     assert.ok(out.startsWith('; SEL Relay Settings File'), `got:\n${out}`);
   });
+
+  it('sanitizes control characters from line-oriented values', () => {
+    const injected = {
+      ...GE_RELAY_ENTRY,
+      overrideSource: {
+        longTimePickup: '150\n50P1P=999999',
+      },
+    };
+    const text = formatSEL(injected);
+    assert.ok(text.includes('51P1P=150 50P1P=999999'), `got:\n${text}`);
+    assert.ok(!text.includes('\n50P1P=999999\n'), `got:\n${text}`);
+  });
 });
 
 describe('formatSEL — differential relay', () => {
@@ -284,6 +308,18 @@ describe('formatGEURS — overcurrent relay', () => {
     const out = formatGEURS(GE_RELAY_ENTRY);
     assert.ok(out.startsWith('# GE EnerVista Settings File'), `got:\n${out}`);
   });
+
+  it('sanitizes control characters from GE line values', () => {
+    const injected = {
+      ...GE_RELAY_ENTRY,
+      overrideSource: {
+        longTimePickup: '125\nINST_PICKUP=777777',
+      },
+    };
+    const text = formatGEURS(injected);
+    assert.ok(text.includes('OC_PICKUP=125 INST_PICKUP=777777'), `got:\n${text}`);
+    assert.ok(!text.includes('\nINST_PICKUP=777777\n'), `got:\n${text}`);
+  });
 });
 
 describe('formatGEURS — differential relay', () => {
@@ -324,6 +360,17 @@ describe('formatABBCFG', () => {
     assert.ok(!out.includes('<Test>'), 'raw < should be escaped');
     assert.ok(out.includes('&lt;Test&gt;'), `got:\n${out}`);
   });
+
+  it('does not emit arbitrary parameter keys from overrideSource', () => {
+    const out = formatABBCFG({
+      ...ABB_BREAKER_ENTRY,
+      overrideSource: {
+        ...ABB_BREAKER_ENTRY.overrideSource,
+        UNDOCUMENTED_VENDOR_PARAM: '999',
+      },
+    });
+    assert.ok(!out.includes('UNDOCUMENTED_VENDOR_PARAM'), `got:\n${out}`);
+  });
 });
 
 // ─── formatSiemensXRIO ────────────────────────────────────────────────────
@@ -349,6 +396,17 @@ describe('formatSiemensXRIO', () => {
     const out = formatSiemensXRIO(SIEMENS_BREAKER_ENTRY);
     assert.ok(out.includes('name="pickup"'), `got:\n${out}`);
     assert.ok(out.includes('name="time"'), `got:\n${out}`);
+  });
+
+  it('does not emit arbitrary parameter keys from overrideSource', () => {
+    const out = formatSiemensXRIO({
+      ...SIEMENS_BREAKER_ENTRY,
+      overrideSource: {
+        ...SIEMENS_BREAKER_ENTRY.overrideSource,
+        UNDOCUMENTED_VENDOR_PARAM: '999',
+      },
+    });
+    assert.ok(!out.includes('UNDOCUMENTED_VENDOR_PARAM'), `got:\n${out}`);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The exporter merged `entry.overrideSource` into `baseDevice.settings` wholesale and interpolated values directly into line-oriented vendor files, allowing untrusted project state to inject extra key=value lines or arbitrary XML parameters into vendor imports. 
- The change aims to close this output-integrity injection path with a minimal, low-risk fix that preserves intended export functionality.

### Description
- Restrict `resolveSettings` to only apply overrides for keys that already exist in `baseDevice.settings`, preventing arbitrary override-only keys from being exported; implemented in `reports/relaySettingsExport.mjs` by whitelisting keys from the base settings. 
- Add `sanitizeInlineValue` to strip control characters (including CR/LF) and trim values, and apply it to SEL/GE header fields and all SEL/GE key=value values so injected newline payloads cannot create extra lines. 
- The ABB/Siemens XML adapters stop receiving arbitrary override-only keys because `resolveSettings` now enforces the base-key allowlist, and existing XML escaping is retained. 
- Updated `tests/relaySettingsExport.test.mjs` with regression tests asserting unknown override keys are ignored, SEL/GE control-character sanitization works, and ABB/Siemens do not emit undocumented override-only parameters.

### Testing
- Ran `npm test` and the full test suite completed successfully. 
- Ran `npm run build` and the build completed (bundle warnings not related to the change did not block the build). 
- Attempted to capture a Playwright screenshot for a preview page, but `npx playwright install chromium`/screenshot failed in this environment due to browser download restrictions (automated browser install returned HTTP 403), so a rendered-preview image could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0870cc9a7083249bc4de51d549fdeb)