### PR TITLE
Sanitize imported SVG icon nodes in custom component editor

### DIFF
--- a/custom-components.js
+++ b/custom-components.js
@@ -697,6 +697,32 @@ function decodeSvgDataUrl(dataUrl) {
   }
 }
 
+const SAFE_IMPORTED_ICON_TAGS = new Set(['line', 'rect', 'circle', 'path', 'text']);
+
+function sanitizeImportedIconNode(node) {
+  if (!node || node.nodeType !== 1) return false;
+  const tag = node.tagName.toLowerCase();
+  if (!SAFE_IMPORTED_ICON_TAGS.has(tag)) return false;
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+  let current = walker.currentNode;
+  while (current) {
+    if (!SAFE_IMPORTED_ICON_TAGS.has(current.tagName.toLowerCase())) return false;
+    Array.from(current.attributes).forEach(attr => {
+      const name = attr.name.toLowerCase();
+      const value = String(attr.value || '').trim().toLowerCase();
+      if (name.startsWith('on') || name === 'style') {
+        current.removeAttribute(attr.name);
+        return;
+      }
+      if ((name === 'href' || name === 'xlink:href') && (value.startsWith('javascript:') || value.startsWith('data:'))) {
+        current.removeAttribute(attr.name);
+      }
+    });
+    current = walker.nextNode();
+  }
+  return true;
+}
+
 function importIconData(dataUrl) {
   ensureIconCanvas();
   clearIconCanvas({ resetData: false });
@@ -723,6 +749,7 @@ function importIconData(dataUrl) {
           if (node.nodeType !== 1) return;
           if (node.getAttribute('data-icon-grid') || node.tagName.toLowerCase() === 'defs') return;
           const imported = node.cloneNode(true);
+          if (!sanitizeImportedIconNode(imported)) return;
           imported.dataset.iconShape = '1';
           if (!imported.dataset.shapeType) {
             const tag = imported.tagName.toLowerCase();


### PR DESCRIPTION
### Motivation
- Close a stored DOM‑XSS vector where the `?edit=` auto-load path could import attacker-controlled `data:image/svg+xml` icons and append active SVG content into the live editor DOM. 
- Prevent inline event handlers, style attributes, and dangerous `href`/`xlink:href` URL schemes from surviving the import flow while preserving normal icon geometry.

### Description
- Add a `SAFE_IMPORTED_ICON_TAGS` allowlist containing the editor shapes `line`, `rect`, `circle`, `path`, and `text`.
- Implement `sanitizeImportedIconNode` which rejects nodes with non-allowlist tags and strips any `on*` attributes, `style`, and unsafe `href`/`xlink:href` values that start with `javascript:` or `data:`.
- Integrate the sanitizer into `importIconData` immediately after cloning a parsed child node, skipping any node that fails sanitization so it is never appended to `iconCanvas`.
- Preserve the existing fallback behavior for non-builder-marked icons by falling back to the prior preview path when the importer does not accept the SVG.

### Testing
- Ran `npm test` and the full test suite completed successfully.
- Ran `npm run build` and the project built successfully.
- Attempted to capture a browser screenshot for a visual preview, but `npx playwright install chromium` failed with `403 Forbidden` when downloading browsers so no Playwright screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ac4680b083248588febfa981d913)