### PR TITLE
Harden Custom Curve Builder PDF parsing by disabling eval

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -5771,7 +5771,10 @@ async function openCustomCurveBuilder(curveId = null) {
       if (isPdf) {
         const pdfModule = await ensurePdfJs();
         pendingPdfUrl = URL.createObjectURL(file);
-        const pdf = await pdfModule.getDocument({ url: pendingPdfUrl }).promise;
+        const pdf = await pdfModule.getDocument({
+          url: pendingPdfUrl,
+          isEvalSupported: false
+        }).promise;
         const page = await pdf.getPage(1);
         const viewport = page.getViewport({ scale: 1.6 });
         const tempCanvas = doc.createElement('canvas');


### PR DESCRIPTION
### Motivation
- A user-supplied PDF could trigger arbitrary JavaScript execution via the PDF.js parser; the Custom Curve Builder dynamically loads `pdfjs-dist` and previously called `getDocument` without disabling eval support.
- The change hardens the parsing/rendering path to prevent eval-based code execution while preserving existing upload and rendering behavior.

### Description
- Updated `analysis/tcc.js` so the PDF path uses `pdfModule.getDocument({ url: pendingPdfUrl, isEvalSupported: false })` when loading uploaded PDF references in `handleReferenceFile`.
- The fix is a minimal, targeted hardening at the PDF.js sink and does not change the UI flow or image conversion logic.
- Preserves the existing `ensurePdfJs()` behavior that sets the worker source.

### Testing
- Ran the test suite with `npm test`, and the automated tests completed successfully.
- Built the distribution with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089f26470c8324848dc1d0f6f10e8c)