### PR TITLE
fix: use canonical cable weight field in tray hardware BOM export

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -3574,7 +3574,9 @@ const renderBatchResults = (results) => {
             (res.breakdown || []).forEach(seg => {
                 if (!seg.tray_id) return;
                 const cable = state.cableList.find(c => (c.tag || c.cable_tag) === res.cable);
-                const w = cable && cable.weight_lb_ft != null ? parseFloat(cable.weight_lb_ft) || 0 : 0;
+                const w = cable
+                    ? parseFloat(cable.weight_lb_ft != null ? cable.weight_lb_ft : cable.weight) || 0
+                    : 0;
                 trayWeights[seg.tray_id] = (trayWeights[seg.tray_id] || 0) + w;
             });
         });


### PR DESCRIPTION
### Motivation
- Prevent exported tray hardware BOMs from undercounting support brackets by ensuring per-tray cable loads use the app's canonical per-foot cable weight field rather than ignoring user-entered values.

### Description
- Update the BOM export aggregation in `app.mjs` to prefer `cable.weight` when `cable.weight_lb_ft` is not present, preserving compatibility with either field while keeping existing behavior otherwise.

### Testing
- Ran `npm test` and `npm run build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d5481083248dfafb796cd0a6dd)