### PR TITLE
Fix egress doorway access checks skipping nearby blocker violations

### DIFF
--- a/equipmentarrangements.js
+++ b/equipmentarrangements.js
@@ -351,13 +351,11 @@ function accessViolation(eq, workspace) {
         return false;
     }
   });
-  if (doorwayAccess) return false;
-
   const left = workspace.x;
   const right = state.room.width - (workspace.x + workspace.w);
   const top = workspace.y;
   const bottom = state.room.depth - (workspace.y + workspace.h);
-  const perimeterAccess = left >= 3 || right >= 3 || top >= 3 || bottom >= 3;
+  const perimeterAccess = doorwayAccess || left >= 3 || right >= 3 || top >= 3 || bottom >= 3;
   if (!perimeterAccess) return true;
 
   const hasNearbyBlocker = state.equipment.some(other => {


### PR DESCRIPTION
### Motivation
- Prevent egress-doorway logic from short-circuiting access validation so nearby equipment that obstructs access is still detected and NEC-compliance results remain accurate.

### Description
- Remove the early `if (doorwayAccess) return false;` and fold `doorwayAccess` into the `perimeterAccess` expression so egress doorways satisfy perimeter access without bypassing the existing nearby-blocker (`hasNearbyBlocker`) checks in `equipmentarrangements.js`.

### Testing
- Ran `npm test`, which completed successfully.
- Ran `npm run build`, which completed successfully.
- Attempted an automated page preview via Playwright (install + headless screenshot), but the Playwright browser download failed with a 403 so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09092c2a5083248cc46951e6e6a656)