### PR TITLE
Fix stored XSS in Battery warnings and block reserved keys on import

### DIFF
--- a/battery.js
+++ b/battery.js
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const warnings = Array.isArray(r.warnings) ? r.warnings : [];
     const warningsHtml = warnings.length
       ? `<ul class="drc-findings">${warnings.map(w =>
-          `<li class="drc-finding drc-warn"><span class="drc-msg">${w}</span></li>`
+          `<li class="drc-finding drc-warn"><span class="drc-msg">${escHtml(w)}</span></li>`
         ).join('')}</ul>`
       : '';
 

--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -1028,6 +1028,7 @@ export function importProject(obj) {
   }
   if (data.settings) {
     for (const [k, v] of Object.entries(data.settings)) {
+      if (reserved.has(k)) continue;
       setItem(k, v);
     }
   }


### PR DESCRIPTION
### Motivation
- A stored DOM XSS was reachable when persisted `studyResults.batterySizing.warnings` were interpolated into `innerHTML` on the Battery/UPS page. 
- The project import flow allowed `data.settings` to overwrite reserved storage keys (including `studyResults`), enabling attackers to seed malicious warnings via imported projects.

### Description
- Escape persisted warning strings using the existing `escHtml` helper before interpolating into `warningsHtml` in `battery.js`, preventing attacker-supplied HTML from executing. 
- Harden `importProject` in `dataStore.mjs` to skip any `data.settings` entries whose keys are in the `reserved` set, preventing imports from writing protected keys such as `studyResults`. 
- The change is minimal and preserves existing UX and behavior by reusing the existing `escHtml` function and only skipping reserved import keys; files modified: `battery.js`, `dataStore.mjs`.

### Testing
- Ran the full automated test suite with `npm test` and the tests completed successfully. 
- Built the distribution with `npm run build` and the build completed successfully (Rollup emitted non-fatal unresolved-dependency warnings). 
- Attempted to generate a preview screenshot with Playwright (`npx playwright screenshot`) but the environment could not download the Chromium binary (download failed with HTTP 403), so a preview image could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088388a2b4832489e370106f0b6f1c)