### PR TITLE
fix(drc): bind accepted-risk records to finding signature

### DIFF
--- a/analysis/designRuleChecker.mjs
+++ b/analysis/designRuleChecker.mjs
@@ -1131,6 +1131,19 @@ export function checkHazAreaCompatibility(equipment, areas, checkResult) {
   return findings;
 }
 
+function acceptanceSignatureForFinding(finding) {
+  const normalized = [
+    finding.ruleId,
+    finding.location,
+    finding.severity,
+    finding.message,
+    finding.detail ?? '',
+    finding.reference ?? '',
+    finding.remediation ?? '',
+  ].map(value => String(value ?? '').trim()).join('|');
+  return normalized;
+}
+
 export function runDRC(input, options = {}) {
   const {
     trays = [],
@@ -1172,7 +1185,10 @@ export function runDRC(input, options = {}) {
   const acceptedList = Array.isArray(options.acceptedFindings) ? options.acceptedFindings : [];
   for (const f of findings) {
     f.acceptedKey = `${f.ruleId}:${f.location}`;
-    const acceptance = acceptedList.find(a => a.key === f.acceptedKey);
+    f.acceptedSignature = acceptanceSignatureForFinding(f);
+    const acceptance = acceptedList.find(a =>
+      a.key === f.acceptedKey && a.signature === f.acceptedSignature
+    );
     if (acceptance) {
       f.isAccepted     = true;
       f.acceptanceNote = acceptance.note;

--- a/designrulechecker.js
+++ b/designrulechecker.js
@@ -122,6 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const acceptance = {
         key,
+        signature: finding.acceptedSignature,
         ruleId:     finding.ruleId,
         location:   finding.location,
         note:       result.note,

--- a/tests/designRuleChecker.test.mjs
+++ b/tests/designRuleChecker.test.mjs
@@ -671,7 +671,7 @@ describe('runDRC — accepted findings', () => {
     // 12" × 4" = 48 in²; 20 in² → 41.7 % → triggers DRC-01 ERROR
     const trays = [makeTray('T1', 20, 12, 4)];
     const result = runDRC({ trays, cables: [], trayCableMap: {} }, {
-      acceptedFindings: [{ key: 'DRC-01:T1', ruleId: 'DRC-01', location: 'T1', note: 'Approved per EE-001' }],
+      acceptedFindings: [{ key: 'DRC-01:T1', signature: 'DRC-01|T1|error|Tray fill 41.7 % exceeds NEC 392.22(A) limit of 40 %.|Inside width: 12 in, depth: 4 in, fill: 20.00 in².|NEC 392.22(A)|Widen or deepen the tray, add a parallel tray segment, or use the Optimal Route page to reroute cables to adjacent trays with available capacity.', ruleId: 'DRC-01', location: 'T1', note: 'Approved per EE-001' }],
     });
     const finding = result.findings.find(f => f.ruleId === 'DRC-01' && f.location === 'T1');
     assert.ok(finding, 'DRC-01 finding should exist');
@@ -682,7 +682,7 @@ describe('runDRC — accepted findings', () => {
   it('summary.passed is true when all errors are accepted', () => {
     const trays = [makeTray('T1', 20, 12, 4)];
     const result = runDRC({ trays, cables: [], trayCableMap: {} }, {
-      acceptedFindings: [{ key: 'DRC-01:T1', ruleId: 'DRC-01', location: 'T1', note: 'OK' }],
+      acceptedFindings: [{ key: 'DRC-01:T1', signature: 'DRC-01|T1|error|Tray fill 41.7 % exceeds NEC 392.22(A) limit of 40 %.|Inside width: 12 in, depth: 4 in, fill: 20.00 in².|NEC 392.22(A)|Widen or deepen the tray, add a parallel tray segment, or use the Optimal Route page to reroute cables to adjacent trays with available capacity.', ruleId: 'DRC-01', location: 'T1', note: 'OK' }],
     });
     assert.strictEqual(result.summary.errors, 0);
     assert.strictEqual(result.summary.accepted, 1);
@@ -695,7 +695,7 @@ describe('runDRC — accepted findings', () => {
       makeTray('T2', 20, 12, 4), // overfill → DRC-01 ERROR
     ];
     const result = runDRC({ trays, cables: [], trayCableMap: {} }, {
-      acceptedFindings: [{ key: 'DRC-01:T1', ruleId: 'DRC-01', location: 'T1', note: 'OK' }],
+      acceptedFindings: [{ key: 'DRC-01:T1', signature: 'DRC-01|T1|error|Tray fill 41.7 % exceeds NEC 392.22(A) limit of 40 %.|Inside width: 12 in, depth: 4 in, fill: 20.00 in².|NEC 392.22(A)|Widen or deepen the tray, add a parallel tray segment, or use the Optimal Route page to reroute cables to adjacent trays with available capacity.', ruleId: 'DRC-01', location: 'T1', note: 'OK' }],
     });
     assert.strictEqual(result.summary.accepted, 1);
     assert.strictEqual(result.summary.errors, 1);   // T2 still an error
@@ -705,9 +705,18 @@ describe('runDRC — accepted findings', () => {
   it('non-matching key does not mark finding as accepted', () => {
     const trays = [makeTray('T1', 20, 12, 4)];
     const result = runDRC({ trays, cables: [], trayCableMap: {} }, {
-      acceptedFindings: [{ key: 'DRC-01:T9', ruleId: 'DRC-01', location: 'T9', note: 'Wrong tray' }],
+      acceptedFindings: [{ key: 'DRC-01:T9', signature: 'x', ruleId: 'DRC-01', location: 'T9', note: 'Wrong tray' }],
     });
     const finding = result.findings.find(f => f.ruleId === 'DRC-01');
+    assert.strictEqual(finding.isAccepted, false);
+  });
+
+  it('does not accept finding when signature mismatches', () => {
+    const trays = [makeTray('T1', 20, 12, 4)];
+    const result = runDRC({ trays, cables: [], trayCableMap: {} }, {
+      acceptedFindings: [{ key: 'DRC-01:T1', signature: 'DRC-01|T1|error|old message', note: 'Stale acceptance' }],
+    });
+    const finding = result.findings.find(f => f.ruleId === 'DRC-01' && f.location === 'T1');
     assert.strictEqual(finding.isAccepted, false);
   });
 });
@@ -832,6 +841,7 @@ describe('formatDrcReport() — accepted risk section', () => {
     const result = runDRC({ trays, cables: [], trayCableMap: {} }, {
       acceptedFindings: [{
         key: 'DRC-01:T1',
+        signature: 'DRC-01|T1|error|Tray fill 41.7 % exceeds NEC 392.22(A) limit of 40 %.|Inside width: 12 in, depth: 4 in, fill: 20.00 in².|NEC 392.22(A)|Widen or deepen the tray, add a parallel tray segment, or use the Optimal Route page to reroute cables to adjacent trays with available capacity.',
         ruleId: 'DRC-01',
         location: 'T1',
         note: 'Approved per ENG-042',


### PR DESCRIPTION
### Motivation
- Imported or stale accepted-risk records could suppress active DRC violations because acceptance was trusted solely by a weak `ruleId:location` key, allowing a crafted `.ctr.json` to force a false PASSED status.

### Description
- Introduced a deterministic `acceptanceSignatureForFinding` derived from the finding payload (ruleId, location, severity, message, detail, reference, remediation) and attached it as `acceptedSignature` on findings. 
- Require both the legacy `key` (`ruleId:location`) and the `signature` to match an acceptance record before marking a finding as accepted. 
- Persist the `signature` when creating an acceptance in the UI so new acceptances remain compatible with the stricter check. 
- Updated tests to exercise signature-aware acceptance and added a negative test to ensure stale/mismatched signatures do not suppress findings (files changed: `analysis/designRuleChecker.mjs`, `designrulechecker.js`, `tests/designRuleChecker.test.mjs`).

### Testing
- Ran the automated test suite with `npm test` and all tests passed.  
- Built the distribution with `npm run build` and the build succeeded.  
- Attempted to capture a Playwright screenshot preview but browser binaries could not be downloaded in this environment (download failed with HTTP 403), so no runtime screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0921bb55c0832481778861d6b576b7)