### PR TITLE
Fix CP timeline crash when saved compliance failedCheckKeys is malformed

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -593,12 +593,16 @@ function normalizeSavedStudy(saved) {
 
   const recomputed = runCathodicProtectionAnalysis(normalizedInput);
   const compliance = saved.compliance && typeof saved.compliance === 'object'
-    ? saved.compliance
+    ? {
+      ...saved.compliance,
+      failedCheckKeys: Array.isArray(saved.compliance.failedCheckKeys) ? saved.compliance.failedCheckKeys : []
+    }
     : {
       profileId: CP_STANDARDS_PROFILE.profileId,
       requiredChecks: buildInitialComplianceStatus(),
       optionalChecks: {},
-      lastEvaluatedAt: null
+      lastEvaluatedAt: null,
+      failedCheckKeys: []
     };
 
   const existingHistory = Array.isArray(saved.complianceHistory)
@@ -715,7 +719,8 @@ function summarizeTimelineStep(stepKey, result) {
     return `Criteria evaluation is ${criteriaStatus}; ${countCriteriaPasses(result)} criteria currently pass with correction context ${result.measurementContext || 'unknown'}.`;
   }
   const label = result.compliance?.complianceState || 'provisional';
-  return `Compliance gate resolved as ${label}; unresolved checks: ${(result.compliance?.failedCheckKeys || []).join(', ') || 'none'}.`;
+  const failedCheckKeys = Array.isArray(result.compliance?.failedCheckKeys) ? result.compliance.failedCheckKeys : [];
+  return `Compliance gate resolved as ${label}; unresolved checks: ${failedCheckKeys.join(', ') || 'none'}.`;
 }
 
 function resolveTimelineCheckpoints(stepDefinition, result) {


### PR DESCRIPTION
### Motivation
- The cathodic protection timeline rendered saved study summaries immediately and assumed `compliance.failedCheckKeys` was always an array, which allows a crafted saved/imported project to cause a `TypeError` and break CP page initialization. 
- The change eliminates this client-side availability issue by ensuring the nested `failedCheckKeys` field is normalized before use.

### Description
- Normalize the saved-study compliance object in `normalizeSavedStudy` by coercing `failedCheckKeys` to an array and adding a default `failedCheckKeys: []` for the fallback compliance object. 
- Harden `summarizeTimelineStep` so it reads `failedCheckKeys` only after verifying `Array.isArray(...)` and uses an empty array otherwise, avoiding `.join` on non-array values. 
- The fix is localized to `cathodicprotection.js` and preserves existing behavior for valid saved data.

### Testing
- Ran the test suite with `npm test`, and all automated tests completed successfully. 
- Ran `npm run build`, and the project build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0911446fa08324861ed74c2491ec4f)