### PR TITLE
Restore forgot-password token retrieval for administrators

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1191,8 +1191,8 @@ export async function createApp(options = {}) {
         res.json({ message: 'If that account exists, a reset token has been generated.' });
         return;
       }
-      resetTokenStore.create(trimmedUser);
-      console.error(`[password-reset] Reset requested for "${trimmedUser}".`);
+      const resetToken = resetTokenStore.create(trimmedUser);
+      console.error(`[password-reset] Reset requested for "${trimmedUser}". Share token securely with the user: ${resetToken}`);
       res.json({ message: 'If that account exists, a reset token has been generated.' });
     })
   );


### PR DESCRIPTION
### Motivation
- The `/forgot-password` handler generated a bearer reset token via `ResetTokenStore.create()` but discarded the returned value, which made legitimate account recovery impossible because `/reset-password` still requires that token.

### Description
- Capture the token returned by `resetTokenStore.create(trimmedUser)` and assign it to `resetToken` so the generated token is preserved.
- Log the generated token to the server error log with guidance to share it securely with the user while preserving the existing generic API response to avoid user enumeration.

### Testing
- Ran the full unit test suite with `npm test`, which completed successfully.
- Ran the build pipeline with `npm run build`, which completed successfully.
- Attempted to generate a page preview with Playwright (`npx playwright screenshot ...`) but browser installation failed due to network/download restrictions (Chromium download returned HTTP 403), so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ff21e514832487fa80cc01dba5b3)