### PR TITLE
Use clearing (max) TCC curve for arc‑flash clearing time

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -271,7 +271,10 @@ function clearingTime(comp, Ibf, devices, protectiveComp, scResults, protectiveD
   if (settings.instantaneous && effectiveKA * 1000 >= settings.instantaneous) {
     return Math.max(settings.instantaneousDelay || 0.01, 0.005);
   }
-  return interpolateTime(scaled.curve || [], effectiveKA * 1000);
+  const clearingCurve = Array.isArray(scaled.maxCurve) && scaled.maxCurve.length
+    ? scaled.maxCurve
+    : scaled.curve || [];
+  return interpolateTime(clearingCurve, effectiveKA * 1000);
 }
 
 // IEEE 1584‑2018 arcing current model
@@ -491,4 +494,3 @@ export function incidentEnergyLimitCurve(params, thresholdCalCm2, currentRangeKA
   points.sort((a, b) => a.current - b.current);
   return points;
 }
-


### PR DESCRIPTION
### Motivation
- Custom TCC profiles can include role-marked `melting` and `clearing` variants but arc‑flash clearing time was interpolating the primary/selected curve which can be a melting curve and therefore understate clearing time and incident energy.

### Description
- Update `analysis/arcFlash.mjs` so `clearingTime()` prefers `scaled.maxCurve` (the role-marked clearing/upper curve) when available and falls back to `scaled.curve`, preserving legacy behavior with a minimal change.

### Testing
- Ran `npm test` and `npm run build`, both completed successfully; attempted to capture a browser preview with `npx playwright screenshot` but Playwright browser installation failed due to CDN download 403 responses so no screenshot could be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c75e9e08324a85624934a476549)