### PR TITLE
Require positive CP correction evidence for ON/coupon methods

### DIFF
--- a/cathodicprotection.html
+++ b/cathodicprotection.html
@@ -414,11 +414,11 @@ Life_years = (W_installed × Q_anode × U × F_design) / (I_req × 8760)</pre>
           </div>
           <div class="field-row">
             <label for="measured-ir-drop">Measured/estimated IR-drop magnitude (mV)</label>
-            <input type="number" id="measured-ir-drop" min="0" step="1" value="0">
+            <input type="number" id="measured-ir-drop" min="0" step="1" value="" placeholder="Enter >0 for on-potential studies">
           </div>
           <div class="field-row">
             <label for="coupon-depolarization">Coupon depolarization shift (mV)</label>
-            <input type="number" id="coupon-depolarization" min="0" step="1" value="0">
+            <input type="number" id="coupon-depolarization" min="0" step="1" value="" placeholder="Enter >0 for coupon studies">
           </div>
           <div class="field-row">
             <label for="measured-off-potential">Measured structure potential (mV vs CSE)</label>

--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -563,6 +563,14 @@ function validateInputs(input) {
     errors.push('couponDepolarizationMv cannot be negative.');
   }
 
+  if (input.testMethod === 'on-potential' && (!Number.isFinite(input.measuredIrDropMv) || input.measuredIrDropMv <= 0)) {
+    errors.push('on-potential testMethod requires measuredIrDropMv greater than 0 mV.');
+  }
+
+  if (input.testMethod === 'coupon' && (!Number.isFinite(input.couponDepolarizationMv) || input.couponDepolarizationMv <= 0)) {
+    errors.push('coupon testMethod requires couponDepolarizationMv greater than 0 mV.');
+  }
+
   return errors;
 }
 

--- a/docs/cathodic_protection.md
+++ b/docs/cathodic_protection.md
@@ -99,7 +99,7 @@ Acceptance checks now evaluate **corrected** values and retain raw values in out
 - For `coupon` tests with supplied depolarization: `V_corrected = V_raw + |ΔV_coupon|`
 - For coupon workflows with missing explicit polarization shift, the shift defaults to `|ΔV_coupon|`
 
-When required metadata is missing (unknown context/location, no compensation value for ON/coupon methods, or compensation explicitly set to `none`), the study reports validation warnings so acceptance decisions can be reviewed with caution.
+When required metadata is missing (unknown context/location, no compensation value for ON/coupon methods, or compensation explicitly set to `none`), the study reports validation warnings so acceptance decisions can be reviewed with caution. In addition, `on-potential` requires `ΔV_IR > 0` and `coupon` requires `ΔV_coupon > 0` at validation time so default/zero correction values cannot be treated as corrected evidence.
 
 ## Assumptions and Limits
 


### PR DESCRIPTION
### Motivation

- A validation gap allowed default or zero-valued IR-drop/coupon corrections to be treated as supplied evidence, letting `on-potential`/`coupon` workflows appear corrected and pass acceptance checks incorrectly. 
- This is an integrity risk for safety-relevant CP compliance outputs because corrected values (possibly +0 mV) were used directly in pass/fail logic. 
- The intent is to ensure correction-required measurement workflows must supply explicit positive correction magnitudes before being treated as corrected.

### Description

- Add explicit validation in `cathodicprotection.js` so `on-potential` requires `measuredIrDropMv > 0` and `coupon` requires `couponDepolarizationMv > 0`. 
- Remove the `value="0"` defaults for the correction input fields in `cathodicprotection.html` and add placeholders prompting users to enter `>0`, forcing an explicit input. 
- Update `docs/cathodic_protection.md` to document the invariant that `ΔV_IR > 0` for `on-potential` and `ΔV_coupon > 0` for `coupon` at validation time.

### Testing

- Ran the full automated test suite with `npm test`, which completed successfully (including the CP unit and integration tests). 
- Built the application with `npm run build`, which completed successfully and produced the `dist` artifacts. 
- Attempted a Playwright page screenshot via `npx playwright screenshot` but browser binaries could not be downloaded in the environment (`npx playwright install chromium` returned HTTP 403), so an automated visual preview could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0913fc84d08324a8c7ca6db0db528e)