### PR TITLE
Clamp haz-area and lighting preview input bounds

### DIFF
--- a/analysis/hazAreaClassification.mjs
+++ b/analysis/hazAreaClassification.mjs
@@ -190,6 +190,11 @@ export const DEFAULT_HAZAREA_LAYOUT = Object.freeze({
   elevationFt: 20
 });
 
+export const MAX_HAZAREA_LAYOUT_WIDTH_FT = 2000;
+export const MAX_HAZAREA_LAYOUT_HEIGHT_FT = 2000;
+export const MAX_HAZAREA_LAYOUT_ELEVATION_FT = 1000;
+export const MAX_HAZAREA_GRID_LINES_PER_AXIS = 200;
+
 const HAZAREA_COLORS = Object.freeze({
   severe: Object.freeze({ fill: '#fca5a5', stroke: '#b91c1c', label: 'Zone 0/20 or Div 1' }),
   elevated: Object.freeze({ fill: '#fdba74', stroke: '#c2410c', label: 'Zone 1/21' }),
@@ -224,11 +229,24 @@ function roundFt(value) {
 }
 
 export function normalizeHazAreaLayout(layout = {}) {
-  const widthFt = finitePositive(layout.widthFt, DEFAULT_HAZAREA_LAYOUT.widthFt);
-  const heightFt = finitePositive(layout.heightFt, DEFAULT_HAZAREA_LAYOUT.heightFt);
-  const elevationFt = finitePositive(layout.elevationFt, DEFAULT_HAZAREA_LAYOUT.elevationFt);
+  const widthFt = clamp(
+    finitePositive(layout.widthFt, DEFAULT_HAZAREA_LAYOUT.widthFt),
+    1,
+    MAX_HAZAREA_LAYOUT_WIDTH_FT
+  );
+  const heightFt = clamp(
+    finitePositive(layout.heightFt, DEFAULT_HAZAREA_LAYOUT.heightFt),
+    1,
+    MAX_HAZAREA_LAYOUT_HEIGHT_FT
+  );
+  const elevationFt = clamp(
+    finitePositive(layout.elevationFt, DEFAULT_HAZAREA_LAYOUT.elevationFt),
+    1,
+    MAX_HAZAREA_LAYOUT_ELEVATION_FT
+  );
   const maxGrid = Math.max(1, Math.min(widthFt, heightFt));
-  const gridFt = clamp(finitePositive(layout.gridFt, DEFAULT_HAZAREA_LAYOUT.gridFt), 1, maxGrid);
+  const minGrid = Math.max(widthFt / MAX_HAZAREA_GRID_LINES_PER_AXIS, heightFt / MAX_HAZAREA_GRID_LINES_PER_AXIS, 1);
+  const gridFt = clamp(finitePositive(layout.gridFt, DEFAULT_HAZAREA_LAYOUT.gridFt), minGrid, maxGrid);
 
   return {
     widthFt: roundFt(widthFt),

--- a/analysis/lighting.mjs
+++ b/analysis/lighting.mjs
@@ -67,6 +67,7 @@ export const GENERIC_CU_TABLE = Object.freeze([
 export const NFPA_EGRESS_AVG_FC  = 1.0;
 /** NFPA 101-2021 §7.9.2.1 — minimum illuminance threshold on egress path. */
 export const NFPA_EGRESS_MIN_FC  = 0.1;
+export const MAX_LIGHTING_FIXTURE_LAYOUT_COUNT = 1000;
 
 // ---------------------------------------------------------------------------
 // IES LM-63 photometric file parser
@@ -271,7 +272,7 @@ export function generateDefaultFixtureLayout(roomLengthFt, roomWidthFt, numFixtu
   if (!isFinite(roomWidthFt) || roomWidthFt <= 0) throw new Error('Room width must be > 0');
   if (!isFinite(numFixtures) || numFixtures < 1) throw new Error('Number of fixtures must be >= 1');
 
-  const count = Math.floor(numFixtures);
+  const count = Math.min(MAX_LIGHTING_FIXTURE_LAYOUT_COUNT, Math.floor(numFixtures));
   let best = { rows: 1, cols: count, score: Infinity };
 
   for (let rows = 1; rows <= count; rows++) {

--- a/lighting.js
+++ b/lighting.js
@@ -2,6 +2,7 @@ import {
   runLightingStudy,
   parseIES,
   generateDefaultFixtureLayout,
+  MAX_LIGHTING_FIXTURE_LAYOUT_COUNT,
 } from './analysis/lighting.mjs';
 import { getStudies, setStudies } from './dataStore.mjs';
 import { initStudyApprovalPanel } from './src/components/studyApproval.js';
@@ -238,11 +239,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const ceilingHeightFt = positiveNumber(inputs.ceilingHeightFt, Math.max(9, positiveNumber(inputs.mountingHeightFt, 9)));
     const mountingHeightFt = positiveNumber(inputs.mountingHeightFt, ceilingHeightFt);
     const workplaneHeightFt = nonNegativeNumber(inputs.workplaneHeightFt, 0);
-    const fixtureCount = Math.max(1, Math.floor(positiveNumber(inputs.numFixtures, 1)));
+    const fixtureCount = Math.min(
+      MAX_LIGHTING_FIXTURE_LAYOUT_COUNT,
+      Math.max(1, Math.floor(positiveNumber(inputs.numFixtures, 1)))
+    );
     const lumens = positiveNumber(inputs.lumensPerFixture, 0);
     const area = lengthFt * widthFt;
     const enteredPositions = Array.isArray(inputs.fixturePositions)
-      ? inputs.fixturePositions.filter(pos => isFinite(pos.x) && isFinite(pos.y))
+      ? inputs.fixturePositions
+        .slice(0, MAX_LIGHTING_FIXTURE_LAYOUT_COUNT)
+        .filter(pos => isFinite(pos.x) && isFinite(pos.y))
       : [];
 
     let layoutSource = 'Auto-spaced preview';

--- a/tests/hazAreaClassification.test.mjs
+++ b/tests/hazAreaClassification.test.mjs
@@ -19,6 +19,10 @@ import {
   T_RATINGS,
   NEC_DIV_TO_IEC_ZONE,
   DEFAULT_HAZAREA_LAYOUT,
+  MAX_HAZAREA_LAYOUT_WIDTH_FT,
+  MAX_HAZAREA_LAYOUT_HEIGHT_FT,
+  MAX_HAZAREA_LAYOUT_ELEVATION_FT,
+  MAX_HAZAREA_GRID_LINES_PER_AXIS,
   classifyArea,
   checkEquipmentCompatibility,
   checkAllEquipment,
@@ -128,6 +132,19 @@ describe('Hazardous area visual map model', () => {
     assert.strictEqual(layout.widthFt, 30);
     assert.strictEqual(layout.heightFt, 20);
     assert.strictEqual(layout.gridFt, 20);
+  });
+
+  it('caps layout dimensions and enforces minimum grid spacing density', () => {
+    const layout = normalizeHazAreaLayout({
+      widthFt: Number.MAX_SAFE_INTEGER,
+      heightFt: Number.MAX_SAFE_INTEGER,
+      elevationFt: Number.MAX_SAFE_INTEGER,
+      gridFt: 0.01
+    });
+    assert.strictEqual(layout.widthFt, MAX_HAZAREA_LAYOUT_WIDTH_FT);
+    assert.strictEqual(layout.heightFt, MAX_HAZAREA_LAYOUT_HEIGHT_FT);
+    assert.strictEqual(layout.elevationFt, MAX_HAZAREA_LAYOUT_ELEVATION_FT);
+    assert.strictEqual(layout.gridFt, MAX_HAZAREA_LAYOUT_WIDTH_FT / MAX_HAZAREA_GRID_LINES_PER_AXIS);
   });
 
   it('generates default area geometry for sparse legacy studies', () => {

--- a/tests/lighting.test.mjs
+++ b/tests/lighting.test.mjs
@@ -16,6 +16,7 @@ import {
   coefficientOfUtilization,
   averageIlluminance,
   generateDefaultFixtureLayout,
+  MAX_LIGHTING_FIXTURE_LAYOUT_COUNT,
   interpolateCandela,
   pointIlluminanceGrid,
   egressComplianceCheck,
@@ -225,6 +226,10 @@ describe('generateDefaultFixtureLayout', () => {
     assert.throws(() => generateDefaultFixtureLayout(0, 10, 2), /length/i);
     assert.throws(() => generateDefaultFixtureLayout(10, 0, 2), /width/i);
     assert.throws(() => generateDefaultFixtureLayout(10, 10, 0), /fixtures/i);
+  });
+  it('caps fixture count to prevent unbounded preview generation', () => {
+    const layout = generateDefaultFixtureLayout(60, 10, MAX_LIGHTING_FIXTURE_LAYOUT_COUNT * 10);
+    assert.strictEqual(layout.positions.length, MAX_LIGHTING_FIXTURE_LAYOUT_COUNT);
   });
 });
 


### PR DESCRIPTION
### Motivation

- Prevent client-side DoS from malicious persisted study inputs that could force unbounded SVG/grid generation in the hazardous-area map and unbounded fixture allocations in lighting previews. 

### Description

- Add hard limits and density constraints to hazardous-area layout normalization in `analysis/hazAreaClassification.mjs` by introducing `MAX_HAZAREA_LAYOUT_*` constants and clamping `widthFt`, `heightFt`, `elevationFt` and `gridFt` to safe ranges. 
- Add `MAX_LIGHTING_FIXTURE_LAYOUT_COUNT` to `analysis/lighting.mjs` and cap `generateDefaultFixtureLayout` to avoid creating more than the configured maximum positions. 
- Enforce the same fixture cap in the UI preview code `lighting.js` by clamping the auto-generated fixture count and truncating restored/entered fixture position arrays before rendering. 
- Add regression tests: `tests/hazAreaClassification.test.mjs` checks layout clamping and minimum grid spacing, and `tests/lighting.test.mjs` verifies fixture-count capping. 

### Testing

- Ran the full test suite with `npm test` and all automated tests completed successfully. 
- Built distribution with `npm run build` and the build finished without errors. 
- Attempted a Playwright screenshot with `npx playwright screenshot` to capture an in-browser preview, but browser installation failed (`npx playwright install chromium` returned a download 403), so an automated visual snapshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f68aaf7c8324825f9c6afa767ba2)