### PR TITLE
Restore N-1 reliability SPF detection and validation findings

### DIFF
--- a/analysis/reliability.js
+++ b/analysis/reliability.js
@@ -17,6 +17,40 @@ function isConnectorComponent(comp) {
   return false;
 }
 
+
+function buildAdjacency(components = [], skipIds = new Set()) {
+  const adj = new Map();
+  components.forEach(c => {
+    if (!c?.id || skipIds.has(c.id)) return;
+    adj.set(c.id, new Set());
+  });
+  components.forEach(c => {
+    if (!c?.id || skipIds.has(c.id)) return;
+    (c.connections || []).forEach(conn => {
+      const target = conn?.target;
+      if (!target || skipIds.has(target) || !adj.has(target)) return;
+      adj.get(c.id).add(target);
+      adj.get(target).add(c.id);
+    });
+  });
+  return adj;
+}
+
+function findConnected(startIds = [], adj = new Map()) {
+  const visited = new Set();
+  const queue = [...startIds.filter(id => adj.has(id))];
+  queue.forEach(id => visited.add(id));
+  while (queue.length) {
+    const id = queue.shift();
+    (adj.get(id) || []).forEach(next => {
+      if (visited.has(next)) return;
+      visited.add(next);
+      queue.push(next);
+    });
+  }
+  return visited;
+}
+
 export function runReliability(components = []) {
   // Filter out non-operational components like dimensions or annotations
   const ops = components.filter(c => !isVisualComponent(c));
@@ -45,9 +79,43 @@ export function runReliability(components = []) {
   const n1Impacts = [];
   const n2Impacts = [];
   const n1FailureDetails = {};
+
+  const diagram = ops.filter(c => c && c.id);
+  const busIds = diagram.filter(c => c.type === 'bus').map(c => c.id);
+  const sourceIds = diagram
+    .filter(c => ['source', 'utility', 'generator', 'swing'].includes(`${c.type || ''}`.toLowerCase()))
+    .map(c => c.id);
+  const baselineAdj = buildAdjacency(diagram);
+  const baselineInbound = new Map(busIds.map(id => [id, 0]));
+  diagram.forEach(c => (c.connections || []).forEach(conn => {
+    if (baselineInbound.has(conn?.target)) baselineInbound.set(conn.target, (baselineInbound.get(conn.target) || 0) + 1);
+  }));
+  const implicitSources = busIds.filter(id => (baselineInbound.get(id) || 0) === 0 && (baselineAdj.get(id)?.size || 0) > 0);
+  const fallbackSources = busIds.length ? [busIds[0]] : [];
+  const startIds = [...new Set([...(sourceIds.length ? sourceIds : (implicitSources.length ? implicitSources : fallbackSources))])];
+
+  if (startIds.length) {
+    eligible.forEach(component => {
+      const failedId = component.id;
+      if (startIds.includes(failedId)) return;
+      const connected = findConnected(startIds.filter(id => id !== failedId), buildAdjacency(diagram, new Set([failedId])));
+      const impactedLoads = diagram
+        .filter(c => c.type === 'bus' && c.id !== failedId && !connected.has(c.id) && (baselineAdj.get(c.id)?.size || 0) > 0)
+        .map(c => c.id);
+      if (!impactedLoads.length) return;
+      n1Failures.push(failedId);
+      const pEntry = availMap[failedId];
+      const probability = pEntry
+        ? (pEntry.q / Math.max(pEntry.p, 1e-12)) * baseProd
+        : 0;
+      n1Impacts.push({ failed: [failedId], impacted: impactedLoads, probability });
+      n1FailureDetails[failedId] = { isolatedLoads: impactedLoads };
+    });
+  }
+
   const unavailability = n1Impacts.reduce((s, i) => s + i.probability, 0)
     + n2Impacts.reduce((s, i) => s + i.probability, 0);
-  const systemAvailability = 1 - unavailability;
+  const systemAvailability = Math.max(0, 1 - unavailability);
 
   return {
     systemAvailability,

--- a/tests/analysis.test.cjs
+++ b/tests/analysis.test.cjs
@@ -116,15 +116,15 @@ function caseToDiagram(data) {
       assert.strictEqual(label, 'REF-1');
     });
 
-    it('does not emit radial reliability failures', () => {
+    it('emits radial reliability failures', () => {
       const source = { id: 'source', type: 'bus', connections: [{ target: 'breaker' }] };
       const breaker = { id: 'breaker', type: 'breaker', tag: 'BRK-1', connections: [{ target: 'source' }, { target: 'load' }] };
       const load = { id: 'load', type: 'bus', props: { tag: 'LD-1' }, connections: [{ target: 'breaker' }] };
       const components = [source, breaker, load];
 
       const reliability = runReliability(components);
-      assert.deepStrictEqual(reliability.n1Failures, []);
-      assert.deepStrictEqual(reliability.n1FailureDetails, {});
+      assert.deepStrictEqual(reliability.n1Failures, ['breaker']);
+      assert.deepStrictEqual(reliability.n1FailureDetails, { breaker: { isolatedLoads: ['load'] } });
 
       const issues = runValidation(components, {
         reliability: {
@@ -132,7 +132,7 @@ function caseToDiagram(data) {
           n1FailureDetails: reliability.n1FailureDetails
         }
       });
-      assert.strictEqual(issues.length, 0);
+      assert.strictEqual(issues.length, 1);
     });
   });
 })();

--- a/tests/reliabilityAnalysis.test.mjs
+++ b/tests/reliabilityAnalysis.test.mjs
@@ -152,26 +152,33 @@ describe('runReliability - expectedOutage', () => {
 });
 
 describe('runReliability - result structure', () => {
-  it('always returns empty n1Failures and n2Failures arrays', () => {
+  it('detects n1Failures for radial topologies while keeping n2Failures empty', () => {
     const components = [
-      { id: 'bus-x', type: 'bus', mtbf: 8760, mttr: 4 }
+      { id: 'source', type: 'bus', mtbf: 1000, mttr: 10, connections: [{ target: 'breaker' }] },
+      { id: 'breaker', type: 'breaker', mtbf: 1000, mttr: 10, connections: [{ target: 'source' }, { target: 'load' }] },
+      { id: 'load', type: 'bus', mtbf: 1000, mttr: 10, connections: [{ target: 'breaker' }] }
     ];
     const result = runReliability(components);
-    assert.deepStrictEqual(result.n1Failures, []);
+    assert.deepStrictEqual(result.n1Failures, ['breaker']);
     assert.deepStrictEqual(result.n2Failures, []);
   });
 
-  it('always returns empty n1FailureDetails object', () => {
-    const result = runReliability([]);
-    assert.deepStrictEqual(result.n1FailureDetails, {});
+  it('returns n1FailureDetails for detected failures', () => {
+    const result = runReliability([
+      { id: 'source', type: 'bus', mtbf: 1000, mttr: 10, connections: [{ target: 'breaker' }] },
+      { id: 'breaker', type: 'breaker', mtbf: 1000, mttr: 10, connections: [{ target: 'source' }, { target: 'load' }] },
+      { id: 'load', type: 'bus', mtbf: 1000, mttr: 10, connections: [{ target: 'breaker' }] }
+    ]);
+    assert.deepStrictEqual(result.n1FailureDetails, { breaker: { isolatedLoads: ['load'] } });
   });
 
-  it('systemAvailability is 1 when N-1 analysis produces no failures', () => {
-    // Currently n1Impacts is always empty, so systemAvailability = 1 - 0 = 1
+  it('systemAvailability drops below 1 when N-1 analysis detects failures', () => {
     const result = runReliability([
-      { id: 'bus-y', type: 'bus', mtbf: 8760, mttr: 4 }
+      { id: 'source', type: 'bus', mtbf: 1000, mttr: 10, connections: [{ target: 'breaker' }] },
+      { id: 'breaker', type: 'breaker', mtbf: 1000, mttr: 10, connections: [{ target: 'source' }, { target: 'load' }] },
+      { id: 'load', type: 'bus', mtbf: 1000, mttr: 10, connections: [{ target: 'breaker' }] }
     ]);
-    assert.strictEqual(result.systemAvailability, 1);
+    assert.ok(result.systemAvailability < 1);
   });
 
   it('returns all expected keys in result', () => {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -614,5 +614,18 @@ export function runValidation(components = [], studies = {}) {
     msgs.forEach(msg => issues.push({ component: id, message: msg }));
   });
 
+  const reliabilityFailures = studies?.reliability?.n1Failures || [];
+  const reliabilityDetails = studies?.reliability?.n1FailureDetails || {};
+  reliabilityFailures.forEach(id => {
+    const isolatedLoads = reliabilityDetails[id]?.isolatedLoads || [];
+    const isolatedMsg = isolatedLoads.length
+      ? ` Isolates: ${isolatedLoads.map(loadId => describe(loadId)).join(', ')}.`
+      : '';
+    issues.push({
+      component: id,
+      message: `Single point of failure under N-1 reliability check.${isolatedMsg}`
+    });
+  });
+
   return issues;
 }


### PR DESCRIPTION
### Motivation
- A recent change disabled topology-based N-1/N-2 cut-set analysis and returned empty failure/impact arrays which caused `systemAvailability` to be 1 for all projects, silently masking single-point failures and removing safety-critical findings.
- The intent of this PR is to restore the original connectivity-based SPF detection and ensure reliability studies feed visible validation issues so engineering integrity is preserved.

### Description
- Reintroduced adjacency and connectivity analysis and N-1 detection in `analysis/reliability.js` so `n1Failures`, `n1Impacts`, and `n1FailureDetails` are computed from topology and used to derive `systemAvailability`.
- Restored conversion of `studies.reliability.n1Failures` into user-visible validation issues in `validation/rules.js`, including contextual isolated-load messages.
- Updated tests in `tests/analysis.test.cjs` and `tests/reliabilityAnalysis.test.mjs` to assert SPF detection for simple radial source→breaker→load topologies and to expect lowered `systemAvailability` when impacts exist.
- Changes are localized and keep the public result shape; computation now produces non-empty impact arrays when appropriate instead of always returning empty arrays.

### Testing
- Ran the full test suite with `npm test` and the modified reliability tests passed as part of the run (no failing assertions remain). 
- Built the distribution with `npm run build` and the build completed successfully.
- Attempted to produce a webpage preview by running Playwright to capture `index.html`, but `npx playwright install chromium` failed due to Playwright CDN download returning HTTP 403, so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a96745148324b86c5b3a91312166)