### PR TITLE
Fix unsafe motor terminal temperature inference default

### DIFF
--- a/analysis/autoSize.mjs
+++ b/analysis/autoSize.mjs
@@ -299,8 +299,9 @@ export function tableAmpacity(size, material = 'copper', tempRating = 75) {
 }
 
 export function inferTerminalTempRating({ requiredOcpd = null, equipmentRatedAmps = null } = {}) {
-  const rating = Number.parseFloat(equipmentRatedAmps ?? requiredOcpd);
-  if (Number.isFinite(rating) && rating > 0 && rating <= 100) return 60;
+  const equipmentRating = Number.parseFloat(equipmentRatedAmps);
+  if (!Number.isFinite(equipmentRating) || equipmentRating <= 0) return 60;
+  if (equipmentRating <= 100) return 60;
   return 75;
 }
 

--- a/autosize.html
+++ b/autosize.html
@@ -309,7 +309,7 @@
             <div class="field-row">
               <label for="motor-terminal-temp">Equipment terminal temperature rating</label>
               <select id="motor-terminal-temp">
-                <option value="">Infer from OCPD rating</option>
+                <option value="">Infer from equipment rating (defaults to 60 C)</option>
                 <option value="60">60 C</option>
                 <option value="75">75 C</option>
                 <option value="90">90 C</option>

--- a/tests/autoSize.test.mjs
+++ b/tests/autoSize.test.mjs
@@ -159,9 +159,10 @@ describe('selectConductorSize — NEC Table 310.16 baseline', () => {
     assert.strictEqual(tableAmpacity('#10 AWG', 'aluminum', 60), 25);
   });
 
-  it('infers 60C terminals through 100A and 75C above 100A', () => {
-    assert.strictEqual(inferTerminalTempRating({ requiredOcpd: 100 }), 60);
-    assert.strictEqual(inferTerminalTempRating({ requiredOcpd: 125 }), 75);
+  it('defaults to 60C without equipment rating and uses equipment rating threshold when provided', () => {
+    assert.strictEqual(inferTerminalTempRating({ requiredOcpd: 125 }), 60);
+    assert.strictEqual(inferTerminalTempRating({ equipmentRatedAmps: 90 }), 60);
+    assert.strictEqual(inferTerminalTempRating({ equipmentRatedAmps: 125 }), 75);
   });
 
   it('applies NEC 110.14(C) terminal caps separately from insulation ampacity', () => {
@@ -294,7 +295,7 @@ describe('sizeMotorBranch — NEC 430', () => {
     // OCPD: 250% × 65 = 162.5A → 175A standard
     const r = sizeMotorBranch({ hp: 50, voltage: 460, phase: '3ph' });
     assert.strictEqual(r.flc, 65);
-    assert.strictEqual(r.conductorSize, '#4 AWG');
+    assert.strictEqual(r.conductorSize, '#3 AWG');
     assert.strictEqual(r.ocpdRating, 175);
   });
 
@@ -319,6 +320,14 @@ describe('sizeMotorBranch — NEC 430', () => {
   it('includes NEC references', () => {
     const r = sizeMotorBranch({ hp: 25, voltage: 460 });
     assert.ok(r.nec && r.nec.conductorRule && r.nec.ocpdRule);
+  });
+
+  it('does not infer 75C terminals from oversized motor OCPD when equipment rating is omitted', () => {
+    const r = sizeMotorBranch({ hp: 40, voltage: 460, phase: '3ph', material: 'copper' });
+    assert.strictEqual(r.flc, 52);
+    assert.strictEqual(r.ocpdRating, 150);
+    assert.strictEqual(r.terminalTempRating, 60);
+    assert.strictEqual(r.conductorSize, '#4 AWG');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent unsafe conductor sizing by avoiding inference of equipment terminal temperature from the oversized motor branch OCPD, which could understate required conductor size. 
- Ensure blank/omitted terminal temperature defaults to a conservative basis consistent with NEC 110.14(C) unless a valid equipment rating is supplied.

### Description
- Change `inferTerminalTempRating` in `analysis/autoSize.mjs` to base inference only on `equipmentRatedAmps` and to return `60`°C when the equipment rating is absent/invalid, instead of using `requiredOcpd`. 
- Update the motor UI text in `autosize.html` to read "Infer from equipment rating (defaults to 60 C)" so the behavior is clear to users. 
- Update `tests/autoSize.test.mjs` to cover the new inference policy and add a regression that verifies a 40 HP/460 V motor no longer infers 75°C from an oversized OCPD; adjust one motor-sizing expectation that changed due to the safer default. 
- Commit includes the small code change, UI wording change, and test updates only.

### Testing
- Ran the full test suite with `npm test`, and the updated `tests/autoSize.test.mjs` passed as part of the suite (final run succeeded). 
- Built the distribution with `npm run build` and the build completed successfully. 
- Attempted a Playwright screenshot for a visual preview, but browser installation failed due to an external download 403 error in the environment so no automated screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09044166208324af911419a4379c4f)