### PR TITLE
fix(tcc): guard motor thermal curve from non-finite values

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -6804,8 +6804,8 @@ function plot() {
       allTimes.push(normalizedDuration);
     } else if (entry.kind === 'transformerDamage' || entry.kind === 'motorStart' || entry.kind === 'motorThermal') {
       entry.curve.forEach(point => {
-        if (point.current > 0) allCurrents.push(point.current);
-        if (point.time > 0) allTimes.push(point.time);
+        if (Number.isFinite(point.current) && point.current > 0) allCurrents.push(point.current);
+        if (Number.isFinite(point.time) && point.time > 0) allTimes.push(point.time);
       });
     }
   });
@@ -9071,7 +9071,9 @@ function resolveMotorThermalLimit(
   if (!Number.isFinite(stallTime) || stallTime <= 0) return null;
   const serviceFactor = normalizeServiceFactor(getNumericValue(motor, ['service_factor', 'sf', 'serviceFactor']));
   const continuousCurrent = Math.max(fla * serviceFactor, fla * 1.05);
+  if (!Number.isFinite(continuousCurrent) || continuousCurrent <= 0) return null;
   const thermalConstant = lockedRotor * lockedRotor * stallTime;
+  if (!Number.isFinite(thermalConstant) || thermalConstant <= 0) return null;
   let longTime = thermalConstant / (continuousCurrent * continuousCurrent);
   if (!Number.isFinite(longTime) || longTime <= stallTime) {
     longTime = stallTime * 3;
@@ -9095,7 +9097,8 @@ function resolveMotorThermalLimit(
     .map(time => {
       const current = Math.max(Math.sqrt(thermalConstant / time), continuousCurrent);
       return { time, current };
-    });
+    })
+    .filter(point => Number.isFinite(point.time) && point.time > 0 && Number.isFinite(point.current) && point.current > 0);
   if (!points.length) return null;
   const last = points[points.length - 1];
   if (last) last.current = continuousCurrent;


### PR DESCRIPTION
### Motivation
- Prevent crafted motor inputs (very large but finite locked-rotor / stall-time values) from producing `Infinity`/`NaN` thermal-curve points that can poison log-scale domains and break TCC rendering.

### Description
- Harden `resolveMotorThermalLimit` to reject non-finite or non-positive `continuousCurrent` and `thermalConstant` before deriving curve times and currents in `analysis/tcc.js`.
- Filter generated motor thermal curve points so only finite positive `{ time, current }` pairs are returned from the thermal limit generator.
- Tighten overlay domain aggregation when collecting `allCurrents` / `allTimes` so transformer/motor overlay points are only included if `Number.isFinite(...)` and positive, preventing Infinity/NaN from entering the d3 log-scale domain.

### Testing
- Ran the full automated test suite with `npm test` and the run completed successfully.
- Built the distribution with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0934cd9b5083249ddbf5f9c8673cb3)