### PR TITLE
Fix incorrect cable editor voltage-drop percentage derivation

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -519,13 +519,15 @@ async function initCableSchedule() {
     });
   };
 
-  const calculateVoltageDrop = (length, current, impedance) => {
+  const calculateVoltageDrop = (length, current, impedance, operatingVoltage) => {
     const len = Number(length);
     const cur = Number(current);
     const imp = Number(impedance);
-    if (!Number.isFinite(len) || !Number.isFinite(cur) || !Number.isFinite(imp)) return null;
-    if (len <= 0 || cur <= 0 || imp <= 0) return null;
-    return len * cur * imp;
+    const voltage = Number(operatingVoltage);
+    if (!Number.isFinite(len) || !Number.isFinite(cur) || !Number.isFinite(imp) || !Number.isFinite(voltage)) return null;
+    if (len <= 0 || cur <= 0 || imp <= 0 || voltage <= 0) return null;
+    const dropVolts = len * cur * imp;
+    return (dropVolts / voltage) * 100;
   };
   window.calculateVoltageDrop = calculateVoltageDrop;
 
@@ -533,13 +535,14 @@ async function initCableSchedule() {
     const lengthField = editorFieldMap.get('length');
     const currentField = editorFieldMap.get('est_load');
     const impedanceField = editorFieldMap.get('impedance');
+    const operatingVoltageField = editorFieldMap.get('operating_voltage');
     const voltageField = editorFieldMap.get('voltage_drop_pct');
-    if (!lengthField || !currentField || !impedanceField || !voltageField) return;
+    if (!lengthField || !currentField || !impedanceField || !operatingVoltageField || !voltageField) return;
     voltageField.readOnly = true;
     voltageField.setAttribute('aria-readonly', 'true');
     voltageField.tabIndex = -1;
     const updateVoltageDropField = () => {
-      const result = calculateVoltageDrop(lengthField.value, currentField.value, impedanceField.value);
+      const result = calculateVoltageDrop(lengthField.value, currentField.value, impedanceField.value, operatingVoltageField.value);
       if (result === null) {
         voltageField.value = '';
       } else {
@@ -549,7 +552,7 @@ async function initCableSchedule() {
         activeRowData.voltage_drop_pct = voltageField.value;
       }
     };
-    [lengthField, currentField, impedanceField].forEach(field => {
+    [lengthField, currentField, impedanceField, operatingVoltageField].forEach(field => {
       field.addEventListener('input', updateVoltageDropField);
       field.addEventListener('change', updateVoltageDropField);
     });


### PR DESCRIPTION
### Motivation
- The editor automation previously computed `voltage_drop_pct` as `length * current * impedance` and made the field read-only, which produces a non-percent value and can mislead designers. 
- The change restores the intended percent semantics by ensuring the operating system voltage is used in the derived percent calculation.

### Description
- Updated `calculateVoltageDrop` to accept `operatingVoltage` and return a percentage as `(length * current * impedance / operatingVoltage) * 100` with guards for non-finite and non-positive inputs. 
- Wired the modal automation in `attachVoltageDropAutomation` to require `operating_voltage` and pass it into the calculation. 
- Included `operating_voltage` in the list of input listeners so edits to voltage immediately recompute the displayed estimate. 
- Kept the existing modal UX (field remains read-only and is synced into `activeRowData`) while fixing the derivation logic.

### Testing
- Ran the full unit/test suite with `npm test`, and the test run completed successfully. 
- Built the production bundles with `npm run build`, and the build completed successfully. 
- Attempted to capture a browser preview with Playwright, but `npx playwright install chromium` failed due to remote browser download `403 Forbidden` responses so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d58c1c8324bc3688658e4d1d7c)