### PR TITLE
fix: align fill gauge colors with computed NEC limits

### DIFF
--- a/cabletrayfill.js
+++ b/cabletrayfill.js
@@ -364,7 +364,7 @@ checkPrereqs([{key:'traySchedule',page:'racewayschedule.html',label:'Raceway Sch
         const compLabel = compartments.length > 1 ? ' (worst compartment)' : '';
         fillSummaryEl.textContent = `Total Cable Area: ${totalArea.toFixed(2)} in², Fill: ${worstFill.toFixed(1)}%${compLabel}`;
         fillSummaryEl.style.color = worstFill > allow ? 'var(--color-error)' : '';
-        trayGauge.update(worstFill);
+        trayGauge.update(worstFill, allow);
         updateTrayFillStatus(worstFill, allow);
         return { totalArea, fillP: worstFill, allow };
       }

--- a/conduitfill.js
+++ b/conduitfill.js
@@ -309,8 +309,8 @@ checkPrereqs([{key:'conduitSchedule',page:'racewayschedule.html',label:'Raceway 
 
         const sumArea = cables.reduce((s,c)=> s + Math.PI*(c.r**2),0);
         const fillPct = (sumArea / area) * 100;
-        conduitGauge.update(fillPct);
         const allowed = cables.length===1?53:(cables.length===2?31:40);
+        conduitGauge.update(fillPct, allowed);
         let results = `<p><strong>Conduit:</strong> ${escapeHtml(type)} ${escapeHtml(size)}" (ID ${(2*R).toFixed(2)}")</p>`;
         results += `<p><strong>Fill:</strong> ${fillPct.toFixed(1)} % (Allowed ${allowed}% )</p>`;
         if(fillPct > allowed){

--- a/src/components/fillGauge.js
+++ b/src/components/fillGauge.js
@@ -20,7 +20,7 @@ const DEFAULT_ZONES = [
  * @param {number} [options.strokeWidth=18]    - Arc stroke width.
  * @param {string} [options.label='Fill %']    - Label shown below numeric value.
  * @param {Array}  [options.zones]             - Color zone thresholds.
- * @returns {{ update: function(number): void }}
+ * @returns {{ update: function(number, number=): void }}
  */
 export function createFillGauge(containerId, options = {}) {
   const {
@@ -111,9 +111,9 @@ export function createFillGauge(containerId, options = {}) {
   container.appendChild(svg);
 
   // ── Public API ────────────────────────────────────────────────────────────
-  function update(percentage) {
+  function update(percentage, allowedLimit = null) {
     const pct = Math.max(0, percentage);
-    const color = getZoneColor(pct, zones);
+    const color = getColorForValue(pct, zones, allowedLimit);
 
     if (pct <= 0) {
       fillArc.setAttribute('d', `M ${cx - r} ${cy} L ${cx - r} ${cy}`);
@@ -159,4 +159,13 @@ function getZoneColor(pct, zones) {
     if (pct <= zone.limit) return zone.color;
   }
   return zones[zones.length - 1].color;
+}
+
+function getColorForValue(pct, zones, allowedLimit) {
+  if (!Number.isFinite(allowedLimit) || allowedLimit <= 0) {
+    return getZoneColor(pct, zones);
+  }
+  if (pct > allowedLimit) return '#dc3545';
+  if (pct > allowedLimit * 0.9) return '#ffc107';
+  return '#28a745';
 }


### PR DESCRIPTION
### Motivation
- The SVG fill gauge used fixed color zones (40%/50%/etc.) and chose colors based only on the raw fill percentage, which can misreport NEC compliance for tray types and conduit cable counts that have different allowed limits.
- The goal is to make the visual gauge reflect the same computed NEC `allowed` limit already used by the textual warnings so the gauge cannot display a false-safe or false-overlimit state.

### Description
- Extended `createFillGauge().update()` to accept an optional `allowedLimit` parameter and added `getColorForValue()` to choose colors based on the computed limit (red when `fill > allowedLimit`, yellow when within 90% of the limit, green otherwise), while preserving legacy zone behavior when `allowedLimit` is not provided (`src/components/fillGauge.js`).
- Passed the tray `allow` into the gauge call in `cabletrayfill.js` so tray gauges reflect ladder vs solid tray limits (`trayGauge.update(worstFill, allow)`).
- Computed the conduit `allowed` value before updating the gauge in `conduitfill.js` and passed it into `conduitGauge.update(fillPct, allowed)`, preventing two-cable conduit overfills from appearing green.
- Maintained existing UI semantics and fallback behavior to avoid changing appearances when no allowed limit is available.

### Testing
- Ran the full test suite with `npm test`, which completed successfully.
- Built assets with `npm run build`, which completed successfully.
- Attempted to capture a preview screenshot via Playwright, but browser installation failed in this environment due to CDN download `403` errors, so no screenshot could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09237088d483248ba63ef1f9d0324a)