### PR TITLE
fix(tcc): apply IEC auto-coordinate suggestions to tms override

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -7758,10 +7758,11 @@ function autoCoordinate() {
       if (i === 0) return;
       const entry = phaseOrderedEntries[i];
       if (!entry || !r.found) return;
-      const baseSettings = entry.selection?.baseDevice?.settings || {};
+      const baseDevice = entry.selection?.baseDevice;
+      const baseSettings = baseDevice?.settings || {};
       const phaseDialKey = (baseSettings.longTimePickup !== undefined || baseSettings.longTimeDelay !== undefined)
         ? 'longTimeDelay'
-        : 'time';
+        : (baseDevice?.iec60255 === true ? 'tms' : 'time');
       entry.overrides = { ...entry.overrides, [phaseDialKey]: r.timeDial };
       if (typeof updateDeviceInputs === 'function') updateDeviceInputs(entry);
     });


### PR DESCRIPTION
### Motivation
- Auto-coordinate computed IEC relay adjustments by varying `tms`, but the UI unconditionally wrote the suggestion into the `time` override, which IEC scaling ignores and could leave IEC devices unchanged while reporting coordination.

### Description
- Update `autoCoordinate()` in `analysis/tcc.js` so phase-device auto-coordinate writes select `tms` for devices with `iec60255 === true`, keep `longTimeDelay` for long-time devices, and otherwise use `time`.
- Extract the base device as `baseDevice = entry.selection?.baseDevice` to inspect `iec60255` safely before choosing the dial key.
- Preserve existing behavior for GFP devices (still write `tms`), and do not change coordination algorithms in `analysis/tccAutoCoord.mjs` or `analysis/tccUtils.js`.

### Testing
- Ran the full JS test suite via `npm test`, which completed successfully (including `tcc` and `tccAutoCoord` tests). 
- Ran `npm run build` which completed successfully and produced the `dist` bundle. 
- Attempted to capture a UI preview with Playwright, but `npx playwright install chromium` failed due to CDN `403 Forbidden` responses so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e5b0d9c8324b46d39c1a6007f5d)