### PR TITLE
Fail-closed for missing impedance: default to high resistance

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -746,19 +746,19 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       if ((isConductorMissing || isTargetOfMissingCable) && comp?.id) {
         defaultedLowImpedanceComponents.set(
           comp.id,
-          `${comp?.type === 'busway' ? 'Busway' : 'Cable'} impedance incomplete; defaulted to very low resistance for fault monitoring.`
+          `${comp?.type === 'busway' ? 'Busway' : 'Cable'} impedance incomplete; results defaulted to high resistance until impedance data is provided.`
         );
-        return { r: 1e-6, x: 1e-6 };
+        return { r: 1e6, x: 1e6 };
       }
       if (isProtectionComponent(comp) && comp?.id) {
         defaultedLowImpedanceComponents.set(
           comp.id,
-          'Protective device properties incomplete; defaulted to very low resistance for fault monitoring.'
+          'Protective device properties incomplete; results defaulted to high resistance until data is provided.'
         );
-        return { r: 1e-6, x: 1e-6 };
+        return { r: 1e6, x: 1e6 };
       }
       if (comp?.id) missingImpedanceComponents.add(comp.id);
-      return { r: 0.0001, x: 0.0001 };
+      return { r: 1e6, x: 1e6 };
     }
     return { r, x };
   };
@@ -834,7 +834,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     if (lowImpedanceWarning) {
       entry.warnings = [lowImpedanceWarning];
     } else if (missingImpedanceComponents.has(comp.id)) {
-      entry.warnings = ['Impedance data missing; results defaulted to conservative low impedance.'];
+      entry.warnings = ['Impedance data missing; results defaulted to high resistance until data is provided.'];
     }
 
     limitFaultByProtection(entry, comp, comps, compMap, protectiveLookupCache, scaledDeviceCache, tccSettings);


### PR DESCRIPTION
### Motivation
- A recent change made missing/zero impedance on conductor and protection components default to an almost-zero impedance, which could fabricate extremely large short-circuit currents consumed by downstream studies. 
- The intended behavior for missing impedance data is to fail closed to a conservative/high-resistance fallback so incomplete or untrusted projects cannot produce spurious fault currents.

### Description
- Changed the `ensureNonZero` fallback in `analysis/shortCircuit.mjs` so conductor (cable/busway), protection-device, and generic missing-impedance paths return a high-resistance impedance (`{ r: 1e6, x: 1e6 }`) instead of a near-zero value. 
- Preserved the existing upstream `fallbackZ` behavior and kept the warning emission path, updating warning text to indicate results default to high resistance until data is provided. 
- No other study logic was altered; results still attach warnings and are still limited by protection where applicable.

### Testing
- Ran the full automated test suite with `npm test`, and the run completed successfully. 
- Performed a production build with `npm run build`, and the build completed successfully. 
- Attempted an automated Playwright page screenshot to produce a preview, but `npx playwright install` failed to download browser binaries in this environment (HTTP 403), so no screenshot could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c75478483249b7212074f90d2dd)