### PR TITLE
Enforce NEC 240.4(D) caps in cost optimization and add regression test

### DIFF
--- a/analysis/autoSize.mjs
+++ b/analysis/autoSize.mjs
@@ -445,15 +445,21 @@ export function meetsParallelRequirement(size) {
  * @param {number} [options.bundledConductors=1]   Applies only when nParallel === 1
  * @param {'conduit'|'tray_spaced'|'tray_touching'} [options.installationType='conduit']
  * @param {60|75|90|null} [options.terminalTempRating]
+ * @param {number|null} [options.requiredOcpd]
  * @returns {object|null}  null when no table entry can satisfy the requirement
  */
 export function evaluateConductorOption(requiredAmps, material, tempRating, nParallel, options = {}) {
-  const { ambientTempC = 30, installationType = 'conduit', terminalTempRating = null } = options;
+  const {
+    ambientTempC = 30,
+    installationType = 'conduit',
+    terminalTempRating = null,
+    requiredOcpd = nextStandardOcpd(requiredAmps),
+  } = options;
   // Parallel sets each run in a separate conduit → 3 current-carrying conductors/conduit
   const bundledConductors = nParallel > 1 ? 3 : (options.bundledConductors ?? 1);
 
   const conductor = selectConductorSize(requiredAmps / nParallel, material, tempRating, {
-    ambientTempC, bundledConductors, installationType, terminalTempRating,
+    ambientTempC, bundledConductors, installationType, terminalTempRating, requiredOcpd,
   });
   if (!conductor) return null;
 
@@ -506,6 +512,7 @@ export function evaluateConductorOption(requiredAmps, material, tempRating, nPar
  * @param {boolean} [options.allowAluminum=true]
  * @param {number}  [options.maxParallel=4]
  * @param {60|75|90|null} [options.terminalTempRating]
+ * @param {number|null} [options.requiredOcpd]
  * @returns {Array<object>}   Code-compliant options sorted by costPerFtPerPhase ascending
  */
 export function minimizeCostConductors(requiredAmps, tempRating = 75, options = {}) {
@@ -516,6 +523,7 @@ export function minimizeCostConductors(requiredAmps, tempRating = 75, options = 
     allowAluminum = true,
     maxParallel = 4,
     terminalTempRating = null,
+    requiredOcpd = nextStandardOcpd(requiredAmps),
   } = options;
 
   const results = [];
@@ -524,7 +532,7 @@ export function minimizeCostConductors(requiredAmps, tempRating = 75, options = 
   for (const material of materials) {
     for (let nParallel = 1; nParallel <= maxParallel; nParallel++) {
       const opt = evaluateConductorOption(requiredAmps, material, tempRating, nParallel, {
-        ambientTempC, bundledConductors, installationType, terminalTempRating,
+        ambientTempC, bundledConductors, installationType, terminalTempRating, requiredOcpd,
       });
       if (!opt || opt.violatesParallelRule) continue;
       results.push(opt);

--- a/tests/autoSize.test.mjs
+++ b/tests/autoSize.test.mjs
@@ -728,6 +728,14 @@ describe('minimizeCostConductors', () => {
     });
   });
 
+
+  it('enforces NEC 240.4(D) in cost optimization for small conductors', () => {
+    const opts = minimizeCostConductors(25, 75, { allowAluminum: false, maxParallel: 1 });
+    assert.ok(opts.length > 0);
+    assert.strictEqual(opts[0].size, '#10 AWG');
+    assert.ok(!opts.some(opt => opt.size === '#12 AWG'));
+  });
+
   it('all installed ampacities satisfy the required load', () => {
     const required = 200;
     const opts = minimizeCostConductors(required, 75);


### PR DESCRIPTION
### Motivation
- The cost-optimization / UI path was still calling `selectConductorSize` without the `requiredOcpd` context, allowing the small-conductor NEC 240.4(D) cap to be bypassed in cost comparisons and producing inconsistent/unsafe recommendations.

### Description
- Propagated the required OCPD into the cost-evaluation path by computing and passing `requiredOcpd` when calling `evaluateConductorOption` and `minimizeCostConductors` in `analysis/autoSize.mjs` so `selectConductorSize` enforces NEC 240.4(D).
- Updated `evaluateConductorOption` to accept and forward a `requiredOcpd` option and to use `nextStandardOcpd(requiredAmps)` as the default when not provided.
- Added a regression test in `tests/autoSize.test.mjs` that asserts `minimizeCostConductors(25, 75, { allowAluminum: false, maxParallel: 1 })` selects `#10 AWG` and does not return `#12 AWG`.
- Kept this change minimal and source-focused and did not alter the checked-in `dist/` bundle in order to avoid unrelated build artifact churn.

### Testing
- Ran the full unit test suite with `npm test`, and the test run completed successfully (the modified `autoSize` tests, including the new regression, passed).
- Built the frontend with `npm run build` and the build completed successfully in CI-local environment without committing generated `dist/` artifacts.
- Attempted to generate a Playwright screenshot preview of `autosize.html`, but browser binaries could not be downloaded in this environment (Playwright `chromium` install failed with HTTP 403), so a preview image could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091fffc69c83249b41cb9639897fab)