### PR TITLE
Fix transient stability generator discovery and unit normalization

### DIFF
--- a/analysis/contingency.mjs
+++ b/analysis/contingency.mjs
@@ -100,12 +100,26 @@ function voltageStatus(vm, min, max) {
  * @param {number} baseMVA
  * @returns {Array<{busId:string, Pm_pu:number}>}
  */
+function getGenerationKw(bus) {
+  if (!bus || typeof bus !== 'object') return 0;
+
+  if (bus.generation && typeof bus.generation === 'object') {
+    const kw = bus.generation.kw ?? bus.generation.kW;
+    if (Number.isFinite(kw)) return kw;
+  }
+
+  if (Number.isFinite(bus.Pg)) return bus.Pg;
+  if (Number.isFinite(bus.gen_MW)) return bus.gen_MW * 1000;
+
+  return 0;
+}
+
 function identifyGeneratorBuses(model, baseMVA) {
   const gens = [];
   for (const bus of (model.buses || [])) {
-    const Pg = bus.Pg ?? bus.gen_MW ?? bus.generation ?? 0;
-    if (Number.isFinite(Pg) && Pg > 0) {
-      gens.push({ busId: bus.id, Pm_pu: Pg / baseMVA });
+    const Pg_kw = getGenerationKw(bus);
+    if (Number.isFinite(Pg_kw) && Pg_kw > 0) {
+      gens.push({ busId: bus.id, Pm_pu: (Pg_kw / 1000) / baseMVA });
     }
   }
   return gens;

--- a/tests/contingency.test.mjs
+++ b/tests/contingency.test.mjs
@@ -223,6 +223,53 @@ describe('runContingency — transient stability coupling', () => {
     assert.strictEqual(contingencies[0].transientStability.checked, false);
   });
 
+  it('with checkTransientStability:true and bus.generation.kw, checked is true', () => {
+    const model = {
+      buses: [
+        { id: 'G1', label: 'Gen Bus', Vm: 1.02, Va: 0, generation: { kw: 2000, kvar: 0 }, connections: [] },
+        { id: 'B2', label: 'Load Bus', Vm: 1.0,  Va: 0, connections: [] },
+      ],
+      branches: [{ id: 'L1', name: 'Line 1', type: 'line' }],
+    };
+    const { contingencies } = runContingency(model, {
+      checkTransientStability: true,
+      generatorInertiaH: 5.0,
+      baseMVA: 100,
+    });
+    assert.strictEqual(contingencies[0].transientStability.checked, true);
+  });
+
+  it('treats Pg in kW consistently with generation.kw', () => {
+    const pgModel = {
+      buses: [
+        { id: 'G1', label: 'Gen Bus', Vm: 1.0, Va: 0, Pg: 2000, connections: [] },
+        { id: 'B2', label: 'Load Bus', Vm: 1.0, Va: 0, connections: [] },
+      ],
+      branches: [{ id: 'L1', name: 'Line 1', type: 'line' }],
+    };
+    const genModel = {
+      buses: [
+        { id: 'G1', label: 'Gen Bus', Vm: 1.0, Va: 0, generation: { kw: 2000, kvar: 0 }, connections: [] },
+        { id: 'B2', label: 'Load Bus', Vm: 1.0, Va: 0, connections: [] },
+      ],
+      branches: [{ id: 'L1', name: 'Line 1', type: 'line' }],
+    };
+
+    const pgRun = runContingency(pgModel, { checkTransientStability: true });
+    const genRun = runContingency(genModel, { checkTransientStability: true });
+
+    assert.strictEqual(pgRun.contingencies[0].transientStability.checked, true);
+    assert.strictEqual(genRun.contingencies[0].transientStability.checked, true);
+    assert.strictEqual(
+      pgRun.contingencies[0].transientStability.deltaMax_deg,
+      genRun.contingencies[0].transientStability.deltaMax_deg,
+    );
+    assert.strictEqual(
+      pgRun.contingencies[0].transientStability.stable,
+      genRun.contingencies[0].transientStability.stable,
+    );
+  });
+
   it('with checkTransientStability:true and a generator bus, checked is true', () => {
     const model = {
       buses: [


### PR DESCRIPTION
### Motivation
- The transient-stability coupling failed to detect standard one-line generator definitions because `identifyGeneratorBuses` only accepted numeric `Pg`/`gen_MW` values and skipped `bus.generation` objects, which caused checks to be silently omitted.
- Numeric generator power was interpreted inconsistently (kW vs MW), producing a 1000x error for some inputs; the transient check must use the same unit conventions as the load-flow code.

### Description
- Add `getGenerationKw()` to normalize generator power from `bus.generation.kw`/`kW`, `Pg`, or `gen_MW` (converting `gen_MW` → kW), and return kW consistently.  (modified `analysis/contingency.mjs`).
- Update `identifyGeneratorBuses()` to derive `Pm_pu` from kW → MW → per-unit by computing `(Pg_kw / 1000) / baseMVA`, aligning with `runLoadFlow` conventions. (modified `analysis/contingency.mjs`).
- Add two regression tests to `tests/contingency.test.mjs` to ensure that `checkTransientStability:true` runs when generation is supplied as `bus.generation.kw` and that `Pg:2000` and `generation.kw:2000` produce identical transient-stability outputs.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (tests passed). 
- Ran the build with `npm run build`, which completed successfully (dist artifacts were produced then cleaned from the working tree). 
- Executed the updated `tests/contingency.test.mjs` which includes the two new regression cases and they passed under the test run. 
- Attempted to capture a visual preview via Playwright (`npx playwright install chromium` / headless screenshot), but browser binaries could not be downloaded in this environment (CDN 403), so a webpage preview image could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092370c1108324a1bcf795e3516108)