### PR TITLE
fix: prevent prototype-key necCategory override crash in demand schedule

### DIFF
--- a/analysis/demandSchedule.mjs
+++ b/analysis/demandSchedule.mjs
@@ -274,7 +274,7 @@ export function buildDemandSchedule(loads, options = {}) {
   // 1. Enrich each load with category and connected kW
   // -------------------------------------------------------------------------
   const enriched = loads.map(load => {
-    const category = (load.necCategory && NEC_CATEGORIES[load.necCategory])
+    const category = (load.necCategory && Object.hasOwn(NEC_CATEGORIES, load.necCategory))
       ? load.necCategory
       : categorise(load.loadType);
     const connKw   = connectedKw(load);

--- a/tests/demandSchedule.test.mjs
+++ b/tests/demandSchedule.test.mjs
@@ -133,6 +133,13 @@ describe('buildDemandSchedule() — empty / edge cases', () => {
     assert.strictEqual(result.summary.totalConnectedKw, 0);
     assert.strictEqual(result.rows.length, 1);
   });
+
+  it('ignores inherited necCategory names and falls back to auto-categorisation', () => {
+    const result = buildDemandSchedule([{ kw: '1', quantity: '1', loadType: 'general', necCategory: 'constructor' }], { mode: 'nec' });
+    assert.strictEqual(result.rows.length, 1);
+    assert.strictEqual(result.rows[0].necCategory, 'general');
+    assert.strictEqual(result.summary.totalDemandKw, 1);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent a client-side availability bug where attacker-controlled `necCategory` values that are inherited prototype keys (e.g. `constructor`, `__proto__`) could be accepted as valid categories and cause `byCategory[...].push` to throw. 
- Harden the demand schedule input handling so persisted/imported load rows cannot crash the NEC demand engine while preserving the existing override capability.

### Description
- Replace the truthy lookup with an own-property check in `buildDemandSchedule()` by using `Object.hasOwn(NEC_CATEGORIES, load.necCategory)` to validate `necCategory` overrides. 
- Add a regression test in `tests/demandSchedule.test.mjs` that supplies `necCategory: 'constructor'` and asserts the engine falls back to auto-categorisation and computes demand correctly. 
- Commit message: `fix: guard demand schedule necCategory override against prototype keys`.

### Testing
- Ran `npm test` which executed the full test suite including the updated `tests/demandSchedule.test.mjs`, and all tests passed. 
- Ran `npm run build` and the build completed successfully. 
- Attempted to produce a page preview via Playwright screenshot, but browser install/download failed (HTTP 403), so a rendered preview image could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090dd90ea083248aa31e4bce8a8e62)