### PR TITLE
Restore load-flow voltage normalization and finite Vm/Va defaults

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -45,6 +45,53 @@ function toNumber(value, scale = 1) {
   return Number.isFinite(num) ? num * scale : 0;
 }
 
+
+function pickFiniteNumber(values, scale = 1) {
+  for (const value of values) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric * scale;
+  }
+  return null;
+}
+
+function resolveBusBaseKV(component) {
+  const baseKV = pickFiniteNumber([
+    component?.baseKV,
+    component?.baseKv,
+    component?.base_kv,
+    component?.baseVoltageKV,
+    component?.base_voltage_kv,
+    component?.voltageKV,
+    component?.voltage_kv,
+    component?.kv,
+    component?.kV,
+    component?.rating?.baseKV,
+    component?.rating?.baseKv,
+    component?.rating?.base_kv,
+    component?.settings?.baseKV,
+    component?.settings?.baseKv,
+    component?.settings?.base_kv,
+    component?.props?.baseKV,
+    component?.props?.baseKv,
+    component?.props?.base_kv
+  ]);
+  if (baseKV && baseKV > 0) return baseKV;
+
+  const derivedKV = pickFiniteNumber([
+    component?.voltage,
+    component?.baseVoltage,
+    component?.base_voltage,
+    component?.nominalVoltage,
+    component?.nominal_voltage,
+    component?.rating?.voltage,
+    component?.settings?.voltage,
+    component?.props?.voltage
+  ], 0.001);
+  if (derivedKV && derivedKV > 0) return derivedKV;
+
+  return 1;
+}
+
 function isUsableComponent(comp) {
   return comp && !IGNORED_TYPES.has(comp.type);
 }
@@ -954,9 +1001,9 @@ export function runLoadFlow(modelOrOpts = {}, maybeOpts = {}) {
         label,
         ref,
         type: c.busType || (idx === 0 ? 'slack' : 'PQ'),
-        Vm: c.Vm,
-        Va: c.Va,
-        baseKV: c.baseKV || 1,
+        Vm: pickFiniteNumber([c.Vm]) || 1,
+        Va: pickFiniteNumber([c.Va]) || 0,
+        baseKV: resolveBusBaseKV(c),
         Pd: loadPQ.kw,
         Qd: loadPQ.kvar,
         Pg: genPQ.kw,


### PR DESCRIPTION
### Motivation
- The load-flow solver was silently falling back to `1 kV` and accepting non-numeric `Vm`/`Va` values after a revert, producing materially incorrect electrical results or throwing at UI render time when `toFixed` was called. 
- The change restores the previous normalization behavior to ensure imported/shared projects using alternate voltage field names or nested rating/settings/props keep correct base-kV semantics. 
- The goal is a minimal, risk‑limited fix that preserves solver logic while preventing silent integrity loss and UI crashes.

### Description
- Add a small helper `pickFiniteNumber(values, scale)` to extract the first finite numeric value from common aliases. 
- Add `resolveBusBaseKV(component)` which resolves `baseKV` from common fields and converts volt-level fields to kV before falling back to a safe default. 
- Coerce bus initialization to safe numeric defaults by replacing raw `c.Vm`, `c.Va`, and `c.baseKV || 1` with `Vm: pickFiniteNumber([c.Vm]) || 1`, `Va: pickFiniteNumber([c.Va]) || 0`, and `baseKV: resolveBusBaseKV(c)`. 
- No other solver algorithms were changed; per‑unit, line flow and current calculations now use the normalized base KV and numeric Vm/Va values.

### Testing
- Ran `npm test` and the full test suite completed successfully. 
- Ran `npm run build` and the build completed successfully. 
- Attempted to capture a browser preview with Playwright but `npx playwright install chromium` failed due to CDN HTTP 403, so an automated headless screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a947e39c8324ac3b1ae19a609745)