### PR TITLE
Fix auto-coordinate default protective-device order to load→source

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -7854,12 +7854,12 @@ function renderCoordOrderList() {
     return;
   }
 
-  // Merge existing coordOrderIds with newly plotted devices
-  const plotted = new Set(protective.map(e => e.selection.uid));
-  coordOrderIds = coordOrderIds.filter(uid => plotted.has(uid));
-  protective.forEach(e => {
-    if (!coordOrderIds.includes(e.selection.uid)) coordOrderIds.push(e.selection.uid);
-  });
+  // Keep only currently plotted devices and default to load→source ordering.
+  const defaultOrderIds = [...protective].reverse().map(e => e.selection.uid);
+  const plotted = new Set(defaultOrderIds);
+  const existingOrder = coordOrderIds.filter(uid => plotted.has(uid));
+  const missingIds = defaultOrderIds.filter(uid => !existingOrder.includes(uid));
+  coordOrderIds = [...existingOrder, ...missingIds];
 
   coordOrderList.innerHTML = '';
   coordOrderIds.forEach((uid, index) => {


### PR DESCRIPTION
### Motivation
- The greedy coordination algorithm requires `deviceEntries` ordered load→source (index 0 = downstream), but the UI seeded `coordOrderIds` in plotted order which can be source→load and cause reversed coordination and false-success results.
- Seeding the list in the wrong direction can produce unsafe suggested time-dial settings without changing the core algorithm, so a minimal UI-side fix is required to ensure the correct default ordering.

### Description
- Modified `renderCoordOrderList()` in `analysis/tcc.js` to default missing coordination entries to load→source by reversing the plotted protective sequence when computing default IDs.
- Preserved any existing user drag-reordered entries for currently plotted devices and appended only the missing devices in the safe default order so user edits are not lost.
- The change is localized to the coord-order seeding logic and does not alter `greedyCoordinate()` or other coordination algorithms.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (including `tests/tcc/tccAutoCoord.test.mjs`).
- Ran `npm run build`, which completed successfully and produced the dist artifacts.
- Attempted an automated Playwright screenshot to generate a preview image, but `npx playwright install chromium` failed due to browser download permissions (403), so the screenshot step could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09236ff5488324987cde43f9fce7dd)