### PR TITLE
Fix rated_kv prefault voltage handling in short-circuit analysis

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -631,6 +631,7 @@ function computePrefaultKV(comp, comps, compMap, cache, visited = new Set()) {
   const voltageCandidates = [
     pickValue(comp, 'voltage'),
     pickValue(comp, 'volts'),
+    pickValue(comp, 'rated_kv'),
     pickValue(comp, 'voltage_class'),
     pickValue(comp, 'kV'),
     pickValue(comp, 'kv'),

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -190,7 +190,6 @@ global.localStorage = {
               rated_kv: 13.8,
               rated_mva: 2.5,
               xdpp_pu: 0.2,
-              volts: 13800,
               connections: [{ target: 'bus1', sourcePort: 0, targetPort: 0 }]
             },
             { id: 'bus1', type: 'bus', subtype: 'Bus' }
@@ -200,6 +199,8 @@ global.localStorage = {
       const res = runShortCircuit();
       const bus = res.bus1;
       assert(bus, 'bus results should exist');
+      assert(Math.abs(bus.prefaultKV - 13.8) < 0.01, 'rated_kv should set prefault voltage');
+      assert.strictEqual(bus.method, 'IEC', 'medium-voltage generator should use IEC method');
       assert(bus.threePhaseKA > 0.1, 'generator-based fault current should be non-zero');
       assert(bus.threePhaseKA < 1, 'xdpp should limit source current contribution');
     });


### PR DESCRIPTION
### Motivation
- A recent change made `getSourceImpedance()` accept generator `rated_kv`, but `computePrefaultKV()` did not consider `rated_kv`, so rated-kV-only generator models fell back to a 1 kV prefault base and ANSI method, silently understating fault currents. 

### Description
- Added `pickValue(comp, 'rated_kv')` to the `voltageCandidates` list in `computePrefaultKV()` in `analysis/shortCircuit.mjs` so rated-field-only generators resolve their prefault voltage correctly. 
- Updated the short-circuit regression test in `tests/shortcircuit/shortCircuit.test.cjs` to remove the legacy `volts` field from the generator fixture and assert that `bus.prefaultKV` resolves to `13.8` and `bus.method` is `IEC`. 
- Changes are minimal and preserve existing behavior for projects that still include legacy voltage fields.

### Testing
- Ran the full test suite with `npm test`, and all tests passed. 
- Ran `npm run build`, and the build completed successfully (with non-fatal warnings about external deps). 
- Attempted to capture an HTML preview using Playwright, but browser binaries could not be downloaded in this environment (Playwright install failed with HTTP 403), so a screenshot preview could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09190fedf08324a93c49b923659ce4)