### PR TITLE
Fix low-voltage kV parsing in source auto-base calculations

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -9947,7 +9947,7 @@ function selectComponent(compOrId) {
       const parseKvValue = raw => {
         if (raw === null || raw === undefined) return null;
         const directKv = toBaseKV(raw);
-        if (Number.isFinite(directKv) && directKv > 0.2) return directKv;
+        if (Number.isFinite(directKv) && directKv > 0) return directKv;
         const numeric = parseNumericValue(raw);
         if (!Number.isFinite(numeric) || numeric <= 0) return null;
         if (numeric > 1000) return numeric / 1000;


### PR DESCRIPTION
### Motivation
- Prevent valid low-voltage inputs like `120 V` or `200 V` from being rejected and misinterpreted as `120 kV`/`200 kV` when auto-populating source base-voltage and Thevenin MVA fields.

### Description
- Adjust `parseKvValue` in `oneline.js` to accept any positive result from `toBaseKV(raw)` by changing the threshold check from `> 0.2` to `> 0`, preserving numeric fallback behavior for unit-less inputs.

### Testing
- Ran the test suite with `npm test`, which completed successfully. 
- Built the distribution with `npm run build`, which completed successfully. 
- Attempted a Playwright-based UI preview screenshot but it failed because browser binaries are not installed in this environment (`chromium_headless_shell` missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092f4600208324adcf7cb07a9e0eed)