### PR TITLE
Harden DC bus validation against crafted object values

### DIFF
--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -562,6 +562,37 @@ describe('runValidation - dc_bus required attributes', () => {
     assert.ok(dcIssue.message.includes('short_circuit_rating_ka'));
   });
 
+
+
+  it('handles adversarial object values without throwing', () => {
+    const components = [
+      {
+        id: 'dc-bus-ref-3',
+        type: 'bus',
+        connections: [{ target: 'dc-bus-3' }]
+      },
+      {
+        id: 'dc-bus-3',
+        type: 'bus',
+        subtype: 'dc_bus',
+        connections: [{ target: 'dc-bus-ref-3' }],
+        props: {
+          nominal_voltage_vdc: { toString: 'x' },
+          grounding_scheme: { toString: 'x' },
+          max_continuous_current_a: { toString: 'x' },
+          short_circuit_rating_ka: { toString: 'x' }
+        }
+      }
+    ];
+    assert.doesNotThrow(() => runValidation(components, {}));
+    const issues = runValidation(components, {});
+    const dcIssue = issues.find(issue => issue.component === 'dc-bus-3');
+    assert.ok(dcIssue);
+    assert.ok(dcIssue.message.includes('nominal_voltage_vdc'));
+    assert.ok(dcIssue.message.includes('grounding_scheme'));
+    assert.ok(dcIssue.message.includes('max_continuous_current_a'));
+    assert.ok(dcIssue.message.includes('short_circuit_rating_ka'));
+  });
   it('does not flag a dc_bus with all required fields present', () => {
     const components = [
       {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -5,6 +5,24 @@ function coerceNumber(value) {
   return Number.isFinite(num) ? num : null;
 }
 
+
+function safeNumber(value) {
+  try {
+    return Number(value);
+  } catch {
+    return NaN;
+  }
+}
+
+function safeTrimmedText(value) {
+  if (value == null) return '';
+  try {
+    return `${value}`.trim();
+  } catch {
+    return '';
+  }
+}
+
 function readField(component, key) {
   if (!component || typeof component !== 'object') return undefined;
   if (Object.prototype.hasOwnProperty.call(component, key)) return component[key];
@@ -339,12 +357,12 @@ export function runValidation(components = [], studies = {}) {
     if (!isDcBus) return;
     const props = c.props && typeof c.props === 'object' ? c.props : c;
     const missing = [];
-    const nominalVoltage = Number(props.nominal_voltage_vdc);
+    const nominalVoltage = safeNumber(props.nominal_voltage_vdc);
     if (!Number.isFinite(nominalVoltage) || nominalVoltage <= 0) missing.push('nominal_voltage_vdc');
-    if (!`${props.grounding_scheme ?? ''}`.trim()) missing.push('grounding_scheme');
-    const maxContinuousCurrent = Number(props.max_continuous_current_a);
+    if (!safeTrimmedText(props.grounding_scheme)) missing.push('grounding_scheme');
+    const maxContinuousCurrent = safeNumber(props.max_continuous_current_a);
     if (!Number.isFinite(maxContinuousCurrent) || maxContinuousCurrent <= 0) missing.push('max_continuous_current_a');
-    const shortCircuitRating = Number(props.short_circuit_rating_ka);
+    const shortCircuitRating = safeNumber(props.short_circuit_rating_ka);
     if (!Number.isFinite(shortCircuitRating) || shortCircuitRating <= 0) missing.push('short_circuit_rating_ka');
     if (missing.length) {
       issues.push({


### PR DESCRIPTION
### Motivation
- The dc_bus validation block was coercing untrusted fields with `Number(...)` and template literals which can throw `TypeError` for crafted non-primitive JSON values and abort client-side validation/rendering. 

### Description
- Add `safeNumber` and `safeTrimmedText` helpers to `validation/rules.js` to perform guarded conversions that return non-finite/empty results instead of throwing. 
- Replace direct uses of `Number(...)` and template-literal trimming in the `dc_bus` checks with `safeNumber` and `safeTrimmedText` so malformed object values are treated as invalid fields. 
- Add a regression test in `tests/validation.test.mjs` that feeds adversarial object values into dc_bus fields and asserts `runValidation` does not throw while still reporting the expected missing/invalid attributes. 

### Testing
- Ran the full test suite with `npm test`, which exercised the new test; the run failed due to an existing unrelated failure in `tests/serverSecurity.test.mjs` (`401 !== 204`) and not because of the dc_bus changes. 
- Ran `npm run build`, which completed successfully and produced updated build artifacts. 
- Attempted to produce a webpage preview screenshot with Playwright, but browser installation failed in the environment (download 403), so a preview image could not be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091a89f4c48324a4d557b646e4f639)