### PR TITLE
Fix meter validation bypass with desynchronized props/top-level fields

### DIFF
--- a/tests/validation.test.mjs
+++ b/tests/validation.test.mjs
@@ -218,6 +218,24 @@ describe('runValidation - meter CT/PT completeness', () => {
     ];
     assert.deepStrictEqual(runValidation(components, {}), []);
   });
+
+  it('flags a meter with top-level metering enabled when props is desynchronized', () => {
+    const components = [
+      {
+        id: 'meter-4',
+        type: 'meter',
+        supports_thd: true,
+        ct_ratio: '',
+        pt_ratio: '',
+        props: {}
+      }
+    ];
+    const issues = runValidation(components, {});
+    assert.strictEqual(issues.length, 1);
+    assert.strictEqual(issues[0].component, 'meter-4');
+    assert.ok(issues[0].message.includes('CT ratio'));
+    assert.ok(issues[0].message.includes('PT ratio'));
+  });
 });
 
 describe('runValidation - PT/VT completeness and compatibility', () => {

--- a/validation/rules.js
+++ b/validation/rules.js
@@ -207,15 +207,14 @@ export function runValidation(components = [], studies = {}) {
   // Meter ratio completeness for study-enabled metering features
   components.forEach(c => {
     if (c.type !== 'meter') return;
-    const props = c.props && typeof c.props === 'object' ? c.props : c;
     const meteringEnabled = Boolean(
-      props.supports_thd
-      || props.supports_flicker
-      || props.supports_waveform_capture
+      readField(c, 'supports_thd')
+      || readField(c, 'supports_flicker')
+      || readField(c, 'supports_waveform_capture')
     );
     if (!meteringEnabled) return;
-    const ctRatio = `${props.ct_ratio ?? ''}`.trim();
-    const ptRatio = `${props.pt_ratio ?? ''}`.trim();
+    const ctRatio = `${readField(c, 'ct_ratio') ?? ''}`.trim();
+    const ptRatio = `${readField(c, 'pt_ratio') ?? ''}`.trim();
     if (!ctRatio || !ptRatio) {
       issues.push({
         component: c.id,


### PR DESCRIPTION
### Motivation
- The meter completeness rule previously treated `c.props` as the sole source when present, which allowed a component with top-level metering flags and an empty `props` to bypass CT/PT ratio checks.

### Description
- Use `readField(c, ...)` when checking `supports_thd`, `supports_flicker`, `supports_waveform_capture`, `ct_ratio`, and `pt_ratio` so both top-level and nested `props` representations are respected.
- Add a regression test in `tests/validation.test.mjs` that reproduces the desynchronization case (`supports_thd` at top level with `props: {}`) and asserts the expected validation issue is emitted.

### Testing
- Ran `npm test` (full test suite) and it passed, including the new regression case.
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a browser preview with Playwright but `npx playwright install` failed to download browsers (HTTP 403), so a webpage screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091a8a651c8324be985a7d3580d8bc)