### PR TITLE
Limit cathodic protection anode count during saved/imported study normalization

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -20,6 +20,7 @@ const MM_TO_M = 0.001;
 const FT_TO_M = 0.3048;
 const SQM_TO_SQFT = 10.76391041671;
 const COMMISSIONING_CHECKLIST_ITEMS = [];
+const MAX_NUMBER_OF_ANODES = 10000;
 
 const TABLE_CURRENT_DENSITY_MA_M2 = {
   pipe: { low: 5, moderate: 10, high: 20 },
@@ -488,8 +489,8 @@ function validateInputs(input) {
     errors.push('anodeTypeSystem must be galvanic or iccp.');
   }
 
-  if (!Number.isInteger(input.numberOfAnodes) || input.numberOfAnodes <= 0) {
-    errors.push('numberOfAnodes must be a positive integer.');
+  if (!Number.isInteger(input.numberOfAnodes) || input.numberOfAnodes <= 0 || input.numberOfAnodes > MAX_NUMBER_OF_ANODES) {
+    errors.push(`numberOfAnodes must be a positive integer up to ${MAX_NUMBER_OF_ANODES}.`);
   }
 
   ['anodeSpacingM', 'anodeDistanceToStructureM', 'anodeBurialDepthM'].forEach((fieldName) => {


### PR DESCRIPTION
### Motivation
- Prevent denial-of-service from untrusted saved/imported cathodic protection studies by bounding the attacker-controlled `numberOfAnodes` before the code recomputes distribution arrays during restoration.

### Description
- Add a `MAX_NUMBER_OF_ANODES = 10000` constant and enforce it in `validateInputs` so `numberOfAnodes` must be a positive integer no greater than `MAX_NUMBER_OF_ANODES`, rejecting oversized inputs before `runCathodicProtectionAnalysis` can allocate large arrays.

### Testing
- Ran `npm test` and all automated tests completed successfully.
- Ran `npm run build` and the project build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f307cb848324a430c201a4c2164b)