### PR TITLE
Fix DRC-02 suppression validation for multi-slot trays

### DIFF
--- a/analysis/designRuleChecker.mjs
+++ b/analysis/designRuleChecker.mjs
@@ -218,6 +218,51 @@ export function traySlotFillPercent(tray, slotIndex, slotFillSqIn) {
  * @param {number} conductorCount
  * @returns {number}
  */
+
+function parseSlotGroupAssignments(rawSlotGroups, slotGroupsMap, numSlots) {
+  const assignments = new Map();
+  const addAssignment = (slotKey, groupValue) => {
+    const slotIndex = Number.parseInt(String(slotKey), 10);
+    const group = String(groupValue ?? '').trim();
+    if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex >= numSlots || !group) return false;
+    if (assignments.has(group) && assignments.get(group) !== slotIndex) return false;
+    assignments.set(group, slotIndex);
+    return true;
+  };
+
+  const applyEntries = (entries) => {
+    for (const [slotKey, groupValue] of entries) {
+      if (!addAssignment(slotKey, groupValue)) return false;
+    }
+    return true;
+  };
+
+  if (rawSlotGroups) {
+    try {
+      const parsed = typeof rawSlotGroups === 'string' ? JSON.parse(rawSlotGroups) : rawSlotGroups;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+      if (!applyEntries(Object.entries(parsed))) return null;
+      return assignments;
+    } catch {
+      return null;
+    }
+  }
+
+  if (slotGroupsMap instanceof Map) {
+    if (!applyEntries(slotGroupsMap.entries())) return null;
+    return assignments;
+  }
+
+  return null;
+}
+
+function cableSlotIndex(cable) {
+  const raw = cable.slot_index ?? cable.slotIndex ?? cable.tray_slot;
+  if (raw === undefined || raw === null || raw === '') return null;
+  const parsed = Number.parseInt(String(raw), 10);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
 function derateFactor(conductorCount) {
   for (const entry of TRAY_DERATING_FACTORS) {
     if (conductorCount <= entry.maxConductors) return entry.factor;
@@ -449,27 +494,22 @@ function checkSegregation(trays, trayCableMap) {
     );
 
     if (groups.size > 1) {
-      // Suppress DRC-02 when the tray is physically compartmented with a valid
-      // slot_groups mapping — mixed groups are intentional in that configuration
-      // because a listed metallic divider strip separates the voltage classes.
       const numSlots = Math.max(1, parseInt(tray.num_slots) || 1);
       if (numSlots > 1) {
-        const rawSlotGroups = tray.slot_groups;
-        let slotGroupsValid = false;
-        if (rawSlotGroups) {
-          try {
-            const parsed = typeof rawSlotGroups === 'string'
-              ? JSON.parse(rawSlotGroups)
-              : rawSlotGroups;
-            // Valid if at least one slot has a group assignment
-            slotGroupsValid = Object.keys(parsed).length > 0;
-          } catch { /* malformed JSON — not valid */ }
+        const assignments = parseSlotGroupAssignments(tray.slot_groups, tray.slotGroups, numSlots);
+        if (assignments) {
+          const groupsCovered = [...groups].every(group => assignments.has(group));
+          const assignedSlots = new Set([...groups].map(group => assignments.get(group)));
+          const groupsSeparated = assignedSlots.size === groups.size;
+          const cablesRespectAssignments = cables.every((cable) => {
+            const group = (cable.allowed_cable_group ?? cable.cable_group ?? '').trim();
+            if (!group || !assignments.has(group)) return true;
+            const slotIndex = cableSlotIndex(cable);
+            if (slotIndex === null) return true;
+            return slotIndex === assignments.get(group);
+          });
+          if (groupsCovered && groupsSeparated && cablesRespectAssignments) continue;
         }
-        // Also accept a slotGroups Map (from the routing system)
-        if (!slotGroupsValid && tray.slotGroups instanceof Map) {
-          slotGroupsValid = tray.slotGroups.size > 0;
-        }
-        if (slotGroupsValid) continue;
       }
 
       const trayGroup = (tray.allowed_cable_group ?? '').trim();

--- a/tests/designRuleChecker.test.mjs
+++ b/tests/designRuleChecker.test.mjs
@@ -169,6 +169,25 @@ describe('DRC-02 Voltage Segregation', () => {
     assert.strictEqual(drc02.length, 0);
   });
 
+
+  it('does not suppress DRC-02 when slot_groups only covers one of multiple groups', () => {
+    const trays = [makeTray('T1', 5, 12, 4, { num_slots: 2, slot_groups: JSON.stringify({ 0: 'HV' }) })];
+    const cable1 = { name: 'C1', allowed_cable_group: 'HV' };
+    const cable2 = { name: 'C2', allowed_cable_group: 'LV' };
+    const { findings } = runDRC({ trays, cables: [], trayCableMap: { T1: [cable1, cable2] } });
+    const drc02 = findings.filter(f => f.ruleId === 'DRC-02');
+    assert.ok(drc02.length > 0, 'Expected DRC-02 finding for incomplete slot_groups mapping');
+  });
+
+  it('suppresses DRC-02 when every mixed group has a distinct mapped slot', () => {
+    const trays = [makeTray('T1', 5, 12, 4, { num_slots: 2, slot_groups: JSON.stringify({ 0: 'HV', 1: 'LV' }) })];
+    const cable1 = { name: 'C1', allowed_cable_group: 'HV', slot_index: 0 };
+    const cable2 = { name: 'C2', allowed_cable_group: 'LV', slot_index: 1 };
+    const { findings } = runDRC({ trays, cables: [], trayCableMap: { T1: [cable1, cable2] } });
+    const drc02 = findings.filter(f => f.ruleId === 'DRC-02');
+    assert.strictEqual(drc02.length, 0, 'Expected DRC-02 suppression for valid per-group compartment mapping');
+  });
+
   it('ignores cables with no group assigned', () => {
     const trays = [makeTray('T1', 5)];
     const cable1 = { name: 'C1', allowed_cable_group: '' };


### PR DESCRIPTION
### Motivation
- Prevent incomplete or malformed `slot_groups` mappings from silently suppressing the DRC-02 voltage-segregation finding for multi-slot trays by enforcing structural and semantic validation of assignments.
- Restore safety-preserving behavior so mixed-voltage cable mixes cannot be hidden by a user-controlled JSON field unless the mapping truly models separate compartments.

### Description
- Added `parseSlotGroupAssignments(rawSlotGroups, slotGroupsMap, numSlots)` to validate and normalize slot→group assignments, checking parseability, slot range, non-empty group names, and preventing conflicting assignments.
- Added `cableSlotIndex(cable)` helper to read optional per-cable slot metadata for verification when available.
- Tightened `checkSegregation` so suppression occurs only when all mixed cable groups are covered by the mapping, each group maps to a distinct slot, and (when cable slot indices exist) cables occupy their assigned slots; otherwise `DRC-02` is emitted as before.
- Added tests in `tests/designRuleChecker.test.mjs` covering an incomplete `slot_groups` mapping (must still raise `DRC-02`) and a valid distinct-per-group mapping with per-cable slot indices (may suppress `DRC-02`).

### Testing
- Ran `npm test` and the full test suite completed successfully with the new tests included (no failures).
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a webpage preview with Playwright (`npx playwright screenshot` / `npx playwright install chromium`) but browser download failed in this environment (CDN 403), so the DOM screenshot step could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e5aeba483249c751edfe2a40578)