### PR TITLE
Fix stored XSS in arc flash print labels

### DIFF
--- a/reports/arcFlashReport.mjs
+++ b/reports/arcFlashReport.mjs
@@ -86,6 +86,15 @@ function safeEntries(results = {}) {
   });
 }
 
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function sanitizeFileName(value, fallback = 'equipment') {
   if (typeof value !== 'string') {
     if (value && typeof value.toString === 'function') {
@@ -143,6 +152,7 @@ export function buildLabelSheetHtml(results = {}, projectName = '') {
   const entries = safeEntries(results);
   const date = new Date().toISOString().split('T')[0];
   const heading = projectName ? `Arc Flash Warning Labels — ${projectName}` : 'Arc Flash Warning Labels';
+  const safeHeading = escapeHtml(heading);
 
   const labelCells = entries.map(([id, info]) => {
     const data = buildArcFlashLabelData(id, info);
@@ -158,7 +168,7 @@ export function buildLabelSheetHtml(results = {}, projectName = '') {
 <style>${LABEL_SHEET_STYLE}</style>
 </head>
 <body>
-<h1>${heading}</h1>
+<h1>${safeHeading}</h1>
 <p class="meta">Generated: ${date} &nbsp;|&nbsp; ${entries.length} label(s)</p>
 <button class="no-print" onclick="window.print()">Print All Labels</button>
 <div class="label-grid">
@@ -176,7 +186,7 @@ ${labelCells}
  */
 export function openLabelPrintWindow(results = {}, projectName = '') {
   const html = buildLabelSheetHtml(results, projectName);
-  const win = window.open('', '_blank');
+  const win = window.open('', '_blank', 'noopener,noreferrer');
   if (!win) return null;
   win.document.open();
   win.document.write(html);

--- a/reports/labels.mjs
+++ b/reports/labels.mjs
@@ -35,11 +35,20 @@ try {
   }
 } catch {}
 
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export function generateArcFlashLabel(data = {}) {
   let svg = template;
   Object.entries(data).forEach(([k, v]) => {
     const re = new RegExp(`{{${k}}}`, 'g');
-    svg = svg.replace(re, v ?? '');
+    svg = svg.replace(re, escapeXml(v));
   });
   return svg;
 }

--- a/tests/arcFlashLabels.test.mjs
+++ b/tests/arcFlashLabels.test.mjs
@@ -132,6 +132,12 @@ describe('buildLabelSheetHtml', () => {
     const html = buildLabelSheetHtml({ bus1: warningInfo });
     assert.ok(html.includes('@media print'), 'Expected @media print in style');
   });
+
+  it('escapes project name markup in heading', () => {
+    const html = buildLabelSheetHtml({ bus1: warningInfo }, '<img src=x onerror=alert(1)>');
+    assert.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'), 'Expected escaped project name in heading');
+    assert.ok(!html.includes('<img src=x onerror=alert(1)>'), 'Expected raw project name markup to be absent');
+  });
 });
 
 // ── generateArcFlashLabel ─────────────────────────────────────────────────────
@@ -150,6 +156,25 @@ describe('generateArcFlashLabel', () => {
     const svg = generateArcFlashLabel(data);
     const unresolved = svg.match(/\{\{[^}]+\}\}/g);
     assert.ok(!unresolved, `Unresolved tokens found: ${JSON.stringify(unresolved)}`);
+  });
+
+  it('escapes xml/html special characters in substituted values', () => {
+    const svg = generateArcFlashLabel({
+      signalColor: '#f57c00',
+      signalWord: 'WARNING',
+      equipmentTag: 'MCC-1</tspan><script>alert(1)</script>',
+      voltage: '480 V',
+      incidentEnergy: '1.00 cal/cm²',
+      workingDistance: '18 in',
+      arcFlashBoundary: '24 in',
+      limitedApproach: 'N/A',
+      restrictedApproach: 'N/A',
+      upstreamDevice: 'CB-1',
+      ppeCategory: '2',
+      studyDate: '2026-04-07'
+    });
+    assert.ok(svg.includes('&lt;/tspan&gt;&lt;script&gt;alert(1)&lt;/script&gt;'), 'Expected escaped injected markup');
+    assert.ok(!svg.includes('<script>alert(1)</script>'), 'Expected raw script tag to be absent');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent stored XSS where project-controlled fields (equipmentTag, upstreamDevice, projectName) were inserted raw into SVG and into an about:blank print popup, allowing injected markup to execute with application origin privileges.

### Description
- Escape substituted values in `generateArcFlashLabel` by adding `escapeXml` and using it for every `{{key}}` replacement in `reports/labels.mjs` to neutralize markup/script input. 
- Escape the sheet heading by adding `escapeHtml` and using `safeHeading` in `buildLabelSheetHtml` in `reports/arcFlashReport.mjs` so `projectName` cannot inject HTML into the print page. 
- Open the print popup with `noopener,noreferrer` in `openLabelPrintWindow` to sever the `window.opener` linkage and limit blast radius if future issues occur. 
- Add regression tests in `tests/arcFlashLabels.test.mjs` to assert heading escaping and that `generateArcFlashLabel` escapes XML/HTML special characters.

### Testing
- Ran the full test suite with `npm test` and the run completed successfully. 
- Executed the focused arc-flash label tests (`tests/arcFlashLabels.test.mjs`) and the new assertions passed. 
- Built the project with `npm run build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088549b1488324a6b644ca21a562f5)