### PR TITLE
Fix parsing of explicit transformer baseKV to treat values as kV

### DIFF
--- a/tests/transformerProperties.test.mjs
+++ b/tests/transformerProperties.test.mjs
@@ -65,3 +65,27 @@ const approxEqual = (a, b, tolerance = 1e-9) => {
   assert(transformer.impedance && Number.isFinite(transformer.impedance.r), 'Impedance.r should be numeric');
   assert(transformer.impedance && Number.isFinite(transformer.impedance.x), 'Impedance.x should be numeric');
 }
+
+
+// Explicit baseKV fields must be interpreted as kV values, not volts
+{
+  const transformer = {
+    type: 'transformer',
+    kva: 2500,
+    percent_z: 6,
+    xr_ratio: 10,
+    baseKV: 15
+  };
+  const baseKV = computeTransformerBaseKV(transformer);
+  approxEqual(baseKV, 15, 1e-9);
+
+  const impedance = calculateTransformerImpedance({
+    kva: 2500,
+    percentZ: 6,
+    xrRatio: 10,
+    baseKV: 15
+  });
+  assert(impedance, 'Impedance should be calculated for explicit baseKV');
+  approxEqual(Number(impedance.r.toFixed(6)), 0.53732, 1e-6);
+  approxEqual(Number(impedance.x.toFixed(6)), 5.373201, 1e-6);
+}

--- a/utils/transformerImpedance.js
+++ b/utils/transformerImpedance.js
@@ -1,4 +1,4 @@
-import { toBaseKV, normalizeVoltageToVolts } from './voltage.js';
+import { normalizeVoltageToVolts } from './voltage.js';
 
 function parseNumeric(raw) {
   if (raw === null || raw === undefined) return null;
@@ -30,7 +30,7 @@ function resolveVoltageKV(inputs) {
     if (kv > 0) return kv;
   }
   if (inputs.baseKV !== undefined || inputs.prefault_voltage !== undefined) {
-    const kv = toBaseKV(inputs.baseKV ?? inputs.prefault_voltage);
+    const kv = parseNumeric(inputs.baseKV ?? inputs.prefault_voltage);
     if (Number.isFinite(kv) && kv > 0) return kv;
   }
   return null;

--- a/utils/transformerProperties.js
+++ b/utils/transformerProperties.js
@@ -92,7 +92,7 @@ export function readTransformerBaseKV(record) {
   const baseKeys = ['baseKV', 'kV', 'kv', 'prefault_voltage'];
   for (const key of baseKeys) {
     const raw = getCandidateValue(record, key);
-    const kv = toBaseKV(raw);
+    const kv = parseNumeric(raw);
     if (Number.isFinite(kv) && kv > 0) return kv;
   }
   return null;


### PR DESCRIPTION
### Motivation
- Close a security/integrity bug where explicit transformer fields named `baseKV`, `kV`, `kv`, or `prefault_voltage` were passed through ambiguous voltage heuristics and integer kV values like `15` were misinterpreted as 0.015 kV, producing drastically understated impedances.
- Ensure persisted transformer defaults and impedance calculations never silently store a mis-scaled value when a caller supplies an explicit kV-rating.

### Description
- Treat explicit base-voltage fields as direct kV numeric values by replacing the heuristic `toBaseKV()` call with numeric parsing in `readTransformerBaseKV()` in `utils/transformerProperties.js`.
- Apply the same change in `utils/transformerImpedance.js` by resolving `baseKV`/`prefault_voltage` with numeric parsing instead of the voltage normalizer, and remove the unused `toBaseKV` import.
- Add a regression test to `tests/transformerProperties.test.mjs` that asserts `baseKV: 15` yields `15 kV` and produces the expected impedance magnitudes to guard against regressions.
- Keep existing behavior for derived voltages (those in volts fields such as `volts_secondary`) unchanged by continuing to use the voltage normalizer for those keys.

### Testing
- Ran the full test suite with `npm test`, and all tests completed successfully (exit 0), including the new regression test for explicit `baseKV` parsing.
- Built the distribution with `npm run build` and the build completed successfully.
- Attempted to capture a UI preview via Playwright (`npx playwright screenshot`), but browser binaries could not be downloaded in this environment so the screenshot step failed; this does not affect the automated test or build results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a093053bb288324ae93e40833515b20)