### PR TITLE
Reject generic Ex d for Zone 0 and add regression test

### DIFF
--- a/analysis/hazAreaClassification.mjs
+++ b/analysis/hazAreaClassification.mjs
@@ -139,7 +139,7 @@ export const T_RATINGS = Object.freeze([
  * Each protection type is permitted in specific zones.
  */
 export const EX_PROTECTION_TYPES = Object.freeze([
-  { value: 'd',   label: 'Ex d — Flameproof enclosure',           zones: ['0','1','2'], dustZones: [] },
+  { value: 'd',   label: 'Ex d — Flameproof enclosure',           zones: ['1','2'],     dustZones: [] },
   { value: 'e',   label: 'Ex e — Increased safety',               zones: ['1','2'],     dustZones: [] },
   { value: 'ia',  label: 'Ex ia — Intrinsic safety (Cat ia)',      zones: ['0','1','2'], dustZones: ['20','21','22'] },
   { value: 'ib',  label: 'Ex ib — Intrinsic safety (Cat ib)',      zones: ['1','2'],     dustZones: ['21','22'] },

--- a/tests/hazAreaClassification.test.mjs
+++ b/tests/hazAreaClassification.test.mjs
@@ -322,6 +322,14 @@ describe('checkEquipmentCompatibility — protection type vs zone', () => {
     assert.ok(pass);
   });
 
+  it('Ex d fails Zone 0 (generic flameproof is not Zone 0 rated)', () => {
+    const { pass, failures } = checkEquipmentCompatibility(
+      { id: 'e1', label: 'Motor', exProtection: 'd' }, zone0
+    );
+    assert.ok(!pass);
+    assert.ok(failures.length > 0);
+  });
+
   it('Ex e fails Zone 0 (not rated for continuous exposure)', () => {
     const { pass, failures } = checkEquipmentCompatibility(
       { id: 'e1', label: 'JB', exProtection: 'e' }, zone0


### PR DESCRIPTION
### Motivation
- Fix an unsafe lookup that marked generic `Ex d` (flameproof enclosure) as permitted in IEC `Zone 0`, which could cause hazardous-area studies to report false PASS results for continuous-exposure areas.

### Description
- Update the `EX_PROTECTION_TYPES` entry for `value: 'd'` so its `zones` are `['1','2']` (removed `'0'`), and add a regression test in `tests/hazAreaClassification.test.mjs` that asserts generic `Ex d` fails compatibility checks in `Zone 0`.

### Testing
- Ran `npm test` (all tests passed) and `npm run build` (build succeeded); an attempt to capture a UI preview with `npx playwright screenshot` failed because the Playwright browser download is blocked in this environment, so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090a221f3c83249ba045f113d7d888)