### PR TITLE
fix: neutralize spreadsheet formula injection in equipment CSV export

### DIFF
--- a/analysis/equipmentEvaluation.mjs
+++ b/analysis/equipmentEvaluation.mjs
@@ -379,15 +379,15 @@ export function buildEquipmentReport(evaluations) {
       const rating  = _checkRatingStr(checkName, result);
       const notes   = _checkNotes(checkName, result);
       rows.push([
-        entry.id,
-        entry.label,
-        entry.type,
-        checkName,
-        result.status,
-        rating,
-        result.faultKA  != null ? String(result.faultKA)  : '',
-        result.marginKA != null ? String(result.marginKA) : '',
-        notes,
+        _escapeSpreadsheetCell(entry.id),
+        _escapeSpreadsheetCell(entry.label),
+        _escapeSpreadsheetCell(entry.type),
+        _escapeSpreadsheetCell(checkName),
+        _escapeSpreadsheetCell(result.status),
+        _escapeSpreadsheetCell(rating),
+        _escapeSpreadsheetCell(result.faultKA  != null ? String(result.faultKA)  : ''),
+        _escapeSpreadsheetCell(result.marginKA != null ? String(result.marginKA) : ''),
+        _escapeSpreadsheetCell(notes),
       ]);
     }
   }
@@ -411,6 +411,11 @@ export function summariseEvaluation(evaluations) {
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
+
+function _escapeSpreadsheetCell(value) {
+  const cell = String(value ?? '');
+  return /^[=+\-@]/.test(cell) ? `'${cell}` : cell;
+}
 
 function numOrNull(v) {
   const n = Number(v);

--- a/tests/equipmentEvaluation.test.mjs
+++ b/tests/equipmentEvaluation.test.mjs
@@ -359,6 +359,21 @@ describe('buildEquipmentReport()', () => {
     assert.strictEqual(rows[0].length, REPORT_HEADERS.length);
   });
 
+  it('neutralizes spreadsheet formula prefixes in report cells', () => {
+    const evals = [{
+      id: '=2+3',
+      label: '@cmd',
+      type: 'breaker',
+      status: 'fail',
+      checks: {
+        aic: { status: 'fail', ratingKA: 10, faultKA: 20, marginKA: -10 },
+      },
+    }];
+    const [row] = buildEquipmentReport(evals);
+    assert.strictEqual(row[0], "'=2+3");
+    assert.strictEqual(row[1], "'@cmd");
+  });
+
   it('returns empty array for empty evaluations', () => {
     assert.deepStrictEqual(buildEquipmentReport([]), []);
   });


### PR DESCRIPTION
### Motivation
- The Equipment Evaluation CSV export included project-controlled `id`/`label` values verbatim, which allows spreadsheet formula injection when values begin with `=`, `+`, `-`, or `@`.
- Quoting CSV fields alone does not prevent spreadsheet applications from interpreting quoted fields as formulas, so a minimal neutralization is required before CSV serialization.

### Description
- Added a helper `_escapeSpreadsheetCell(value)` in `analysis/equipmentEvaluation.mjs` that prefixes an apostrophe to any cell beginning with `=`, `+`, `-`, or `@` to force text semantics in spreadsheets.
- Updated `buildEquipmentReport()` to call `_escapeSpreadsheetCell()` for all report cells so exported CSV rows are safe from formula evaluation while preserving existing CSV shape.
- Added a focused unit test in `tests/equipmentEvaluation.test.mjs` that validates `id` and `label` values starting with formula characters are neutralized in the report rows.

### Testing
- Ran the full test suite with `npm test` and the tests passed, including the new regression test for `buildEquipmentReport()`.
- Ran `npm run build` to ensure bundling succeeds and the project builds successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090f6e45c08324bbe722f1530c1404)