### PR TITLE
Fix stale MCC lineup leakage when applying remote snapshots

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -802,7 +802,7 @@ export function applyRemoteSnapshot(snapshot, projectId) {
     if (Array.isArray(cableTemplates)) setCableTemplates(cableTemplates);
     if (cableTagSettings && typeof cableTagSettings === 'object' && !Array.isArray(cableTagSettings)) setCableTagSettings(cableTagSettings);
     if (Array.isArray(cableChangeLog)) setCableChangeLog(cableChangeLog);
-    if (Array.isArray(mccLineups)) setMccLineups(mccLineups);
+    if (Array.isArray(mccLineups)) setMccLineups(mccLineups); else setMccLineups([]);
     setTrays(Array.isArray(raceways.trays) ? raceways.trays : []);
     setConduits(Array.isArray(raceways.conduits) ? raceways.conduits : []);
     setDuctbanks(Array.isArray(raceways.ductbanks) ? raceways.ductbanks : []);


### PR DESCRIPTION
### Motivation
- Remote `applyRemoteSnapshot()` did not clear persisted `mccLineups` when the incoming snapshot omitted the field, which could leave stale MCC lineup data from another project in storage and cause cross-project leakage.

### Description
- Ensure `applyRemoteSnapshot()` resets MCC lineups by calling `setMccLineups([])` when `mccLineups` is not an array, aligning its behavior with `loadProject()` semantics (`dataStore.mjs` change: `if (Array.isArray(mccLineups)) setMccLineups(mccLineups); else setMccLineups([]);`).

### Testing
- Ran the full test suite with `npm test` which completed successfully.  
- Built the distribution with `npm run build` which completed successfully.  
- Attempted to capture a browser preview via Playwright, but `npx playwright install chromium` failed with a remote download `403` so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090683b1c883249d85a5df10201e62)