### PR TITLE
Remove unsupported fuse `speed` setting so UI matches TCC scaling

### DIFF
--- a/data/protectiveDevices.json
+++ b/data/protectiveDevices.json
@@ -119,15 +119,10 @@
     "withstandRatingKA": 200,
     "withstandCycles": 1,
     "settings": {
-      "ampRating": 400,
-      "speed": "time_delay"
+      "ampRating": 400
     },
     "settingOptions": {
-      "ampRating": [100, 200, 400, 600],
-      "speed": [
-        { "value": "time_delay", "label": "Time-Delay" },
-        { "value": "fast", "label": "Fast-Acting" }
-      ]
+      "ampRating": [100, 200, 400, 600]
     },
     "curve": [
       { "current": 400, "time": 100 },
@@ -149,15 +144,10 @@
     "withstandRatingKA": 200,
     "withstandCycles": 1,
     "settings": {
-      "ampRating": 200,
-      "speed": "time_delay"
+      "ampRating": 200
     },
     "settingOptions": {
-      "ampRating": [100, 200, 225, 250],
-      "speed": [
-        { "value": "time_delay", "label": "Time-Delay" },
-        { "value": "fast", "label": "Fast-Acting" }
-      ]
+      "ampRating": [100, 200, 225, 250]
     },
     "curve": [
       { "current": 200, "time": 120 },

--- a/data/protectiveDevices.mjs
+++ b/data/protectiveDevices.mjs
@@ -119,15 +119,10 @@ export default [
     "withstandRatingKA": 200,
     "withstandCycles": 1,
     "settings": {
-      "ampRating": 400,
-      "speed": "time_delay"
+      "ampRating": 400
     },
     "settingOptions": {
-      "ampRating": [100, 200, 400, 600],
-      "speed": [
-        { "value": "time_delay", "label": "Time-Delay" },
-        { "value": "fast", "label": "Fast-Acting" }
-      ]
+      "ampRating": [100, 200, 400, 600]
     },
     "curve": [
       { "current": 400, "time": 100 },
@@ -149,15 +144,10 @@ export default [
     "withstandRatingKA": 200,
     "withstandCycles": 1,
     "settings": {
-      "ampRating": 200,
-      "speed": "time_delay"
+      "ampRating": 200
     },
     "settingOptions": {
-      "ampRating": [100, 200, 225, 250],
-      "speed": [
-        { "value": "time_delay", "label": "Time-Delay" },
-        { "value": "fast", "label": "Fast-Acting" }
-      ]
+      "ampRating": [100, 200, 225, 250]
     },
     "curve": [
       { "current": 200, "time": 120 },


### PR DESCRIPTION
### Motivation
- New fuse records exposed `ampRating` and `speed` as user-selectable settings, but the scaling engine (`scaleCurve`) does not consume `speed`, creating a misleading no-op configuration that can affect safety-relevant outputs.
- Apply a minimal, conservative remediation that prevents users from persisting unsupported overrides while preserving existing calculation behavior.

### Description
- Removed the `speed` setting and its `settingOptions` from the Bussmann (`bussmann_lpsrksp_400`) and Mersen (`mersen_trs200r`) fuse entries in both `data/protectiveDevices.mjs` and `data/protectiveDevices.json`, leaving `ampRating` as the only configurable fuse setting.
- Kept existing `curve`, `tolerance`, and interrupt/withstand fields unchanged so runtime behavior and calculations remain identical to current HEAD.

### Testing
- Ran the full automated test suite via `npm test`, and the suite completed successfully (all tests passed).
- Built production assets with `npm run build`, and the build completed successfully (dist artifacts updated where applicable).
- Attempted to produce a screenshot preview with `npx playwright screenshot ...` but the Playwright browser install failed (download 403), so a runtime preview image could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0934cddb148324916d03e5184d4be7)