### PR TITLE
Fix conservative short-circuit fallback for missing impedance

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -756,7 +756,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
         return { r: 1e-6, x: 1e-6 };
       }
       if (comp?.id) missingImpedanceComponents.add(comp.id);
-      return { r: 1e6, x: 1e6 };
+      return { r: 0.0001, x: 0.0001 };
     }
     return { r, x };
   };
@@ -832,7 +832,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     if (lowImpedanceWarning) {
       entry.warnings = [lowImpedanceWarning];
     } else if (missingImpedanceComponents.has(comp.id)) {
-      entry.warnings = ['Impedance data missing; results limited by default high resistance.'];
+      entry.warnings = ['Impedance data missing; results defaulted to conservative low impedance.'];
     }
 
     limitFaultByProtection(entry, comp, comps, compMap, protectiveLookupCache, scaledDeviceCache, tccSettings);


### PR DESCRIPTION
### Motivation

- Missing or zero impedance values were being defaulted to an extremely large impedance (`1e6 + j1e6`), which produced near-zero short-circuit currents and caused downstream arc-flash calculations and labels to report misleading zero hazard values instead of failing or flagging the result as invalid.
- Restore a conservative fallback that errs on the side of safety (higher fault current) so missing data does not silently understate hazards.

### Description

- In `analysis/shortCircuit.mjs` updated the `ensureNonZero` fallback for missing/zero impedance from a very large impedance to a conservative low impedance `0.0001 + j0.0001` so short-circuit currents remain conservative when inputs are incomplete.
- Adjusted the associated warning text to `"Impedance data missing; results defaulted to conservative low impedance."` to clearly communicate the conservative default.
- This is a minimal, targeted change limited to `analysis/shortCircuit.mjs` and preserves the existing short-circuit and arc-flash calculation flows.

### Testing

- Ran `npm test` which executed the test suite and completed successfully (all tests passed).
- Ran `npm run build` which produced the distribution artifacts successfully (build succeeded).
- Attempted to produce a preview screenshot with `npx playwright install chromium` and `npx playwright screenshot`, but browser download failed (HTTP 403) in this environment so an automated preview image could not be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a4f882808324bb1325f888024b40)