### PR TITLE
Guard ground-grid analysis from non-physical safety pass conditions

### DIFF
--- a/analysis/groundGrid.mjs
+++ b/analysis/groundGrid.mjs
@@ -210,6 +210,10 @@ export function analyzeGroundGrid(params) {
   const Ks = stepFactor(D, h, n);
   const Ki = irregularityFactor(n);
 
+  if (!Number.isFinite(Km) || Km < 0) throw new Error('Computed mesh factor is invalid for the selected geometry');
+  if (!Number.isFinite(Ks) || Ks < 0) throw new Error('Computed step factor is invalid for the selected geometry');
+  if (!Number.isFinite(Ki) || Ki < 0) throw new Error('Computed irregularity factor is invalid for the selected geometry');
+
   // Lm and Ls — effective lengths for voltage calculations (IEEE 80-2013 §16.5)
   // For grids without ground rods: Lm = Ls = L
   const Lm = effectiveLength;
@@ -224,6 +228,9 @@ export function analyzeGroundGrid(params) {
   // Mesh and step voltages
   const Em = (rho * Ig * Km * Ki) / Lm;
   const Es = (rho * Ig * Ks * Ki) / Ls;
+
+  if (!Number.isFinite(Em) || Em < 0) throw new Error('Computed mesh voltage is invalid for the selected geometry');
+  if (!Number.isFinite(Es) || Es < 0) throw new Error('Computed step voltage is invalid for the selected geometry');
 
   // Surface layer factor
   const effectiveRhoS = rhoS > 0 ? rhoS : rho;

--- a/tests/groundGrid.test.mjs
+++ b/tests/groundGrid.test.mjs
@@ -271,4 +271,23 @@ describe('analyzeGroundGrid — integration', () => {
   it('throws for negative rod length', () => {
     assert.throws(() => analyzeGroundGrid({ ...base, hasRods: true, rodCount: 4, rodLength: -1 }));
   });
+
+
+  it('throws when derived mesh factor yields a non-physical mesh voltage', () => {
+    assert.throws(() => analyzeGroundGrid({
+      rho: 100,
+      gridLx: 30.48,
+      gridLy: 30.48,
+      nx: 100,
+      ny: 100,
+      h: 0.4572,
+      d: 0.01,
+      Ig: 5000,
+      tf: 0.5,
+      hasRods: true,
+      rodCount: 10000,
+      rodLength: 1.3716,
+      bw: 70,
+    }), /Computed mesh factor is invalid|Computed mesh voltage is invalid/);
+  });
 });


### PR DESCRIPTION
### Motivation
- The analysis path allowed preview-derived rod counts and estimated rod lengths to inflate the effective buried length and produce non-physical intermediate factors/voltages that could make safety checks return a false PASS. 
- Introduce sanity checks to ensure computed IEEE 80 correction factors and voltages are finite and non-negative before they are used to derive safety booleans.

### Description
- Added validation in `analyzeGroundGrid` to reject non-finite or negative computed correction factors `Km`, `Ks`, and `Ki` by throwing an error when these values are invalid. 
- Added validation in `analyzeGroundGrid` to reject non-finite or negative computed mesh/step voltages `Em` and `Es` before tolerable-limit comparisons. 
- Added a regression test in `tests/groundGrid.test.mjs` that reproduces the high-rod-count preview scenario and asserts the analysis now throws instead of returning a non-physical negative mesh voltage. 

### Testing
- Ran `npm test` and the full test suite completed successfully, including the new regression test in `tests/groundGrid.test.mjs`. 
- Ran `npm run build` and the build completed successfully. 
- The change is limited to `analysis/groundGrid.mjs` and the test file `tests/groundGrid.test.mjs`, and existing IEEE-80-related tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091a8a53088324810ad50f6bdff6f2)