### PR TITLE
Fix dwelling profile to preserve NEC largest-motor demand adder

### DIFF
--- a/analysis/demandSchedule.mjs
+++ b/analysis/demandSchedule.mjs
@@ -64,7 +64,7 @@ export const DEMAND_PROFILES = {
     label: 'Dwelling Unit',
     standard: 'NEC Article 220 dwelling unit calculations',
     description: 'Dwelling unit calculations require a dedicated standard/optional dwelling method; this profile keeps load rows at 100% and flags review.',
-    conservativeCategories: ['lighting', 'receptacle', 'motor', 'kitchen', 'hvac', 'ev', 'appliance', 'critical', 'general'],
+    conservativeCategories: ['lighting', 'receptacle', 'kitchen', 'hvac', 'ev', 'appliance', 'critical', 'general'],
   },
   healthcare: {
     label: 'Health Care Facility',

--- a/tests/demandSchedule.test.mjs
+++ b/tests/demandSchedule.test.mjs
@@ -235,6 +235,13 @@ describe('buildDemandSchedule() — NEC 430.24 motor demand', () => {
     assert.strictEqual(result.rows[0].demandFactor, 1.25);
     assert.strictEqual(result.summary.totalDemandKw, 12.5);
   });
+
+  it('keeps the 125% largest-motor adder in dwelling profile', () => {
+    const loads = [{ tag: 'M1', kw: '10', quantity: '1', loadType: 'motor', powerFactor: '1' }];
+    const result = buildDemandSchedule(loads, { mode: 'nec', profile: 'dwelling' });
+    assert.strictEqual(result.rows[0].demandFactor, 1.25);
+    assert.strictEqual(result.summary.totalDemandKw, 12.5);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- The dwelling demand-profile incorrectly classified `motor` as a conservative category, which forced a 100% demand factor and bypassed the NEC 430.24 largest-motor +25% adder, risking understated motor demand for dwelling projects.

### Description
- Removed `motor` from `DEMAND_PROFILES.dwelling.conservativeCategories` in `analysis/demandSchedule.mjs` so motor loads are processed by the existing motor branch and receive the NEC 430.24 treatment when applicable.
- Added a regression test in `tests/demandSchedule.test.mjs` that verifies a single/largest motor still receives a `1.25` demand factor when running `buildDemandSchedule` with the `dwelling` profile.

### Testing
- Ran `npm test` and the full test suite completed successfully, including the new regression test that asserts a single motor totals `12.5` kW demand under NEC mode.
- Ran `npm run build` and the project build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fb7a2b448324ba84174541654f8f)