### PR TITLE
Fix long-time dial key handling in TCC auto-coordination

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -7758,7 +7758,11 @@ function autoCoordinate() {
       if (i === 0) return;
       const entry = phaseOrderedEntries[i];
       if (!entry || !r.found) return;
-      entry.overrides = { ...entry.overrides, time: r.timeDial };
+      const baseSettings = entry.selection?.baseDevice?.settings || {};
+      const phaseDialKey = (baseSettings.longTimePickup !== undefined || baseSettings.longTimeDelay !== undefined)
+        ? 'longTimeDelay'
+        : 'time';
+      entry.overrides = { ...entry.overrides, [phaseDialKey]: r.timeDial };
       if (typeof updateDeviceInputs === 'function') updateDeviceInputs(entry);
     });
   } else if (phaseDeviceEntries.length === 1) {

--- a/analysis/tccAutoCoord.mjs
+++ b/analysis/tccAutoCoord.mjs
@@ -23,13 +23,18 @@ const DEFAULT_MARGIN = 0.3;
 
 /**
  * Return the override key used to vary the time dial for a device.
- * IEC 60255-151 formula-based relays use 'tms'; all others use 'time'.
+ * IEC 60255-151 formula-based relays use 'tms'.
+ * Long-time electronic trip models use 'longTimeDelay'.
+ * Other devices use the legacy 'time' alias.
  *
  * @param {object} device - Raw device object from protectiveDevices.json
- * @returns {string} 'tms' | 'time'
+ * @returns {string} 'tms' | 'longTimeDelay' | 'time'
  */
 function dialOverrideKey(device) {
-  return device?.iec60255 === true ? 'tms' : 'time';
+  if (device?.iec60255 === true) return 'tms';
+  const base = device?.settings ?? {};
+  if (base.longTimePickup !== undefined || base.longTimeDelay !== undefined) return 'longTimeDelay';
+  return 'time';
 }
 
 /**

--- a/tests/tcc/tccAutoCoord.test.mjs
+++ b/tests/tcc/tccAutoCoord.test.mjs
@@ -201,6 +201,20 @@ describe('findCoordinatingTimeDial', () => {
     assert.strictEqual(reCheck.coordinated, true, 'Re-check must confirm coordination');
   });
 
+  it('uses longTimeDelay dial key for long-time devices when override already exists', () => {
+    const longTimeDownstream = scaleCurve(ge, { pickup: 1.5, longTimeDelay: 0.2, instantaneous: 0, shortTimePickup: 0 });
+    const longTimeFaultCurrents = generateFaultCurrents(100, 700, 50);
+    const r = findCoordinatingTimeDial(
+      ge,
+      { pickup: 1.5, longTimeDelay: 0.15, instantaneous: 0, shortTimePickup: 0 },
+      longTimeDownstream,
+      longTimeFaultCurrents,
+      0.3
+    );
+    assert.strictEqual(r.found, true, 'Should find a coordinating dial for long-time relay');
+    assert(Math.abs((r.scaledResult.settings?.longTimeDelay ?? 0) - r.timeDial) < 1e-6);
+  });
+
   it('scaledResult has settings.time equal to timeDial', () => {
     const r = findCoordinatingTimeDial(abb, { pickup: 160 }, downstream, faultCurrents, 0.3);
     assert(r.scaledResult, 'scaledResult must be set');


### PR DESCRIPTION
### Motivation
- Auto-coordination varied and applied the legacy `time` alias for non-IEC devices while `scaleCurve` gives precedence to `longTimeDelay` for long-time trip models, which could cause generated dials to be ignored and produce incorrect coordination guidance.

### Description
- Updated `dialOverrideKey` in `analysis/tccAutoCoord.mjs` to return `'longTimeDelay'` for devices whose base settings include `longTimePickup` or `longTimeDelay`, retain `'tms'` for IEC devices, and use `'time'` otherwise.
- Changed the phase-device apply path in `analysis/tcc.js` to write the suggested dial using the detected key (`longTimeDelay` or `time`) instead of always writing `time`.
- Added a regression test in `tests/tcc/tccAutoCoord.test.mjs` that exercises a long-time device scenario and asserts the computed dial appears in `scaledResult.settings.longTimeDelay`.

### Testing
- Ran `npm test` and the full test suite succeeded, including the updated `tests/tcc/tccAutoCoord.test.mjs`.
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a Playwright screenshot for a preview but browser installation failed in the environment, so no preview image could be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f8dc9a988324be85b79061a6b85e)