### PR TITLE
Clamp negative parallel_count in routing and fill calculations

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -58,6 +58,7 @@ function escapeHtml(str) {
 }
 /** Alias for escapeHtml — use in attribute value contexts for readability. */
 const escapeAttr = escapeHtml;
+const getParallelCount = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
 
 /**
  * Return true only for URLs that are safe to use as href values.
@@ -2374,7 +2375,7 @@ const openConduitFill = (cables) => {
     }).filter(Boolean);
     const spec = CONDUIT_SPECS[conduitType] || {};
     const count = cableObjs.length;
-    const totalArea = cableObjs.reduce((s, c) => s + Math.PI * Math.pow(c.diameter / 2, 2) * (parseInt(c.parallel_count) || 1), 0);
+    const totalArea = cableObjs.reduce((s, c) => s + Math.PI * Math.pow(c.diameter / 2, 2) * getParallelCount(c.parallel_count), 0);
     /* NEC Chapter 9 Table 1 fill limits (see docs/standards.md) */
     const fillPct = count === 1 ? 0.53 : count === 2 ? 0.31 : 0.40;
     let tradeSize = null;
@@ -4232,7 +4233,7 @@ const renderBatchResults = (results) => {
             const cable = cableMap.get(name);
             const info = resultMap.get(name);
             if (!cable || !info) return;
-            const area = Math.PI * (cable.diameter / 2) ** 2 * (parseInt(cable.parallel_count) || 1);
+            const area = Math.PI * (cable.diameter / 2) ** 2 * getParallelCount(cable.parallel_count);
             if (Array.isArray(info.row.tray_segments)) {
                 routingSystem.updateTrayFill(info.row.tray_segments, -area, cable.allowed_cable_group);
             }

--- a/batchRouteWorker.js
+++ b/batchRouteWorker.js
@@ -2,6 +2,7 @@ importScripts('routeWorker.js');
 
 let state = null;
 let cancel = false;
+const getParallelCount = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
 
 function processFrom(index) {
     const { system, cables, results, allRoutes } = state;
@@ -18,7 +19,7 @@ function processFrom(index) {
         }
 
         const cable = cables[i];
-        const cableArea = Math.PI * (cable.diameter / 2) ** 2 * (parseInt(cable.parallel_count) || 1);
+        const cableArea = Math.PI * (cable.diameter / 2) ** 2 * getParallelCount(cable.parallel_count);
         const routeStart = performance.now();
         const result = system.calculateRoute(
             cable.start,
@@ -83,7 +84,7 @@ self.onmessage = function(e) {
         cancel = false;
         cables.forEach((c, idx) => {
             if (c.locked && Array.isArray(c.route_segments) && c.route_segments.length) {
-                const area = Math.PI * (c.diameter / 2) ** 2 * (parseInt(c.parallel_count) || 1);
+                const area = Math.PI * (c.diameter / 2) ** 2 * getParallelCount(c.parallel_count);
                 const traySegs = c.route_segments.filter(seg => seg.tray_id).map(seg => seg.tray_id);
                 system.updateTrayFill(traySegs, area);
                 system.recordSharedFieldSegments(c.route_segments);
@@ -124,4 +125,3 @@ self.onmessage = function(e) {
         }
     }
 };
-

--- a/cableschedule.js
+++ b/cableschedule.js
@@ -226,7 +226,7 @@ async function initCableSchedule() {
     {key:'install_method',label:'Install Method',type:'select',options:installMethods,group:'Cable Construction',tooltip:'Installation method'},
     {key:'insulation_type',label:'Insulation Type',type:'select',options:Object.keys(INSULATION_TEMP_LIMIT),group:'Cable Construction',tooltip:'Insulation material type'},
     {key:'insulation_rating',label:'Insul Rating (°C)',type:'select',options:insulationRatings,group:'Cable Construction',tooltip:'Maximum temperature rating of insulation'},
-    {key:'parallel_count',label:'Parallel Runs',type:'number',group:'Cable Construction',tooltip:'Number of identical cables run in parallel for this circuit (e.g. 3 × 240 kcmil in parallel). Tray fill and ampacity are multiplied by this count.'},
+    {key:'parallel_count',label:'Parallel Runs',type:'number',group:'Cable Construction',min:1,step:1,tooltip:'Number of identical cables run in parallel for this circuit (e.g. 3 × 240 kcmil in parallel). Tray fill and ampacity are multiplied by this count.'},
     {key:'operating_voltage',label:'Operating Voltage (V)',type:'number',group:'Electrical Entry',tooltip:'Nominal operating voltage'},
     {key:'est_load',label:'Est Load (A)',type:'number',group:'Electrical Entry',tooltip:'Estimated operating current'},
     {key:'ocpd_rating',label:'OCPD Rating (A)',type:'number',group:'Electrical Entry',tooltip:'Overcurrent protective device rating used for NEC 240.4/250.122 screening'},


### PR DESCRIPTION
### Motivation
- Prevent negative `parallel_count` values from producing negative cable areas that can understate tray/conduit fill and bypass capacity checks.
- Harden routing and conduit-sizing boundaries so imported or malicious schedule data cannot silently alter engineering outputs.

### Description
- Add a shared `getParallelCount(value) => Math.max(1, Number.parseInt(value, 10) || 1)` helper and use it in `batchRouteWorker.js` to clamp `parallel_count` for batch routing and locked-route replay area calculations.
- Add the same `getParallelCount` helper to `app.mjs` and replace unclamped `parseInt(... ) || 1` uses for conduit fill sizing (`openConduitFill`) and reroute area math so negative counts cannot produce negative `totalArea` or `area` values.
- Add UI guardrails to the cable schedule column by setting `min: 1` and `step: 1` for the `parallel_count` field in `cableschedule.js` to discourage invalid entry via the normal form path.

### Testing
- Ran the full automated test suite with `npm test`, and the test run completed successfully (all tests passed).
- Built the distribution with `npm run build`, and the build completed successfully.
- Attempted to capture a webpage preview with Playwright (`npx playwright screenshot ...`) but the browser binaries are not installed in this environment, so an automated screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0923700cf483249b8815dc68a09c24)