### PR TITLE
Harden CP comparison baseline import rendering

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -1601,6 +1601,76 @@ function countCriteriaPasses(result) {
   return rows.filter((row) => row?.status === 'pass').length;
 }
 
+
+function coerceFiniteNumber(value, fallback = 0, { min = -Infinity, max = Infinity } = {}) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, numeric));
+}
+
+function sanitizeGeometryPoint(point, fallbackX, fallbackY) {
+  if (!point || typeof point !== 'object') {
+    return { x: fallbackX, y: fallbackY };
+  }
+  return {
+    x: coerceFiniteNumber(point.x, fallbackX, { min: -5000, max: 5000 }),
+    y: coerceFiniteNumber(point.y, fallbackY, { min: -5000, max: 5000 })
+  };
+}
+
+function sanitizeLayoutGeometry(geometry, fallbackGeometry) {
+  if (!geometry || typeof geometry !== 'object') {
+    return fallbackGeometry;
+  }
+  const maxItems = 100;
+  const structureSegments = Array.isArray(geometry.structureSegments)
+    ? geometry.structureSegments.slice(0, maxItems).map((segment, index) => ({
+      x1: coerceFiniteNumber(segment?.x1, fallbackGeometry.structureSegments[index % fallbackGeometry.structureSegments.length].x1, { min: -5000, max: 5000 }),
+      y1: coerceFiniteNumber(segment?.y1, fallbackGeometry.structureSegments[index % fallbackGeometry.structureSegments.length].y1, { min: -5000, max: 5000 }),
+      x2: coerceFiniteNumber(segment?.x2, fallbackGeometry.structureSegments[index % fallbackGeometry.structureSegments.length].x2, { min: -5000, max: 5000 }),
+      y2: coerceFiniteNumber(segment?.y2, fallbackGeometry.structureSegments[index % fallbackGeometry.structureSegments.length].y2, { min: -5000, max: 5000 })
+    }))
+    : fallbackGeometry.structureSegments;
+  const anodes = Array.isArray(geometry.anodes)
+    ? geometry.anodes.slice(0, maxItems).map((anode, index) => sanitizeGeometryPoint(anode, fallbackGeometry.anodes[index % fallbackGeometry.anodes.length].x, fallbackGeometry.anodes[index % fallbackGeometry.anodes.length].y))
+    : fallbackGeometry.anodes;
+  const testPoints = Array.isArray(geometry.testPoints)
+    ? geometry.testPoints.slice(0, maxItems).map((point, index) => sanitizeGeometryPoint(point, fallbackGeometry.testPoints[index % fallbackGeometry.testPoints.length].x, fallbackGeometry.testPoints[index % fallbackGeometry.testPoints.length].y))
+    : fallbackGeometry.testPoints;
+  const referenceElectrode = sanitizeGeometryPoint(
+    geometry.referenceElectrode,
+    fallbackGeometry.referenceElectrode.x,
+    fallbackGeometry.referenceElectrode.y
+  );
+  return { structureSegments, anodes, testPoints, referenceElectrode };
+}
+
+function sanitizeComparisonStudy(study) {
+  const normalized = normalizeSavedStudy(study);
+  if (!normalized) {
+    return null;
+  }
+  if (!Number.isFinite(Number(normalized.requiredCurrentA)) || !Number.isFinite(Number(normalized.predictedLifeYears))) {
+    return null;
+  }
+  const fallbackGeometry = resolveLayoutGeometry({ ...normalized, cpLayout: null });
+  return {
+    ...normalized,
+    requiredCurrentA: coerceFiniteNumber(normalized.requiredCurrentA, 0, { min: 0, max: 1e6 }),
+    predictedLifeYears: coerceFiniteNumber(normalized.predictedLifeYears, 0, { min: 0, max: 1e4 }),
+    interferenceAssessment: {
+      ...(normalized.interferenceAssessment && typeof normalized.interferenceAssessment === 'object' ? normalized.interferenceAssessment : {}),
+      score: coerceFiniteNumber(normalized.interferenceAssessment?.score, 0, { min: 0, max: 100 })
+    },
+    cpLayout: {
+      ...(normalized.cpLayout && typeof normalized.cpLayout === 'object' ? normalized.cpLayout : {}),
+      geometry: sanitizeLayoutGeometry(normalized.cpLayout?.geometry, fallbackGeometry)
+    }
+  };
+}
+
 function formatDelta(value, unit = '') {
   if (!Number.isFinite(value)) {
     return 'n/a';
@@ -1633,17 +1703,17 @@ function buildComparisonPanelMarkup(activeStudy, baselineStudy) {
           <article class="cp-delta-card">
             <h4>Required current Δ</h4>
             <p>${formatDelta(requiredCurrentDelta, 'A')}</p>
-            <small>A: ${activeStudy.requiredCurrentA} A · B: ${baselineStudy.requiredCurrentA} A</small>
+            <small>A: ${escapeHtml(String(activeStudy.requiredCurrentA))} A · B: ${escapeHtml(String(baselineStudy.requiredCurrentA))} A</small>
           </article>
           <article class="cp-delta-card">
             <h4>Predicted life Δ</h4>
             <p>${formatDelta(lifeDelta, 'years')}</p>
-            <small>A: ${activeStudy.predictedLifeYears} y · B: ${baselineStudy.predictedLifeYears} y</small>
+            <small>A: ${escapeHtml(String(activeStudy.predictedLifeYears))} y · B: ${escapeHtml(String(baselineStudy.predictedLifeYears))} y</small>
           </article>
           <article class="cp-delta-card">
             <h4>Risk score Δ</h4>
             <p>${formatDelta(riskDelta)}</p>
-            <small>A: ${activeStudy.interferenceAssessment?.score || 0} · B: ${baselineStudy.interferenceAssessment?.score || 0}</small>
+            <small>A: ${escapeHtml(String(activeStudy.interferenceAssessment?.score || 0))} · B: ${escapeHtml(String(baselineStudy.interferenceAssessment?.score || 0))}</small>
           </article>
           <article class="cp-delta-card">
             <h4>Criteria pass count Δ</h4>
@@ -1764,13 +1834,13 @@ function resolveLayoutGeometry(study) {
 function parseComparisonStudyFromImport(rawText) {
   const parsed = JSON.parse(rawText);
   if (parsed?.studyResults?.cathodicProtection) {
-    return normalizeSavedStudy(parsed.studyResults.cathodicProtection);
+    return sanitizeComparisonStudy(parsed.studyResults.cathodicProtection);
   }
   if (parsed?.cathodicProtection) {
-    return normalizeSavedStudy(parsed.cathodicProtection);
+    return sanitizeComparisonStudy(parsed.cathodicProtection);
   }
   if (parsed?.requiredCurrentA && parsed?.predictedLifeYears) {
-    return normalizeSavedStudy(parsed);
+    return sanitizeComparisonStudy(parsed);
   }
   return null;
 }


### PR DESCRIPTION
### Motivation
- Resolve a high-severity XSS risk where imported cathodic-protection comparison baselines were parsed and rendered without schema validation, allowing attacker-controlled fields and SVG geometry to be injected into `innerHTML` and SVG attributes.
- Validate and coerce imported comparison data before it is persisted or rendered so the comparison workflow cannot be used to execute script in the application origin.

### Description
- Added sanitization helpers: `coerceFiniteNumber`, `sanitizeGeometryPoint`, `sanitizeLayoutGeometry`, and `sanitizeComparisonStudy` to coerce numeric fields, range-check values, cap geometry array sizes, and produce a safe geometry object.
- Replaced calls to `normalizeSavedStudy(...)` during import with `sanitizeComparisonStudy(...)` in `parseComparisonStudyFromImport` so all accepted JSON shapes are validated and coerced before use.
- Escaped displayed numeric fields in `buildComparisonPanelMarkup` (e.g., required current, predicted life, and interference score) via `escapeHtml(String(...))` to prevent HTML injection through interpolated text.
- Capped geometry arrays (`maxItems = 100`) and clamped coordinate values to a safe numeric range to prevent attribute/markup injection via SVG attributes.

### Testing
- Ran `npm test` and the full test suite completed successfully.
- Ran `npm run build` and the build completed successfully producing the `dist` artifacts.
- Attempted to generate a preview screenshot using Playwright but the Chromium browser download failed (403) in this environment, so an automated screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087a3129688324b942f0675c1b84ee)