### PR TITLE
Harden collaboration WebSocket handshake and message validation

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -828,6 +828,7 @@ export async function createApp(options = {}) {
   }
 
   const app = express();
+  app.set('sessionStore', sessionStore);
 
   if (enforceHttps) {
     app.enable('trust proxy');
@@ -2030,7 +2031,10 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.a
   // Real-time collaboration via WebSocket
   try {
     const { WebSocketServer } = await import('ws');
-    attachCollaborationServer(server, new WebSocketServer({ noServer: true }));
+    attachCollaborationServer(server, new WebSocketServer({ noServer: true }), {
+      sessionStore: app.get('sessionStore'),
+      maxMessageBytes: 64 * 1024,
+    });
   } catch {
     // ws not installed — collaboration disabled; app still works fine
     console.info('ws package not found; real-time collaboration disabled');

--- a/src/collabManager.js
+++ b/src/collabManager.js
@@ -41,7 +41,12 @@ export function initCollaboration({ projectId, username } = {}) {
   const authState = getAuthContextState ? getAuthContextState() : null;
   const resolvedUsername = username || (authState && authState.user) || 'Guest';
 
-  activeClient = new CollabClient({ projectId, username: resolvedUsername });
+  activeClient = new CollabClient({
+    projectId,
+    username: resolvedUsername,
+    token: authState?.token || '',
+    csrfToken: authState?.csrfToken || '',
+  });
 
   // Conflict notifications (out-of-order patches warning)
   initConflictNotifications(activeClient);

--- a/src/collaboration.js
+++ b/src/collaboration.js
@@ -34,13 +34,17 @@ export class CollabClient extends EventTarget {
   #reconnectAttempt = 0;
   #intentionalClose = false;
   #pingTimer = null;
+  #token;
+  #csrfToken;
   /** Sequence number of the last patch received from the server. */
   #lastSeq = 0;
 
-  constructor({ projectId, username }) {
+  constructor({ projectId, username, token = '', csrfToken = '' }) {
     super();
     this.#projectId = projectId;
     this.#username = username;
+    this.#token = token;
+    this.#csrfToken = csrfToken;
   }
 
   get connected() {
@@ -54,7 +58,10 @@ export class CollabClient extends EventTarget {
 
     this.#intentionalClose = false;
     this.#lastSeq = 0;
-    this.#ws = new WebSocket(WS_URL);
+    const wsUrl = new URL(WS_URL);
+    if (this.#token) wsUrl.searchParams.set('token', this.#token);
+    if (this.#csrfToken) wsUrl.searchParams.set('csrfToken', this.#csrfToken);
+    this.#ws = new WebSocket(wsUrl.toString());
 
     this.#ws.addEventListener('open', () => {
       this.#reconnectAttempt = 0;

--- a/src/collaborationServer.mjs
+++ b/src/collaborationServer.mjs
@@ -21,8 +21,14 @@
  *
  * @param {import('http').Server} httpServer
  * @param {object} wss - WebSocketServer instance
+ * @param {{
+ *   sessionStore?: { get(token: string): Promise<object|null> },
+ *   maxMessageBytes?: number
+ * }} [options]
  */
-export function attachCollaborationServer(httpServer, wss) {
+export function attachCollaborationServer(httpServer, wss, options = {}) {
+  const sessionStore = options.sessionStore;
+  const maxMessageBytes = Number(options.maxMessageBytes) > 0 ? Number(options.maxMessageBytes) : 64 * 1024;
   // projectId → Set of { ws, username }
   const rooms = new Map();
   // projectId → monotonically increasing sequence counter
@@ -52,19 +58,45 @@ export function attachCollaborationServer(httpServer, wss) {
   }
 
   httpServer.on('upgrade', (request, socket, head) => {
-    const { pathname } = new URL(request.url, 'http://localhost');
+    const upgradeUrl = new URL(request.url, 'http://localhost');
+    const { pathname } = upgradeUrl;
     if (pathname !== '/ws/collab') {
       socket.destroy();
       return;
     }
-    wss.handleUpgrade(request, socket, head, ws => {
-      wss.emit('connection', ws, request);
-    });
+    const completeUpgrade = (authSession = null) => {
+      request.authSession = authSession;
+      wss.handleUpgrade(request, socket, head, ws => {
+        wss.emit('connection', ws, request);
+      });
+    };
+    if (!sessionStore) {
+      completeUpgrade();
+      return;
+    }
+    const headers = request.headers || {};
+    const originHeader = headers.origin;
+    const hostHeader = headers.host;
+    if (typeof originHeader !== 'string' || typeof hostHeader !== 'string') return socket.destroy();
+    let originHost;
+    try { originHost = new URL(originHeader).host; } catch { return socket.destroy(); }
+    if (originHost !== hostHeader) return socket.destroy();
+    const authHeader = headers.authorization;
+    const [scheme, headerToken = ''] = String(authHeader || '').split(' ');
+    const queryToken = upgradeUrl.searchParams.get('token') || '';
+    const token = (scheme === 'Bearer' && headerToken) ? headerToken : queryToken;
+    const csrfToken = headers['x-csrf-token'] || upgradeUrl.searchParams.get('csrfToken');
+    if (!token || typeof csrfToken !== 'string') return socket.destroy();
+    Promise.resolve(sessionStore.get(token)).then(session => {
+      if (!session || csrfToken !== session.csrfToken) return socket.destroy();
+      completeUpgrade(session);
+    }).catch(() => socket.destroy());
   });
 
-  wss.on('connection', (ws) => {
+  wss.on('connection', (ws, request) => {
+    const userFromSession = request?.authSession?.username;
     let currentProjectId = null;
-    let currentUsername = null;
+    let currentUsername = String(userFromSession || 'Anonymous').slice(0, 100);
 
     function removeFromRoom() {
       if (!currentProjectId) return;
@@ -93,7 +125,11 @@ export function attachCollaborationServer(httpServer, wss) {
       if (msg.type === 'join') {
         removeFromRoom();
         currentProjectId = String(msg.projectId || '');
-        currentUsername = String(msg.username || 'Anonymous').slice(0, 100);
+        if (!currentProjectId) {
+          ws.send(JSON.stringify({ type: 'error', message: 'projectId is required' }));
+          return;
+        }
+        currentUsername = String(userFromSession || msg.username || 'Anonymous').slice(0, 100);
         if (!rooms.has(currentProjectId)) rooms.set(currentProjectId, new Set());
         if (!seqCounters.has(currentProjectId)) seqCounters.set(currentProjectId, 0);
         rooms.get(currentProjectId).add({ ws, username: currentUsername });
@@ -113,6 +149,10 @@ export function attachCollaborationServer(httpServer, wss) {
       if (msg.type === 'patch') {
         if (!currentProjectId) {
           ws.send(JSON.stringify({ type: 'error', message: 'Join a project first' }));
+          return;
+        }
+        if (Buffer.byteLength(JSON.stringify(msg.patch ?? null), 'utf8') > maxMessageBytes) {
+          ws.send(JSON.stringify({ type: 'error', message: 'Patch too large' }));
           return;
         }
         // Assign the next sequence number to this patch


### PR DESCRIPTION
### Motivation
- Close an unauthenticated, origin-unchecked WebSocket path that allowed remote sites to join collaboration rooms and receive/inject project patches.
- Prevent leakage of full project snapshots by binding usernames to authenticated sessions instead of trusting client-supplied names.
- Reduce abuse/DoS risk by adding a message-size guard for incoming patch payloads.

### Description
- Pass the existing `sessionStore` into `attachCollaborationServer` by setting it on the Express `app` and calling `attachCollaborationServer(server, wss, { sessionStore, maxMessageBytes })` from `server.mjs`.
- In `src/collaborationServer.mjs` enforce same-origin on the upgrade (`Origin` host must match `Host`), require an authenticated session token (from `Authorization: Bearer` or `?token=`) and a matching CSRF token (`X-CSRF-Token` header or `?csrfToken=`) when a `sessionStore` is configured, bind the username from the validated session, and reject invalid upgrades; preserve previous behavior when no `sessionStore` is provided.
- Add a configurable `maxMessageBytes` check in `src/collaborationServer.mjs` to reject oversized `patch` payloads.
- Update the browser client wiring so `CollabClient` receives `token` and `csrfToken` from `getAuthContextState()` (`src/collabManager.js`) and includes them as query params on the WebSocket URL in `src/collaboration.js` so the server can validate the handshake.

### Testing
- Ran the full test suite with `npm test` (the project's `test:full` script); the suite completed successfully.
- Built the frontend with `npm run build`; the build completed successfully (rollup warnings for existing unresolved externals were unchanged).
- Attempted an automated page preview screenshot using Playwright, but Playwright browser download/install failed (HTTP 403 from the CDN), so a runtime screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088d4340348324ac2f4d5c1d49b100)