### PR TITLE
Fix bus fallback impedance to include transformer-fed path impedance

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -570,17 +570,16 @@ function combineParallel(base, addition) {
 
 function resolveUpstreamImpedance(comp, comps, compMap, cache) {
   if (!comp?.id) return null;
-  const visited = new Set([comp.id]);
+  const visited = new Set();
   let current = comp;
-  while (current) {
-    const parent = findParentInfo(current, comps, compMap, visited);
-    if (!parent?.component?.id || visited.has(parent.component.id)) break;
-    const candidate = computeImpedance(parent.component, comps, compMap, cache);
+  while (current?.id && !visited.has(current.id)) {
+    visited.add(current.id);
+    const candidate = computeImpedance(current, comps, compMap, cache);
     if (candidate && (Math.abs(candidate.r) >= 1e-9 || Math.abs(candidate.x) >= 1e-9)) {
       return { r: candidate.r, x: candidate.x };
     }
-    visited.add(parent.component.id);
-    current = parent.component;
+    const parent = findParentInfo(current, comps, compMap, visited);
+    current = parent?.component || null;
   }
   return null;
 }


### PR DESCRIPTION
### Motivation
- A fallback used for buses with explicit zero sequence impedances could omit transformer and connection impedance, producing unrealistically high short-circuit currents and suppressing missing-impedance warnings. 
- The change aims to preserve the intended non-zero fallback behavior while ensuring transformer-fed bus paths include the transformer/connection contributions for safe fault calculations.

### Description
- `resolveUpstreamImpedance()` in `analysis/shortCircuit.mjs` now calls `computeImpedance()` starting from the current component and then walks upstream instead of immediately computing the parent component. 
- The visited set and loop logic were adjusted so the computed candidate includes the downstream connection and transformer contributions that are only added when computing a downstream component's impedance. 
- The change is minimal and localized to `analysis/shortCircuit.mjs` to avoid altering other impedance propagation logic.

### Testing
- Ran `npm test` and the full test suite completed successfully. 
- Ran `npm run build` and the build completed successfully (Rollup emitted existing unresolved-external warnings but the build output was produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c75e6b883249d4bb5f89edd46c8)