### PR TITLE
Fix short-circuit limiter to avoid interrupt-rating fault capping

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -515,9 +515,6 @@ function computeLetThroughLimitKA(baseDevice, scaledDevice, faultKA) {
     }, 0);
     if (maxPeak > 0) return maxPeak / 1000;
   }
-  if (Number.isFinite(baseDevice.interruptRating) && baseDevice.interruptRating > 0 && faultKA > baseDevice.interruptRating) {
-    return baseDevice.interruptRating;
-  }
   return null;
 }
 

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -133,6 +133,50 @@ global.localStorage = {
       assert(Math.abs(ratioBase - ratioLimited) < 0.05, 'fault components should scale consistently');
     });
 
+
+    it('does not cap available fault current to interrupt rating-only devices', () => {
+      const buildModel = withTcc => {
+        const breaker = {
+          id: 'breaker1',
+          type: 'breaker',
+          connections: [{ target: 'bus480', sourcePort: 1, targetPort: 0 }]
+        };
+        if (withTcc) breaker.tccId = 'eaton_seriesC_100';
+        return {
+          activeSheet: 0,
+          sheets: [{
+            name: 'Breaker Duty',
+            components: [
+              {
+                id: 'utility',
+                type: 'utility_source',
+                voltage: 480,
+                thevenin_mva: 1200,
+                connections: [{ target: 'breaker1', sourcePort: 0, targetPort: 0 }]
+              },
+              breaker,
+              { id: 'bus480', type: 'bus', subtype: 'Bus' }
+            ]
+          }]
+        };
+      };
+
+      setItem('tccSettings', { devices: [], settings: {}, componentOverrides: {} });
+
+      setOneLine(buildModel(false));
+      const baseline = runShortCircuit();
+      const base = baseline.bus480;
+      assert(base, 'baseline bus should exist');
+      assert(base.threePhaseKA > 25, 'baseline fault should exceed interrupt rating threshold');
+
+      setOneLine(buildModel(true));
+      const withProtection = runShortCircuit();
+      const bus = withProtection.bus480;
+      assert(bus, 'protected bus should exist');
+      assert(Math.abs(bus.threePhaseKA - base.threePhaseKA) < 0.05, 'interrupt rating must not cap available fault current');
+      assert(!bus.protectionLimit, 'no protection limit metadata should be applied without let-through data');
+    });
+
     it('derives generator source impedance from rated and subtransient fields', () => {
       setOneLine({
         activeSheet: 0,


### PR DESCRIPTION
### Motivation
- The short-circuit limiter was treating a device `interruptRating` as a downstream current cap, which can hide the actual available fault current and suppress overduty or arc-flash warnings.
- The intent is to preserve legitimate let-through/clearing-based limiting (`i2t`, `peak_curve`) while ensuring the authoritative bolted-fault results remain unchanged when only an interrupt rating is present.

### Description
- Removed the interrupt-rating fallback from `computeLetThroughLimitKA()` in `analysis/shortCircuit.mjs` so `interruptRating` is no longer returned as a let-through cap. 
- Preserved existing limiting from `letThrough.i2t` and `scaledDevice.peakCurve` so real current-limiting metadata still applies.
- Added a regression test `does not cap available fault current to interrupt rating-only devices` in `tests/shortcircuit/shortCircuit.test.cjs` that verifies a breaker with only `interruptRating` (no let-through data) does not reduce `threePhaseKA` or set `protectionLimit`.

### Testing
- Ran the full automated test suite with `npm test`, and the tests completed successfully (including the new regression test).
- Built distribution bundles with `npm run build`, which completed successfully.
- Attempted to capture a webpage preview with Playwright, but the browser binaries are not installed in the environment so the screenshot step failed (Playwright install required); this does not affect the automated test or build results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089affd4e883248295276465a3e254)