### PR TITLE
fix: cap TCC annotation preview text and lines

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -95,6 +95,8 @@ const PREVIEW_SHAPE_DASH_PATTERNS = {
   dashed: '8 4',
   dotted: '2 2'
 };
+const MAX_PREVIEW_ANNOTATION_TEXT_LENGTH = 4000;
+const MAX_PREVIEW_ANNOTATION_LINES = 24;
 
 const clampValue = (value, min, max) => {
   if (!Number.isFinite(value)) return min;
@@ -135,7 +137,8 @@ function normalizeAnnotationPreview(comp) {
   const fillColor = typeof pick('fillColor') === 'string' && pick('fillColor').trim()
     ? pick('fillColor').trim()
     : '#ffffff';
-  const text = typeof pick('text') === 'string' ? pick('text') : (typeof comp.text === 'string' ? comp.text : '');
+  const rawText = typeof pick('text') === 'string' ? pick('text') : (typeof comp.text === 'string' ? comp.text : '');
+  const text = rawText.slice(0, MAX_PREVIEW_ANNOTATION_TEXT_LENGTH);
   return {
     subtype,
     shapeType,
@@ -147,6 +150,16 @@ function normalizeAnnotationPreview(comp) {
     cornerRadius,
     text
   };
+}
+
+function buildAnnotationPreviewLines(content) {
+  if (!content) return [];
+  return content
+    .slice(0, MAX_PREVIEW_ANNOTATION_TEXT_LENGTH)
+    .split(/\r?\n/, MAX_PREVIEW_ANNOTATION_LINES)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .slice(0, MAX_PREVIEW_ANNOTATION_LINES);
 }
 
 function buildComponentPreviewDefinitionMap() {
@@ -8502,9 +8515,7 @@ function renderOneLinePreview(componentId) {
         .attr('rx', 8)
         .attr('ry', 8);
       const content = (config.text && config.text.trim()) || datum.label || '';
-      const lines = content
-        ? content.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
-        : [];
+      const lines = buildAnnotationPreviewLines(content);
       if (lines.length) {
         const textEl = group.append('text')
           .attr('class', 'preview-annotation-text')


### PR DESCRIPTION
### Motivation
- The TCC one-line preview accepted attacker-controlled annotation text and split it into unbounded lines, allowing a crafted project to force creation of arbitrarily many SVG `tspan` nodes and cause client-side DoS by exhausting memory or hanging the browser.
- The intent of the change is to reliably bound preview work (text length and rendered line count) so preview rendering cannot be abused while preserving the existing annotation preview feature.

### Description
- Added constants `MAX_PREVIEW_ANNOTATION_TEXT_LENGTH = 4000` and `MAX_PREVIEW_ANNOTATION_LINES = 24` in `analysis/tcc.js` to cap preview input size. 
- Truncate normalized annotation preview text (`text`) to the configured maximum before it is stored in the preview config. 
- Introduced `buildAnnotationPreviewLines(content)` to safely slice, split and limit line fan-out and used it in the `annotation_text_box` rendering path to avoid unbounded `tspan` creation. 
- Only `analysis/tcc.js` was modified and the change is intentionally minimal to mitigate the availability risk while preserving existing preview appearance for normal inputs.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully. 
- Built the distribution with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c7640608324ad353a534b3eb93d)