### PR TITLE
Fix voltage-drop study fail-open handling for incomplete cable data

### DIFF
--- a/analysis/voltageDropStudy.mjs
+++ b/analysis/voltageDropStudy.mjs
@@ -59,7 +59,7 @@ export function classifyCircuit(cable) {
  *   dropPct: number,
  *   circuitType: 'feeder'|'branch',
  *   limit: number,
- *   status: 'pass'|'warn'|'fail',
+ *   status: 'pass'|'warn'|'fail'|'not-evaluated',
  *   evaluated: boolean,
  *   basis: string
  * }}
@@ -82,7 +82,7 @@ export function evaluateCable(cable, lengthFt) {
 
   let status;
   if (!evaluated) {
-    status = 'pass'; // no data - preserve legacy status while marking the row not evaluated
+    status = 'not-evaluated';
   } else if (dropPct > limit) {
     status = 'fail';
   } else if (dropPct > limit * 0.8) {

--- a/tests/voltageDropStudy.test.mjs
+++ b/tests/voltageDropStudy.test.mjs
@@ -75,17 +75,17 @@ describe('classifyCircuit', () => {
 
 // ---------------------------------------------------------------------------
 describe('evaluateCable', () => {
-  it('returns pass for cable with no length data', () => {
+  it('returns not-evaluated for cable with no length data', () => {
     const result = evaluateCable({ cable_tag: 'C01', est_load: '100', cable_rating: '480' });
-    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.status, 'not-evaluated');
     assert.strictEqual(result.dropPct, 0);
     assert.strictEqual(result.evaluated, false);
     assert.ok(result.basis.includes('informational-note recommendation'));
   });
 
-  it('returns pass for cable with no load data', () => {
+  it('returns not-evaluated for cable with no load data', () => {
     const result = evaluateCable({ cable_tag: 'C02', length: '500', cable_rating: '480' });
-    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.status, 'not-evaluated');
     assert.strictEqual(result.evaluated, false);
   });
 
@@ -208,7 +208,7 @@ describe('runVoltageDropStudy', () => {
     assert.ok('limit' in r);
     assert.ok('evaluated' in r);
     assert.ok('basis' in r);
-    assert.ok(['pass', 'warn', 'fail'].includes(r.status));
+    assert.ok(['pass', 'warn', 'fail', 'not-evaluated'].includes(r.status));
     assert.ok(['feeder', 'branch'].includes(r.circuitType));
   });
 });


### PR DESCRIPTION
### Motivation
- The voltage-drop evaluator previously treated missing or uncomputable inputs as a passing result, which conflated incomplete data with compliant circuits and could overstate NEC screening compliance.
- The change prevents incomplete rows from being counted as `PASS` so report-level compliance metrics reflect only evaluated rows.

### Description
- In `analysis/voltageDropStudy.mjs` `evaluateCable` now sets `status = 'not-evaluated'` when required inputs are missing or the calculation is uncomputable, while preserving the existing `evaluated` gating and pass/warn/fail logic for rows that can be computed.
- The study summary continues to compute `pass`, `warn`, and `fail` only from `evaluated` rows and includes a `notEvaluated` count for incomplete rows.
- Updated `tests/voltageDropStudy.test.mjs` to assert `not-evaluated` for incomplete rows and to accept `not-evaluated` in the status shape assertion.
- No UI behavior was changed other than relying on the explicit per-row `evaluated`/`status` semantics already rendered by the study page.

### Testing
- Ran `npm test` and the full test suite (including the updated voltage-drop tests), which completed successfully.
- Ran `npm run build` to produce distribution assets, which completed successfully.
- Attempted a Playwright screenshot for a preview with `npx playwright screenshot`, but browser binaries could not be downloaded in this environment (Playwright `chromium` install failed with upstream 403), so an in-container visual preview could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09237069ac8324941c42cb80a7157e)