### PR TITLE
Bind OIDC state to initiating browser via HttpOnly cookie

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1828,6 +1828,29 @@ When answering queries:
   function base64urlEncode(buf) {
     return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
   }
+  function serializeCookie(name, value, attrs = {}) {
+    const parts = [`${name}=${encodeURIComponent(value)}`];
+    if (attrs.maxAge !== undefined) parts.push(`Max-Age=${Math.floor(Number(attrs.maxAge))}`);
+    if (attrs.path) parts.push(`Path=${attrs.path}`);
+    if (attrs.httpOnly) parts.push('HttpOnly');
+    if (attrs.secure) parts.push('Secure');
+    if (attrs.sameSite) parts.push(`SameSite=${attrs.sameSite}`);
+    return parts.join('; ');
+  }
+  function getCookieValue(req, cookieName) {
+    const header = req.headers.cookie;
+    if (!header || typeof header !== 'string') return null;
+    for (const entry of header.split(';')) {
+      const [rawName, ...rest] = entry.trim().split('=');
+      if (rawName !== cookieName) continue;
+      try {
+        return decodeURIComponent(rest.join('='));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
 
   async function getOidcDiscovery(issuer) {
     if (oidcDiscoveryCache) return oidcDiscoveryCache;
@@ -1860,7 +1883,15 @@ When answering queries:
       for (const [k, v] of oidcStateStore) {
         if (Date.now() - v.createdAt > OIDC_STATE_TTL_MS) oidcStateStore.delete(k);
       }
-      oidcStateStore.set(state, { codeVerifier, createdAt: Date.now() });
+      const stateBinding = base64urlEncode(crypto.randomBytes(32));
+      oidcStateStore.set(state, { codeVerifier, stateBinding, createdAt: Date.now() });
+      res.setHeader('Set-Cookie', serializeCookie('oidc_state_binding', stateBinding, {
+        path: '/auth/oidc',
+        maxAge: Math.floor(OIDC_STATE_TTL_MS / 1000),
+        httpOnly: true,
+        sameSite: 'Lax',
+        secure: req.secure || req.headers['x-forwarded-proto'] === 'https',
+      }));
 
       const redirectUri = process.env.OIDC_REDIRECT_URI ||
         `${req.secure || req.headers['x-forwarded-proto'] === 'https' ? 'https' : 'http'}://${req.get('host')}/auth/oidc/callback`;
@@ -1892,7 +1923,34 @@ When answering queries:
         res.redirect('/login.html?error=oidc_state_invalid');
         return;
       }
+      const stateBindingCookie = getCookieValue(req, 'oidc_state_binding');
+      const expectedBinding = Buffer.from(flow.stateBinding || '');
+      const providedBinding = Buffer.from(stateBindingCookie || '');
+      if (
+        !flow.stateBinding ||
+        !stateBindingCookie ||
+        expectedBinding.length !== providedBinding.length ||
+        !crypto.timingSafeEqual(expectedBinding, providedBinding)
+      ) {
+        oidcStateStore.delete(String(state));
+        res.setHeader('Set-Cookie', serializeCookie('oidc_state_binding', '', {
+          path: '/auth/oidc',
+          maxAge: 0,
+          httpOnly: true,
+          sameSite: 'Lax',
+          secure: req.secure || req.headers['x-forwarded-proto'] === 'https',
+        }));
+        res.redirect('/login.html?error=oidc_state_invalid');
+        return;
+      }
       oidcStateStore.delete(String(state));
+      res.setHeader('Set-Cookie', serializeCookie('oidc_state_binding', '', {
+        path: '/auth/oidc',
+        maxAge: 0,
+        httpOnly: true,
+        sameSite: 'Lax',
+        secure: req.secure || req.headers['x-forwarded-proto'] === 'https',
+      }));
 
       const issuer = process.env.OIDC_ISSUER;
       const clientId = process.env.OIDC_CLIENT_ID;

--- a/tests/oidc.test.mjs
+++ b/tests/oidc.test.mjs
@@ -138,6 +138,10 @@ async function check(name, fn) {
 async function fetchNoFollow(url, init = {}) {
   return fetch(url, { ...init, redirect: 'manual' });
 }
+function getCookieHeaderFromSetCookie(setCookieHeader) {
+  if (!setCookieHeader) return '';
+  return setCookieHeader.split(';')[0];
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -182,6 +186,7 @@ process.env.OIDC_REDIRECT_URI = `${appBase}/auth/oidc/callback`;
 
 let relayUrl = null;
 let capturedState = null;
+let oidcCookie = '';
 
 await check('/auth/oidc/login redirects to IdP authorization_endpoint', async () => {
   const r = await fetchNoFollow(`${appBase}/auth/oidc/login`);
@@ -193,12 +198,14 @@ await check('/auth/oidc/login redirects to IdP authorization_endpoint', async ()
   assert.ok(capturedState, 'state parameter present');
   assert.equal(locationUrl.searchParams.get('code_challenge_method'), 'S256', 'PKCE S256 used');
   assert.ok(locationUrl.searchParams.get('code_challenge'), 'code_challenge present');
+  oidcCookie = getCookieHeaderFromSetCookie(r.headers.get('set-cookie'));
+  assert.ok(oidcCookie.startsWith('oidc_state_binding='), 'OIDC binding cookie was set');
 });
 
 // Simulate the IdP callback by calling our callback directly with the state from the login step
 await check('/auth/oidc/callback with valid code provisions user and redirects to relay', async () => {
   const callbackUrl = `${appBase}/auth/oidc/callback?code=stub_auth_code_abc123&state=${capturedState}`;
-  const r = await fetchNoFollow(callbackUrl);
+  const r = await fetchNoFollow(callbackUrl, { headers: { Cookie: oidcCookie } });
   assert.ok([301, 302, 303, 307, 308].includes(r.status), `expected redirect, got ${r.status}`);
   const location = r.headers.get('location');
   assert.ok(location.includes('oidc-relay.html'), `expected relay redirect, got ${location}`);
@@ -228,7 +235,10 @@ await check('second OIDC login for same sub reuses existing account', async () =
   const r2 = await fetchNoFollow(`${appBase}/auth/oidc/login`);
   const location2 = r2.headers.get('location');
   const state2 = new URL(location2).searchParams.get('state');
-  const r3 = await fetchNoFollow(`${appBase}/auth/oidc/callback?code=stub_auth_code_abc123&state=${state2}`);
+  const cookie2 = getCookieHeaderFromSetCookie(r2.headers.get('set-cookie'));
+  const r3 = await fetchNoFollow(`${appBase}/auth/oidc/callback?code=stub_auth_code_abc123&state=${state2}`, {
+    headers: { Cookie: cookie2 },
+  });
   const location3 = r3.headers.get('location');
   const secondUsername = new URL(location3, appBase).searchParams.get('user');
   assert.equal(secondUsername, firstUsername, 'same username on re-login');
@@ -252,7 +262,10 @@ await check('JIT-provisioned user appears in admin users list', async () => {
   // Login as OIDC user via another flow
   const r1 = await fetchNoFollow(`http://127.0.0.1:${p2}/auth/oidc/login`);
   const st = new URL(r1.headers.get('location')).searchParams.get('state');
-  const r2 = await fetchNoFollow(`http://127.0.0.1:${p2}/auth/oidc/callback?code=stub_auth_code_abc123&state=${st}`);
+  const cookie = getCookieHeaderFromSetCookie(r1.headers.get('set-cookie'));
+  const r2 = await fetchNoFollow(`http://127.0.0.1:${p2}/auth/oidc/callback?code=stub_auth_code_abc123&state=${st}`, {
+    headers: { Cookie: cookie },
+  });
   const relayParams = new URL(r2.headers.get('location'), `http://127.0.0.1:${p2}`).searchParams;
   const token = relayParams.get('token');
 
@@ -288,6 +301,14 @@ await check('callback with unknown state redirects to login with error', async (
   const r = await fetchNoFollow(`${errBase}/auth/oidc/callback?code=abc&state=not_a_real_state`);
   assert.ok([301, 302, 303].includes(r.status));
   assert.ok(r.headers.get('location').includes('error='), 'error param in redirect');
+});
+
+await check('callback without OIDC state cookie is rejected', async () => {
+  const login = await fetchNoFollow(`${errBase}/auth/oidc/login`);
+  const state = new URL(login.headers.get('location')).searchParams.get('state');
+  const callback = await fetchNoFollow(`${errBase}/auth/oidc/callback?code=stub_auth_code_abc123&state=${state}`);
+  assert.ok([301, 302, 303].includes(callback.status));
+  assert.ok(callback.headers.get('location').includes('oidc_state_invalid'), 'missing state cookie is rejected');
 });
 
 await check('callback with IdP error param redirects to login with error', async () => {


### PR DESCRIPTION
### Motivation
- The OIDC authorization-code flow stored `state`/PKCE verifier only in a process-global Map and did not bind the flow to the initiating browser, enabling login CSRF / account-swapping attacks.  
- The intent is to prevent a captured callback URL from being replayed in a different browser while preserving the existing PKCE and JIT-provisioning behavior.

### Description
- Added small cookie helpers (`serializeCookie`, `getCookieValue`) and generate a per-flow `stateBinding` value stored alongside `state` in the in-memory `oidcStateStore`.  
- Set an HttpOnly, SameSite=Lax, path-scoped `oidc_state_binding` cookie from `/auth/oidc/login` and clear it on both invalid and successful callbacks.  
- Validate the `oidc_state_binding` cookie on `/auth/oidc/callback` using `crypto.timingSafeEqual` before exchanging the code and creating an application session, rejecting callbacks that lack a valid browser-bound binding.  
- Updated `tests/oidc.test.mjs` to assert cookie issuance, include the cookie during valid callbacks, and verify rejection when the cookie is missing.

### Testing
- Ran the full automated test suite with `npm test`, and the tests completed successfully.  
- Built the frontend with `npm run build`, which completed successfully.  
- Attempted to produce a Playwright screenshot preview, but Playwright browser installation failed in this environment (download 403), so an interactive/visual preview could not be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090a21031c8324aaffc8f321ca9d96)