### PR TITLE
Fix Raceway Schedule normalize TDZ startup crash

### DIFF
--- a/src/racewayschedule.js
+++ b/src/racewayschedule.js
@@ -1828,8 +1828,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     whenPresent(DUCTBANK_ROW_SELECTOR, () => emitSticky('samples-loaded','samplesLoaded'));
   });
 
-  const normalize=s=>(s||'').trim().toUpperCase();
-
   function attachConduitsToDuctbanks(rows){
     const banks=(typeof window.getDuctbanks==='function'?window.getDuctbanks():[]);
     const tags=new Set(banks.map(db=>normalize(db.tag)));


### PR DESCRIPTION
### Motivation
- The DOMContentLoaded handler introduced a block-scoped `const normalize` that shadowed the module-level helper and put earlier calls (used by the new reconciliation logic) into a temporal dead zone, causing `ReferenceError` and aborting Raceway Schedule initialization when ductbank data is present.
- The change aims to ensure early reconciliation and later conduit-attachment logic consistently use the same `normalize` helper to avoid a client-side denial-of-service on page load.

### Description
- Removed the inner `const normalize` redeclaration inside the `DOMContentLoaded` handler so all code in the module uses the module-level `normalize` helper.
- Kept existing reconciliation and conduit-attachment logic unchanged otherwise so behavior is preserved while eliminating the TDZ crash.

### Testing
- Ran the full unit/test suite with `npm test` and all automated tests completed successfully.
- Ran `npm run build` and the build completed successfully (warnings unrelated to this fix were shown but do not affect the change).
- Attempted an automated Playwright screenshot of `/racewayschedule.html` but browser installation failed (Playwright download returned HTTP 403), so the visual preview could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f68ade0c8324baa4532e883f2c27)