### PR TITLE
Fix stale static-load kVA when PF or watts are edited

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -9775,7 +9775,10 @@ function selectComponent(compOrId) {
           kwVal = kvaVal * pfMagnitude;
         }
 
-        if (!Number.isFinite(kvaVal) && Number.isFinite(kwVal) && pfMagnitude !== null && pfMagnitude > 0) {
+        const sourceIsWattsOrPf = source === 'watts' || pfFieldNames.includes(source);
+        if (sourceIsWattsOrPf && Number.isFinite(kwVal) && pfMagnitude !== null && pfMagnitude > 0) {
+          kvaVal = kwVal / pfMagnitude;
+        } else if (!Number.isFinite(kvaVal) && Number.isFinite(kwVal) && pfMagnitude !== null && pfMagnitude > 0) {
           kvaVal = kwVal / pfMagnitude;
         }
 


### PR DESCRIPTION
### Motivation
- Default static loads include populated `kva` and `pf`, which allowed a stale `kva` to be treated as authoritative when users edited `watts` or `pf`, producing incorrect persisted `load.kvar` and `load.kw` values.

### Description
- Update `updateStaticPowerFields` in `oneline.js` to recompute `kva` from `kw / |pf|` when the edited `source` is `watts` or any PF field, while preserving the existing fallback behavior when `kva` is missing.

### Testing
- Ran `npm test` and `npm run build` (both passed); attempted `npx playwright install chromium` and `npx playwright screenshot` to capture a preview image, but the browser download failed with HTTP 403 so no automated screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c75e6a88324aec9600f39d36675)