### PR TITLE
Fix PT/VT compatibility validation bypass for consumer-side explicit links

### DIFF
--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -296,6 +296,35 @@ describe('runValidation - PT/VT completeness and compatibility', () => {
     const ptIssues = issues.filter(issue => issue.component === 'pt-3');
     assert.deepStrictEqual(ptIssues, []);
   });
+
+  it('flags PT/VT when consumer links via explicit pt_vt_id field', () => {
+    const components = [
+      {
+        id: 'meter-explicit',
+        type: 'meter',
+        props: {
+          voltage: 480,
+          pt_vt_id: 'pt-4'
+        }
+      },
+      {
+        id: 'pt-4',
+        subtype: 'pt_vt',
+        type: 'vt',
+        props: {
+          tag: 'PT-4',
+          primary_voltage: 12470,
+          secondary_voltage: 120,
+          accuracy_class: '0.3',
+          burden_va: 50,
+          connection_type: 'wye-grounded',
+          fuse_protection: 'yes'
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    assert.ok(issues.some(issue => issue.component === 'pt-4' && issue.message.includes('incompatible')));
+  });
 });
 
 

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -38,6 +38,15 @@ function normalizeIdList(value) {
   return value.split(',').map(v => v.trim()).filter(Boolean);
 }
 
+function getConsumerLinkedPtVtId(component) {
+  return `${readField(component, 'pt_vt_id')
+    || readField(component, 'vt_id')
+    || readField(component, 'pt_id')
+    || readField(component, 'potential_transformer_id')
+    || readField(component, 'voltage_transformer_id')
+    || ''}`.trim();
+}
+
 export function runValidation(components = [], studies = {}) {
   const issues = [];
   const componentLookup = new Map(components.map(c => [c.id, c]));
@@ -159,6 +168,9 @@ export function runValidation(components = [], studies = {}) {
         `${props.meter_id ?? ''}`.trim(),
         `${props.relay_id ?? ''}`.trim(),
         ...normalizeIdList(props.consumer_ids),
+        ...components
+          .filter(target => getConsumerLinkedPtVtId(target) === `${c.id ?? ''}`.trim())
+          .map(target => `${target?.id ?? ''}`.trim()),
         ...(Array.isArray(c.connections) ? c.connections.map(conn => `${conn?.target ?? ''}`.trim()) : [])
       ].filter(Boolean)
     );


### PR DESCRIPTION
### Motivation
- Close a validation gap where resolver logic accepted consumer-side explicit PT/VT references (`pt_vt_id`, `vt_id`, `pt_id`, `potential_transformer_id`, `voltage_transformer_id`) but the PT/VT compatibility validator did not consider those consumer-side references, allowing crafted projects to bypass safety checks.

### Description
- Add a helper `getConsumerLinkedPtVtId` that reads consumer-side explicit PT/VT reference fields via existing `readField` logic and normalizes the result.
- Include components that explicitly reference a PT/VT in the PT/VT `linkedIds` set so compatibility checks examine consumers that point to the PT/VT from their own props.
- Add a focused regression test in `tests/validation.test.mjs` that verifies an incompatible PT/VT is flagged when a consumer uses the `pt_vt_id` field.
- Preserve existing PT/VT-side linking behavior and scoring; the change only expands which consumers are considered during compatibility validation.

### Testing
- Ran `npm test` and the full test suite completed successfully with the new regression test included.
- Ran `npm run build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09174e97fc8324aec5e87fc9d0a160)