### PR TITLE
Restore fixed cap for TCC one-line preview rendering

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -8040,11 +8040,8 @@ function renderOneLinePreview(componentId) {
   const neighborSet = componentId && adjacency.has(componentId)
     ? adjacency.get(componentId)
     : new Set();
-  const neighborCount = neighborSet.size + 1; // include the active component itself
   const includeEntireSheet = sameSheetSelections.length > 0;
-  const MAX_COMPONENTS = includeEntireSheet
-    ? Math.max(sheetComponents.length, sameSheetSelections.length + neighborCount, 50)
-    : Math.max(20, neighborCount, sameSheetSelections.length + 5);
+  const MAX_COMPONENTS = 50;
   const addUnique = (list, id) => {
     if (!id) return;
     if (!componentMap.has(id)) return;
@@ -8109,11 +8106,11 @@ function renderOneLinePreview(componentId) {
 
   let displayedTargets;
   if (includeEntireSheet) {
-    displayedTargets = sheetComponents.map(comp => comp.id);
+    displayedTargets = sheetComponents.map(comp => comp.id).slice(0, MAX_COMPONENTS);
   } else {
     displayedTargets = availableTargets.slice(0, MAX_COMPONENTS);
   }
-  const truncatedCount = includeEntireSheet ? 0 : Math.max(0, availableTargets.length - displayedTargets.length);
+  const truncatedCount = Math.max(0, availableTargets.length - displayedTargets.length);
   const displayedSet = new Set(displayedTargets);
   const hiddenSelectionCount = sameSheetSelections.filter(id => !displayedSet.has(id)).length;
 


### PR DESCRIPTION
### Motivation
- The one-line preview previously derived `MAX_COMPONENTS` from `neighborSet.size`, which allows attacker-controlled high-degree components to force rendering thousands of SVG nodes/edges and hang the browser. 
- The change bounds client-side rendering to prevent this availability/DoS vector while retaining existing target prioritization behavior.

### Description
- Replace the attacker-influenced sizing with a fixed `MAX_COMPONENTS = 50` in `analysis/tcc.js` to cap preview rendering. 
- Apply the same cap when "entire sheet" mode is active by slicing `sheetComponents.map(...).slice(0, MAX_COMPONENTS)` so large imported sheets cannot bypass the limit. 
- Preserve existing `orderedTargets` / `prioritizedTargets` selection and ordering logic; only the render-size bounding was modified.

### Testing
- Ran `npm test` and the full test suite completed successfully. 
- Ran `npm run build` and the build completed successfully and produced `dist/` artifacts. 
- Attempted to capture a Playwright screenshot for a webpage preview but installing/downloading Chromium failed due to blocked downloads (HTTP 403), so no browser screenshot could be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c7507d4832487cf431652a88b48)