### PR TITLE
Propagate `parallel_count` when grouping cables for pull cards

### DIFF
--- a/analysis/pullCards.mjs
+++ b/analysis/pullCards.mjs
@@ -207,6 +207,10 @@ export function groupCablesIntoPulls(routeResults = [], cableList = []) {
       conductor_size: cableSpec.conductor_size || result.conductor_size || '',
       diameter: parseFloat(cableSpec.diameter) || parseFloat(result.diameter) || 0,
       weight: parseFloat(cableSpec.weight) || parseFloat(result.weight) || 0,
+      parallel_count: Math.max(
+        1,
+        parseInt(cableSpec.parallel_count ?? result.parallel_count, 10) || 1
+      ),
       allowed_cable_group: cableSpec.allowed_cable_group || '',
     });
   }


### PR DESCRIPTION
### Motivation
- Pull-card calculations in `buildPullCard()` were made parallel-aware but the grouping path used by `buildPullTable()` dropped `parallel_count`, causing grouped pull cards to under-report weight, area, physical cable count, and estimated tension.

### Description
- Update `groupCablesIntoPulls()` to copy a normalized `parallel_count` into each grouped cable object so downstream `buildPullCard()` sees the intended value; the new field is sourced from the cable schedule row (`cableSpec.parallel_count`) or the route result (`result.parallel_count`).
- Normalize `parallel_count` to an integer >= 1 using `Math.max(1, parseInt(..., 10) || 1)` so existing single-cable behavior is preserved when the field is missing or invalid.
- Change is localized to `analysis/pullCards.mjs` and does not alter other pull-card math (weight/area/tension calculations remain unchanged).

### Testing
- Ran the full test suite with `npm test` which completed successfully (all tests passed). 
- Ran the production bundling step with `npm run build` which completed successfully and produced the expected `dist` outputs.
- Attempted an automated page screenshot using Playwright to produce a preview image, but Playwright failed to download the Chromium browser binary (HTTP 403), so a preview image could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e5a1804832499b52197a5ba90ad)