### PR TITLE
Fix MCC subtype normalization in validation rules

### DIFF
--- a/validation/rules.js
+++ b/validation/rules.js
@@ -330,8 +330,10 @@ export function runValidation(components = [], studies = {}) {
 
   // Panel required field completeness for panel studies and reports
   components.forEach(c => {
+    const type = `${c?.type ?? ''}`.trim().toLowerCase();
     const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();
-    const isPanel = (c?.type === 'panel' || subtype === 'panel') && subtype !== 'mcc';
+    const isMcc = type === 'mcc' || subtype === 'mcc' || subtype.endsWith('_mcc');
+    const isPanel = (type === 'panel' || subtype === 'panel' || subtype.startsWith('panel_')) && !isMcc;
     if (!isPanel) return;
     const props = c.props && typeof c.props === 'object' ? c.props : c;
     const missing = [];
@@ -361,7 +363,9 @@ export function runValidation(components = [], studies = {}) {
 
   // MCC required field completeness for lineup and study metadata
   components.forEach(c => {
-    const isMcc = c?.subtype === 'mcc' || c?.type === 'mcc';
+    const type = `${c?.type ?? ''}`.trim().toLowerCase();
+    const subtype = `${c?.subtype ?? ''}`.trim().toLowerCase();
+    const isMcc = type === 'mcc' || subtype === 'mcc' || subtype.endsWith('_mcc');
     if (!isMcc) return;
     const props = c.props && typeof c.props === 'object' ? c.props : c;
     const missing = [];


### PR DESCRIPTION
### Motivation
- The validation logic treated MCCs only when `type` or `subtype` exactly equalled `"mcc"`, but component metadata and the palette use composite keys (e.g., `panel_mcc`) and case-insensitive subtype semantics. 
- This caused UI-created MCCs (`{ type: "panel", subtype: "panel_mcc" }`) to be misclassified as generic panels and valid imported variants like `"MCC"` to bypass MCC checks.

### Description
- Normalize both `type` and `subtype` to lowercase in `validation/rules.js` and detect MCCs when `type === 'mcc'`, `subtype === 'mcc'`, or `subtype` ends with `'_mcc'`.
- Update the panel detection gate to consider `panel_*` composite subtypes while explicitly excluding detected MCC variants so MCCs no longer trigger generic-panel required-field checks.
- Apply the same normalized/composite detection to the MCC-specific required-field validation so both UI-created `panel_mcc` and case-variant imports (e.g., `MCC`) are validated consistently.
- Change is limited to `validation/rules.js` and preserves existing validation behavior for non-MCC panels.

### Testing
- Ran the full test suite with `npm test` (invoked `npm run test:full`) and it completed successfully.
- Ran the build with `npm run build` and it completed successfully producing the distribution artifacts and `validationManifest.json`.
- Attempted to capture a UI preview with Playwright via `npx playwright screenshot`, but `npx playwright install chromium` failed due to browser download being blocked by the environment (HTTP 403), so no automated browser screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09174e8be08324be75d17369e04b0c)