### PR TITLE
fix: use live DRC findings in report package generation

### DIFF
--- a/src/projectreport.js
+++ b/src/projectreport.js
@@ -13,12 +13,12 @@ import {
   getCables, getTrays, getConduits, getDuctbanks,
   getStudies, getStudyApprovals,
   getReportSnapshots, setReportSnapshot, deleteReportSnapshot,
-  getDrcAcceptedFindings,
   getLifecyclePackages,
   getItem,
 } from '../dataStore.mjs';
 import { getProjectState } from '../projectStorage.js';
 import { buildDeliverableReadinessDiagnostics } from '../analysis/deliverableWorkflow.mjs';
+import { runDRC } from '../analysis/designRuleChecker.mjs';
 import { generateProjectReport } from '../analysis/projectReport.mjs';
 import {
   renderPackageHTML,
@@ -180,14 +180,24 @@ function escAttr(s) {
 // ---------------------------------------------------------------------------
 
 function loadProjectData() {
+  const cables = getCables();
+  const trays = getTrays();
+  const routeState = getItem('latestRouteResults', {}) || {};
+  const drcRun = runDRC({
+    trays,
+    cables,
+    trayCableMap: routeState.trayCableMap || {},
+    routedCableNames: routeState.routedCableNames,
+  });
+
   return {
-    cables:    getCables(),
-    trays:     getTrays(),
+    cables,
+    trays,
     conduits:  getConduits(),
     ductbanks: getDuctbanks(),
     studies:   getStudies(),
     approvals: getStudyApprovals(),
-    drcResults: getDrcAcceptedFindings ? getDrcAcceptedFindings() : [],
+    drcResults: Array.isArray(drcRun?.findings) ? drcRun.findings : [],
   };
 }
 


### PR DESCRIPTION
### Motivation
- The report package DRC section was sourcing `getDrcAcceptedFindings()` (engineer "accept risk" annotations) instead of running the live DRC engine, which can produce misleading “No DRC errors — all rules passed” output for projects with active findings.

### Description
- Import `runDRC` from `analysis/designRuleChecker.mjs` and remove the page-level dependency on `getDrcAcceptedFindings` in `src/projectreport.js`.
- Update `loadProjectData()` to call `runDRC()` with the current `trays`, `cables`, and routing state from `getItem('latestRouteResults')`, and set `drcResults` to `runDRC(...).findings`.
- Leave `buildDRCSection()` and rendering unchanged so the DRC section behavior remains identical but now reflects live rule evaluation rather than stored accepted-risk annotations.
- Keep the change minimal and scoped to `src/projectreport.js` to preserve existing functionality and accepted-risk persistence.

### Testing
- Ran the test suite with `npm test`, and the full test run completed successfully.
- Built the app with `npm run build`, and the build completed successfully.
- Attempted to capture a page preview with Playwright using `npx playwright screenshot ...` but the environment failed to download Chromium (Playwright browser download returned 403), so no screenshot was produced and no preview artifact was generated (intended path: `artifacts/projectreport-preview.png`).
- The fix was validated by ensuring report generation now sources live DRC findings while leaving accepted-risk storage untouched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090f72bc2c8324aa200da0db557c64)