### PR TITLE
fix(drc): align DRC-06 power classification with existing DRC semantics

### DIFF
--- a/analysis/designRuleChecker.mjs
+++ b/analysis/designRuleChecker.mjs
@@ -347,6 +347,15 @@ function hasCircuitSpecificOcpdAllowance(cable) {
   return /\b(motor|hvac|air conditioning|refrigeration|transformer|tap)\b/.test(text);
 }
 
+function normalizedCableType(cable) {
+  return (cable.cable_type ?? cable.type ?? '').toLowerCase();
+}
+
+function isPowerCable(cable) {
+  const cableType = normalizedCableType(cable);
+  return cableType === '' || cableType === 'power' || cableType === 'pwr';
+}
+
 // ---------------------------------------------------------------------------
 // Rule implementations
 // ---------------------------------------------------------------------------
@@ -519,8 +528,7 @@ function checkAmpacity(cables, trayCableMap) {
     if (!name) continue;
 
     // Only check power cables (not control/signal — those are not ampacity-rated)
-    const cableType = (cable.cable_type ?? cable.type ?? '').toLowerCase();
-    if (cableType && cableType !== 'power' && cableType !== 'pwr') continue;
+    if (!isPowerCable(cable)) continue;
 
     const ratedAmpacity =
       parseFloat(cable.ampacity) ||
@@ -538,8 +546,7 @@ function checkAmpacity(cables, trayCableMap) {
       const cohabitants = trayCableMap.get(trayId) ?? [];
       // Count current-carrying conductors (power cables × conductors × parallel sets)
       const conductorCount = cohabitants.reduce((sum, c) => {
-        const type = (c.cable_type ?? c.type ?? '').toLowerCase();
-        if (type && type !== 'power' && type !== 'pwr') return sum;
+        if (!isPowerCable(c)) return sum;
         const conductors = parseInt(c.conductors, 10) || 3;
         const parallelSets = Math.max(1, parseInt(c.parallel_count) || 1);
         return sum + conductors * parallelSets;
@@ -665,8 +672,7 @@ function checkGrounding(cables) {
   for (const cable of cables) {
     const name = cable.name ?? cable.tag;
     if (!name) continue;
-    const cableType = (cable.cable_type ?? cable.type ?? '').toLowerCase();
-    if (cableType && cableType !== 'power' && cableType !== 'pwr') continue;
+    if (!isPowerCable(cable)) continue;
 
     const egcRaw = firstDefinedText(cable, EGC_SIZE_FIELDS);
     const egcSize = normalizeEgcSize(egcRaw);
@@ -748,8 +754,7 @@ function checkOcpdProtection(cables) {
   for (const cable of cables) {
     const name = cable.name ?? cable.tag;
     if (!name) continue;
-    const cableType = (cable.cable_type ?? cable.type ?? '').toLowerCase();
-    if (cableType && cableType !== 'power' && cableType !== 'pwr') continue;
+    if (!isPowerCable(cable)) continue;
 
     const ocpdRating = cableOcpdRating(cable);
     if (!ocpdRating) continue;
@@ -968,17 +973,15 @@ function checkDataCableSegregation(trayCableMap) {
   const findings = [];
   for (const [trayId, cables] of trayCableMap) {
     if (cables.length < 2) continue;
-    const hasPower = cables.some(c =>
-      (c.cable_type ?? c.type ?? '').toLowerCase() === 'power'
-    );
+    const hasPower = cables.some(c => isPowerCable(c));
     const hasStructured = cables.some(c => {
-      const t = (c.cable_type ?? c.type ?? '').toLowerCase();
+      const t = normalizedCableType(c);
       return t === 'data' || t === 'fiber';
     });
     if (!hasPower || !hasStructured) continue;
     const structuredNames = cables
       .filter(c => {
-        const t = (c.cable_type ?? c.type ?? '').toLowerCase();
+        const t = normalizedCableType(c);
         return t === 'data' || t === 'fiber';
       })
       .map(c => c.name ?? c.tag)

--- a/tests/designRuleChecker.test.mjs
+++ b/tests/designRuleChecker.test.mjs
@@ -872,6 +872,38 @@ describe('DRC-06 — Structured cabling EMI segregation', () => {
     assert.ok(drc06[0].message.includes('FIBER-SPINE-01'), 'Message should name the structured cable');
   });
 
+  it('fires WARNING when a Data cable shares a tray with a pwr alias cable', () => {
+    const trayCableMap = {
+      'TRAY-PWR-ALIAS': [
+        makeCable('PWR-ALIAS-01', { cable_type: 'pwr' }),
+        makeCable('DATA-001', { cable_type: 'Data' }),
+      ],
+    };
+    const { findings } = runDRC({
+      trays: [makeTray('TRAY-PWR-ALIAS', 0)],
+      cables: [],
+      trayCableMap,
+    });
+    const drc06 = findings.filter(f => f.ruleId === 'DRC-06');
+    assert.strictEqual(drc06.length, 1, 'Expected DRC-06 for pwr alias + Data mixing');
+  });
+
+  it('fires WARNING when a Data cable shares a tray with a legacy blank cable_type power cable', () => {
+    const trayCableMap = {
+      'TRAY-BLANK-POWER': [
+        makeCable('LEGACY-PWR-001', { cable_type: '' }),
+        makeCable('DATA-001', { cable_type: 'Data' }),
+      ],
+    };
+    const { findings } = runDRC({
+      trays: [makeTray('TRAY-BLANK-POWER', 0)],
+      cables: [],
+      trayCableMap,
+    });
+    const drc06 = findings.filter(f => f.ruleId === 'DRC-06');
+    assert.strictEqual(drc06.length, 1, 'Expected DRC-06 for blank cable_type + Data mixing');
+  });
+
   it('does NOT fire when only Data cables share a tray (no power)', () => {
     const trayCableMap = {
       'TRAY-DATA-ONLY': [


### PR DESCRIPTION
### Motivation
- DRC-06 only matched exact `power`, causing false negatives for legacy rows with blank `cable_type` or the `pwr` alias that other DRC checks consider power. 
- The change centralizes cable-type parsing so segregation warnings reliably fire for mixed Data/Fiber + Power scenarios across legacy/imported data.

### Description
- Added `normalizedCableType` and `isPowerCable` helpers to `analysis/designRuleChecker.mjs` to centralize cable-type normalization and classification. 
- Updated `checkAmpacity`, `checkGrounding`, `checkOcpdProtection`, and `checkDataCableSegregation` to use `isPowerCable` so blank, `power`, and `pwr` are treated consistently. 
- Replaced inline `toLowerCase()` checks with the shared helpers in the DRC implementations. 
- Extended `tests/designRuleChecker.test.mjs` with two regression tests for DRC-06 covering the `pwr` alias and legacy blank `cable_type` records.

### Testing
- Ran the full test suite with `npm test`, and all tests (including the updated DRC-06 tests) passed. 
- Built assets with `npm run build` and the build completed successfully. 
- Attempted to capture a preview screenshot using Playwright, but `npx playwright install chromium` failed due to remote download `403 Forbidden`, so an automated page preview could not be produced in this environment. 
- The change is minimal and targeted to preserve existing functionality while eliminating DRC-06 false negatives for legacy/alias power records.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e5aeb588324ab48e6ed0a8606c8)