### PR TITLE
Harden study approval panel against forged PE stamps

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -241,7 +241,7 @@ export const setDrcAcceptedFindings = list => write(EXTRA_KEYS.drcAcceptedFindin
 /**
  * Study-level engineer approval / PE stamp records.
  * Keyed by study name (e.g. 'arcFlash', 'loadFlow', 'shortCircuit').
- * Each entry: { status: 'pending'|'approved'|'flagged', reviewedBy, approvedAt, note }
+ * Each entry: { status: 'pending'|'flagged', reviewedBy, approvedAt, note }
  * @returns {Object.<string, {status:string, reviewedBy:string, approvedAt:string, note:string}>}
  */
 export const getStudyApprovals = () => read(EXTRA_KEYS.studyApprovals, {});
@@ -253,7 +253,15 @@ export const getStudyApprovals = () => read(EXTRA_KEYS.studyApprovals, {});
  */
 export const setStudyApproval = (studyKey, approval) => {
   const all = getStudyApprovals();
-  all[studyKey] = { ...all[studyKey], ...approval };
+  const status = approval?.status === 'flagged' ? 'flagged' : 'pending';
+  all[studyKey] = {
+    ...all[studyKey],
+    ...approval,
+    status,
+    reviewedBy: typeof approval?.reviewedBy === 'string' ? approval.reviewedBy : (all[studyKey]?.reviewedBy || ''),
+    approvedAt: typeof approval?.approvedAt === 'string' ? approval.approvedAt : (all[studyKey]?.approvedAt || ''),
+    note: typeof approval?.note === 'string' ? approval.note : (all[studyKey]?.note || ''),
+  };
   write(EXTRA_KEYS.studyApprovals, all);
 };
 

--- a/src/components/studyApproval.js
+++ b/src/components/studyApproval.js
@@ -21,13 +21,11 @@ const TODAY = new Date().toISOString().split('T')[0];
 
 const STATUS_LABELS = {
   pending:  'Pending Review',
-  approved: 'Approved by PE',
   flagged:  'Flagged — Needs Attention',
 };
 
 const STATUS_BADGE_CLASS = {
   pending:  'approval-badge--pending',
-  approved: 'approval-badge--approved',
   flagged:  'approval-badge--flagged',
 };
 
@@ -52,11 +50,12 @@ function esc(s) {
  * @returns {string} HTML string
  */
 export function getApprovalBadgeHTML(approval) {
-  if (!approval || approval.status === 'pending') {
+  const normalizedStatus = approval?.status === 'flagged' ? 'flagged' : 'pending';
+  if (!approval || normalizedStatus === 'pending') {
     return '<span class="approval-badge approval-badge--pending">● Pending Review</span>';
   }
-  const cls  = esc(STATUS_BADGE_CLASS[approval.status] ?? 'approval-badge--pending');
-  const lbl  = esc(STATUS_LABELS[approval.status]      ?? approval.status);
+  const cls  = esc(STATUS_BADGE_CLASS[normalizedStatus] ?? 'approval-badge--pending');
+  const lbl  = esc(STATUS_LABELS[normalizedStatus]      ?? approval.status);
   const by   = approval.reviewedBy ? ` — ${esc(approval.reviewedBy)}` : '';
   const date = approval.approvedAt ? `, ${esc(approval.approvedAt)}` : '';
   return `<span class="approval-badge ${cls}">● ${lbl}${by}${date}</span>`;
@@ -119,11 +118,10 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
           <label for="${statusId}">Status</label>
           <select id="${statusId}" name="status" aria-describedby="${statusId}-hint">
             <option value="pending">Pending Review</option>
-            <option value="approved">Approved by PE</option>
-            <option value="flagged">Flagged — Needs Attention</option>
+                        <option value="flagged">Flagged — Needs Attention</option>
           </select>
           <span id="${statusId}-hint" class="field-hint">
-            Set to <em>Approved by PE</em> once the study results have been reviewed and accepted.
+            Approval stamping requires authenticated server-side review. This panel stores local coordination notes only.
           </span>
         </div>
 
@@ -133,7 +131,7 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
                  placeholder="Name, title, or initials"
                  autocomplete="name"
                  aria-describedby="${byId}-hint">
-          <span id="${byId}-hint" class="field-hint">PE name, initials, or licence number.</span>
+          <span id="${byId}-hint" class="field-hint">Reviewer name or initials (informational only).</span>
         </div>
 
         <div class="auth-field">
@@ -141,7 +139,7 @@ export function initStudyApprovalPanel(studyKey, containerId = 'study-review-pan
           <input id="${dateId}" name="approvedAt" type="date"
                  value="${TODAY}"
                  aria-describedby="${dateId}-hint">
-          <span id="${dateId}-hint" class="field-hint">Date of review (defaults to today).</span>
+          <span id="${dateId}-hint" class="field-hint">Review date (informational only).</span>
         </div>
 
         <div class="auth-field">

--- a/tests/studyApproval.test.mjs
+++ b/tests/studyApproval.test.mjs
@@ -58,7 +58,7 @@ describe('setStudyApproval', () => {
   it('stores a full approval record under the correct key', () => {
     resetStore();
     const record = {
-      status: 'approved',
+      status: 'pending',
       reviewedBy: 'J. Smith PE',
       approvedAt: '2026-04-04',
       note: 'Results verified.',
@@ -70,12 +70,12 @@ describe('setStudyApproval', () => {
 
   it('stores a second study independently from the first', () => {
     resetStore();
-    setStudyApproval('arcFlash',    { status: 'approved', reviewedBy: 'A', approvedAt: '2026-04-01', note: '' });
+    setStudyApproval('arcFlash',    { status: 'pending', reviewedBy: 'A', approvedAt: '2026-04-01', note: '' });
     setStudyApproval('loadFlow',    { status: 'flagged',  reviewedBy: 'B', approvedAt: '2026-04-02', note: 'Check' });
     setStudyApproval('shortCircuit',{ status: 'pending',  reviewedBy: '',  approvedAt: '2026-04-03', note: '' });
 
     const all = getStudyApprovals();
-    assert.strictEqual(all['arcFlash'].status,     'approved');
+    assert.strictEqual(all['arcFlash'].status,     'pending');
     assert.strictEqual(all['loadFlow'].status,      'flagged');
     assert.strictEqual(all['shortCircuit'].status,  'pending');
     assert.strictEqual(Object.keys(all).length, 3);
@@ -95,9 +95,9 @@ describe('setStudyApproval', () => {
   it('overwrites an existing record when given a full object', () => {
     resetStore();
     setStudyApproval('harmonics', { status: 'flagged', reviewedBy: 'Old', approvedAt: '2026-01-01', note: '' });
-    setStudyApproval('harmonics', { status: 'approved', reviewedBy: 'New', approvedAt: '2026-04-04', note: 'OK' });
+    setStudyApproval('harmonics', { status: 'pending', reviewedBy: 'New', approvedAt: '2026-04-04', note: 'OK' });
     const all = getStudyApprovals();
-    assert.strictEqual(all['harmonics'].status,     'approved');
+    assert.strictEqual(all['harmonics'].status,     'pending');
     assert.strictEqual(all['harmonics'].reviewedBy, 'New');
   });
 });
@@ -105,7 +105,7 @@ describe('setStudyApproval', () => {
 describe('clearStudyApproval', () => {
   it('removes only the specified study key', () => {
     resetStore();
-    setStudyApproval('arcFlash', { status: 'approved', reviewedBy: 'A', approvedAt: '2026-04-04', note: '' });
+    setStudyApproval('arcFlash', { status: 'pending', reviewedBy: 'A', approvedAt: '2026-04-04', note: '' });
     setStudyApproval('loadFlow', { status: 'pending',  reviewedBy: '',  approvedAt: '2026-04-04', note: '' });
 
     clearStudyApproval('arcFlash');
@@ -136,17 +136,15 @@ describe('getApprovalBadgeHTML', () => {
     assert.ok(html.includes('approval-badge--pending'));
   });
 
-  it('returns an approved badge with reviewer name and date', () => {
+  it('normalizes approved status to pending badge', () => {
     const html = getApprovalBadgeHTML({
-      status: 'approved',
+      status: 'pending',
       reviewedBy: 'J. Smith PE',
       approvedAt: '2026-04-04',
       note: '',
     });
-    assert.ok(html.includes('approval-badge--approved'), 'Should have approved class');
-    assert.ok(html.includes('Approved by PE'),           'Should label as Approved by PE');
-    assert.ok(html.includes('J. Smith PE'),              'Should include reviewer name');
-    assert.ok(html.includes('2026-04-04'),               'Should include date');
+    assert.ok(html.includes('approval-badge--pending'), 'Should normalize to pending class');
+    assert.ok(html.includes('Pending Review'),           'Should normalize label to pending');
   });
 
   it('returns a flagged badge', () => {
@@ -157,7 +155,7 @@ describe('getApprovalBadgeHTML', () => {
 
   it('escapes HTML in reviewer name to prevent XSS', () => {
     const html = getApprovalBadgeHTML({
-      status: 'approved',
+      status: 'flagged',
       reviewedBy: '<script>alert(1)</script>',
       approvedAt: '2026-04-04',
       note: '',


### PR DESCRIPTION
### Motivation
- Prevent untrusted client-side state from producing a forged “Approved by PE” trust signal in exports/prints by removing the unauthenticated approval path. 
- Preserve local reviewer notes and a flagged/needs-attention workflow while shifting any authoritative stamping to a server-side, authenticated flow. 
- Minimize behavioral change by keeping local coordination features but ensure persisted `studyApprovals` cannot be used to impersonate a PE.

### Description
- Removed the client-visible `approved`/"Approved by PE" label and CSS class from `src/components/studyApproval.js` and replaced the form hint to state that stamping requires authenticated server-side review. 
- Normalized badge rendering in `getApprovalBadgeHTML` so non-supported statuses are rendered as `pending` and only `flagged` remains as the alternate visible state. 
- Hardened the client setter `setStudyApproval` in `dataStore.mjs` to sanitize persisted `status` values to only `pending` or `flagged` and to validate string types for `reviewedBy`, `approvedAt`, and `note` before writing. 
- Updated `tests/studyApproval.test.mjs` to reflect the new security posture while preserving XSS-escaping assertions for the badge helper.

### Testing
- Ran the full suite via `npm test` and used the failure to update expectations in `tests/studyApproval.test.mjs`, after which targeted tests passed. 
- Executed `node tests/studyApproval.test.mjs` which completed successfully. 
- Built the project with `npm run build` which completed successfully. 
- Attempted a Playwright page screenshot for a visual preview but the environment lacked Playwright browser binaries so the screenshot step could not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e5a2c148324b2cbc8b023859ecc)