### PR TITLE
Harden collaboration WebSocket upgrade authentication

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2015,6 +2015,39 @@ When answering queries:
     res.status(500).json({ error: 'Internal server error' });
   });
 
+
+  app.set('collabUpgradeValidator', async (request) => {
+    const origin = String(request.headers.origin || '');
+    const host = String(request.headers.host || '');
+    if (!origin || !host) return false;
+    let originUrl;
+    try {
+      originUrl = new URL(origin);
+    } catch {
+      return false;
+    }
+    if (originUrl.host !== host) return false;
+
+    const requestUrl = new URL(request.url || '/ws/collab', `http://${host}`);
+    const token = requestUrl.searchParams.get('token') || '';
+    const csrfHeader = request.headers['x-csrf-token'];
+    const csrfToken = typeof csrfHeader === 'string' ? csrfHeader : (requestUrl.searchParams.get('csrfToken') || '');
+    if (!token || !csrfToken || !/^[0-9a-fA-F]+$/.test(csrfToken)) return false;
+
+    const session = await sessionStore.get(token);
+    if (!session) return false;
+
+    let provided;
+    try {
+      provided = Buffer.from(csrfToken, 'hex');
+    } catch {
+      return false;
+    }
+    const expected = Buffer.from(session.csrfToken, 'hex');
+    if (provided.length !== expected.length) return false;
+    return crypto.timingSafeEqual(provided, expected);
+  });
+
   return app;
 }
 
@@ -2030,7 +2063,9 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.a
   // Real-time collaboration via WebSocket
   try {
     const { WebSocketServer } = await import('ws');
-    attachCollaborationServer(server, new WebSocketServer({ noServer: true }));
+    attachCollaborationServer(server, new WebSocketServer({ noServer: true }), {
+      validateUpgrade: app.get('collabUpgradeValidator'),
+    });
   } catch {
     // ws not installed — collaboration disabled; app still works fine
     console.info('ws package not found; real-time collaboration disabled');

--- a/src/collaboration.js
+++ b/src/collaboration.js
@@ -20,7 +20,13 @@
 const WS_URL = (() => {
   if (typeof window === 'undefined') return null;
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  return `${proto}//${location.host}/ws/collab`;
+  const authToken = typeof localStorage !== 'undefined' ? (localStorage.getItem('authToken') || '') : '';
+  const csrfToken = typeof localStorage !== 'undefined' ? (localStorage.getItem('authCsrfToken') || '') : '';
+  const params = new URLSearchParams();
+  if (authToken) params.set('token', authToken);
+  if (csrfToken) params.set('csrfToken', csrfToken);
+  const query = params.toString();
+  return `${proto}//${location.host}/ws/collab${query ? `?${query}` : ''}`;
 })();
 
 const RECONNECT_DELAYS_MS = [1000, 2000, 5000, 10000, 30000];

--- a/src/collaborationServer.mjs
+++ b/src/collaborationServer.mjs
@@ -22,7 +22,8 @@
  * @param {import('http').Server} httpServer
  * @param {object} wss - WebSocketServer instance
  */
-export function attachCollaborationServer(httpServer, wss) {
+export function attachCollaborationServer(httpServer, wss, options = {}) {
+  const validateUpgrade = typeof options.validateUpgrade === 'function' ? options.validateUpgrade : null;
   // projectId → Set of { ws, username }
   const rooms = new Map();
   // projectId → monotonically increasing sequence counter
@@ -51,11 +52,23 @@ export function attachCollaborationServer(httpServer, wss) {
     }
   }
 
-  httpServer.on('upgrade', (request, socket, head) => {
+  httpServer.on('upgrade', async (request, socket, head) => {
     const { pathname } = new URL(request.url, 'http://localhost');
     if (pathname !== '/ws/collab') {
       socket.destroy();
       return;
+    }
+    if (validateUpgrade) {
+      let valid = false;
+      try {
+        valid = await validateUpgrade(request);
+      } catch {
+        valid = false;
+      }
+      if (!valid) {
+        socket.destroy();
+        return;
+      }
     }
     wss.handleUpgrade(request, socket, head, ws => {
       wss.emit('connection', ws, request);


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated, cross-origin clients from joining collaboration rooms and delivering arbitrary patches that are applied and persisted by the client, which could corrupt safety-relevant project data. 

### Description

- Added an optional `validateUpgrade` hook to `attachCollaborationServer` and enforced it before accepting `/ws/collab` upgrades so the server can reject unauthorized handshakes (`src/collaborationServer.mjs`).
- Implemented a server-side upgrade validator exposed via `app.set('collabUpgradeValidator', ...)` that requires same-origin `Origin`/`Host` match, an auth token and CSRF token in the handshake, a valid session lookup, and a timing-safe CSRF comparison (`server.mjs`).
- Wired the validator into the production WebSocket attachment call so unauthorized upgrades are rejected before any room join or patch relay runs (`server.mjs`).
- Updated the collaboration client WebSocket URL construction to append stored auth and CSRF tokens as query parameters, with safe guards for non-browser test environments so the client presents credentials at handshake time (`src/collaboration.js`).

### Testing

- Ran the full test suite with `npm test` and observed the test run complete successfully (server and collaboration-related unit tests passed).
- Built production artifacts with `npm run build` which completed successfully and produced updated `dist` assets.
- Attempted to produce a preview screenshot via Playwright but the environment lacked the browser binary, so the screenshot step failed; this does not affect the code changes or server-side validation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088dc3beac8324b487b6fecfed8ae9)