### PR TITLE
Fix CT metadata canonicalization and CT field conflict validation

### DIFF
--- a/analysis/ctMetadata.mjs
+++ b/analysis/ctMetadata.mjs
@@ -5,10 +5,10 @@ function coerceNumber(value) {
 
 function readField(comp, key) {
   if (!comp || typeof comp !== 'object') return undefined;
-  if (Object.prototype.hasOwnProperty.call(comp, key)) return comp[key];
   if (comp.props && typeof comp.props === 'object' && Object.prototype.hasOwnProperty.call(comp.props, key)) {
     return comp.props[key];
   }
+  if (Object.prototype.hasOwnProperty.call(comp, key)) return comp[key];
   return undefined;
 }
 
@@ -22,7 +22,7 @@ export function isCtComponent(comp) {
 export function parseCtRatio(ctLike) {
   const primary = coerceNumber(readField(ctLike, 'ratio_primary'));
   const secondary = coerceNumber(readField(ctLike, 'ratio_secondary'));
-  if (!Number.isFinite(primary) || !Number.isFinite(secondary) || secondary <= 0) {
+  if (!Number.isFinite(primary) || !Number.isFinite(secondary) || primary <= 0 || secondary <= 0 || primary < secondary) {
     return null;
   }
   return {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -93,7 +93,8 @@ export function runValidation(components = [], studies = {}) {
   components.forEach(c => {
     const isCt = c?.subtype === 'ct' || c?.type === 'ct';
     if (!isCt) return;
-    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const hasProps = c.props && typeof c.props === 'object';
+    const props = hasProps ? c.props : c;
     const missing = [];
 
     if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
@@ -114,6 +115,19 @@ export function runValidation(components = [], studies = {}) {
 
     const locationContext = `${props.location_context ?? ''}`.trim().toLowerCase();
     if (!['metering', 'protection'].includes(locationContext)) missing.push('location_context');
+
+    const ctKeys = [
+      'tag', 'ratio_primary', 'ratio_secondary', 'accuracy_class', 'burden_va', 'knee_point_v', 'polarity',
+      'location_context', 'protected_device_id', 'meter_id', 'relay_id', 'ct_id', 'current_transformer_id'
+    ];
+    if (hasProps) {
+      const conflicts = ctKeys.filter(key => Object.prototype.hasOwnProperty.call(c, key)
+        && Object.prototype.hasOwnProperty.call(props, key)
+        && `${c[key] ?? ''}`.trim() !== `${props[key] ?? ''}`.trim());
+      if (conflicts.length) {
+        missing.push(`conflicting_top_level_fields(${conflicts.join('|')})`);
+      }
+    }
 
     if (missing.length) {
       issues.push({


### PR DESCRIPTION
### Motivation
- CT metadata normalization previously read top-level component fields before `props`, which could let an attacker place conflicting invalid CT values at the top level while validation checked only `props`. 
- `parseCtRatio()` also accepted physically impossible ratios (`ratio_primary <= 0` or `ratio_primary < ratio_secondary`), allowing invalid study metadata to propagate into results.

### Description
- Updated `readField()` in `analysis/ctMetadata.mjs` to prefer `props` fields before top-level fields so normalization uses the same canonical source as validation. 
- Hardened `parseCtRatio()` in `analysis/ctMetadata.mjs` to reject `ratio_primary <= 0`, `ratio_secondary <= 0`, and `ratio_primary < ratio_secondary`. 
- Added conflict detection in `validation/rules.js` to flag components that have both top-level CT fields and `props` CT fields with mismatched values. 
- Changes touch `analysis/ctMetadata.mjs` and `validation/rules.js` to align normalization and validation and to enforce physical constraints consistently.

### Testing
- Ran `npm test` and the full test suite completed successfully. 
- Ran `npm run build` which completed successfully (Rollup emitted unresolved-external warnings but the build finished). 
- Attempted to capture a webpage preview with `npx playwright screenshot`, but Playwright browser installation failed due to network/403 when downloading Chromium, so a preview image could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09174f3a2083249f204e73cfada118)