### PR TITLE
fix: neutralize formula-like CSV cells in report exports

### DIFF
--- a/reports/reporting.mjs
+++ b/reports/reporting.mjs
@@ -46,17 +46,22 @@ async function ensureJsPDF() {
  * @param {Array<Object>} rows
  * @returns {string}
  */
+function sanitizeCsvCell(value) {
+  const raw = value ?? '';
+  let cell = String(raw);
+  if (typeof raw === 'string' && /^[\s]*[=+\-@]/.test(cell)) {
+    cell = `'${cell}`;
+  }
+  if (cell.includes(',') || cell.includes('"')) {
+    cell = '"' + cell.replace(/"/g, '""') + '"';
+  }
+  return cell;
+}
+
 export function toCSV(headers = [], rows = []) {
   const lines = [headers.join(',')];
   rows.forEach(r => {
-    const line = headers.map(h => {
-      const val = r[h] ?? '';
-      let cell = String(val);
-      if (cell.includes(',') || cell.includes('"')) {
-        cell = '"' + cell.replace(/"/g, '""') + '"';
-      }
-      return cell;
-    }).join(',');
+    const line = headers.map(h => sanitizeCsvCell(r[h])).join(',');
     lines.push(line);
   });
   return lines.join('\n');

--- a/tests/reporting.test.cjs
+++ b/tests/reporting.test.cjs
@@ -38,6 +38,22 @@ function it(name, fn){
       const pdf = await toPDF('Test', headers, rows);
       assert(pdf.byteLength > 0);
     });
+
+    it('neutralizes spreadsheet formula strings in CSV cells', () => {
+      const headers = ['name', 'value'];
+      const rows = [{ name: '=HYPERLINK("https://example.com")', value: '  +SUM(1,2)' }];
+      const csv = toCSV(headers, rows);
+      assert(csv.includes("'=HYPERLINK"));
+      assert(csv.includes("'  +SUM(1,2)"));
+    });
+
+    it('keeps numeric values unchanged for CSV exports', () => {
+      const headers = ['delta'];
+      const rows = [{ delta: -5 }];
+      const csv = toCSV(headers, rows);
+      assert(csv.includes('-5'));
+      assert(!csv.includes("'-5"));
+    });
   });
 
   describe('label templates', () => {


### PR DESCRIPTION
### Motivation

- CSV exports were writing project-controlled device names and other strings directly into cells, which permits spreadsheet formula injection when values begin with `=`, `+`, `-`, or `@` (possibly after leading whitespace).
- The serializer did not neutralize formula-like cells centrally, so the new CTI CSV export path exposed this risk and required a minimal centralized remediation.

### Description

- Add a centralized `sanitizeCsvCell(value)` helper to `reports/reporting.mjs` that prefixes string cells matching `/^[\s]*[=+\-@]/` with an apostrophe and then applies existing CSV quoting for commas/quotes.
- Replace the inlined cell serialization in `toCSV` with calls to `sanitizeCsvCell` so all CSV exports benefit from the fix.
- Add regression tests to `tests/reporting.test.cjs` asserting that formula-like strings are neutralized and that numeric values (including negative numbers) remain unchanged.
- Preserve existing CSV quoting behavior and numeric semantics so visible CSV output/consumers are not broken.

### Testing

- Ran `npm test` and the test suite completed successfully with the new assertions included.
- Ran `npm run build` and the site build completed successfully.
- Attempted to capture a browser preview via Playwright but browser download/install failed in the environment (Playwright CDN returned 403), so a screenshot preview could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e5aab7883248a539d2d7d84dce6)