### PR TITLE
Fix IBR short-circuit voltage unit normalization

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -236,7 +236,11 @@ function getIBRStudyMetadata(comp) {
     return null;
   };
   const sRated_kVA = read('rated_kva', 'kva', 'kVA', 's_rated_kva') || 0;
-  const vLL_kV = read('voltage', 'volts', 'rated_kv', 'baseKV') || 0;
+  const vLL_kV = (
+    toKV(pickValue(comp, 'voltage')) ??
+    toKV(pickValue(comp, 'volts')) ??
+    read('rated_kv', 'baseKV')
+  ) || 0;
   const limitFactor = read('fault_limit_factor') || IBR_DEFAULTS.faultCurrentLimitFactor;
   const rideThrough = comp.ride_through !== false && comp.rideThrough !== false;
   if (!sRated_kVA || !vLL_kV) return null;

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -204,6 +204,32 @@ global.localStorage = {
       assert(bus.threePhaseKA < 1, 'xdpp should limit source current contribution');
     });
 
+
+    it('normalizes IBR voltage fields expressed in volts before fault contribution math', () => {
+      setOneLine({
+        activeSheet: 0,
+        sheets: [{
+          name: 'IBR volts normalization',
+          components: [
+            {
+              id: 'ibr1',
+              type: 'pv_inverter',
+              rated_kva: 1000,
+              voltage: '480V',
+              connections: [{ target: 'bus1', sourcePort: 0, targetPort: 0 }]
+            },
+            { id: 'bus1', type: 'bus', subtype: 'Bus' }
+          ]
+        }]
+      });
+
+      const res = runShortCircuit();
+      const bus = res.bus1;
+      assert(bus && bus.ibr, 'IBR metadata should be attached');
+      assert(Math.abs(bus.ibr.vLL_kV - 0.48) < 1e-9, 'IBR voltage should be normalized to kV');
+      assert(Math.abs(bus.ibr.Ifault_A - 1323.0943668928928) < 1e-6, 'Fault contribution should match 480 V base');
+    });
+
     it('includes normalized UPS metadata in short-circuit results', () => {
       setOneLine({
         activeSheet: 0,


### PR DESCRIPTION
### Motivation
- `getIBRStudyMetadata()` previously read `voltage`/`volts` as raw numbers and passed them into `ibrFaultContribution()` as `vLL_kV`, which caused 480 (V) inputs to be treated as 480 kV and underreport IBR fault current by ≈1000×.

### Description
- Normalize IBR voltage fields by using the existing `toKV()` helper for `voltage` and `volts` before falling back to `rated_kv`/`baseKV` in `getIBRStudyMetadata()` in `analysis/shortCircuit.mjs`.
- Preserve prior fallback behavior for `rated_kv`/`baseKV` (already expressed in kV) and keep the `ibrFaultContribution()` API unchanged.
- Add a focused regression test in `tests/shortcircuit/shortCircuit.test.cjs` that verifies a `pv_inverter` with `voltage: "480V"` is interpreted as `0.48` kV and produces the expected ~1323 A fault contribution.

### Testing
- Ran the full test suite with `npm test` and all tests passed, including the new short-circuit regression test.
- Built the distribution with `npm run build` and the build succeeded.
- The new test is included in `tests/shortcircuit/shortCircuit.test.cjs` and was exercised as part of the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09114564388324b851bafedcd25405)