### PR TITLE
Harden cable typical import/export value sanitization

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -566,6 +566,16 @@ async function initCableSchedule() {
   };
 
   const cloneTemplates = templates => (Array.isArray(templates) ? templates.map(t => JSON.parse(JSON.stringify(t))) : []);
+  const sanitizeTemplateFieldValue = value => {
+    if (value == null) return '';
+    if (Array.isArray(value)) {
+      return value.map(item => (item == null ? '' : `${item}`)).join(', ');
+    }
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+    return value;
+  };
   const filterTemplateFields = (input = {}, options = {}) => {
     const { keepLabel = true, keepTypicalId = false } = options;
     const copy = { ...input };
@@ -580,6 +590,9 @@ async function initCableSchedule() {
     if (!keepTypicalId && Object.prototype.hasOwnProperty.call(copy, 'typical_id')) {
       delete copy.typical_id;
     }
+    Object.keys(copy).forEach(key => {
+      copy[key] = sanitizeTemplateFieldValue(copy[key]);
+    });
     return copy;
   };
   const generateTemplateId = () => {
@@ -1450,12 +1463,6 @@ async function initCableSchedule() {
         showAlertModal('Notice', 'No cable typicals to export yet.');
         return;
       }
-      const safeValue = value => {
-        if (Array.isArray(value)) {
-          return value.map(item => (item == null ? '' : `${item}`)).join(', ');
-        }
-        return value == null ? '' : value;
-      };
       const templatesForExport = this.templates.map(tpl =>
         filterTemplateFields(tpl, { keepLabel: true, keepTypicalId: true })
       );
@@ -1465,9 +1472,9 @@ async function initCableSchedule() {
           const headerRow = headerConfig.map(cfg => cfg.header);
           const rows = templatesForExport.map(tpl =>
             headerConfig.map(({ key }) => {
-              if (key === 'label') return safeValue(tpl.label);
-              if (key === 'template_id') return safeValue(tpl.template_id);
-              return safeValue(tpl[key]);
+              if (key === 'label') return sanitizeTemplateFieldValue(tpl.label);
+              if (key === 'template_id') return sanitizeTemplateFieldValue(tpl.template_id);
+              return sanitizeTemplateFieldValue(tpl[key]);
             })
           );
           const sheetData = [headerRow, ...rows];


### PR DESCRIPTION
### Motivation
- Close a SheetJS spreadsheet-injection sink where object-valued template fields could be interpreted as SheetJS cell objects (including formula cells) during `.xlsx` export. 
- Ensure imported JSON template data cannot persist attacker-controlled non-primitive values that later reach the XLSX export path.

### Description
- Add `sanitizeTemplateFieldValue` in `cableschedule.js` to coerce field values to inert primitives/strings (arrays normalized, objects JSON-stringified, nulls to empty string). 
- Apply the sanitizer inside `filterTemplateFields` so normalized/imported templates are stored with safe, exported-friendly values. 
- Use the sanitizer when building the XLSX `aoa_to_sheet` input so every exported cell value is inert and cannot become a SheetJS cell object with formulas.

### Testing
- Ran the full test suite with `npm test`, and all automated tests completed successfully. 
- Built assets with `npm run build`, and the build completed successfully. 
- Attempted to produce a Playwright screenshot preview but browser binaries could not be installed in this environment (Playwright downloads failed with HTTP 403), so no screenshot could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a093371e36c8324be7d9a126ec6d211)