### PR TITLE
fix: prevent infinite loop in custom curve ID sanitizers

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -819,14 +819,25 @@ function sanitizeCustomCurveProfiles(rawProfiles = []) {
   if (!Array.isArray(rawProfiles)) return [];
   const seenIds = new Set();
   let counter = 0;
+  const MAX_SUFFIX_COUNTER = Number.MAX_SAFE_INTEGER;
   const ensureName = (name, index) => {
     if (typeof name === 'string' && name.trim()) return name.trim();
     return `Curve ${index + 1}`;
   };
-  const syncCounter = id => {
+  const parseTrailingCounter = id => {
+    if (typeof id !== 'string') return null;
     const match = /([0-9]+)$/.exec(id);
-    if (match) {
-      counter = Math.max(counter, Number(match[1]));
+    if (!match) return null;
+    const suffix = match[1];
+    if (suffix.length > 15) return null;
+    const parsed = Number(suffix);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) return null;
+    return Math.min(parsed, MAX_SUFFIX_COUNTER);
+  };
+  const syncCounter = id => {
+    const suffixCounter = parseTrailingCounter(id);
+    if (suffixCounter !== null) {
+      counter = Math.max(counter, suffixCounter);
     }
   };
   const reserveId = candidate => {
@@ -4847,9 +4858,12 @@ async function openCustomCurveBuilder(curveId = null) {
   const syncVariantCounter = id => {
     if (typeof id !== 'string') return;
     const match = /([0-9]+)$/.exec(id);
-    if (match) {
-      variantCounter = Math.max(variantCounter, Number(match[1]));
-    }
+    if (!match) return;
+    const suffix = match[1];
+    if (suffix.length > 15) return;
+    const parsed = Number(suffix);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) return;
+    variantCounter = Math.max(variantCounter, Math.min(parsed, Number.MAX_SAFE_INTEGER));
   };
 
   const reserveVariantId = candidate => {


### PR DESCRIPTION
### Motivation
- Imported/shared TCC project data could include profile IDs with extremely large trailing digit strings that parse to `Infinity`, which allowed the duplicate-ID resolver to loop forever and hang the TCC page. 
- The change aims to harden ID suffix parsing so attacker-controlled large numeric suffixes are ignored instead of poisoning the duplicate-resolution counter.

### Description
- Hardened `sanitizeCustomCurveProfiles` in `analysis/tcc.js` to parse trailing digit suffixes safely and ignore oversized/unsafe suffixes instead of converting them to `Infinity` (added `parseTrailingCounter`, length/safety checks, and `MAX_SUFFIX_COUNTER`).
- Applied the same safe-suffix checks to the builder-side variant parsing (`syncVariantCounter`) to prevent the same failure mode when editing curve variants.
- Preserved existing ID reservation behavior for ordinary finite suffixes while ensuring the duplicate-ID `while` loop can no longer be driven into a non-terminating state by malicious suffixes.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully.
- Built the project with `npm run build`, which completed successfully and produced the `dist/` artifacts.
- Attempted to capture a browser screenshot of `dist/index.html` using Playwright to provide a preview image, but browser binaries could not be downloaded in this environment (Playwright download returned HTTP 403), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c75eeb48324b3beb3544fd355b8)