### PR TITLE
Harden TCC component detail formatting against array DoS

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -1816,23 +1816,44 @@ function formatOptionLabel(value) {
 }
 
 function formatDetailValue(value) {
-  if (value === null || value === undefined) return '';
-  if (Array.isArray(value)) {
-    return value
-      .map(item => formatDetailValue(item))
-      .filter(str => str)
-      .join(', ');
-  }
-  if (typeof value === 'boolean') {
-    return value ? 'Yes' : 'No';
-  }
-  if (typeof value === 'number') {
-    return formatSettingValue(value);
-  }
-  if (typeof value === 'string') {
-    return value.trim();
-  }
-  return '';
+  const MAX_ARRAY_DEPTH = 8;
+  const MAX_ARRAY_ITEMS = 100;
+  const MAX_OUTPUT_LENGTH = 1000;
+
+  const trimOutput = str => {
+    if (!str) return '';
+    if (str.length <= MAX_OUTPUT_LENGTH) return str;
+    return `${str.slice(0, MAX_OUTPUT_LENGTH - 1)}…`;
+  };
+
+  const walk = (current, depth, seen) => {
+    if (current === null || current === undefined) return '';
+    if (Array.isArray(current)) {
+      if (depth >= MAX_ARRAY_DEPTH || seen.has(current)) return '[…]';
+      seen.add(current);
+      const parts = [];
+      const maxItems = Math.min(current.length, MAX_ARRAY_ITEMS);
+      for (let idx = 0; idx < maxItems; idx += 1) {
+        const part = walk(current[idx], depth + 1, seen);
+        if (part) parts.push(part);
+      }
+      if (current.length > MAX_ARRAY_ITEMS) parts.push('…');
+      seen.delete(current);
+      return trimOutput(parts.join(', '));
+    }
+    if (typeof current === 'boolean') {
+      return current ? 'Yes' : 'No';
+    }
+    if (typeof current === 'number') {
+      return formatSettingValue(current);
+    }
+    if (typeof current === 'string') {
+      return current.trim();
+    }
+    return '';
+  };
+
+  return walk(value, 0, new Set());
 }
 
 function normalizeSettingOptions(options) {


### PR DESCRIPTION
### Motivation
- The TCC component browser began rendering raw one-line component fields/props and used an unbounded recursive formatter, which allows a malicious project to cause a stack overflow or excessive CPU/memory use when viewing component details. 
- The change aims to prevent client-side denial-of-service by bounding traversal and output from attacker-controlled arrays while preserving normal scalar rendering.

### Description
- Replace the previous unbounded `formatDetailValue` implementation in `analysis/tcc.js` with a guarded walker that enforces a maximum array depth, a maximum number of array items processed, and a maximum output length. 
- Add cycle detection for arrays by tracking visited array references and short-circuiting with an ellipsis placeholder (`[…]`) when a cycle or depth limit is hit. 
- Trim excessively long rendered strings and cap item iteration to avoid large CPU/memory work while retaining original scalar formatting for booleans, numbers, and strings. 
- Change is localized to `analysis/tcc.js` (the `formatDetailValue` function) and is intended to be minimal to reduce behavioral impact on the component browser.

### Testing
- Ran the full automated test suite with `npm test`, and all tests completed successfully in this environment. 
- Ran the build with `npm run build`, which produced a successful `dist` build. 
- Attempted to capture a page preview with Playwright (`npx playwright screenshot`) but `playwright` browser installation failed due to remote download being blocked (HTTP 403), so the headless screenshot step could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0934ce2d508324a2c40eb29c6f0590)