### PR TITLE
Harden custom catalog merge against trusted SKU overrides

### DIFF
--- a/src/catalogBrowser.js
+++ b/src/catalogBrowser.js
@@ -19,19 +19,35 @@ const CATALOG_URL = 'data/manufacturer_catalog.json';
 
 let catalogCache = null;
 
+function normalizeCustomProduct(product) {
+  if (!product || typeof product !== 'object') return null;
+  const id = String(product.id || '').trim();
+  if (!id) return null;
+  return {
+    ...product,
+    id,
+  };
+}
+
 function getCustomProducts() {
   const stored = getTrayHardwareCatalogCustomProducts();
-  return Array.isArray(stored) ? stored : [];
+  if (!Array.isArray(stored)) return [];
+  return stored.map(normalizeCustomProduct).filter(Boolean);
 }
 
 function setCustomProducts(products) {
-  setTrayHardwareCatalogCustomProducts(Array.isArray(products) ? products : []);
+  const normalized = Array.isArray(products)
+    ? products.map(normalizeCustomProduct).filter(Boolean)
+    : [];
+  setTrayHardwareCatalogCustomProducts(normalized);
 }
 
 function mergeCatalogProducts(base, custom) {
   const byId = new Map();
   for (const product of base) byId.set(product.id, product);
-  for (const product of custom) byId.set(product.id, product);
+  for (const product of custom) {
+    if (!byId.has(product.id)) byId.set(product.id, product);
+  }
   return [...byId.values()];
 }
 


### PR DESCRIPTION
### Motivation
- Persisted/imported custom tray-hardware products could contain attacker-controlled records that overwrite trusted manufacturer SKUs when the catalogs were merged, undermining BOM/procurement integrity and causing runtime errors for malformed entries.
- The change hardens the custom-product code paths to validate persisted data and ensure custom entries cannot shadow or replace built-in catalog records.

### Description
- Add `normalizeCustomProduct(product)` to reject non-object values and require a non-empty trimmed `id` before accepting a custom product into the application catalog.
- Sanitize persisted custom products on read (`getCustomProducts`) and write (`setCustomProducts`) so only normalized entries are stored and returned.
- Change `mergeCatalogProducts(base, custom)` to prevent custom entries from replacing existing base products by only inserting custom records for IDs not already present in the trusted base catalog.
- All changes are contained in `src/catalogBrowser.js` and preserve the existing add-form UI behavior while removing the storage/import attack vector.

### Testing
- Ran the full test suite via `npm test` (the project's `test:full`) and all automated tests completed successfully.
- Built distribution artifacts via `npm run build` and the build completed successfully.
- Attempted to capture a page preview with Playwright (`npx playwright screenshot ...`) but browser binaries could not be downloaded in this environment (Chromium downloads returned HTTP 403), so an automated preview image could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091a8a1ed883248383dda53abf0734)