### PR TITLE
Require explicit opt-in before starting real-time collaboration

### DIFF
--- a/site.js
+++ b/site.js
@@ -2647,8 +2647,14 @@ globalThis.showSelfCheckModal=showSelfCheckModal;
     function startCollab() {
       const auth = getAuthContextState ? getAuthContextState() : null;
       if (!auth) return; // only start when logged in
+      if (window.localStorage?.getItem('ctrEnableCollaboration') !== 'true') return;
       const projectId = (window.currentProjectId || 'default').trim();
-      initCollaboration({ projectId, username: auth.user });
+      initCollaboration({
+        projectId,
+        username: auth.user,
+        authToken: auth.token,
+        csrfToken: auth.csrfToken,
+      });
     }
     startCollab();
     // Re-init when project changes (project manager fires storage events)


### PR DESCRIPTION
### Motivation
- Prevent passive project-data leakage caused by the client automatically joining collaboration rooms for any authenticated page load by requiring an explicit user opt-in before auto-starting collaboration.

### Description
- Gate the auto-start logic in `site.js` so collaboration is only started when `localStorage.ctrEnableCollaboration === 'true'` and the user is authenticated.
- Pass the stored auth token and CSRF token into the `initCollaboration` call so the client supplies credentials when a page intentionally enables collaboration.

### Testing
- Ran the full test suite with `npm test` and the build with `npm run build`, both succeeded in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089579da688324b2046d3867590930)