### PR TITLE
Mitigate load-flow model BFS denial-of-service path

### DIFF
--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -665,6 +665,33 @@ function findDirectBusId(comp, busMap) {
 const DEFAULT_BFS_WARN_THRESHOLD = 2000;
 const DEFAULT_BFS_MAX_NODES = 10000;
 
+function mapNearestBusIds(adjacency, busMap) {
+  if (!(adjacency instanceof Map) || !(busMap instanceof Map) || !busMap.size) return new Map();
+  const nearestByNode = new Map();
+  const queue = [];
+  let head = 0;
+
+  busMap.forEach((_bus, busId) => {
+    nearestByNode.set(busId, busId);
+    queue.push(busId);
+  });
+
+  while (head < queue.length) {
+    const id = queue[head];
+    head += 1;
+    const nearestBusId = nearestByNode.get(id);
+    const neighbors = adjacency.get(id);
+    if (!neighbors) continue;
+    for (const neighbor of neighbors) {
+      if (nearestByNode.has(neighbor)) continue;
+      nearestByNode.set(neighbor, nearestBusId);
+      queue.push(neighbor);
+    }
+  }
+
+  return nearestByNode;
+}
+
 function findNearestBusId(comp, busMap, adjacency, options) {
   if (!comp || !comp.id) return null;
   const direct = findDirectBusId(comp, busMap);
@@ -900,10 +927,13 @@ export function buildLoadFlowModel(oneLine = {}) {
     buses = components.map(cloneBusComponent);
   }
   const busMap = new Map(buses.map(b => [b.id, b]));
+  const nearestBusByNode = mapNearestBusIds(adjacency, busMap);
 
   components.forEach(comp => {
     if (!comp || isBusComponent(comp) || typeof comp.busType === 'string' && comp.busType) return;
-    const busId = findDirectBusId(comp, busMap) || findNearestBusId(comp, busMap, adjacency);
+    const busId = findDirectBusId(comp, busMap)
+      || nearestBusByNode.get(comp.id)
+      || findNearestBusId(comp, busMap, adjacency);
     if (!busId) return;
     const bus = busMap.get(busId);
     if (!bus) return;


### PR DESCRIPTION
### Motivation
- The previous change replaced a shallow, depth-limited nearest-bus lookup with a per-component unbounded BFS which can traverse up to 10,000 nodes and be invoked for every non-bus component, enabling an algorithmic client-side DoS on crafted long chains.
- The intent is to eliminate repeated deep traversals during model construction while preserving existing attribution behavior and fallbacks in `analysis/loadFlowModel.js`.

### Description
- Add a model-wide multi-source BFS helper `mapNearestBusIds(adjacency, busMap)` that seeds a queue from all bus nodes and computes each node’s nearest bus once per `buildLoadFlowModel()` run.
- Use the precomputed `nearestBusByNode` inside `buildLoadFlowModel()` when attributing load/generation to non-bus components and retain `findNearestBusId()` as a fallback for compatibility.
- Keep the existing traversal safety features intact (`findNearestBusId` warnings / max-nodes) but avoid invoking it repeatedly for every component by using the cached map when available.
- Change is localized to `analysis/loadFlowModel.js` and preserves existing outward behavior of `buildLoadFlowModel()`.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (tests including load-flow-related suites passed).
- Built the distribution with `npm run build`, which completed successfully and produced `dist/` output.
- Attempted to capture a site preview via Playwright (`npx playwright install chromium` / screenshot), but the browser download failed with upstream 403 so an automated screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d52d38832497305b27c16623f6)