### PR TITLE
Fix hidden source-field spoofing in short-circuit impedance fallback

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -724,7 +724,6 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     cablesMissingImpedance.add(component.id);
     (component.connections || []).forEach(conn => {
       if (typeof conn?.target === 'string') cableDefaultTargets.add(conn.target);
-      if (typeof conn?.source === 'string') cableDefaultTargets.add(conn.source);
     });
     const upstream = reverseConnectionMap.get(component.id);
     if (upstream) {


### PR DESCRIPTION
### Motivation
- Prevent non-schema `conn.source` fields on missing-impedance cables/busways from nominating arbitrary component IDs into the near-zero impedance fallback, which could generate misleadingly large short-circuit currents.

### Description
- Remove the code that added `conn.source` into `cableDefaultTargets` in `analysis/shortCircuit.mjs` while keeping `conn.target` and reverse-map upstream logic so only actual modeled connectivity can trigger the low-impedance default.

### Testing
- Ran `npm test` and `npm run build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092b4c59388324ab4d80f2ceffe885)