### PR TITLE
Fix CP commissioning checklist empty-state compliance bypass

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -2023,6 +2023,9 @@ function getCommissioningChecklist(approval = null) {
 }
 
 function isCommissioningChecklistComplete(approval = null) {
+  if (!COMMISSIONING_CHECKLIST_ITEMS.length) {
+    return false;
+  }
   const checklist = getCommissioningChecklist(approval);
   return COMMISSIONING_CHECKLIST_ITEMS.every((item) => {
     const completion = checklist[item.key];


### PR DESCRIPTION
### Motivation
- A recent change emptied `COMMISSIONING_CHECKLIST_ITEMS` which caused `isCommissioningChecklistComplete()` to evaluate to true via `Array.prototype.every()` (vacuous truth), allowing cathodic protection studies to be marked `compliant` with no commissioning evidence; this fix closes that integrity bypass.

### Description
- Add a defensive guard to `isCommissioningChecklistComplete(approval)` in `cathodicprotection.js` to explicitly return `false` when `COMMISSIONING_CHECKLIST_ITEMS` is empty, preserving the existing per-item completion checks when items are present.

### Testing
- Ran `npm test`, which completed successfully and all relevant CP tests passed.
- Ran `npm run build`, which completed successfully and produced the `dist/` artifacts.
- Attempted to produce a webpage preview with Playwright (`npx playwright install chromium` / screenshot), but the browser download failed with HTTP 403 so a screenshot could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091144dfc88324a98dc9266d5a823b)