### PR TITLE
fix: sanitize differential protection restored result rendering

### DIFF
--- a/differentialprotection.js
+++ b/differentialprotection.js
@@ -167,14 +167,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const warningsHtml = r.warnings.length
       ? `<ul class="drc-findings">${r.warnings.map(w =>
-          `<li class="drc-finding drc-warn"><span class="drc-msg">${w}</span></li>`
+          `<li class="drc-finding drc-warn"><span class="drc-msg">${escHtml(String(w))}</span></li>`
         ).join('')}</ul>`
       : '';
 
     const tripClass = r.tripResult.trip ? 'status-fail' : 'status-pass';
     const tripLabel = r.tripResult.trip ? '⚡ TRIP' : '✓ NO TRIP';
     const restrainHtml = r.harmonic.restrain
-      ? `<p class="field-hint">${r.harmonic.reason}</p>`
+      ? `<p class="field-hint">${escHtml(String(r.harmonic.reason || ''))}</p>`
       : '';
 
     const ctMismatchHtml = !r.ctMismatch.acceptable
@@ -223,7 +223,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <tr><td>I₁ (CT₁ secondary normalised to tap, pu)</td><td>${r.currents.i1Pu.toFixed(4)}</td></tr>
             <tr><td>I₂ (CT₂ secondary normalised to tap, pu)</td><td>${r.currents.i2Pu.toFixed(4)}</td></tr>
             <tr><td>CT₁ / CT₂ nominal tap</td><td>${r.ctMismatch.nominalTap.toFixed(4)}</td></tr>
-            <tr><td>Set tap</td><td>${r.inputs.tapSetting}</td></tr>
+            <tr><td>Set tap</td><td>${escHtml(String(r.inputs.tapSetting))}</td></tr>
             <tr><td>CT mismatch</td><td>${r.ctMismatch.mismatchPct.toFixed(2)}%</td></tr>
             <tr><td>2nd harmonic</td><td>${r.harmonic.secondPct.toFixed(1)}%</td></tr>
             <tr><td>5th harmonic</td><td>${r.harmonic.fifthPct.toFixed(1)}%</td></tr>


### PR DESCRIPTION
### Motivation
- Prevent stored DOM XSS when persisted `studies.differentialProtection` data is restored and rendered into the results pane without escaping.
- The renderer previously interpolated persisted strings such as warnings, harmonic reason, and tap setting directly into `innerHTML`, enabling a malicious imported project to execute script in the application origin.

### Description
- Escape restored warning entries before interpolation by using `escHtml(String(w))` when building `warningsHtml` in `renderResults()`.
- Escape the harmonic restraint reason with `escHtml(String(r.harmonic.reason || ''))` before injecting it into the results markup.
- Escape `r.inputs.tapSetting` with `escHtml(String(r.inputs.tapSetting))` in the CT details table.
- These are minimal changes contained to `differentialprotection.js` that preserve current visual output while ensuring untrusted persisted strings are rendered as text.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully.
- Built the application with `npm run build`, which completed and produced `dist/` artifacts successfully.
- Attempted to capture a browser preview using Playwright, but Playwright browser binaries could not be downloaded in this environment (CDN download returned 403), so a rendered screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087814e3fc832498d4c60ecb0abb1d)