### PR TITLE
Fix inherited transformer voltage unit loss during base-kV propagation

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -5050,8 +5050,7 @@ function resolveTransformerVoltageValue(transformer, portIndex) {
     if (!key || seen.has(key)) continue;
     seen.add(key);
     const value = transformer[key] ?? transformer.props?.[key] ?? metaProps[key];
-    const num = parseVoltageNumber(value);
-    if (num !== null) return num;
+    if (parseVoltageNumber(value) !== null) return value;
   }
   return null;
 }


### PR DESCRIPTION
### Motivation
- A recent propagation path was using a stripped numeric token when reading transformer voltages, losing unit context (e.g. `"13 kV"` → `13`) and allowing `normalizeVoltageToVolts()` to misinterpret integer kV values as volts, which caused downstream `baseKV`/`kV`/`prefault_voltage` metadata to be overwritten with values 1000× too small.

### Description
- Make a minimal change in `oneline.js` so `resolveTransformerVoltageValue()` returns the original matched value (preserving unit text or key context) instead of the parsed numeric token, ensuring `normalizeVoltageToVolts()` receives the unit hint during transformer voltage propagation.

### Testing
- Ran the full test suite with `npm test` and it completed successfully.
- Ran the production build with `npm run build` and it completed successfully.
- Attempted an automated Playwright screenshot to produce a preview image but the required browser binary was not available in the environment, so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928d5d0008324a73c3da631e3dac9)