### PR TITLE
Harden collaboration WebSocket upgrade authentication

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2030,7 +2030,38 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.a
   // Real-time collaboration via WebSocket
   try {
     const { WebSocketServer } = await import('ws');
-    attachCollaborationServer(server, new WebSocketServer({ noServer: true }));
+    attachCollaborationServer(server, new WebSocketServer({ noServer: true }), {
+      authorizeUpgrade: async (request) => {
+        const origin = request.headers.origin;
+        const host = request.headers.host;
+        if (typeof origin === 'string') {
+          try {
+            const parsedOrigin = new URL(origin);
+            if (!host || parsedOrigin.host !== host) return { ok: false };
+          } catch {
+            return { ok: false };
+          }
+        }
+
+        const header = request.headers.authorization || '';
+        const [scheme, token] = header.split(' ');
+        if (scheme !== 'Bearer' || !token) return { ok: false };
+        const session = await sessionStore.get(token);
+        if (!session) return { ok: false };
+
+        const csrfHeader = request.headers['x-csrf-token'];
+        if (typeof csrfHeader !== 'string' || !/^[0-9a-fA-F]+$/.test(csrfHeader)) return { ok: false };
+        let provided;
+        try {
+          provided = Buffer.from(csrfHeader, 'hex');
+        } catch {
+          return { ok: false };
+        }
+        const expected = Buffer.from(session.csrfToken, 'hex');
+        if (provided.length !== expected.length || !crypto.timingSafeEqual(provided, expected)) return { ok: false };
+        return { ok: true, username: session.username };
+      }
+    });
   } catch {
     // ws not installed — collaboration disabled; app still works fine
     console.info('ws package not found; real-time collaboration disabled');

--- a/src/collaborationServer.mjs
+++ b/src/collaborationServer.mjs
@@ -21,8 +21,11 @@
  *
  * @param {import('http').Server} httpServer
  * @param {object} wss - WebSocketServer instance
+ * @param {object} [options]
+ * @param {(request: import('http').IncomingMessage) => Promise<{ok: boolean, username?: string}>} [options.authorizeUpgrade]
  */
-export function attachCollaborationServer(httpServer, wss) {
+export function attachCollaborationServer(httpServer, wss, options = {}) {
+  const { authorizeUpgrade } = options;
   // projectId → Set of { ws, username }
   const rooms = new Map();
   // projectId → monotonically increasing sequence counter
@@ -51,20 +54,35 @@ export function attachCollaborationServer(httpServer, wss) {
     }
   }
 
-  httpServer.on('upgrade', (request, socket, head) => {
+  httpServer.on('upgrade', async (request, socket, head) => {
     const { pathname } = new URL(request.url, 'http://localhost');
     if (pathname !== '/ws/collab') {
       socket.destroy();
       return;
+    }
+    if (authorizeUpgrade) {
+      try {
+        const authz = await authorizeUpgrade(request);
+        if (!authz?.ok) {
+          socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+        request.collabAuth = authz;
+      } catch {
+        socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+        socket.destroy();
+        return;
+      }
     }
     wss.handleUpgrade(request, socket, head, ws => {
       wss.emit('connection', ws, request);
     });
   });
 
-  wss.on('connection', (ws) => {
+  wss.on('connection', (ws, request) => {
     let currentProjectId = null;
-    let currentUsername = null;
+    let currentUsername = request?.collabAuth?.username || null;
 
     function removeFromRoom() {
       if (!currentProjectId) return;
@@ -93,7 +111,7 @@ export function attachCollaborationServer(httpServer, wss) {
       if (msg.type === 'join') {
         removeFromRoom();
         currentProjectId = String(msg.projectId || '');
-        currentUsername = String(msg.username || 'Anonymous').slice(0, 100);
+        currentUsername = currentUsername || String(msg.username || 'Anonymous').slice(0, 100);
         if (!rooms.has(currentProjectId)) rooms.set(currentProjectId, new Set());
         if (!seqCounters.has(currentProjectId)) seqCounters.set(currentProjectId, 0);
         rooms.get(currentProjectId).add({ ws, username: currentUsername });


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated, cross-origin WebSocket clients from joining collaboration rooms and observing or injecting full-project snapshots and patches. 
- Mitigate the high-severity exposure introduced when the `ws` package became available and the `/ws/collab` handler was reachable without upgrade-time checks.

### Description
- Add an optional `authorizeUpgrade` hook to `attachCollaborationServer` in `src/collaborationServer.mjs` and enforce it before calling `handleUpgrade` so upgrades can be rejected with `401 Unauthorized`.
- Carry authenticated identity from the upgrade request into the WebSocket connection and prefer that session-bound `username` over a client-supplied `username` during `join`.
- Wire the hook in `server.mjs` to validate same-host `Origin` (when provided), require a `Bearer` token validated via `sessionStore`, and verify `x-csrf-token` using a timing-safe comparison against the session CSRF token.
- Keep the changes minimal and focused on upgrade-time authorization so existing collaboration protocol behavior and message flow remain unchanged for authenticated clients.

### Testing
- Ran the test suite with `npm test` and all automated tests completed successfully.
- Ran the build with `npm run build` and the build completed successfully.
- Attempted to capture a UI screenshot via Playwright for a preview but the required browser binaries were not available in this environment, so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088d779e208324a797fceae2843801)