### PR TITLE
Fix CTI export to include ground-fault coordination rows

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -4079,8 +4079,13 @@ if (autoCoordBtn) {
 if (exportCtiBtn) {
   exportCtiBtn.addEventListener('click', () => {
     if (!lastCoordState) return;
-    const { deviceEntries, result, maxFaultA, margin } = lastCoordState;
-    const rows = buildCTIRows(deviceEntries, result, maxFaultA, margin);
+    const { deviceEntries, result, gfpResult, maxFaultA, margin } = lastCoordState;
+    const phaseEntries = deviceEntries.filter(entry => !entry.device?.groundFault);
+    const gfpEntries = deviceEntries.filter(entry => entry.device?.groundFault === true);
+    const rows = [
+      ...buildCTIRows(phaseEntries, result, maxFaultA, margin),
+      ...buildCTIRows(gfpEntries, gfpResult, maxFaultA, margin)
+    ];
     downloadCSV(CTI_HEADERS, rows, 'coordination-cti-report.csv');
   });
 }


### PR DESCRIPTION
### Motivation
- The CTI CSV export previously only consumed the phase `result` from `lastCoordState`, so ground-fault-plane (GFP) coordination rows were omitted for GFP-only studies and interleaved GFP pairs could cause valid phase rows to be skipped.

### Description
- Update the CTI export click handler in `analysis/tcc.js` to read `gfpResult` from `lastCoordState` and partition `deviceEntries` into phase and GFP subsets.
- Generate CTI rows for the phase plane and GFP plane independently by calling `buildCTIRows()` for each subset and concatenate the outputs so both planes are exported.
- The fix is minimal and preserves existing coordination logic and row formatting while ensuring GFP data is included in exports.

### Testing
- Ran `npm test` and the test suite completed (no failures reported for this change).
- Ran `npm run build` and the project build completed successfully.
- Attempted to produce an automated browser screenshot preview using Playwright, but downloading the Chromium browser binary failed in this environment, so no visual preview image could be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e5a96dc8324bcdf632daac48e73)