### PR TITLE
Preserve full component payloads in structured library editor

### DIFF
--- a/library.html
+++ b/library.html
@@ -454,6 +454,10 @@
       }
     }
 
+    function cloneJsonValue(value) {
+      return parseJsonSafe(JSON.stringify(value), null);
+    }
+
     function escapeHtml(value) {
       return String(value ?? '')
         .replaceAll('&', '&amp;')
@@ -476,7 +480,7 @@
     function getStructuredPayload() {
       return {
         categories: [...structuredState.categories],
-        components: structuredState.components.map((component) => ({ ...component })),
+        components: structuredState.components.map((component) => cloneJsonValue(component) || {}),
         icons: { ...structuredState.icons },
       };
     }
@@ -610,16 +614,22 @@
       const parsedCategories = Array.isArray(data.categories) ? data.categories : [];
       const parsedIcons = iconsValue
         || (data && typeof data.icons === 'object' && data.icons ? data.icons : {});
-      structuredState.components = parsedComponents.map((component) => ({
-        subtype: component?.subtype ?? '',
-        label: component?.label ?? '',
-        category: component?.category ?? '',
-        icon: component?.icon ?? '',
-        ports: Number.isFinite(Number(component?.ports)) ? Number(component.ports) : NaN,
-        schema: (component?.schema && typeof component.schema === 'object' && !Array.isArray(component.schema))
-          ? component.schema
-          : {},
-      }));
+      structuredState.components = parsedComponents.map((component) => {
+        const normalized = (component && typeof component === 'object' && !Array.isArray(component))
+          ? cloneJsonValue(component) || {}
+          : {};
+        if (!Object.hasOwn(normalized, 'subtype') || normalized.subtype == null) normalized.subtype = '';
+        if (!Object.hasOwn(normalized, 'label') || normalized.label == null) normalized.label = '';
+        if (!Object.hasOwn(normalized, 'category') || normalized.category == null) normalized.category = '';
+        if (!Object.hasOwn(normalized, 'icon') || normalized.icon == null) normalized.icon = '';
+        if (!Object.hasOwn(normalized, 'schema')
+          || typeof normalized.schema !== 'object'
+          || normalized.schema == null
+          || Array.isArray(normalized.schema)) {
+          normalized.schema = {};
+        }
+        return normalized;
+      });
       structuredState.categories = parsedCategories.map((value) => String(value ?? ''));
       structuredState.icons = Object.fromEntries(
         Object.entries(parsedIcons || {}).map(([k, v]) => [k, String(v ?? '')]),


### PR DESCRIPTION
### Motivation
- The structured editor previously reduced components to a fixed subset (`subtype`, `label`, `category`, `icon`, `ports`, `schema`), which silently dropped important metadata like `type`, `props`, `deviceProperties`, dimensions/defaultRotation, and array-valued `ports`, causing data corruption when users saved/downloaded/cloud-synced libraries.
- The change aims to stop this lossy normalization so libraries loaded into the structured UI are persisted unchanged except for intentional, editable defaults shown to users.

### Description
- Added a JSON-safe deep-clone helper `cloneJsonValue` and used it to avoid shared-reference mutation when producing persistence payloads via `getStructuredPayload()`.
- Rewrote `hydrateStructuredState()` to deep-clone the incoming component objects and only apply minimal editable defaults (`subtype`, `label`, `category`, `icon`, `schema`) while preserving all other fields present in the original component objects.
- Updated `getStructuredPayload()` to emit deep-cloned component objects so saved/downloaded/cloud-synced payloads contain the full original component metadata; all edits still surface through the structured editor UI.
- All changes are confined to `library.html` and preserve the structured-editor behavior while preventing loss of fields during load/save flows.

### Testing
- Ran the full test suite with `npm test` and the run completed successfully (all automated tests passed). 
- Ran the build with `npm run build` and the distribution was produced successfully (Rollup build completed).
- Attempted to produce a preview screenshot using Playwright (`node -e "const { chromium } = require('playwright'); ..."`) but failed because the Playwright Chromium binary is not available in this environment, and `npx playwright install chromium` failed with HTTP 403 when attempting to download browser binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091a8a6dbc832482d00c6a3a68ced5)