### PR TITLE
Prevent WebSocket auth credential leakage via query string

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2021,10 +2021,21 @@ When answering queries:
     }
     if (originUrl.host !== host) return false;
 
-    const requestUrl = new URL(request.url || '/ws/collab', `http://${host}`);
-    const token = requestUrl.searchParams.get('token') || '';
-    const csrfHeader = request.headers['x-csrf-token'];
-    const csrfToken = typeof csrfHeader === 'string' ? csrfHeader : (requestUrl.searchParams.get('csrfToken') || '');
+    const protocolHeader = request.headers['sec-websocket-protocol'];
+    if (typeof protocolHeader !== 'string') return false;
+
+    const protocols = protocolHeader.split(',').map((value) => value.trim()).filter(Boolean);
+    const authProtocol = protocols.find((value) => value.startsWith('auth.')) || '';
+    const csrfProtocol = protocols.find((value) => value.startsWith('csrf.')) || '';
+    if (!authProtocol || !csrfProtocol) return false;
+
+    let token = '';
+    try {
+      token = Buffer.from(authProtocol.slice(5).replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+    } catch {
+      return false;
+    }
+    const csrfToken = csrfProtocol.slice(5);
     if (!token || !csrfToken || !/^[0-9a-fA-F]+$/.test(csrfToken)) return false;
 
     const session = await sessionStore.get(token);

--- a/src/collaboration.js
+++ b/src/collaboration.js
@@ -20,14 +20,25 @@
 const WS_URL = (() => {
   if (typeof window === 'undefined') return null;
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const authToken = typeof localStorage !== 'undefined' ? (localStorage.getItem('authToken') || '') : '';
-  const csrfToken = typeof localStorage !== 'undefined' ? (localStorage.getItem('authCsrfToken') || '') : '';
-  const params = new URLSearchParams();
-  if (authToken) params.set('token', authToken);
-  if (csrfToken) params.set('csrfToken', csrfToken);
-  const query = params.toString();
-  return `${proto}//${location.host}/ws/collab${query ? `?${query}` : ''}`;
+  return `${proto}//${location.host}/ws/collab`;
 })();
+
+function buildWsProtocols() {
+  if (typeof localStorage === 'undefined' || typeof TextEncoder === 'undefined') return ['ctr-collab'];
+  const authToken = localStorage.getItem('authToken') || '';
+  const csrfToken = localStorage.getItem('authCsrfToken') || '';
+  const protocols = ['ctr-collab'];
+
+  if (authToken) {
+    const encoded = btoa(String.fromCharCode(...new TextEncoder().encode(authToken)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
+    protocols.push(`auth.${encoded}`);
+  }
+  if (csrfToken) protocols.push(`csrf.${csrfToken}`);
+  return protocols;
+}
 
 const RECONNECT_DELAYS_MS = [1000, 2000, 5000, 10000, 30000];
 const PING_INTERVAL_MS = 25000;
@@ -60,7 +71,7 @@ export class CollabClient extends EventTarget {
 
     this.#intentionalClose = false;
     this.#lastSeq = 0;
-    this.#ws = new WebSocket(WS_URL);
+    this.#ws = new WebSocket(WS_URL, buildWsProtocols());
 
     this.#ws.addEventListener('open', () => {
       this.#reconnectAttempt = 0;


### PR DESCRIPTION
### Motivation
- The collaboration client previously embedded long-lived bearer and CSRF secrets in the WebSocket URL query string, which can leak via reverse-proxy/CDN/load-balancer access logs and enable session compromise. 
- The change moves transport of auth material off the request URI to avoid accidental exposure while preserving secure session validation on the server.

### Description
- Updated the browser client (`src/collaboration.js`) to stop appending `?token=...&csrfToken=...` to `/ws/collab` and instead send credentials in WebSocket subprotocols via a new `buildWsProtocols()` helper. 
- The client encodes the bearer token using base64url and advertises `auth.<base64url(token)>` and `csrf.<hex>` alongside the existing `ctr-collab` protocol when present, and calls `new WebSocket(WS_URL, buildWsProtocols())`.
- Updated the server upgrade validator (`server.mjs`) to parse `Sec-WebSocket-Protocol` values, extract and decode the `auth.` and `csrf.` entries, look up the session via `sessionStore.get(token)`, and retain the timing-safe CSRF comparison logic instead of accepting credentials from the request URL.
- The change preserves the `/ws/collab` endpoint and existing session-store / timing-safe validation semantics while removing URL-based credential acceptance.

### Testing
- Ran the full test suite with `npm test` and all automated tests completed successfully. 
- Built the frontend with `npm run build` and the build completed successfully. 
- Attempted to capture a UI preview via Playwright, but browser binaries could not be downloaded in this environment (Playwright install failed with HTTP 403), so a screenshot preview could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ff218fe083249b51727669673ee9)