### PR TITLE
Harden arc-flash resolver against hidden non-protection TCC IDs

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -6,6 +6,12 @@ import { showAlertModal } from '../src/components/modal.js';
 let deviceCache = null;
 
 const PROTECTIVE_TYPES = new Set(['breaker', 'fuse', 'relay', 'recloser', 'contactor', 'switch']);
+function isProtectiveComponent(component) {
+  if (!component || typeof component !== 'object') return false;
+  if (component.category === 'protection') return true;
+  if (!component.type) return true;
+  return PROTECTIVE_TYPES.has(component.type);
+}
 const FALLBACK_TYPES = new Set(['motor_load', 'static_load', 'load', 'panel', 'equipment', 'bus', 'cable', 'mcc']);
 const UPSTREAM_CANDIDATE_TYPES = new Set([
   'transformer',
@@ -157,7 +163,7 @@ function createProtectiveResolver(comps = []) {
     }
     stack.add(component.id);
     let result = null;
-    if (component?.tccId) {
+    if (component?.tccId && isProtectiveComponent(component)) {
       result = component;
     } else {
       const parents = getParents(component);
@@ -241,7 +247,7 @@ function clearingTime(comp, Ibf, devices, protectiveComp, scResults, protectiveD
     if (protectiveClearing !== null) return protectiveClearing;
   }
   const deviceComp = protectiveComp || comp;
-  if (!deviceComp?.tccId) return 0.2;
+  if (!deviceComp?.tccId || !isProtectiveComponent(deviceComp)) return 0.2;
   const dev = protectiveDevice || devices.find(d => d.id === deviceComp.tccId);
   if (!dev) return 0.2;
   const saved = getItem('tccSettings', { devices: [], settings: {}, componentOverrides: {} });
@@ -323,7 +329,9 @@ export async function runArcFlash(options = {}) {
     const shortCircuitAvailable = Number.isFinite(fault?.threePhaseKA) && fault.threePhaseKA > 0;
     const Ibf = shortCircuitAvailable ? fault.threePhaseKA : 0;
     const protectiveComp = protection.findNearest(comp);
-    const protectiveDevice = protectiveComp ? devices.find(d => d.id === protectiveComp.tccId) : null;
+    const protectiveDevice = protectiveComp && isProtectiveComponent(protectiveComp)
+      ? devices.find(d => d.id === protectiveComp.tccId)
+      : null;
     const compClearing = parseNumeric(comp?.clearing_time);
     const upstreamClearing = protectiveComp && protectiveComp !== comp
       ? parseNumeric(protectiveComp?.clearing_time)


### PR DESCRIPTION
### Motivation
- A change made the TCC UI field invisible for non-protection components while preserving any existing `tccId`, allowing imported or legacy non-protection components to silently influence arc‑flash clearing-time and incident‑energy calculations. 
- Arc‑flash logic previously treated any component with a `tccId` as a protective device regardless of type/category, creating an integrity risk for safety calculations.

### Description
- Added `isProtectiveComponent(component)` to `analysis/arcFlash.mjs` to explicitly classify which components may act as protective devices. 
- Updated the protective resolver traversal (`visit`) so a component is only considered protective if it both has a `tccId` and passes `isProtectiveComponent(...)`.
- Hardened `clearingTime(...)` and protective‑device lookup so `tccId` on non‑protection components is ignored when selecting device curves. 
- Changes are limited to `analysis/arcFlash.mjs` and preserve existing behavior for legitimately classified protection components.

### Testing
- Ran the full automated test suite via `npm test`; the suite completed successfully after the fix and the previously failing `tests/arcflash/arcFlashExample.test.cjs` now passes. 
- Built the distribution with `npm run build` and the build completed successfully. 
- Attempted to produce an HTML preview screenshot with Playwright, but browser installation failed due to upstream download (Playwright Chromium download returned HTTP 403), so a preview image could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09317ae5c88324b5dbb2ac1dfd5458)