### PR TITLE
Harden HTTPS redirect against Host header poisoning

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -761,7 +761,8 @@ function resolveOptions(options = {}) {
     staticRoot = process.cwd(),
     tokenTtlMs = DEFAULT_TOKEN_TTL_MS,
     rateLimit = {},
-    enforceHttps = process.env.NODE_ENV === 'production'
+    enforceHttps = process.env.NODE_ENV === 'production',
+    httpsRedirectHost = process.env.HTTPS_REDIRECT_HOST || ''
   } = options;
 
   const { windowMs = DEFAULT_RATE_LIMIT_WINDOW_MS, max = DEFAULT_RATE_LIMIT_MAX } = rateLimit;
@@ -772,7 +773,8 @@ function resolveOptions(options = {}) {
     tokenTtlMs: Number(tokenTtlMs) || DEFAULT_TOKEN_TTL_MS,
     rateLimitWindowMs: Number(windowMs) || DEFAULT_RATE_LIMIT_WINDOW_MS,
     rateLimitMax: Number(max) || DEFAULT_RATE_LIMIT_MAX,
-    enforceHttps: Boolean(enforceHttps)
+    enforceHttps: Boolean(enforceHttps),
+    httpsRedirectHost: String(httpsRedirectHost || '').trim()
   };
 }
 
@@ -788,7 +790,8 @@ export async function createApp(options = {}) {
     tokenTtlMs,
     rateLimitWindowMs,
     rateLimitMax,
-    enforceHttps
+    enforceHttps,
+    httpsRedirectHost
   } = resolveOptions(options);
   const dataDirWithinStaticRoot = isSubPath(staticRoot, dataDir);
 
@@ -836,7 +839,7 @@ export async function createApp(options = {}) {
         next();
         return;
       }
-      if (!req.headers.host) {
+      if (!httpsRedirectHost) {
         res.status(400).json({ error: 'HTTPS required' });
         return;
       }
@@ -851,7 +854,7 @@ export async function createApp(options = {}) {
         res.status(400).json({ error: 'HTTPS required' });
         return;
       }
-      res.redirect(308, `https://${req.headers.host}${req.originalUrl}`);
+      res.redirect(308, `https://${httpsRedirectHost}${req.originalUrl}`);
     });
   }
 

--- a/tests/serverSecurity.test.mjs
+++ b/tests/serverSecurity.test.mjs
@@ -548,7 +548,8 @@ async function httpsRedirectScenario() {
     dataDir: tmpDir,
     tokenTtlMs: 5000,
     rateLimit: { windowMs: 60000, max: 100 },
-    enforceHttps: true
+    enforceHttps: true,
+    httpsRedirectHost: 'app.example.test'
   });
   const baseUrl = `http://127.0.0.1:${port}`;
 
@@ -568,12 +569,12 @@ async function httpsRedirectScenario() {
     await check('redirects non-API HTTP requests with 308 to preserve method', async () => {
       const res = await fetch(`${baseUrl}/login.html`, {
         method: 'GET',
-        headers: { host: '127.0.0.1' },
+        headers: { host: 'attacker.example.test' },
         redirect: 'manual'
       });
       assert.strictEqual(res.status, 308, 'navigation requests should use 308 redirect');
       const location = res.headers.get('location');
-      assert(location && location.startsWith('https://'), 'should redirect to HTTPS');
+      assert.strictEqual(location, 'https://app.example.test/login.html', 'should redirect to configured HTTPS host');
     });
   } finally {
     await closeServer(server);
@@ -587,4 +588,3 @@ async function httpsRedirectScenario() {
   await passwordChangeScenario();
   await httpsRedirectScenario();
 })();
-


### PR DESCRIPTION
### Motivation
- The HTTPS enforcement middleware previously constructed the `Location` for HTTP→HTTPS redirects from the client-supplied `Host` header, and using `308` made that a body-preserving cross-origin replay risk for POSTs and other sensitive requests.
- Provide a minimal defense by moving redirect targets to a configured canonical host so attacker-controlled `Host` headers cannot force requests (and bodies) to an arbitrary origin.

### Description
- Add a new `httpsRedirectHost` option (resolved from `options.httpsRedirectHost` or the `HTTPS_REDIRECT_HOST` env var) in `resolveOptions` and flow it into `createApp`.
- Change the HTTPS middleware to require a configured `httpsRedirectHost` and return `400` if missing, and to build redirects as `https://${httpsRedirectHost}${req.originalUrl}` instead of using `req.headers.host`.
- Update `tests/serverSecurity.test.mjs` to pass `httpsRedirectHost: 'app.example.test'` to `startServer` and assert that a forged `Host` header is ignored and the redirect location equals `https://app.example.test/login.html`.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully and includes the updated `tests/serverSecurity.test.mjs` assertions (all tests passed).
- Ran the build with `npm run build`, which completed successfully and produced the distribution artifacts.
- Attempted to generate a runtime preview screenshot with Playwright, but `npx playwright install` failed due to blocked browser downloads in this environment (so no screenshot could be produced here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0927acfc5c8324b88d6f83ab2bda12)