### PR TITLE
Don't auto-overwrite Thevenin R/X in motor properties modal

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -8699,9 +8699,7 @@ function selectComponent(compOrId) {
       'load_kw',
       'load_kvar',
       'impedance_r',
-      'impedance_x',
-      'thevenin_r',
-      'thevenin_x'
+      'impedance_x'
     ]);
     const staticCalculatedFields = isStaticLoadComponent
       ? new Set(['load_kw', 'load_kvar', 'baseKV', 'kV', 'kv', 'prefault_voltage'])
@@ -9608,20 +9606,10 @@ function selectComponent(compOrId) {
           if (Number.isFinite(baseKv) && baseKv > 0) voltageVal = baseKv * 1000;
         }
         let phasesVal = getNumeric(['phases', 'phase_count', 'phaseCount']);
-        const multipleVal = getNumeric([
-          'inrushMultiple',
-          'lr_current_pu',
-          'locked_rotor_multiple',
-          'lockedRotorMultiple'
-        ]);
-
         const loadKwInput = motorInputMap.get('load_kw');
         const loadKvarInput = motorInputMap.get('load_kvar');
         const impRInput = motorInputMap.get('impedance_r');
         const impXInput = motorInputMap.get('impedance_x');
-        const thRInput = motorInputMap.get('thevenin_r');
-        const thXInput = motorInputMap.get('thevenin_x');
-
         effVal = effVal !== null ? clamp(effVal, 0.01, 0.9999) : null;
         pfVal = pfVal !== null ? clamp(pfVal, 0.01, 0.9999) : null;
         phasesVal = Number.isFinite(phasesVal) && phasesVal > 0 ? phasesVal : 3;
@@ -9656,24 +9644,6 @@ function selectComponent(compOrId) {
               const reactance = impedanceMag * sinPhi;
               impRInput.value = formatNumber(resistance, 4);
               impXInput.value = formatNumber(reactance, 4);
-            }
-          }
-        }
-
-        const supplyPf = 0.25;
-        const sagTarget = 0.3;
-        if (lineCurrent && lineCurrent > 0 && voltageValid !== null && (thRInput || thXInput)) {
-          const inrushMultiple = Number.isFinite(multipleVal) && multipleVal > 0 ? multipleVal : 6;
-          const lockedRotorCurrent = lineCurrent * inrushMultiple;
-          if (lockedRotorCurrent > 0) {
-            const isSinglePhase = phasesVal <= 1.5;
-            const phaseVoltage = isSinglePhase ? voltageValid : voltageValid / Math.sqrt(3);
-            const theveninMag = (sagTarget * phaseVoltage) / lockedRotorCurrent;
-            if (Number.isFinite(theveninMag) && theveninMag > 0) {
-              const pfClamp = clamp(supplyPf, 0.01, 0.9999);
-              const sinSupply = Math.sqrt(Math.max(1 - pfClamp * pfClamp, 0));
-              if (thRInput) thRInput.value = formatNumber(theveninMag * pfClamp, 4);
-              if (thXInput) thXInput.value = formatNumber(theveninMag * sinSupply, 4);
             }
           }
         }


### PR DESCRIPTION
### Motivation

- The one-line motor properties modal was treating `thevenin_r`/`thevenin_x` as calculated/read-only and immediately recomputing them with hard-coded assumptions, which can silently corrupt user- or import-provided source impedance used by motor-start analysis. 
- The intent of this change is to preserve user-supplied Thevenin/source impedance values and eliminate the accidental persistence of synthetic Thevenin values when a user merely opens the motor modal.

### Description

- Removed `thevenin_r` and `thevenin_x` from the motor calculated fields set so they are no longer treated as `Calculated`/read-only in the modal (`oneline.js`).
- Deleted the automatic Thevenin derivation/writeback code inside `updateMotorDerivedFields()` that used hard-coded `supplyPf` and `sagTarget` and referenced Thevenin inputs so the routine no longer overwrites source impedance fields. 
- Kept existing motor derivations for `load_kw`, `load_kvar`, and impedance (`impedance_r`/`impedance_x`) intact so normal derived-load behavior remains unchanged.

### Testing

- Ran the full JS test suite with `npm test` and all tests completed successfully. 
- Built the frontend with `npm run build` and the build completed successfully. 
- Attempted an automated preview capture with Playwright (`npx playwright screenshot ...`) but it failed in this environment because Playwright browser binaries were not installed, so a screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09317a3af883249ef1f58c16f92a08)