### PR TITLE
Fix hidden TCC alias precedence for long-time relay settings

### DIFF
--- a/analysis/tccUtils.js
+++ b/analysis/tccUtils.js
@@ -194,26 +194,49 @@ export function scaleCurve(device = {}, overrides = {}) {
   );
   const profile = pickCurveProfile(device, selectedProfileId);
   const combinedBase = { ...baseSettings, ...profile.settings };
+  const hasLongTimeModel = combinedBase.longTimePickup !== undefined
+    || combinedBase.longTimeDelay !== undefined;
 
-  const pickup = firstDefined(
-    overrides.pickup,
-    overrides.longTimePickup,
-    overrides.ampRating,
-    combinedBase.pickup,
-    combinedBase.longTimePickup,
-    combinedBase.ampRating,
-    device.ampRating,
-    1
-  );
-  const time = firstDefined(
-    overrides.time,
-    overrides.delay,
-    overrides.longTimeDelay,
-    combinedBase.time,
-    combinedBase.delay,
-    combinedBase.longTimeDelay,
-    1
-  );
+  const pickup = hasLongTimeModel
+    ? firstDefined(
+      overrides.longTimePickup,
+      overrides.pickup,
+      overrides.ampRating,
+      combinedBase.longTimePickup,
+      combinedBase.pickup,
+      combinedBase.ampRating,
+      device.ampRating,
+      1
+    )
+    : firstDefined(
+      overrides.pickup,
+      overrides.longTimePickup,
+      overrides.ampRating,
+      combinedBase.pickup,
+      combinedBase.longTimePickup,
+      combinedBase.ampRating,
+      device.ampRating,
+      1
+    );
+  const time = hasLongTimeModel
+    ? firstDefined(
+      overrides.longTimeDelay,
+      overrides.time,
+      overrides.delay,
+      combinedBase.longTimeDelay,
+      combinedBase.time,
+      combinedBase.delay,
+      1
+    )
+    : firstDefined(
+      overrides.time,
+      overrides.delay,
+      overrides.longTimeDelay,
+      combinedBase.time,
+      combinedBase.delay,
+      combinedBase.longTimeDelay,
+      1
+    );
   const rawShortTimePickup = firstDefined(overrides.shortTimePickup, combinedBase.shortTimePickup);
   const rawShortTimeDelay = firstDefined(overrides.shortTimeDelay, combinedBase.shortTimeDelay);
   const parsedShortTimePickup = Number(rawShortTimePickup);


### PR DESCRIPTION
### Motivation
- Prevent imported or malicious hidden legacy aliases (`pickup`/`time`) from silently overriding the visible `longTimePickup`/`longTimeDelay` relay settings and corrupting TCC and arc‑flash calculations.
- Preserve compatibility with older device models that still use the legacy `pickup`/`time` fields so behavior for legacy profiles does not regress.

### Description
- Added detection of a long‑time model in `analysis/tccUtils.js` by checking for `combinedBase.longTimePickup` or `combinedBase.longTimeDelay` and stored it in `hasLongTimeModel`.
- When `hasLongTimeModel` is true, prioritized `longTimePickup`/`longTimeDelay` (and their overrides) ahead of legacy `pickup`/`time` when resolving `pickup` and `time` in `scaleCurve`.
- Kept the original alias precedence for devices that do not expose long‑time fields, preserving backward compatibility with legacy device data.
- The change is minimal and localized to `analysis/tccUtils.js` to avoid wider impact on other modules.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully (all tests passed).
- Built the distribution with `npm run build`, which completed successfully and produced the build artifacts.
- Attempted to capture a UI preview with Playwright (`npx playwright screenshot` / `npx playwright install chromium`) but browser binaries could not be downloaded in this environment (CDN `403`), so the runtime screenshot step failed outside of the test/build workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08abb2ce5c8324b8ad944444371daf)