### PR TITLE
Fix stored DOM XSS in cathodic protection sensitivity rendering

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -1530,12 +1530,12 @@ function renderResults(result, root) {
               <tr>
                 <td>${escapeHtml(scenario.label)}</td>
                 <td>${escapeHtml(scenario.approvalStatus || 'Review required')}</td>
-                <td>${scenario.coatingFactor}</td>
-                <td>${scenario.requiredCurrentA}</td>
-                <td>${scenario.worstCaseSegmentDemandA} (${escapeHtml(scenario.worstCaseSegmentLabel || 'Segment 1')})</td>
-                <td>${scenario.minimumAnodeMassKg} kg (${scenario.minimumAnodeMassLb} lb)</td>
-                <td>${scenario.predictedLifeYears}</td>
-                <td>${scenario.safetyMarginYears} years (${scenario.safetyMarginPercent}%)</td>
+                <td>${formatFiniteValue(scenario.coatingFactor, 4)}</td>
+                <td>${formatFiniteValue(scenario.requiredCurrentA, 6)}</td>
+                <td>${formatFiniteValue(scenario.worstCaseSegmentDemandA, 6)} (${escapeHtml(scenario.worstCaseSegmentLabel || 'Segment 1')})</td>
+                <td>${formatFiniteValue(scenario.minimumAnodeMassKg, 3)} kg (${formatFiniteValue(scenario.minimumAnodeMassLb, 3)} lb)</td>
+                <td>${formatFiniteValue(scenario.predictedLifeYears, 2)}</td>
+                <td>${formatFiniteValue(scenario.safetyMarginYears, 2)} years (${formatFiniteValue(scenario.safetyMarginPercent, 2)}%)</td>
               </tr>`).join('')}
           </tbody>
         </table>
@@ -1607,6 +1607,17 @@ function formatDelta(value, unit = '') {
   }
   const sign = value > 0 ? '+' : '';
   return `${sign}${roundTo(value, 2)}${unit ? ` ${unit}` : ''}`;
+}
+
+function formatFiniteValue(value, decimals = null) {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) {
+    return 'n/a';
+  }
+  if (Number.isInteger(decimals) && decimals >= 0) {
+    return parsed.toFixed(decimals);
+  }
+  return String(parsed);
 }
 
 function buildComparisonPanelMarkup(activeStudy, baselineStudy) {


### PR DESCRIPTION
### Motivation
- A stored DOM XSS was introduced by rendering persisted cathodic protection sensitivity rows into `innerHTML` without validating or escaping numeric fields, which allowed attacker-controlled strings from imported project settings to execute as HTML.
- The goal is a minimal, targeted fix that removes the XSS sink while preserving the existing results layout and numeric display.

### Description
- Added a small helper `formatFiniteValue(value, decimals)` to `cathodicprotection.js` that coerces values to numbers, returns a formatted numeric string when finite, and falls back to `n/a` for invalid inputs.
- Replaced raw interpolations in the sensitivity table with `formatFiniteValue(...)` for numeric columns (`coatingFactor`, `requiredCurrentA`, `worstCaseSegmentDemandA`, `minimumAnodeMassKg`, `minimumAnodeMassLb`, `predictedLifeYears`, `safetyMarginYears`, `safetyMarginPercent`) while keeping `escapeHtml` for textual cells.
- Changes are confined to `cathodicprotection.js` and are intentionally minimal to avoid impacting other UI flows.

### Testing
- Ran `npm test` and the test suite completed successfully (includes cathodic protection tests). 
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a preview screenshot with Playwright, but browser binaries are not installed in the environment so screenshot generation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087b9ad4f883249cd33cd78cf69345)