### PR TITLE
Cap one-line preview rendering to prevent client-side DoS

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -8041,10 +8041,11 @@ function renderOneLinePreview(componentId) {
     ? adjacency.get(componentId)
     : new Set();
   const neighborCount = neighborSet.size + 1; // include the active component itself
-  const includeEntireSheet = sameSheetSelections.length > 0;
-  const MAX_COMPONENTS = includeEntireSheet
-    ? Math.max(sheetComponents.length, sameSheetSelections.length + neighborCount, 50)
-    : Math.max(20, neighborCount, sameSheetSelections.length + 5);
+  const HARD_MAX_PREVIEW_COMPONENTS = 200;
+  const maxComponents = Math.min(
+    HARD_MAX_PREVIEW_COMPONENTS,
+    Math.max(20, neighborCount, sameSheetSelections.length + 5)
+  );
   const addUnique = (list, id) => {
     if (!id) return;
     if (!componentMap.has(id)) return;
@@ -8107,13 +8108,8 @@ function renderOneLinePreview(componentId) {
   if (onelinePreviewContainer) onelinePreviewContainer.classList.remove('empty');
   if (onelinePreviewEmpty) onelinePreviewEmpty.classList.add('hidden');
 
-  let displayedTargets;
-  if (includeEntireSheet) {
-    displayedTargets = sheetComponents.map(comp => comp.id);
-  } else {
-    displayedTargets = availableTargets.slice(0, MAX_COMPONENTS);
-  }
-  const truncatedCount = includeEntireSheet ? 0 : Math.max(0, availableTargets.length - displayedTargets.length);
+  const displayedTargets = availableTargets.slice(0, maxComponents);
+  const truncatedCount = Math.max(0, availableTargets.length - displayedTargets.length);
   const displayedSet = new Set(displayedTargets);
   const hiddenSelectionCount = sameSheetSelections.filter(id => !displayedSet.has(id)).length;
 


### PR DESCRIPTION
### Motivation
- A recent change allowed the one-line preview to render every component on a sheet when any selected component lived on that sheet, enabling an attacker-controlled project to force unbounded DOM/CPU/heap work and freeze the browser.
- The intent of this patch is to restore a hard rendering cap for the one-line preview while preserving the prioritized selection/neighborhood behavior and user truncation messaging.

### Description
- Introduced a hard cap `HARD_MAX_PREVIEW_COMPONENTS = 200` and compute `maxComponents` with `Math.min(...)` to bound preview size in `renderOneLinePreview` (`analysis/tcc.js`).
- Removed the unbounded `includeEntireSheet` path and always compute `displayedTargets` as a capped slice of `availableTargets` instead of mapping every `sheet.components` to IDs.
- Preserved the existing prioritization (active component, neighbors, same-sheet selections) and retained `truncatedCount`/note messaging to inform users when the preview is limited.

### Testing
- Ran `npm test` and the full test suite completed successfully (all automated tests passed).
- Ran `npm run build` and the project built successfully (dist artifacts produced without errors).
- Attempted to capture a browser preview via `npx playwright screenshot`, but the Playwright browser binaries are not installed in this environment so the screenshot command failed (no browser executable available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c7578a88324ac2ad60a979e29ff)