### PR TITLE
Add guardrails for Library Manager CSV/XLSX imports

### DIFF
--- a/docs/componentLibrary.md
+++ b/docs/componentLibrary.md
@@ -94,6 +94,7 @@ Library Manager imports `.json`, `.csv`, `.xlsx`, and `.xls` files.
 - Use **Import mode → Replace library** to overwrite the current editor state.
 - Use **Import mode → Merge into existing** to merge categories/icons and upsert components by `subtype`.
 - Spreadsheet imports use workbook sheets documented in [componentLibraryTemplateSpec.md](componentLibraryTemplateSpec.md).
+- Import safeguards reject oversized files before parsing (10 MB max file size, 10-sheet max workbook, 20,000-row max per sheet/CSV, 2,000-character max per cell, and 10,000 imported components max).
 
 Use **Download Template** in Library Manager to export a starter workbook containing all supported sheets and sample rows.
 

--- a/library.html
+++ b/library.html
@@ -781,6 +781,36 @@
       }
     }
 
+    
+    const IMPORT_LIMITS = {
+      maxFileBytes: 10 * 1024 * 1024,
+      maxCsvRows: 20000,
+      maxWorkbookSheets: 10,
+      maxRowsPerSheet: 20000,
+      maxCellChars: 2000,
+      maxComponents: 10000,
+    };
+
+    function assertImportFileSize(file) {
+      if (file.size > IMPORT_LIMITS.maxFileBytes) {
+        throw new Error('Import file is too large. Maximum size is 10 MB.');
+      }
+    }
+
+    function assertRowCount(rows, label) {
+      if (rows.length > IMPORT_LIMITS.maxRowsPerSheet) {
+        throw new Error(`${label} has too many rows. Maximum is ${IMPORT_LIMITS.maxRowsPerSheet}.`);
+      }
+    }
+
+    function clampCellValue(value) {
+      const normalized = String(value ?? '').trim();
+      if (normalized.length > IMPORT_LIMITS.maxCellChars) {
+        throw new Error(`A cell value exceeds the maximum length of ${IMPORT_LIMITS.maxCellChars} characters.`);
+      }
+      return normalized;
+    }
+
     function parseBoolean(value) {
       if (typeof value === 'boolean') return value;
       if (typeof value !== 'string') return false;
@@ -816,16 +846,19 @@
 
     function parseCsvRows(text) {
       const lines = text
-        .split(/\r?\n/)
+        .split(/?
+/)
         .map((line) => line.trim())
         .filter((line) => line.length > 0);
       if (!lines.length) return [];
-      const headers = parseCsvLine(lines[0]).map((header) => header.trim());
-      return lines.slice(1).map((line) => {
+      const headers = parseCsvLine(lines[0]).map((header) => clampCellValue(header));
+      const dataLines = lines.slice(1);
+      assertRowCount(dataLines, 'CSV import');
+      return dataLines.map((line) => {
         const cols = parseCsvLine(line);
         const row = {};
         headers.forEach((header, index) => {
-          row[header] = String(cols[index] ?? '').trim();
+          row[header] = clampCellValue(cols[index]);
         });
         return row;
       });
@@ -901,6 +934,9 @@
         if (key && path) icons[key] = path;
       });
 
+      if (components.length > IMPORT_LIMITS.maxComponents) {
+        throw new Error(`Import has too many components. Maximum is ${IMPORT_LIMITS.maxComponents}.`);
+      }
       return {
         categories: [...new Set(categories)],
         components,
@@ -911,6 +947,7 @@
     async function parseLibraryImportFile(file) {
       const name = file.name.toLowerCase();
       if (name.endsWith('.json')) {
+        assertImportFileSize(file);
         const obj = parseJsonSafe(await file.text(), null);
         if (!obj) throw new Error('Invalid JSON file.');
         return {
@@ -923,6 +960,7 @@
         };
       }
       if (name.endsWith('.csv')) {
+        assertImportFileSize(file);
         const rows = parseCsvRows(await file.text());
         return {
           version: '',
@@ -930,15 +968,23 @@
         };
       }
       if (name.endsWith('.xlsx') || name.endsWith('.xls')) {
+        assertImportFileSize(file);
         if (!globalThis.XLSX) {
           throw new Error('Spreadsheet parser unavailable. Please import JSON or CSV instead.');
         }
         const data = new Uint8Array(await file.arrayBuffer());
         const workbook = XLSX.read(data, { type: 'array' });
+        if (workbook.SheetNames.length > IMPORT_LIMITS.maxWorkbookSheets) {
+          throw new Error(`Workbook has too many sheets. Maximum is ${IMPORT_LIMITS.maxWorkbookSheets}.`);
+        }
         const sheets = {};
         workbook.SheetNames.forEach((sheetName) => {
           const sheet = workbook.Sheets[sheetName];
-          sheets[sheetName] = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+          const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+          assertRowCount(rows, `Sheet "${sheetName}"`);
+          sheets[sheetName] = rows.map((row) => Object.fromEntries(
+            Object.entries(row).map(([key, value]) => [clampCellValue(key), clampCellValue(value)]),
+          ));
         });
         return {
           version: '',


### PR DESCRIPTION
### Motivation
- The library import flow previously expanded attacker-controlled CSV/XLSX/XLS files without bounds, allowing large or malicious files to exhaust browser resources and hang/crash the tab. 
- The change aims to reject oversized imports early and validate bounds during parsing so resource exhaustion is prevented before hydration/rendering.

### Description
- Introduced `IMPORT_LIMITS` and helper checks (`assertImportFileSize`, `assertRowCount`, `clampCellValue`) to centralize import bounds and error messages. 
- Enforced file-size checks before calling `file.text()` / `file.arrayBuffer()` and added workbook-level checks for sheet count and per-sheet row limits. 
- Hardened CSV parsing to apply row-count limits and per-cell length clamping, and applied per-cell clamping for workbook sheet rows; also reject imports with too many components in `mapWorkbookRowsToLibrary`. 
- Updated user docs in `docs/componentLibrary.md` to document the new import limits (10 MB file, 10 sheets, 20,000 rows per sheet/CSV, 2,000 chars per cell, 10,000 components).

### Testing
- Ran the full test suite with `npm test`, which completed successfully. 
- Built the distributable with `npm run build`, which completed successfully. 
- Attempted to capture a page preview with Playwright (`npx playwright screenshot ...`) but the environment could not download Chromium (download returned `403 Forbidden`), so an automated preview image could not be produced in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091a8a33388324a4e11801a8d7e631)