### PR TITLE
Escape harmonic violation output to prevent stored DOM XSS in DER Interconnect

### DIFF
--- a/derinterconnect.js
+++ b/derinterconnect.js
@@ -280,7 +280,7 @@ function renderResults(result) {
     ${result.harmonics.violations.length > 0 ? `
     <div class="result-card result-card--warn">
       <span class="result-label">Harmonic Violations</span>
-      <span class="result-value">${result.harmonics.violations.map(v => `${v.order}th: ${v.actual_pct}% > ${v.limit_pct}%`).join('; ')}</span>
+      <span class="result-value">${result.harmonics.violations.map(v => escHtml(`${v.order}th: ${v.actual_pct}% > ${v.limit_pct}%`)).join('; ')}</span>
     </div>` : ''}
   `;
 }


### PR DESCRIPTION
### Motivation
- Prevent a stored DOM XSS where persisted DER study results (imported via project settings) could inject HTML into the harmonic violations detail card and execute script when `derinterconnect.html` restores and renders saved results.

### Description
- Escape harmonic violation text before interpolating into the detail-cards `innerHTML` in `derinterconnect.js` by wrapping the formatted violation string with `escHtml(...)`, so attacker-controlled `order`, `actual_pct`, or `limit_pct` values are rendered as plain text rather than HTML.

### Testing
- Ran the full automated test suite via `npm test`, which completed successfully.
- Built production assets via `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087710d1088324806c59205f7b9b9a)