### PR TITLE
Harden custom icon builder SVG imports against DOM XSS

### DIFF
--- a/custom-components.js
+++ b/custom-components.js
@@ -697,6 +697,31 @@ function decodeSvgDataUrl(dataUrl) {
   }
 }
 
+const IMPORTABLE_SVG_TAGS = new Set(['line', 'rect', 'circle', 'path', 'text']);
+const IMPORTABLE_ATTRS = {
+  line: ['x1', 'y1', 'x2', 'y2', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'fill', 'opacity'],
+  rect: ['x', 'y', 'width', 'height', 'rx', 'ry', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'fill', 'opacity'],
+  circle: ['cx', 'cy', 'r', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'fill', 'opacity'],
+  path: ['d', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'fill', 'opacity'],
+  text: ['x', 'y', 'fill', 'font-size', 'font-family', 'font-weight', 'text-anchor', 'dominant-baseline', 'opacity']
+};
+
+function sanitizeImportedIconNode(node) {
+  if (!node || node.nodeType !== 1) return null;
+  const tag = node.tagName.toLowerCase();
+  if (!IMPORTABLE_SVG_TAGS.has(tag)) return null;
+  const sanitized = document.createElementNS(SVG_NS, tag);
+  const allowedAttrs = IMPORTABLE_ATTRS[tag] || [];
+  allowedAttrs.forEach(attr => {
+    const value = node.getAttribute(attr);
+    if (value !== null) sanitized.setAttribute(attr, value);
+  });
+  if (tag === 'text') {
+    sanitized.textContent = node.textContent || '';
+  }
+  return sanitized;
+}
+
 function importIconData(dataUrl) {
   ensureIconCanvas();
   clearIconCanvas({ resetData: false });
@@ -722,7 +747,8 @@ function importIconData(dataUrl) {
         Array.from(root.children).forEach(node => {
           if (node.nodeType !== 1) return;
           if (node.getAttribute('data-icon-grid') || node.tagName.toLowerCase() === 'defs') return;
-          const imported = node.cloneNode(true);
+          const imported = sanitizeImportedIconNode(node);
+          if (!imported) return;
           imported.dataset.iconShape = '1';
           if (!imported.dataset.shapeType) {
             const tag = imported.tagName.toLowerCase();


### PR DESCRIPTION
### Motivation

- The builder import path for custom component icons parsed `data:image/svg+xml` and appended cloned SVG children into the live `#icon-canvas`, creating a stored DOM XSS sink. 
- The goal is to eliminate the ability for malicious SVG elements/attributes (such as event handlers, `foreignObject`, `<image>`, animations, etc.) to be persisted and executed in the application origin while preserving the icon-builder experience for simple shape primitives.

### Description

- Replaced the unsafe `cloneNode(true)` import path in `custom-components.js` with a sanitizer that rebuilds nodes using `document.createElementNS(SVG_NS, tag)` and an explicit allow-list of supported tags (`line`, `rect`, `circle`, `path`, `text`).
- Implemented per-tag attribute allow-lists and only copy whitelisted attributes into the reconstructed node, and preserved `textContent` only for `<text>` nodes, dropping unsupported elements and attributes.
- Kept existing icon-builder behavior for supported primitives by mapping the reconstructed tag to the same `data-shapeType` and class hooks used by the canvas, while rejecting any other SVG constructs as unsafe.

### Testing

- Ran the full unit/test suite with `npm test` and all automated tests completed successfully.
- Built the distribution with `npm run build` and the build completed without errors.
- Attempted to capture an on-disk preview with Playwright (`npx playwright screenshot …`) but browser binaries could not be downloaded in this environment (Playwright Chromium install failed with HTTP 403), so an automated screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ac76b2dc83248d6628187eec94b6)