### PR TITLE
Preserve missing Phase 1 study metadata in migration

### DIFF
--- a/projectStorage.js
+++ b/projectStorage.js
@@ -147,9 +147,6 @@ function ensureComponentField(component, key, defaultValue) {
     return;
   }
   if (hasRootValue || hasPropValue) return;
-  const nextValue = typeof defaultValue === 'function' ? defaultValue(component) : defaultValue;
-  component[key] = nextValue;
-  component.props[key] = nextValue;
 }
 
 function applySubtypeDefaults(component, subtype) {

--- a/tests/projectStorageMigration.test.mjs
+++ b/tests/projectStorageMigration.test.mjs
@@ -26,26 +26,26 @@ const components = migrated.settings.oneLineDiagram.sheets[0].components;
 const getComponent = (subtype) => components.find((component) => component.subtype === subtype);
 
 const mcc = getComponent('mcc');
-assert.equal(mcc.props.sccr_ka, 65);
-assert.equal(mcc.props.bucket_count, 6);
-assert.equal(mcc.props.form_type, 'form_2b');
+assert.equal(mcc.props.sccr_ka, undefined);
+assert.equal(mcc.props.bucket_count, undefined);
+assert.equal(mcc.props.form_type, undefined);
 
 const busway = getComponent('busway');
-assert.equal(busway.props.busway_type, 'feeder');
-assert.equal(busway.props.short_circuit_rating_ka, 65);
+assert.equal(busway.props.busway_type, undefined);
+assert.equal(busway.props.short_circuit_rating_ka, undefined);
 
 const ct = getComponent('ct');
-assert.equal(ct.props.ratio_primary, 600);
-assert.equal(ct.props.ratio_secondary, 5);
-assert.equal(ct.props.location_context, 'protection');
+assert.equal(ct.props.ratio_primary, undefined);
+assert.equal(ct.props.ratio_secondary, undefined);
+assert.equal(ct.props.location_context, undefined);
 
 const ptVt = getComponent('pt_vt');
-assert.equal(ptVt.props.primary_voltage, 12470);
-assert.equal(ptVt.props.secondary_voltage, 120);
+assert.equal(ptVt.props.primary_voltage, undefined);
+assert.equal(ptVt.props.secondary_voltage, undefined);
 
 const ups = getComponent('ups');
 assert.equal(ups.props.runtime_battery_min, 20);
 assert.equal(ups.props.battery_runtime_min, 20);
-assert.equal(ups.props.mode_battery_enabled, true);
+assert.equal(ups.props.mode_battery_enabled, undefined);
 
-console.log('✓ projectStorage migrateProject backfills Phase 1 component defaults');
+console.log('✓ projectStorage migrateProject preserves missing Phase 1 study fields');


### PR DESCRIPTION
### Motivation
- Migration was silently filling in engineering-significant Phase 1 values (MCC/busway/CT/PT-VT/UPS) when both root and `props` fields were missing, which can hide missing-data validation warnings and corrupt study integrity.

### Description
- Stop `ensureComponentField` from writing fallback defaults when neither the root nor `props` contain a real value so missing fields remain undefined.
- Keep root↔`props` synchronization when one side has a real value and preserve the UPS runtime alias/backfill behavior when one runtime field is present.
- Update `tests/projectStorageMigration.test.mjs` to assert that Phase 1 study fields remain `undefined` after migration while verifying UPS runtime aliasing still copies a provided value.

### Testing
- Ran `npm test` (full test suite) and it passed.
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091629a5748324bdf753f5ea6807e9)