### PR TITLE
Fix collaboration WebSocket seq counter memory leak

### DIFF
--- a/src/collaborationServer.mjs
+++ b/src/collaborationServer.mjs
@@ -71,8 +71,10 @@ export function attachCollaborationServer(httpServer, wss) {
       const room = rooms.get(currentProjectId);
       if (room) {
         room.forEach(c => { if (c.ws === ws) room.delete(c); });
-        if (room.size === 0) rooms.delete(currentProjectId);
-        else broadcastPresence(currentProjectId);
+        if (room.size === 0) {
+          rooms.delete(currentProjectId);
+          seqCounters.delete(currentProjectId);
+        } else broadcastPresence(currentProjectId);
       }
     }
 
@@ -92,7 +94,7 @@ export function attachCollaborationServer(httpServer, wss) {
 
       if (msg.type === 'join') {
         removeFromRoom();
-        currentProjectId = String(msg.projectId || '');
+        currentProjectId = String(msg.projectId || '').slice(0, 200);
         currentUsername = String(msg.username || 'Anonymous').slice(0, 100);
         if (!rooms.has(currentProjectId)) rooms.set(currentProjectId, new Set());
         if (!seqCounters.has(currentProjectId)) seqCounters.set(currentProjectId, 0);

--- a/tests/collaborationServer.test.mjs
+++ b/tests/collaborationServer.test.mjs
@@ -255,6 +255,23 @@ describe('attachCollaborationServer — leave', () => {
   });
 });
 
+
+  it('resets sync sequence after the last member leaves a project', () => {
+    const { httpServer, wss } = setupServer();
+    const alice = joinClient(httpServer, wss, 'proj1', 'alice');
+
+    alice._receive({ type: 'patch', projectId: 'proj1', username: 'alice', patch: { n: 1 } });
+    const acks = alice.sentOfType('ack');
+    assert.strictEqual(acks[acks.length - 1].seq, 1, 'first patch should advance seq to 1');
+
+    alice.close();
+
+    const bob = joinClient(httpServer, wss, 'proj1', 'bob');
+    const sync = bob.sentOfType('sync');
+    assert.ok(sync.length >= 1, 'rejoin should receive sync');
+    assert.strictEqual(sync[sync.length - 1].seq, 0, 'seq should reset after room cleanup');
+  });
+
 describe('attachCollaborationServer — close event', () => {
   it('removes client from room on ws close', () => {
     const { httpServer, wss } = setupServer();


### PR DESCRIPTION
### Motivation
- The per-project `seqCounters` Map retained attacker-controlled `projectId` keys indefinitely, enabling unauthenticated remote memory growth and potential OOM, so room cleanup and input bounds are needed.

### Description
- Delete the `seqCounters` entry when the last client leaves a room in `src/collaborationServer.mjs` to avoid retained keys across disconnects.
- Bound incoming `projectId` on `join` to 200 characters (`String(msg.projectId || '').slice(0, 200)`) to reduce risk from oversized attacker-controlled keys in `src/collaborationServer.mjs`.
- Add a regression test in `tests/collaborationServer.test.mjs` that verifies the sequence resets to `0` after the last member leaves and a new client rejoins the same project.
- Preserve existing patch sequencing and presence broadcast behavior while only changing cleanup and input normalization.

### Testing
- Ran `npm test` and the full test suite passed successfully.
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a browser preview with Playwright, but `npx playwright install chromium` failed due to remote CDN `403` so a screenshot/preview could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088d39b15083248ad81709d1872d47)