### PR TITLE
Fix prototype-key DoS in wind load schedule tray weight accumulation

### DIFF
--- a/windload.js
+++ b/windload.js
@@ -249,11 +249,16 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       // Accumulate cable weight per tray
-      const trayWeightMap = {};
-      trays.forEach(t => { trayWeightMap[t.tray_id] = 0; });
+      const trayWeightMap = Object.create(null);
+      trays.forEach(t => {
+        const trayId = t?.tray_id;
+        if (typeof trayId === 'string' && trayId.length > 0) {
+          trayWeightMap[trayId] = 0;
+        }
+      });
       cables.forEach(cable => {
         const trayId = cable.route_preference;
-        if (trayId && trayWeightMap[trayId] !== undefined) {
+        if (typeof trayId === 'string' && Object.hasOwn(trayWeightMap, trayId)) {
           let w = 0;
           if (cable.weight_lb_ft != null) {
             w = parseFloat(cable.weight_lb_ft) || 0;
@@ -281,7 +286,8 @@ document.addEventListener('DOMContentLoaded', () => {
             ...aerodynamicInputs,
           });
         } catch { /* skip trays with invalid data */ }
-        const cableWeight = trayWeightMap[tray.tray_id] || 0;
+        const rawCableWeight = Object.hasOwn(trayWeightMap, tray.tray_id) ? trayWeightMap[tray.tray_id] : 0;
+        const cableWeight = Number.isFinite(rawCableWeight) ? rawCableWeight : 0;
         const capacity = result ? checkNemaCapacity({
           cableWeight_lbs_ft: cableWeight,
           windForce_per_ft: result.windForce_per_ft,


### PR DESCRIPTION
### Motivation
- Prevent a client-side denial-of-service in schedule-mode wind load evaluation where attacker-controlled tray IDs (e.g. `__proto__`) could make tray-weight lookups return non-numeric prototype values and crash rendering via `.toFixed()`.

### Description
- Replace the plain-object `trayWeightMap` with a null-prototype dictionary created by `Object.create(null)` and only seed entries for non-empty string `tray_id` values in `windload.js` schedule mode.
- Use `Object.hasOwn(trayWeightMap, key)` and explicit `typeof` checks when accumulating and accessing tray-weight entries to avoid prototype-chain collisions.
- Coerce/sanitize retrieved tray weight with `Number.isFinite(...)` and default to `0` so downstream calculations and the `.toFixed()` render call always receive a numeric value.
- Keep the change minimal and localized to the schedule-mode logic in `windload.js` to preserve existing behavior elsewhere.

### Testing
- Ran the full automated test suite with `npm test`, and it completed successfully.
- Built the distribution with `npm run build`, and the build succeeded.
- Attempted a headless Playwright preview to capture `windload.html`, but browser binaries could not be downloaded in this environment so a screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0927b0ba948324a9db2302355939cf)