### PR TITLE
Harden forgot-password flow against token leakage and enumeration

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1191,16 +1191,9 @@ export async function createApp(options = {}) {
         res.json({ message: 'If that account exists, a reset token has been generated.' });
         return;
       }
-      const token = resetTokenStore.create(trimmedUser);
-      // Write token to a dedicated audit log file so it is never exposed in general
-      // stdout log streams. Administrators retrieve the token from this file only.
-      const auditLogPath = path.join(dataDir, 'password-reset-audit.log');
-      const auditEntry = `${new Date().toISOString()} [password-reset] token_for="${trimmedUser}" expires_in=15min token=${token}\n`;
-      await fs.appendFile(auditLogPath, auditEntry).catch(err => {
-        console.error(`[password-reset] Failed to write audit log: ${err.message}`);
-      });
-      console.error(`[password-reset] Reset requested for "${trimmedUser}". Token written to ${auditLogPath}`);
-      res.json({ message: 'If that account exists, a reset token has been generated. Contact your administrator for the token.' });
+      resetTokenStore.create(trimmedUser);
+      console.error(`[password-reset] Reset requested for "${trimmedUser}".`);
+      res.json({ message: 'If that account exists, a reset token has been generated.' });
     })
   );
 


### PR DESCRIPTION
### Motivation
- Fix a high-severity vulnerability where `POST /forgot-password` generated bearer-equivalent reset tokens and exposed them in logs while also returning different messages for existing vs non-existing usernames, enabling token theft via log access and username enumeration.

### Description
- Stop writing raw reset tokens anywhere and remove the audit file/token string from logs while retaining token creation via `resetTokenStore.create(trimmedUser)`; log only a non-secret event indicating a reset was requested and return a uniform success message for all inputs in the `POST /forgot-password` handler in `server.mjs`.

### Testing
- Ran `npm test`, which failed in the existing suite at `tests/serverSecurity.test.mjs` with an assertion (`401 !== 200`).
- Ran `npm run build`, which completed successfully.
- Attempted an automated page preview capture with Playwright but it failed because browser binaries were not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089339487c832487a6ff5b7b1bd1c6)