### PR TITLE
Guard reliability validation against malformed persisted arrays

### DIFF
--- a/validation/rules.js
+++ b/validation/rules.js
@@ -614,10 +614,14 @@ export function runValidation(components = [], studies = {}) {
     msgs.forEach(msg => issues.push({ component: id, message: msg }));
   });
 
-  const reliabilityFailures = studies?.reliability?.n1Failures || [];
+  const reliabilityFailures = Array.isArray(studies?.reliability?.n1Failures)
+    ? studies.reliability.n1Failures
+    : [];
   const reliabilityDetails = studies?.reliability?.n1FailureDetails || {};
   reliabilityFailures.forEach(id => {
-    const isolatedLoads = reliabilityDetails[id]?.isolatedLoads || [];
+    const isolatedLoads = Array.isArray(reliabilityDetails[id]?.isolatedLoads)
+      ? reliabilityDetails[id].isolatedLoads
+      : [];
     const isolatedMsg = isolatedLoads.length
       ? ` Isolates: ${isolatedLoads.map(loadId => describe(loadId)).join(', ')}.`
       : '';


### PR DESCRIPTION
### Motivation
- Prevent a client-side denial-of-service where malformed persisted/imported study data (non-array `n1Failures` or `isolatedLoads`) causes `runValidation()` to throw a `TypeError` and crash validation/report generation.

### Description
- Add `Array.isArray(...)` guards in `validation/rules.js` so `studies.reliability.n1Failures` and `n1FailureDetails[*].isolatedLoads` are validated before being iterated and fall back to empty arrays when malformed.

### Testing
- Ran `npm test` (full suite) and `npm run build`, both completed successfully; attempted an automated Playwright screenshot to produce a preview but Playwright browser install failed in this environment so no UI screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fe1d6490832485452662c8997f3c)