### PR TITLE
Fix voltage-drop compliance calculation in conductor auto-sizing

### DIFF
--- a/sizing.js
+++ b/sizing.js
@@ -75,6 +75,9 @@ export function sizeConductor(load = {}, params = {}) {
       conductor_size: sz,
       conductor_material: params.material || 'cu',
       insulation_rating: params.insulation_rating || 90,
+      est_load: current,
+      operating_voltage: voltage,
+      cable_rating: voltage,
       voltage_rating: voltage
     };
     const vd = calculateVoltageDrop(cable, params.length || 0, phases);


### PR DESCRIPTION
### Motivation
- Repair a regression in auto-sizing where `calculateVoltageDrop()` received a candidate cable without load/voltage fields, causing voltage-drop to be computed as 0 and allowing non-compliant conductors to appear valid.

### Description
- Add `est_load`, `operating_voltage`, and `cable_rating` to the candidate `cable` object in `sizeConductor()` (`sizing.js`) before calling `calculateVoltageDrop()`, restoring the original inputs expected by the voltage-drop routine while keeping the rest of the sizing logic unchanged.

### Testing
- Ran `npm test` and the full test suite completed successfully. 
- Ran `npm run build` and the build succeeded. 
- Attempted an automated Playwright screenshot of `cableschedule.html` to produce a preview but the browser install/download failed (Playwright Chromium download returned 403), so no screenshot could be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bf9f356c832495b538f651931e40)