### PR TITLE
DRC: trust explicit latestRouteResults instead of scanning wildcard route-* keys

### DIFF
--- a/designrulechecker.js
+++ b/designrulechecker.js
@@ -5,7 +5,7 @@
  * raceway data and displays findings grouped by severity.
  */
 import { runDRC, formatDrcReport, DRC_SEVERITY } from './analysis/designRuleChecker.mjs';
-import { getTrays, getConduits, getCables, getDrcAcceptedFindings, setDrcAcceptedFindings } from './dataStore.mjs';
+import { getTrays, getConduits, getCables, getItem, getDrcAcceptedFindings, setDrcAcceptedFindings } from './dataStore.mjs';
 import { openModal } from './src/components/modal.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -147,27 +147,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const conduits = getConduits() || [];
     const cables   = getCables()   || [];
 
-    // Route cache is written under a content-addressed key (route-<hash>) by app.mjs via dataStore.
-    // Scan sessionStorage first (in-session results), then localStorage for any matching entry.
+    // Use the route state published by the router instead of scanning arbitrary storage keys.
     let trayCableMap = {};
     let routedCableNames = new Set();
     try {
-      let cachedEntry = null;
-      for (const storage of [sessionStorage, localStorage]) {
-        for (const key of Object.keys(storage)) {
-          if (key.includes('route-')) {
-            try {
-              const parsed = JSON.parse(storage.getItem(key));
-              if (parsed && parsed.trayCableMap) { cachedEntry = parsed; break; }
-            } catch { /* skip malformed entry */ }
+      const latestRouteResults = getItem('latestRouteResults', null);
+      const hasValidMap = latestRouteResults
+        && typeof latestRouteResults === 'object'
+        && latestRouteResults.trayCableMap
+        && typeof latestRouteResults.trayCableMap === 'object'
+        && !Array.isArray(latestRouteResults.trayCableMap);
+      const batchResults = Array.isArray(latestRouteResults?.batchResults)
+        ? latestRouteResults.batchResults
+        : [];
+      if (hasValidMap) {
+        trayCableMap = latestRouteResults.trayCableMap;
+        batchResults.forEach(r => {
+          if (r && typeof r === 'object' && r.cable && typeof r.status === 'string' && r.status.includes('Routed')) {
+            routedCableNames.add(r.cable);
           }
-        }
-        if (cachedEntry) break;
-      }
-      if (cachedEntry) {
-        trayCableMap = cachedEntry.trayCableMap || {};
-        (cachedEntry.batchResults || []).forEach(r => {
-          if (r.cable && r.status && r.status.includes('Routed')) routedCableNames.add(r.cable);
         });
       }
     } catch (e) {


### PR DESCRIPTION
### Motivation
- Prevent the Design Rule Checker (DRC) from trusting arbitrary `route-*` storage entries that can be injected via imported project settings and thereby mask safety-relevant findings.
- Ensure DRC consumes routing state only from the canonical data-store entry that the routing flows publish, and validate the shape before use.

### Description
- Replaced the storage scan that enumerated `sessionStorage`/`localStorage` keys containing `route-` with a single `getItem('latestRouteResults')` lookup in `designrulechecker.js`. 
- Added lightweight shape checks so `trayCableMap` must be an object and `batchResults` must be an array before the DRC uses them to mark routed cables. 
- Updated imports to use `getItem` from the shared `dataStore.mjs` accessor and preserved the original DRC callsites and behavior otherwise. 
- Change is intentionally minimal to remove the wildcard trust path while keeping existing routing UX when legitimate cached results are present.

### Testing
- Ran `npm test` (full suite) and the test run completed successfully. 
- Ran `npm run build` and the project built successfully (Rollup produced expected bundles with existing externalization warnings). 
- Attempted to capture a page preview screenshot with Playwright to produce the requested preview image, but `npx playwright install chromium` failed with a 403 from the Playwright CDN in this environment, so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091146cd388324a39480e65b38b6c4)