### PR TITLE
Mitigate cable typical import DoS with file and row limits

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -566,6 +566,8 @@ async function initCableSchedule() {
   };
 
   const cloneTemplates = templates => (Array.isArray(templates) ? templates.map(t => JSON.parse(JSON.stringify(t))) : []);
+  const MAX_TEMPLATE_IMPORT_FILE_BYTES = 5 * 1024 * 1024;
+  const MAX_TEMPLATE_IMPORT_COUNT = 5000;
   const filterTemplateFields = (input = {}, options = {}) => {
     const { keepLabel = true, keepTypicalId = false } = options;
     const copy = { ...input };
@@ -1535,6 +1537,11 @@ async function initCableSchedule() {
           resetInput();
           return;
         }
+        if (typeof file.size === 'number' && file.size > MAX_TEMPLATE_IMPORT_FILE_BYTES) {
+          showAlertModal('Import Error', 'The selected file is too large to import. Please choose a file smaller than 5 MB.');
+          resetInput();
+          return;
+        }
         const name = (file.name || '').toLowerCase();
         const type = (file.type || '').toLowerCase();
         const isExcel = name.endsWith('.xlsx') || type.includes('spreadsheet');
@@ -1569,11 +1576,21 @@ async function initCableSchedule() {
             resetInput();
             return;
           }
+          if (rows.length > MAX_TEMPLATE_IMPORT_COUNT) {
+            showAlertModal('Import Error', 'The selected file contains too many cable typicals to import.');
+            resetInput();
+            return;
+          }
           candidates = rows
             .map(row => this.normalizeExcelRow(row))
             .filter(Boolean);
         } else {
           const text = await file.text();
+          if (text.length > MAX_TEMPLATE_IMPORT_FILE_BYTES) {
+            showAlertModal('Import Error', 'The selected file is too large to import. Please choose a file smaller than 5 MB.');
+            resetInput();
+            return;
+          }
           let parsed;
           try {
             parsed = JSON.parse(text);
@@ -1589,6 +1606,11 @@ async function initCableSchedule() {
         }
         if (!candidates.length) {
           showAlertModal('Import Error', 'No cable typicals found in the selected file.');
+          resetInput();
+          return;
+        }
+        if (candidates.length > MAX_TEMPLATE_IMPORT_COUNT) {
+          showAlertModal('Import Error', 'The selected file contains too many cable typicals to import.');
           resetInput();
           return;
         }


### PR DESCRIPTION
### Motivation

- The cable-typical import path read and parsed entire user-selected JSON/Excel files with no bounds, allowing a maliciously large file or huge `templates` array to exhaust browser memory or freeze the UI. 

### Description

- Added two constants: `MAX_TEMPLATE_IMPORT_FILE_BYTES = 5 * 1024 * 1024` and `MAX_TEMPLATE_IMPORT_COUNT = 5000` in `cableschedule.js` to cap resource usage. 
- Early-return guards now reject files whose `file.size` or JSON text length exceed the file-size cap before parsing, and reject Excel imports whose `rows.length` exceed the count cap. 
- Added a final `candidates.length` check for JSON/Excel paths to prevent downstream processing when the candidate count is too large, and surface user-facing errors via `showAlertModal`. 
- The change is minimal and preserves the existing normalization, deduplication, and storage behavior for imports that fall under the limits.

### Testing

- Ran the unit/integration test suite via `npm test` and it completed successfully. 
- Ran the build via `npm run build` and it completed successfully (build emitted existing Rollup unresolved-dependency warnings but did not fail). 
- Attempted `npx playwright install chromium` to enable browser E2E checks but the environment failed to download Chromium (HTTP 403), so Playwright-based E2E/preview steps could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0934cdba488324821c65ccd66be5e2)