### PR TITLE
Fix CSV formula injection in fault bracing export

### DIFF
--- a/cableFaultBracing.js
+++ b/cableFaultBracing.js
@@ -923,6 +923,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
   }
 
+  function csvSpreadsheetSafe(value) {
+    const text = String(value ?? '');
+    return /^[=+\-@]/.test(text) ? `'${text}` : text;
+  }
+
   function buildScheduleCsv(rows) {
     const header = [
       'Cable Tag',
@@ -942,8 +947,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const size = row.cable.conductor_size || row.cable.size || '';
       const status = row.err || !row.result ? `Error${row.err ? `: ${row.err}` : ''}` : 'OK';
       return [
-        tag,
-        size,
+        csvSpreadsheetSafe(tag),
+        csvSpreadsheetSafe(size),
         row.conductors,
         row.sysType,
         row.spacing_mm.toFixed(1),


### PR DESCRIPTION
### Motivation
- The CSV export for the Cable Fault Bracing schedule was writing user-controlled `Cable Tag` and `Size` fields with only CSV quoting, which allowed spreadsheet formula injection when CSVs are opened in Excel/LibreOffice/Sheets.

### Description
- Add `csvSpreadsheetSafe(value)` which prefixes values beginning with `=`, `+`, `-`, or `@` with an apostrophe and apply it to the exported `tag` and `size` columns, while leaving the existing `csvCell` quoting/escaping behaviour unchanged.

### Testing
- Ran `npm test` and `npm run build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f689fd6883249336ea705e42fba0)