### PR TITLE
Enforce minimum CP mitigations from computed interference risk

### DIFF
--- a/src/studies/cp/interferenceAssessment.js
+++ b/src/studies/cp/interferenceAssessment.js
@@ -37,6 +37,12 @@ const MITIGATION_PROFILES = {
   }
 };
 
+const MINIMUM_PROFILE_BY_RISK_LEVEL = {
+  low: 'baseline',
+  medium: 'enhanced',
+  high: 'critical'
+};
+
 function normalizeToken(value) {
   return String(value || '')
     .trim()
@@ -55,7 +61,7 @@ export function evaluateInterferenceAssessment(input) {
   const dcTractionSystem = input.dcTractionSystem || 'none';
   const knownInterferenceSources = input.knownInterferenceSources || 'none';
   const mitigationProfileId = input.mitigationProfile || 'baseline';
-  const mitigationProfile = MITIGATION_PROFILES[mitigationProfileId] || MITIGATION_PROFILES.baseline;
+  const selectedMitigationProfile = MITIGATION_PROFILES[mitigationProfileId] || MITIGATION_PROFILES.baseline;
   const mitigationActions = Array.isArray(input.mitigationActions)
     ? input.mitigationActions.map((action) => normalizeToken(action)).filter((action) => action.length > 0)
     : [];
@@ -86,15 +92,22 @@ export function evaluateInterferenceAssessment(input) {
 
   const totalScore = riskFactorScores.reduce((sum, factor) => sum + factor.score, 0);
   const riskLevel = totalScore >= 13 ? 'high' : (totalScore >= 6 ? 'medium' : 'low');
-  const requiredMitigations = mitigationProfile.requiredMitigations;
+  const minimumProfileId = MINIMUM_PROFILE_BY_RISK_LEVEL[riskLevel] || 'baseline';
+  const minimumMitigationProfile = MITIGATION_PROFILES[minimumProfileId] || MITIGATION_PROFILES.baseline;
+  const requiredMitigations = minimumMitigationProfile.requiredMitigations;
   const missingMitigations = requiredMitigations.filter((requiredAction) => !mitigationActions.includes(requiredAction));
   const verificationDateValid = /^\d{4}-\d{2}-\d{2}$/.test(verificationTestDate);
   const unresolvedHighRisk = riskLevel === 'high' && (missingMitigations.length > 0 || !verificationDateValid);
+  const profileBelowRiskMinimum = selectedMitigationProfile.id !== minimumMitigationProfile.id;
 
   return {
     profile: {
-      id: mitigationProfile.id,
-      label: mitigationProfile.label
+      id: selectedMitigationProfile.id,
+      label: selectedMitigationProfile.label
+    },
+    minimumProfile: {
+      id: minimumMitigationProfile.id,
+      label: minimumMitigationProfile.label
     },
     score: totalScore,
     riskLevel,
@@ -104,6 +117,7 @@ export function evaluateInterferenceAssessment(input) {
     missingMitigations,
     verificationTestDate: verificationTestDate || null,
     verificationDateValid,
-    unresolvedHighRisk
+    unresolvedHighRisk,
+    profileBelowRiskMinimum
   };
 }


### PR DESCRIPTION
### Motivation
- Close a compliance bypass where computed high interference risk could be marked compliant if the user-selected mitigation profile was weaker than required. 
- Ensure required mitigations are enforced according to the computed `riskLevel` rather than relying solely on a user-selected profile.

### Description
- Added a `MINIMUM_PROFILE_BY_RISK_LEVEL` mapping (`low -> baseline`, `medium -> enhanced`, `high -> critical`) and derive `requiredMitigations` from that minimum profile. 
- Keep the user-selected profile in the returned `profile` object and add `minimumProfile` and `profileBelowRiskMinimum` metadata for UI/reporting and transparency. 
- Updated `evaluateInterferenceAssessment()` in `src/studies/cp/interferenceAssessment.js` to compute `minimumMitigationProfile` from `riskLevel` and to compute `missingMitigations` against that minimum set.

### Testing
- Ran the full test suite with `npm test` and all tests completed successfully. 
- Built the frontend with `npm run build` and the build completed without errors. 
- Executed the focused unit test `node tests/cp/interferenceAssessment.test.mjs` which passed. 
- Attempted to produce a webpage preview screenshot but the environment could not download Playwright browsers (HTTP 403) and no system Chromium is available, so no screenshot could be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0913fc77f88324a3be0852d5836d4a)