### PR TITLE
Include breaker 'Load (VA) per Phase' in panel total calculations

### DIFF
--- a/src/panelSchedule.js
+++ b/src/panelSchedule.js
@@ -1032,8 +1032,10 @@ export function assignLoadToBreaker(panelId, loadIndex, breaker) {
  * @returns {{connectedKva:number,connectedKw:number,demandKva:number,demandKw:number}}
  */
 export function calculatePanelTotals(panelId) {
+  const panels = dataStore.getPanels();
+  const panel = findPanelByIdentifier(panels, panelId);
   const loads = dataStore.getLoads().filter(l => l.panelId === panelId);
-  return loads.reduce((acc, l) => {
+  const totals = loads.reduce((acc, l) => {
     const cKva = parseFloat(l.kva) || 0;
     const cKw = parseFloat(l.kw) || 0;
     const dKva = parseFloat(l.demandKva) || cKva;
@@ -1044,6 +1046,33 @@ export function calculatePanelTotals(panelId) {
     acc.demandKw += dKw;
     return acc;
   }, { connectedKva: 0, connectedKw: 0, demandKva: 0, demandKw: 0 });
+
+  if (!panel) return totals;
+  const breakerDetails = ensureBreakerDetails(panel);
+  let customVaTotal = 0;
+  Object.values(breakerDetails).forEach(detail => {
+    if (!detail || detail.loadVaPerPhase == null) return;
+    if (detail.loadVaPerPhase && typeof detail.loadVaPerPhase === "object" && !Array.isArray(detail.loadVaPerPhase)) {
+      Object.values(detail.loadVaPerPhase).forEach(value => {
+        const parsed = parseFloat(value);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          customVaTotal += parsed;
+        }
+      });
+      return;
+    }
+    const parsed = parseFloat(detail.loadVaPerPhase);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      customVaTotal += parsed;
+    }
+  });
+
+  if (customVaTotal > 0) {
+    const customKva = customVaTotal / 1000;
+    totals.connectedKva += customKva;
+    totals.demandKva += customKva;
+  }
+  return totals;
 }
 
 const COLUMN_HEADERS = {


### PR DESCRIPTION
### Motivation
- The UI persists and displays a new breaker-detail field `loadVaPerPhase` but `createPhaseSummary`/`calculatePanelTotals` did not include those values, causing displayed VA/phase annotations to be out of sync with computed panel totals and potentially misleading engineering outputs.

### Description
- Updated `calculatePanelTotals(panelId)` in `src/panelSchedule.js` to locate the `panel` for `panelId` and read `panel.breakerDetails` via `ensureBreakerDetails`.
- Aggregates `loadVaPerPhase` values from breaker details, handling both scalar and per-phase object forms, and sums positive numeric VA entries.
- Converts the aggregated VA total to kVA and adds it to `connectedKva` and `demandKva` so totals reflect displayed VA/phase annotations.
- Preserved original reduction over `dataStore.getLoads()` so existing load-record calculations remain unchanged.

### Testing
- Ran `npm test`, which completed successfully (test suite passed).
- Ran `npm run build`, which completed successfully but emitted existing Rollup unresolved-dependency warnings; the build output was produced.
- Attempted automated page preview via Playwright but browser binaries could not be installed in this environment (download failed with HTTP 403), so no runtime screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d5bf688324aeb8c71808268013)