### PR TITLE
Restrict motor derivations to explicit horsepower fields

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -8754,7 +8754,7 @@ function selectComponent(compOrId) {
       rawSchema = inferSchemaFromProps({ ...metaProps, ...(targetComp.props || {}) });
     }
 
-    const motorHorsepowerIndicators = new Set(['hp', 'horsepower', 'rating']);
+    const motorHorsepowerIndicators = new Set(['hp', 'horsepower']);
     const rawSchemaFieldNames = new Set(
       rawSchema
         .map(field => field && field.name)
@@ -9524,7 +9524,6 @@ function selectComponent(compOrId) {
       const driverFieldNames = [
         'hp',
         'horsepower',
-        'rating',
         'pf',
         'power_factor',
         'efficiency',
@@ -9599,7 +9598,7 @@ function selectComponent(compOrId) {
       };
 
       const updateMotorDerivedFields = () => {
-        const hpVal = getNumeric(['hp', 'horsepower', 'rating']);
+        const hpVal = getNumeric(['hp', 'horsepower']);
         let effVal = getNumeric(['efficiency', 'eff'], { percent: true });
         let pfVal = getNumeric(['pf', 'power_factor'], { percent: true });
         let voltageVal = getNumeric(['voltage', 'volts', 'volts_primary', 'volts_secondary']);


### PR DESCRIPTION
### Motivation
- Prevent non-motor components with a generic `rating` field from enabling motor derivations that lock and overwrite `load_kw`/`load_kvar`/impedance fields.

### Description
- Removed `'rating'` from the motor horsepower indicator set so derivation mode is enabled only by `hp` or `horsepower` in component schema.
- Removed `'rating'` from the `driverFieldNames` list so changes to a generic `rating` no longer trigger motor recalculation logic.
- Stopped reading `rating` in the horsepower lookup used by `updateMotorDerivedFields`, restricting horsepower detection to `hp`/`horsepower` only.
- All changes are localized to `oneline.js` and preserve existing motor derivation behavior for genuine motor components.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (all tests passed).
- Built the distribution with `npm run build`, which completed successfully and produced `dist` artifacts.
- Attempted to capture a UI preview with Playwright via `npx playwright screenshot`, but browser installation failed due to upstream download errors (HTTP 403), so a screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09317a425c8324a8ef9ebf69daa579)