### PR TITLE
Validate seismic bracing component weight inputs

### DIFF
--- a/analysis/seismicBracing.mjs
+++ b/analysis/seismicBracing.mjs
@@ -185,6 +185,9 @@ export function calcComponentForceFactor(params) {
 export function calcBraceForces(params) {
   const { sds, sd1, riskCategory, wp, z, h } = params;
   const ip = params.ip ?? 1.0;
+  if (!Number.isFinite(wp) || wp <= 0) {
+    throw new Error('wp must be a finite positive number (lbs/ft).');
+  }
 
   const sdc = calcSeismicDesignCategory(sds, sd1, riskCategory);
   const spacing = maxBraceSpacing(sdc);

--- a/seismicBracing.js
+++ b/seismicBracing.js
@@ -24,6 +24,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const scheduleSection    = document.getElementById('scheduleSection');
   const scheduleResultsDiv = document.getElementById('scheduleResults');
 
+  function parseNonNegativeFinite(value) {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return null;
+    }
+    return parsed;
+  }
+
   // Mode toggle
   function updateMode() {
     const isSingle = singleModeRadio.checked;
@@ -194,7 +202,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (trayId && trayWeightMap[trayId] !== undefined) {
         let w = 0;
         if (cable.weight_lb_ft != null) {
-          w = parseFloat(cable.weight_lb_ft) || 0;
+          w = parseNonNegativeFinite(cable.weight_lb_ft) ?? 0;
         } else {
           const conductors = cable.conductors != null ? String(cable.conductors) : '3';
           const size = cable.conductor_size || cable.size || '';
@@ -207,7 +215,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const rows = trays.map(tray => {
       // Tray self-weight: estimate from tray type (2 lbs/ft default, adjust for wider trays)
-      const selfWeight = 2 + (parseFloat(tray.inside_width) || 12) * 0.05;
+      const trayWidth = parseNonNegativeFinite(tray.inside_width) ?? 12;
+      const selfWeight = 2 + trayWidth * 0.05;
       const wp = (trayWeightMap[tray.tray_id] || 0) + selfWeight;
       let result;
       try {

--- a/tests/seismicBracing.test.mjs
+++ b/tests/seismicBracing.test.mjs
@@ -312,6 +312,26 @@ describe('calcBraceForces — Ip=1.5 increases forces', () => {
   });
 });
 
+describe('calcBraceForces — wp validation', () => {
+  const base = {
+    sds: 0.6, sd1: 0.25, riskCategory: 'II', z: 10, h: 30,
+  };
+
+  it('throws for negative wp', () => {
+    assert.throws(
+      () => calcBraceForces({ ...base, wp: -1 }),
+      /wp/i
+    );
+  });
+
+  it('throws for non-finite wp', () => {
+    assert.throws(
+      () => calcBraceForces({ ...base, wp: Number.POSITIVE_INFINITY }),
+      /wp/i
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
 // evaluateTraysBracing
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Schedule-mode parsing trusted project-controlled numeric fields (`cable.weight_lb_ft`, `tray.inside_width`) and could produce negative or non-finite `wp` that cancelled real loads and yielded misleading/negative brace forces.
- `calcBraceForces` accepted `wp` without validation and multiplied it directly into lateral/longitudinal/vertical force outputs, exposing safety-relevant integrity issues.
- Introduce minimal validation and sanitization to prevent crafted project data from producing falsified seismic outputs while preserving normal behavior for valid inputs.

### Description
- Added a validation guard to `calcBraceForces` in `analysis/seismicBracing.mjs` that throws when `wp` is not a finite positive number (`wp` must be > 0). 
- Implemented `parseNonNegativeFinite` in `seismicBracing.js` and used it to sanitize `cable.weight_lb_ft` and `tray.inside_width` when deriving tray self-weight and `wp` in schedule mode.
- Schedule-mode now uses safe fallbacks for parsing failures and catches `calcBraceForces` exceptions so invalid inputs do not render authoritative results.
- Added tests in `tests/seismicBracing.test.mjs` to assert `calcBraceForces` rejects negative and non-finite `wp` values.

### Testing
- Ran `npm test` and the full test suite completed successfully (including the new `calcBraceForces` validation tests).
- Ran `npm run build` and the build completed successfully (dist artifacts produced).
- Attempted to capture a webpage preview with Playwright (`npx playwright install chromium` / screenshot), but browser download/installation failed in this environment (HTTP 403), so a screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d55fb48324a3a9b8857d65badd)