### PR TITLE
Fix generator validation bypass for conflicting top-level study fields

### DIFF
--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -1069,6 +1069,40 @@ describe('runValidation - generator required attributes', () => {
     ];
     assert.deepStrictEqual(runValidation(components, {}), []);
   });
+
+  it('flags a generator when top-level study fields conflict with valid props values', () => {
+    const components = [
+      {
+        id: 'gen-3',
+        type: 'generator',
+        subtype: 'synchronous',
+        rated_mva: 0,
+        xdpp_pu: 0,
+        props: {
+          tag: 'GEN-3',
+          description: 'Generator with conflicting fields',
+          manufacturer: 'Generic',
+          model: 'G-100',
+          rated_mva: 1.2,
+          rated_kv: 0.48,
+          xdpp_pu: 0.2,
+          xdp_pu: 0.3,
+          xd_pu: 1.6,
+          h_constant_s: 3.5,
+          governor_mode: 'droop',
+          avr_mode: 'automatic',
+          min_kw: 0,
+          max_kw: 1000,
+          ramp_kw_per_min: 60
+        }
+      }
+    ];
+    const issues = runValidation(components, {});
+    const generatorIssue = issues.find(issue => issue.component === 'gen-3');
+    assert.ok(generatorIssue);
+    assert.ok(generatorIssue.message.includes('rated_mva'));
+    assert.ok(generatorIssue.message.includes('xdpp_pu'));
+  });
 });
 
 describe('runValidation - capacitor/reactor tuning attributes', () => {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -517,31 +517,36 @@ export function runValidation(components = [], studies = {}) {
     const type = `${c?.type ?? ''}`.trim().toLowerCase();
     const isGenerator = type === 'generator' || subtype === 'generator' || subtype === 'synchronous' || subtype === 'asynchronous';
     if (!isGenerator) return;
-    const props = c.props && typeof c.props === 'object' ? c.props : c;
+    const props = c.props && typeof c.props === 'object' ? c.props : {};
+    const getGeneratorValue = key => (
+      c && Object.prototype.hasOwnProperty.call(c, key)
+        ? c[key]
+        : props[key]
+    );
     const missing = [];
-    if (!`${props.tag ?? ''}`.trim()) missing.push('tag');
-    if (!`${props.description ?? ''}`.trim()) missing.push('description');
-    if (!`${props.manufacturer ?? ''}`.trim()) missing.push('manufacturer');
-    if (!`${props.model ?? ''}`.trim()) missing.push('model');
-    const ratedMva = Number(props.rated_mva);
+    if (!`${getGeneratorValue('tag') ?? ''}`.trim()) missing.push('tag');
+    if (!`${getGeneratorValue('description') ?? ''}`.trim()) missing.push('description');
+    if (!`${getGeneratorValue('manufacturer') ?? ''}`.trim()) missing.push('manufacturer');
+    if (!`${getGeneratorValue('model') ?? ''}`.trim()) missing.push('model');
+    const ratedMva = Number(getGeneratorValue('rated_mva'));
     if (!Number.isFinite(ratedMva) || ratedMva <= 0) missing.push('rated_mva');
-    const ratedKv = Number(props.rated_kv);
+    const ratedKv = Number(getGeneratorValue('rated_kv'));
     if (!Number.isFinite(ratedKv) || ratedKv <= 0) missing.push('rated_kv');
-    const xdppPu = Number(props.xdpp_pu);
+    const xdppPu = Number(getGeneratorValue('xdpp_pu'));
     if (!Number.isFinite(xdppPu) || xdppPu <= 0) missing.push('xdpp_pu');
-    const xdpPu = Number(props.xdp_pu);
+    const xdpPu = Number(getGeneratorValue('xdp_pu'));
     if (!Number.isFinite(xdpPu) || xdpPu <= 0) missing.push('xdp_pu');
-    const xdPu = Number(props.xd_pu);
+    const xdPu = Number(getGeneratorValue('xd_pu'));
     if (!Number.isFinite(xdPu) || xdPu <= 0) missing.push('xd_pu');
-    const hConstant = Number(props.h_constant_s);
+    const hConstant = Number(getGeneratorValue('h_constant_s'));
     if (!Number.isFinite(hConstant) || hConstant <= 0) missing.push('h_constant_s');
-    if (!`${props.governor_mode ?? ''}`.trim()) missing.push('governor_mode');
-    if (!`${props.avr_mode ?? ''}`.trim()) missing.push('avr_mode');
-    const minKw = Number(props.min_kw);
+    if (!`${getGeneratorValue('governor_mode') ?? ''}`.trim()) missing.push('governor_mode');
+    if (!`${getGeneratorValue('avr_mode') ?? ''}`.trim()) missing.push('avr_mode');
+    const minKw = Number(getGeneratorValue('min_kw'));
     if (!Number.isFinite(minKw) || minKw < 0) missing.push('min_kw');
-    const maxKw = Number(props.max_kw);
+    const maxKw = Number(getGeneratorValue('max_kw'));
     if (!Number.isFinite(maxKw) || maxKw <= 0 || (Number.isFinite(minKw) && minKw > maxKw)) missing.push('max_kw');
-    const rampKwPerMin = Number(props.ramp_kw_per_min);
+    const rampKwPerMin = Number(getGeneratorValue('ramp_kw_per_min'));
     if (!Number.isFinite(rampKwPerMin) || rampKwPerMin <= 0) missing.push('ramp_kw_per_min');
     if (missing.length) {
       issues.push({


### PR DESCRIPTION
### Motivation
- Generator study fields can appear both on the top-level component and inside `props`, and validation previously validated `props` while the calculation engine used top-level fields first, enabling a validation bypass for crafted project JSON.

### Description
- Updated generator validation in `validation/rules.js` to read canonical values with top-level precedence by adding `getGeneratorValue(key)` and using it for all generator-required checks.
- Preserved fallback to `props` when top-level values are absent so existing project shapes remain supported.
- Added a regression test in `tests/validation.test.mjs` that exercises a generator with valid nested `props` but invalid conflicting top-level `rated_mva`/`xdpp_pu` and asserts validation now flags the conflict.

### Testing
- Ran the full automated test suite with `npm test`, and the run completed successfully including the new regression test.
- Built the distribution with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09190bd98c8324bd69806bf9731165)