### PR TITLE
fix: neutralize spreadsheet formulas in heat-trace CSV exports

### DIFF
--- a/heattracesizing.js
+++ b/heattracesizing.js
@@ -2443,12 +2443,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function downloadCsvData(headers, rows, filename) {
+    const sanitizeCsvCell = (value) => {
+      let normalized = String(value ?? '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      if (/^[=+\-@]/.test(normalized)) normalized = `'${normalized}`;
+      return normalized;
+    };
+    const formatCsvCell = (value) => {
+      const sanitized = sanitizeCsvCell(value);
+      return /[",\n]/.test(sanitized) ? `"${sanitized.replace(/"/g, '""')}"` : sanitized;
+    };
     const lines = [headers.join(',')];
     rows.forEach(row => {
-      lines.push(headers.map(h => {
-        const val = String(row[h] ?? '');
-        return val.includes(',') || val.includes('"') ? `"${val.replace(/"/g, '""')}"` : val;
-      }).join(','));
+      lines.push(headers.map(h => formatCsvCell(row[h])).join(','));
     });
     const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
     const a = document.createElement('a');


### PR DESCRIPTION
### Motivation
- Prevent CSV/spreadsheet injection and broken-row issues where user-controlled fields (for example `circuitTag` and `controllerTag`) could be exported as active spreadsheet formulas or include CR/LF sequences. 
- Apply a minimal, centralized fix so all heat-trace CSV exports inherit sanitization without changing export APIs or CSV column layout.

### Description
- Hardened the CSV serializer in `heattracesizing.js` by adding `sanitizeCsvCell` and `formatCsvCell` to normalize CRLF/CR to LF, prefix cells that start with `=`, `+`, `-`, or `@` with an apostrophe to force text, and escape/quote fields containing `"`, `,`, or newline. 
- Replaced the previous partial quoting logic with `formatCsvCell` so `downloadCsvData` now emits safe CSVs for line-list, BOM, and controller-schedule exports. 
- The change is intentionally minimal and localized to the existing `downloadCsvData` helper so calling code (e.g., `exportLineListCsv`, `exportControllerCsv`) remains unchanged.
- Implemented the fix in `heattracesizing.js` and preserved CSV schema and header ordering.

### Testing
- Ran the full test suite with `npm test` and all automated tests completed successfully. 
- Built the distribution with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09114478b883248c397241025c5e8f)