### PR TITLE
Validate cached route results against active project data

### DIFF
--- a/analysis/deliverableWorkflow.mjs
+++ b/analysis/deliverableWorkflow.mjs
@@ -108,6 +108,64 @@ export function normalizeRouteResults(source) {
   return [];
 }
 
+
+function knownCableTags(cables = []) {
+  return new Set(meaningfulRecords(cables).map(cableTag).map(normalizedKey).filter(Boolean));
+}
+
+function collectRacewayIds(rows = [], fields = []) {
+  const ids = new Set();
+  meaningfulRecords(rows).forEach(row => {
+    for (const field of fields) {
+      const value = row?.[field];
+      const key = normalizedKey(value);
+      if (key) ids.add(key);
+    }
+  });
+  return ids;
+}
+
+function routeResultRacewayIds(result) {
+  const ids = [];
+  const entries = [
+    ...(Array.isArray(result?.breakdown) ? result.breakdown : []),
+    ...(Array.isArray(result?.route_segments) ? result.route_segments : []),
+  ];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    ids.push(
+      entry.tray_id,
+      entry.trayId,
+      entry.raceway_id,
+      entry.racewayId,
+      entry.conduit_id,
+      entry.conduitId,
+      entry.ductbankTag,
+      entry.ductbank_tag,
+      entry.ductbank_id,
+      entry.ductbankId,
+      entry.id,
+    );
+  }
+  return ids.map(normalizedKey).filter(Boolean).filter(id => id !== 'field route');
+}
+
+export function filterRouteResultsForProject(routeResults = [], { cables = [], trays = [], conduits = [], ductbanks = [] } = {}) {
+  const cableTags = knownCableTags(cables);
+  const racewayIds = new Set([
+    ...collectRacewayIds(trays, ['tray_id', 'trayId', 'id', 'tag']),
+    ...collectRacewayIds(conduits, ['conduit_id', 'conduitId', 'id', 'tag']),
+    ...collectRacewayIds(ductbanks, ['tag', 'id', 'ductbankTag', 'ductbank_id']),
+  ]);
+
+  return normalizeRouteResults(routeResults).filter(result => {
+    const tag = normalizedKey(routeResultTag(result));
+    if (!tag || !cableTags.has(tag)) return false;
+    const referencedRaceways = routeResultRacewayIds(result);
+    return referencedRaceways.every(id => racewayIds.has(id));
+  });
+}
+
 export function routeResultsFromCableRows(cables = []) {
   return meaningfulRecords(cables)
     .filter(cableHasRouteSegments)
@@ -115,8 +173,8 @@ export function routeResultsFromCableRows(cables = []) {
     .filter(routeResultSucceeded);
 }
 
-function mergedRouteResults(routeResults = [], cables = []) {
-  const explicit = normalizeRouteResults(routeResults);
+function mergedRouteResults(routeResults = [], { cables = [], trays = [], conduits = [], ductbanks = [] } = {}) {
+  const explicit = filterRouteResultsForProject(routeResults, { cables, trays, conduits, ductbanks });
   const explicitTags = new Set(explicit.map(routeResultTag).map(normalizedKey).filter(Boolean));
   const fromCables = routeResultsFromCableRows(cables).filter(result => {
     const key = normalizedKey(routeResultTag(result));
@@ -185,7 +243,12 @@ export function buildDeliverableReadinessDiagnostics({
   const conduitRows = meaningfulRecords(conduits);
   const ductbankRows = meaningfulRecords(ductbanks);
   const cableSummary = summarizeCableWorkflow(cableRows);
-  const allRouteResults = mergedRouteResults(routeResults, cableRows);
+  const allRouteResults = mergedRouteResults(routeResults, {
+    cables: cableRows,
+    trays: trayRows,
+    conduits: conduitRows,
+    ductbanks: ductbankRows,
+  });
   const routedRouteResults = allRouteResults.filter(routeResultSucceeded);
   const routedTags = uniqueRoutedCableTags(routedRouteResults);
   const scheduleReadyTags = cableRows

--- a/pullcards.js
+++ b/pullcards.js
@@ -1,7 +1,7 @@
 import { buildPullTable, cableQRPayload } from './analysis/pullCards.mjs';
 import { parsePullRouteRows } from './analysis/pullCardRouteImport.mjs';
 import { buildPullRouteVisualModel } from './analysis/pullCardVisualModel.mjs';
-import { buildDeliverableReadinessDiagnostics, normalizeRouteResults } from './analysis/deliverableWorkflow.mjs';
+import { buildDeliverableReadinessDiagnostics, filterRouteResultsForProject, normalizeRouteResults } from './analysis/deliverableWorkflow.mjs';
 import {
   getTrays,
   getCables,
@@ -182,8 +182,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function addRouteCandidate(candidates, seen, key, label, payload) {
-    const routeResults = normalizeRouteResults(payload);
+  function addRouteCandidate(candidates, seen, key, label, payload, projectData) {
+    const routeResults = filterRouteResultsForProject(normalizeRouteResults(payload), projectData);
     if (!routeResults.length || seen.has(key)) return;
     seen.add(key);
     const updatedAt = payload?.updatedAt || payload?.generatedAt || payload?.createdAt || payload?.timestamp || '';
@@ -196,7 +196,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function readSessionRouteCandidates(candidates, seen) {
+  function readSessionRouteCandidates(candidates, seen, projectData) {
     try {
       for (const key of Object.keys(sessionStorage)) {
         const normalized = key.toLowerCase();
@@ -207,7 +207,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch {
           payload = null;
         }
-        addRouteCandidate(candidates, seen, `session:${key}`, 'Current session route cache', payload);
+        addRouteCandidate(candidates, seen, `session:${key}`, 'Current session route cache', payload, projectData);
       }
     } catch {
       // Session storage can be unavailable in hardened browser contexts.
@@ -217,16 +217,22 @@ document.addEventListener('DOMContentLoaded', () => {
   function readRouteResultCandidates() {
     const candidates = [];
     const seen = new Set();
-    addRouteCandidate(candidates, seen, 'latestRouteResults', 'Latest project route results', getItem('latestRouteResults', null));
+    const projectData = {
+      cables: getCables(),
+      trays: getTrays(),
+      conduits: getConduits(),
+      ductbanks: getDuctbanks(),
+    };
+    addRouteCandidate(candidates, seen, 'latestRouteResults', 'Latest project route results', getItem('latestRouteResults', null), projectData);
 
     for (const key of keys()) {
       const lower = String(key).toLowerCase();
       if (key === 'latestRouteResults') continue;
       if (!lower.includes('routecache') && !lower.includes('routeresult') && !lower.startsWith('route-')) continue;
-      addRouteCandidate(candidates, seen, `project:${key}`, `Project route cache (${key})`, getItem(key, null));
+      addRouteCandidate(candidates, seen, `project:${key}`, `Project route cache (${key})`, getItem(key, null), projectData);
     }
 
-    readSessionRouteCandidates(candidates, seen);
+    readSessionRouteCandidates(candidates, seen, projectData);
     return candidates;
   }
 

--- a/tests/deliverableWorkflow.test.mjs
+++ b/tests/deliverableWorkflow.test.mjs
@@ -71,6 +71,27 @@ const routeResults = {
 
 assert.equal(normalizeRouteResults(routeResults).length, 1);
 
+
+const forged = buildDeliverableReadinessDiagnostics({
+  cables,
+  trays,
+  routeResults: {
+    batchResults: [
+      {
+        cable: 'CBL-999',
+        status: 'Routed',
+        total_length: 20,
+        breakdown: [{ tray_id: 'TR-HIDDEN', length: 20 }],
+        route_segments: [{ tray_id: 'TR-HIDDEN', length: 20 }],
+      },
+    ],
+  },
+});
+
+assert.equal(forged.health.routeResults, 0);
+assert.deepEqual(forged.missingRouteResultTags, ['CBL-101', 'CBL-102']);
+
+
 const partial = buildDeliverableReadinessDiagnostics({
   cables,
   trays,


### PR DESCRIPTION
### Motivation
- Cached and imported route payloads (e.g. `latestRouteResults` and project route-cache keys) were accepted by deliverable and pull-card flows by shape/recency alone, allowing stale or forged route data to be treated as authoritative and produce incorrect pull-cards and readiness diagnostics. 
- The intent of the change is to ensure route results are only trusted when they are provably consistent with the currently loaded project model (cable tags and known raceway IDs), preserving deliverable integrity.

### Description
- Added project-consistency helpers in `analysis/deliverableWorkflow.mjs` (`knownCableTags`, `collectRacewayIds`, `routeResultRacewayIds`, and `filterRouteResultsForProject`) that require explicit route rows to reference an existing cable tag and only known tray/conduit/ductbank IDs. 
- Switched explicit-route merging to call `filterRouteResultsForProject` and updated `mergedRouteResults` to accept project collections (`cables`, `trays`, `conduits`, `ductbanks`) so derived and explicit results are reconciled safely. 
- Updated pull-card candidate loading in `pullcards.js` to apply the same `filterRouteResultsForProject` check for `latestRouteResults`, project route-cache keys, and session route caches before a candidate is considered. 
- Added a regression test in `tests/deliverableWorkflow.test.mjs` that injects a forged route payload and asserts it is ignored by the readiness diagnostics.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully and the new regression test passed. 
- Built distributables with `npm run build`, which completed successfully. 
- Attempted to capture a page preview with Playwright (`npx playwright screenshot ...`) but browser binaries could not be downloaded in this environment (Playwright install failed with remote CDN `403 Forbidden`), so a preview screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f5175e6883248a79bf22dc788080)