### PR TITLE
fix: neutralize formulas in quasi-dynamic CSV export

### DIFF
--- a/quasidynamic.js
+++ b/quasidynamic.js
@@ -426,6 +426,12 @@ document.addEventListener('DOMContentLoaded', () => {
   // ---------------------------------------------------------------------------
   // CSV export
   // ---------------------------------------------------------------------------
+  function encodeCsvCell(value) {
+    const raw = value == null ? '' : String(value);
+    const neutralized = /^[=+\-@]/.test(raw) ? `'${raw}` : raw;
+    return `"${neutralized.replaceAll('"', '""')}"`;
+  }
+
   function exportCsv(result) {
     const rows = ['hour,loadScale,genScale,converged,totalLoadKw,totalLossKw'];
     for (const t of result.timeSeries) {
@@ -435,7 +441,7 @@ document.addEventListener('DOMContentLoaded', () => {
     rows.push('Bus voltage envelope:');
     rows.push('busId,busLabel,maxVm_pu,minVm_pu,maxResult,minResult');
     for (const b of result.busEnvelope) {
-      rows.push(`${b.id},${escapeHtml(b.label)},${b.maxVm.toFixed(4)},${b.minVm.toFixed(4)},${b.maxRisk},${b.minRisk}`);
+      rows.push(`${encodeCsvCell(b.id)},${encodeCsvCell(b.label)},${b.maxVm.toFixed(4)},${b.minVm.toFixed(4)},${b.maxRisk},${b.minRisk}`);
     }
     const blob = new Blob([rows.join('\n')], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
### Motivation
- The quasi-dynamic CSV export emitted user-controlled `busId`/`busLabel` values directly into CSV cells, allowing spreadsheet formula injection when opened in Excel/LibreOffice/Google Sheets.
- This change aims to neutralize formula-like prefixes and properly CSV-quote cells to prevent arbitrary formula execution while preserving the existing export layout.

### Description
- Added a CSV cell encoder `encodeCsvCell(value)` in `quasidynamic.js` that coerces values to string, prefixes values starting with `=`, `+`, `-`, or `@` with an apostrophe, and always wraps cells in double-quotes while escaping embedded quotes.
- Updated the quasi-dynamic bus envelope export to use `encodeCsvCell` for `busId` and `busLabel`, keeping numeric fields unchanged so the CSV shape remains identical to callers.
- Change is localized to `quasidynamic.js` and preserves existing behavior for non-formula text while mitigating CSV/formula injection risks.

### Testing
- Ran the full JS test suite with `npm test` which completed successfully including `tests/quasiDynamic.test.mjs` (all assertions passed).
- Built assets with `npm run build` which completed successfully and produced `dist/` without errors.
- Attempted to generate a visual preview via Playwright (`npx playwright screenshot`) but browser binaries could not be downloaded in this environment (Playwright CDN returned HTTP 403), so a page screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090a2146a08324bc7d86019aa3ed80)