### PR TITLE
Harden CP compliance status rendering against malformed saved data

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -595,6 +595,9 @@ function normalizeSavedStudy(saved) {
   const compliance = saved.compliance && typeof saved.compliance === 'object'
     ? {
       ...saved.compliance,
+      requiredChecks: saved.compliance.requiredChecks && typeof saved.compliance.requiredChecks === 'object'
+        ? saved.compliance.requiredChecks
+        : buildInitialComplianceStatus(),
       failedCheckKeys: Array.isArray(saved.compliance.failedCheckKeys) ? saved.compliance.failedCheckKeys : []
     }
     : {
@@ -1961,10 +1964,11 @@ function renderCalculationBasis(root, basis) {
 
 function renderComplianceStatusPanel(root, requiredChecks = {}, lastEvaluatedAt = null, compliance = {}) {
   if (!root) return;
+  const normalizedRequiredChecks = requiredChecks && typeof requiredChecks === 'object' ? requiredChecks : {};
 
   const rows = getRequiredComplianceChecks().map((checkKey) => {
     const check = CP_STANDARDS_PROFILE.checks[checkKey];
-    const status = requiredChecks[checkKey] || 'not-run';
+    const status = normalizedRequiredChecks[checkKey] || 'not-run';
     return {
       key: checkKey,
       label: check?.label || checkKey,


### PR DESCRIPTION
### Motivation
- The cathodic protection compliance renderer could index into a persisted `compliance.requiredChecks` value that was `null` or otherwise not an object, causing a `TypeError` and crashing the study page on load after importing malformed project data.

### Description
- In `normalizeSavedStudy` (`cathodicprotection.js`) normalize `compliance.requiredChecks` so non-object values (including `null`) are replaced with `buildInitialComplianceStatus()` before returning the saved study.
- In `renderComplianceStatusPanel` add a defensive guard (`normalizedRequiredChecks`) so the renderer always indexes a plain object rather than trusting the caller-provided value.
- Changes are minimal and localized to `cathodicprotection.js` to preserve existing storage and import flows while preventing availability failures.

### Testing
- Ran `npm test` and the full test suite completed successfully.
- Ran `npm run build` and the build completed with `dist` produced.
- Attempted `npx playwright screenshot ...` to capture a preview image, but browser installation failed due to remote download (HTTP 403), so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0913fb72bc8324bbf59664cec0503c)