### PR TITLE
fix(security): neutralize formulas in procurement CSV export

### DIFF
--- a/analysis/cableProcurement.mjs
+++ b/analysis/cableProcurement.mjs
@@ -333,8 +333,9 @@ export function exportProcurementCSV(report) {
   const CRLF = '\r\n';
 
   function esc(v) {
-    const s = String(v ?? '');
-    return s.includes(',') || s.includes('"') || s.includes('\n')
+    const raw = String(v ?? '');
+    const s = /^[=+\-@\t\r]/.test(raw) ? `'${raw}` : raw;
+    return s.includes(',') || s.includes('"') || s.includes('\n') || s.includes('\r')
       ? `"${s.replace(/"/g, '""')}"` : s;
   }
 

--- a/tests/cableProcurement.test.mjs
+++ b/tests/cableProcurement.test.mjs
@@ -353,6 +353,47 @@ describe('exportProcurementCSV', () => {
     // Expect exactly: header + TOTALS = 2 lines
     assert.strictEqual(lines.length, 2, `expected 2 lines for empty report, got ${lines.length}`);
   });
+
+
+  it('neutralizes spreadsheet formula prefixes in user-controlled fields', () => {
+    const maliciousReport = {
+      lineItems: [{
+        spec_key: '=2+2::#12 AWG',
+        cable_type: '@SUM(1+1)',
+        conductor_size: '+10 AWG',
+        conductors: '	=CMD()',
+        material: 'copper',
+        cut_count: 1,
+        total_required_ft: 100,
+        selected_reel_size: { name: '250 ft', feet: 250 },
+        num_reels: 1,
+        total_ordered_ft: 250,
+        waste_ft: 150,
+        waste_pct: 60,
+      }],
+      summary: {
+        total_cut_count: 1,
+        total_required_ft: 100,
+        total_ordered_ft: 250,
+        total_waste_ft: 150,
+        avg_waste_pct: 60,
+      },
+    };
+
+    const csv = exportProcurementCSV(maliciousReport);
+    const dataRow = csv.split('\r\n')[1];
+    assert.ok(dataRow.includes("'=2+2::#12 AWG"));
+    assert.ok(dataRow.includes("'@SUM(1+1)"));
+    assert.ok(dataRow.includes("'+10 AWG"));
+    assert.ok(dataRow.includes("'\t=CMD()"));
+  });
+
+  it('quotes carriage-return values to preserve valid CSV rows', () => {
+    const report = calculateProcurement(sampleResults, cableList);
+    report.lineItems[0].cable_type = 'Power\rAlt';
+    const csv = exportProcurementCSV(report);
+    assert.ok(csv.includes('"Power\rAlt"'));
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent CSV formula injection from user-controlled cable metadata exported by the Procurement Schedule, which could be executed when opened in spreadsheet apps.
- Keep existing CSV semantics and spreadsheet compatibility while neutralizing only unsafe leading characters.

### Description
- Hardened `exportProcurementCSV` in `analysis/cableProcurement.mjs` so `esc()` prefixes a single quote for any cell starting with `=`, `+`, `-`, `@`, tab, or `CR` and also treats `CR` as a trigger for quoting. 
- Extended CSV quoting to include carriage returns so multi-line or CR-containing cells are emitted as valid quoted CSV fields. 
- Added regression tests in `tests/cableProcurement.test.mjs` that verify formula-leading values are neutralized and that `CR` values are quoted.

### Testing
- Ran the full test suite with `npm test`, which completed successfully and includes the updated `tests/cableProcurement.test.mjs` assertions. 
- Ran the build with `npm run build`, which completed successfully and produced assets. 
- Attempted to capture a page preview with Playwright, but browser binaries could not be downloaded in this environment (Playwright install failed with HTTP 403), so no screenshot artifact could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09237045bc83249697b8fe6782423b)