### PR TITLE
Guard CP verification plan fields against malformed persisted data

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -1373,6 +1373,15 @@ function renderResults(result, root) {
     : (criteriaEvidence.overallStatus === 'fail' ? 'result-badge--fail' : '');
   const reportExport = result.reportExport || buildReportExportData(result, getStudyApprovals().cathodicProtection || null);
   const verificationPlan = reportExport.verificationPlan || {};
+  const verificationRequiredCommissioningTests = Array.isArray(verificationPlan.requiredCommissioningTests)
+    ? verificationPlan.requiredCommissioningTests
+    : [];
+  const verificationMonitoringIntervals = Array.isArray(verificationPlan.monitoringIntervals)
+    ? verificationPlan.monitoringIntervals
+    : [];
+  const verificationCorrectiveActionThresholds = Array.isArray(verificationPlan.correctiveActionThresholds)
+    ? verificationPlan.correctiveActionThresholds
+    : [];
   const complianceState = result.compliance?.complianceState || 'provisional';
   const complianceBadgeClass = complianceState === 'compliant'
     ? 'result-badge--pass'
@@ -1531,9 +1540,9 @@ function renderResults(result, root) {
 
       <div class="result-group" aria-label="Verification and commissioning plan">
         <h3>Verification and Commissioning Plan</h3>
-        <p class="field-hint">Required commissioning tests: ${escapeHtml((verificationPlan.requiredCommissioningTests || []).join(' | ') || 'Not defined')}</p>
-        <p class="field-hint">Monitoring intervals: ${escapeHtml((verificationPlan.monitoringIntervals || []).join(' | ') || 'Not defined')}</p>
-        <p class="field-hint">Trigger thresholds for corrective action: ${escapeHtml((verificationPlan.correctiveActionThresholds || []).join(' | ') || 'Not defined')}</p>
+        <p class="field-hint">Required commissioning tests: ${escapeHtml(verificationRequiredCommissioningTests.join(' | ') || 'Not defined')}</p>
+        <p class="field-hint">Monitoring intervals: ${escapeHtml(verificationMonitoringIntervals.join(' | ') || 'Not defined')}</p>
+        <p class="field-hint">Trigger thresholds for corrective action: ${escapeHtml(verificationCorrectiveActionThresholds.join(' | ') || 'Not defined')}</p>
       </div>
 
       ${sensitivityRows.length ? `


### PR DESCRIPTION
### Motivation
- Persisted `reportExport.verificationPlan` fields were assumed to be arrays and `.join()` was called directly, which can throw `TypeError` when imported or corrupted project data stores non-array values. 

### Description
- Added defensive normalization in `renderResults` in `cathodicprotection.js` to ensure `verificationPlan.requiredCommissioningTests`, `verificationPlan.monitoringIntervals`, and `verificationPlan.correctiveActionThresholds` are arrays before calling `.join()`.
- The change falls back to empty arrays and preserves the existing `'Not defined'` display text so UI behavior is unchanged for valid data.

### Testing
- Ran `npm test` and the test suite completed successfully.
- Ran `npm run build` and the build completed successfully (non-fatal Rollup warnings present but unrelated).
- Attempted to capture a browser preview via Playwright but `npx playwright install chromium` failed due to CDN `403 Forbidden`, so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0913fb73b8832486ef07dc954c00a2)