### PR TITLE
Fix DOM XSS in reliability override table attribute rendering

### DIFF
--- a/reliability.js
+++ b/reliability.js
@@ -76,12 +76,12 @@ document.addEventListener('DOMContentLoaded', () => {
       return `<tr>
         <td>${esc(c.id || c.tag || '—')}</td>
         <td>${esc(c.type || '—')}</td>
-        <td><input type="number" class="ov-mtbf" data-id="${esc(c.id)}"
-            min="1" step="1" value="${ov.mtbf ?? (c.mtbf || '')}"
-            placeholder="${c.mtbf || 'e.g. 8760'}" aria-label="MTBF hours for ${esc(c.id)}"></td>
-        <td><input type="number" class="ov-mttr" data-id="${esc(c.id)}"
-            min="0" step="0.5" value="${ov.mttr ?? (c.mttr || '')}"
-            placeholder="${c.mttr || 'e.g. 4'}" aria-label="MTTR hours for ${esc(c.id)}"></td>
+        <td><input type="number" class="ov-mtbf" data-id="${escAttr(c.id)}"
+            min="1" step="1" value="${escAttr(ov.mtbf ?? (c.mtbf || ''))}"
+            placeholder="${escAttr(c.mtbf || 'e.g. 8760')}" aria-label="MTBF hours for ${escAttr(c.id)}"></td>
+        <td><input type="number" class="ov-mttr" data-id="${escAttr(c.id)}"
+            min="0" step="0.5" value="${escAttr(ov.mttr ?? (c.mttr || ''))}"
+            placeholder="${escAttr(c.mttr || 'e.g. 4')}" aria-label="MTTR hours for ${escAttr(c.id)}"></td>
       </tr>`;
     }).join('');
 
@@ -270,5 +270,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function esc(s) {
     return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function escAttr(s) {
+    return esc(s).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 });


### PR DESCRIPTION
### Motivation
- The Reliability page interpolated untrusted component fields into quoted HTML attributes without escaping quotes, enabling attribute-breakout DOM XSS when opening a malicious project.
- The goal is to close the attribute-breakout attack surface while preserving the override table rendering and behavior.

### Description
- Escaped all untrusted values used in quoted input attributes in `reliability.js` (`data-id`, `value`, `placeholder`, and `aria-label`) by replacing raw interpolation with an attribute-safe encoder.
- Added a minimal `escAttr()` helper that composes existing HTML escaping with quote escaping (`"` → `&quot;`, `'` → `&#39;`) and used it when rendering table rows.
- Kept the `innerHTML` table construction and existing override change handlers intact to preserve UX and functionality.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (all tests passed in the CI-style run performed here).
- Built production bundles with `npm run build`, which completed successfully and produced `dist/` artifacts.
- Attempted to capture a preview screenshot via Playwright to produce a visual preview, but browser install failed (`npx playwright install chromium` returned HTTP 403), so an automated screenshot could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088d8f91788324b554832da1aaa9ae)