### PR TITLE
Prevent cached baseGraph mutation during tray backtracking cleanup

### DIFF
--- a/routeWorker.js
+++ b/routeWorker.js
@@ -373,9 +373,9 @@ class CableRoutingSystem {
         const result = [];
         let i = 0;
         while (i < segments.length) {
-            const curr = { ...segments[i] };
+            const curr = { ...segments[i], start: segments[i].start.slice(), end: segments[i].end.slice() };
             if (curr.type === 'tray' && i + 1 < segments.length) {
-                const next = { ...segments[i + 1] };
+                const next = { ...segments[i + 1], start: segments[i + 1].start.slice(), end: segments[i + 1].end.slice() };
                 if (next.type === 'field') {
                     const oTray = this._segmentOrientation(curr);
                     const oField = this._segmentOrientation(next);


### PR DESCRIPTION
### Motivation
- Fix a data-integrity bug where `_removeTrayBacktracking` could mutate `start`/`end` arrays that alias cached `baseGraph` node `point` arrays after the graph clone change, causing subsequent batch routes to see corrupted tray coordinates.

### Description
- Update `routeWorker.js` so `_removeTrayBacktracking` makes working copies that deep-copy the `start` and `end` coordinate arrays (using `slice()`), preventing in-place edits from affecting shared graph geometry while preserving existing cleanup logic.

### Testing
- Ran `npm test` which completed successfully.
- Ran `npm run build` which completed successfully (existing Rollup unresolved dependency warnings remain unchanged).
- Attempted `npx playwright screenshot` to produce a preview image but it failed because Playwright browser binaries are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d4cddc83249f8ee6a648b1fb37)