### PR TITLE
Block static access to cloud library data files

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -776,6 +776,11 @@ function resolveOptions(options = {}) {
   };
 }
 
+function isSubPath(parentDir, targetPath) {
+  const relative = path.relative(parentDir, targetPath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
 export async function createApp(options = {}) {
   const {
     dataDir,
@@ -785,6 +790,7 @@ export async function createApp(options = {}) {
     rateLimitMax,
     enforceHttps
   } = resolveOptions(options);
+  const dataDirWithinStaticRoot = isSubPath(staticRoot, dataDir);
 
   await fs.mkdir(dataDir, { recursive: true });
   const usersFile = path.join(dataDir, 'users.json');
@@ -930,6 +936,27 @@ export async function createApp(options = {}) {
       return originalSend(compressed);
     };
 
+    next();
+  });
+  app.use((req, res, next) => {
+    if (!dataDirWithinStaticRoot) {
+      next();
+      return;
+    }
+
+    let decodedPath;
+    try {
+      decodedPath = decodeURIComponent(req.path);
+    } catch {
+      res.status(400).end();
+      return;
+    }
+
+    const requestedPath = path.resolve(staticRoot, `.${decodedPath}`);
+    if (isSubPath(dataDir, requestedPath)) {
+      res.status(404).end();
+      return;
+    }
     next();
   });
   app.use(


### PR DESCRIPTION
### Motivation
- A deployment default allowed `dataDir` (by default `server_data/`) to live under the served `staticRoot`, making persisted cloud library snapshots and `library-shares.json` retrievable via unauthenticated static URLs and bypassing API/share controls. 
- The change closes an authorization bypass where share recipients could derive predictable snapshot file paths and continue reading files after token revocation. 

### Description
- Add a small path helper `isSubPath(parent, target)` to detect whether one filesystem path is nested inside another. 
- Compute `dataDirWithinStaticRoot` and install a middleware before `express.static` that decodes request paths, resolves them with `path.resolve`, and returns `404` if the resolved request points inside `dataDir`. 
- This blocks direct static-file reads of `dataDir` (including `server_data/libraries/...` and `server_data/library-shares.json`) while preserving existing static behavior for other files. 

### Testing
- Ran the test suite with `npm test` and it completed successfully. 
- Built the frontend with `npm run build` and the build completed successfully. 
- Attempted to capture a preview screenshot with Playwright, but `npx playwright install chromium` failed to download browsers in this environment (HTTP 403), so an automated page preview could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0885df086883249974788879a223f3)