### PR TITLE
Validate cable quantities and weights; flag invalid trays in Support Span calculator

### DIFF
--- a/analysis/supportSpan.mjs
+++ b/analysis/supportSpan.mjs
@@ -148,16 +148,25 @@ export function calcMaxSpan(actualLoad, loadClass) {
  */
 export function sumCableWeights(cables) {
   return cables.reduce((total, cable) => {
-    const qty = Number(cable.quantity) || 1;
+    const qty = cable.quantity == null ? 1 : Number(cable.quantity);
+    if (!Number.isFinite(qty) || qty <= 0) {
+      throw new Error('Cable quantity must be a positive finite number');
+    }
 
     // If the caller provided an explicit weight, use it directly
     if (cable.weight_lb_ft != null) {
-      return total + qty * Number(cable.weight_lb_ft);
+      const explicitWeight = Number(cable.weight_lb_ft);
+      if (!Number.isFinite(explicitWeight) || explicitWeight <= 0) {
+        throw new Error('Cable weight_lb_ft must be a positive finite number');
+      }
+      return total + qty * explicitWeight;
     }
 
     // Otherwise look up in the built-in table
     const conductors = cable.conductors != null ? String(cable.conductors) : null;
-    const size = cable.size != null ? String(cable.size) : null;
+    const size = (cable.size ?? cable.conductor_size) != null
+      ? String(cable.size ?? cable.conductor_size)
+      : null;
     const key = conductors && size ? `${conductors}C-${size}` : null;
     const unitWeight = (key && CABLE_WEIGHT_LB_FT[key]) || 0;
     return total + qty * unitWeight;
@@ -174,11 +183,24 @@ export function sumCableWeights(cables) {
 export function evaluateTrays(trays, loadClass) {
   return trays.map(tray => {
     const cables = Array.isArray(tray.cables) ? tray.cables : [];
-    const loadPerFt = sumCableWeights(cables);
+    let loadPerFt = 0;
     let result;
-    if (loadPerFt > 0) {
+    try {
+      loadPerFt = sumCableWeights(cables);
+    } catch (err) {
+      result = {
+        maxSpan: 0,
+        ratedSpan: 0,
+        ratedLoad: 0,
+        utilizationRatio: 0,
+        status: 'INVALID',
+        recommendation: err.message,
+      };
+    }
+
+    if (!result && loadPerFt > 0) {
       result = calcMaxSpan(loadPerFt, loadClass);
-    } else {
+    } else if (!result) {
       // No cables yet — return rated span at zero utilization
       const cls = NEMA_LOAD_CLASSES[loadClass];
       result = {

--- a/supportspan.js
+++ b/supportspan.js
@@ -172,38 +172,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const loadClass = loadClassSel.value;
 
-    // Build a weight map: tray_id → total lbs/ft
-    // Cables are matched to trays via their route_preference field
-    const trayWeightMap = {};
-    trays.forEach(t => { trayWeightMap[t.tray_id] = 0; });
-
-    cables.forEach(cable => {
-      const trayId = cable.route_preference;
-      if (trayId && trayWeightMap[trayId] !== undefined) {
-        // Use stored weight_lb_ft if present, else derive from conductor info
-        let w = 0;
-        if (cable.weight_lb_ft != null) {
-          w = parseFloat(cable.weight_lb_ft) || 0;
-        } else {
-          const conductors = cable.conductors != null ? String(cable.conductors) : '3';
-          const size = cable.conductor_size || cable.size || '';
-          const key = `${conductors}C-${size}`;
-          w = CABLE_WEIGHT_LB_FT[key] || 0;
-        }
-        trayWeightMap[trayId] += w;
-      }
-    });
-
     const rows = trays.map(tray => {
-      const actualLoad = trayWeightMap[tray.tray_id] || 0;
+      const trayCables = cables.filter(cable => cable.route_preference === tray.tray_id);
+      let actualLoad = 0;
       let result;
-      if (actualLoad > 0) {
+
+      try {
+        actualLoad = sumCableWeights(trayCables);
+      } catch (err) {
+        result = { status: 'INVALID', recommendation: err.message };
+      }
+
+      if (!result && actualLoad > 0) {
         try {
           result = calcMaxSpan(actualLoad, loadClass);
-        } catch {
-          result = null;
+        } catch (err) {
+          result = { status: 'INVALID', recommendation: err.message };
         }
       }
+
       return { tray, actualLoad, result };
     });
 
@@ -226,6 +213,17 @@ document.addEventListener('DOMContentLoaded', () => {
           <td>—</td>
           <td>—</td>
           <td class="status-badge result-ok">NO CABLES</td>
+        </tr>`;
+      }
+      if (result.status === 'INVALID') {
+        return `<tr class="result-fail">
+          <td>${esc(tray.tray_id)}</td>
+          <td>${esc(tray.tray_type || '—')}</td>
+          <td>${esc(String(tray.inside_width ?? '—'))}</td>
+          <td>${Number.isFinite(actualLoad) ? actualLoad.toFixed(3) : '—'}</td>
+          <td>—</td>
+          <td>—</td>
+          <td class="status-badge result-fail">INVALID DATA</td>
         </tr>`;
       }
       const statusClass = result.status === 'OK' ? 'result-ok' : 'result-fail';

--- a/tests/supportSpan.test.mjs
+++ b/tests/supportSpan.test.mjs
@@ -237,12 +237,34 @@ describe('sumCableWeights', () => {
     const cables = [{ conductors: 3, size: '#4 AWG' }];
     assert.strictEqual(sumCableWeights(cables), w);
   });
+
+  it('throws for negative explicit weight_lb_ft', () => {
+    const cables = [{ weight_lb_ft: -2, quantity: 1 }];
+    assert.throws(() => sumCableWeights(cables), /positive finite/);
+  });
+
+  it('throws for non-finite explicit weight_lb_ft', () => {
+    const cables = [{ weight_lb_ft: 'NaN', quantity: 1 }];
+    assert.throws(() => sumCableWeights(cables), /positive finite/);
+  });
+
+  it('throws for negative quantity', () => {
+    const cables = [{ conductors: 3, size: '#4 AWG', quantity: -1 }];
+    assert.throws(() => sumCableWeights(cables), /quantity/);
+  });
 });
 
 // ---------------------------------------------------------------------------
 // evaluateTrays
 // ---------------------------------------------------------------------------
 describe('evaluateTrays', () => {
+
+  it('flags trays with invalid cable data', () => {
+    const trays = [{ tray_id: 'T1', cables: [{ weight_lb_ft: -5, quantity: 1 }] }];
+    const [r] = evaluateTrays(trays, '16A');
+    assert.strictEqual(r.result.status, 'INVALID');
+  });
+
   it('returns one result per tray', () => {
     const trays = [
       { tray_id: 'T1', inside_width: 12, cables: [] },


### PR DESCRIPTION
### Motivation
- The support-span code accepted `quantity` and `weight_lb_ft` from project data without checking sign or finiteness, allowing negative or NaN values to cancel real loads and hide overloaded trays. 
- Silent conversion of non-positive totals into an "empty tray / OK" result created an integrity risk for safety-relevant engineering calculations. 
- A minimal, targeted fix is required to validate numeric inputs where they affect span calculations and to surface malformed data rather than treating it as absent.

### Description
- Enforce input validation in `sumCableWeights` so `quantity` defaults to 1 but must be a positive finite number and explicit `weight_lb_ft` must be a positive finite number, otherwise throw an error (`analysis/supportSpan.mjs`).
- Update `evaluateTrays` to catch validation errors from `sumCableWeights` and return an explicit `INVALID` result with a recommendation message instead of treating the tray as empty (`analysis/supportSpan.mjs`).
- Simplify schedule-mode aggregation to reuse `sumCableWeights` per tray and render an "INVALID DATA" row when cable inputs are malformed, preserving correct display for valid trays (`supportspan.js`).
- Add regression tests that assert thrown errors for negative/non-finite explicit weights and negative quantities and that trays with invalid cable data are flagged as `INVALID` (`tests/supportSpan.test.mjs`).

### Testing
- Ran the full unit test suite with `npm test`, and the test run including the new regressions passed. 
- Built the project with `npm run build`, and the rollup/build steps completed successfully. 
- Attempted a Playwright screenshot run but browser binaries could not be downloaded in this environment, so visual E2E checks were not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d580e883248b7d6d3e15cae8d3)