### PR TITLE
Fix arc-flash numeric fallback for blank-string fields

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -45,6 +45,14 @@ function parseNumeric(value) {
   return null;
 }
 
+function firstParsedNumeric(...values) {
+  for (const value of values) {
+    const parsed = parseNumeric(value);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
 function pickValue(comp, ...keys) {
   if (!comp) return undefined;
   for (const key of keys) {
@@ -342,16 +350,16 @@ export async function runArcFlash(options = {}) {
     const gap = Number.isFinite(gapRaw) && gapRaw > 0 ? gapRaw : 25;
     const workingDistanceRaw = parseNumeric(comp.working_distance);
     const dist = Number.isFinite(workingDistanceRaw) && workingDistanceRaw > 0 ? workingDistanceRaw : 455;
-    const heightRaw = parseNumeric(comp.enclosure_height ?? comp.box_height);
-    const widthRaw = parseNumeric(comp.enclosure_width ?? comp.box_width);
-    const depthRaw = parseNumeric(comp.enclosure_depth ?? comp.box_depth);
+    const heightRaw = firstParsedNumeric(comp.enclosure_height, comp.box_height);
+    const widthRaw = firstParsedNumeric(comp.enclosure_width, comp.box_width);
+    const depthRaw = firstParsedNumeric(comp.enclosure_depth, comp.box_depth);
     const h = Number.isFinite(heightRaw) && heightRaw > 0 ? heightRaw : 508;
     const w = Number.isFinite(widthRaw) && widthRaw > 0 ? widthRaw : 508;
     const de = Number.isFinite(depthRaw) && depthRaw > 0 ? depthRaw : 508;
     const sizeFactor = Math.cbrt((h * w * de) / (508 * 508 * 508)) || 1;
     const time = clearingTime(comp, Ibf, devices, protectiveComp, sc, protectiveDevice);
     const cfg = (comp.electrode_config || 'VCB').toUpperCase();
-    const voltageSettingRaw = parseNumeric(comp.kV ?? comp.baseKV ?? comp.prefault_voltage);
+    const voltageSettingRaw = firstParsedNumeric(comp.kV, comp.baseKV, comp.prefault_voltage);
     const V = Number.isFinite(voltageSettingRaw) && voltageSettingRaw > 0 ? voltageSettingRaw : 0.48;
     const rawIa = Ibf > 0 && time > 0
       ? arcingCurrent(Ibf, V, gap, cfg, enclosure)


### PR DESCRIPTION
### Motivation
- Recent changes switched fallback selection to nullish coalescing which treats empty strings (`""`) as present and allowed blank fields to suppress valid legacy fallbacks, causing the energy model to default to 0.48 kV while reports still showed a higher nominal voltage. 
- The intent of this change is to restore the previous fallback semantics where blank/invalid string inputs fall through to alternate fields so calculations use the first parseable numeric input.

### Description
- Added a small helper `firstParsedNumeric(...values)` in `analysis/arcFlash.mjs` that returns the first value that `parseNumeric` can parse as a finite number. 
- Replaced direct `parseNumeric(... ?? ...)` usages with `firstParsedNumeric(...)` for enclosure dimensions (`enclosure_*` then `box_*`) so blank dimension strings no longer block legacy `box_*` values. 
- Replaced the voltage selection (`kV`, `baseKV`, `prefault_voltage`) with `firstParsedNumeric(...)` so blank `kV` does not suppress valid fallback voltages and force the 0.48 kV default. 
- Changes are minimal and localized to `analysis/arcFlash.mjs` and preserve behavior for legitimate numeric inputs.

### Testing
- Ran `npm test`, which failed due to an existing unrelated assertion in `tests/serverSecurity.test.mjs` (expected `409` but got `401`), not caused by this patch. 
- Ran `npm run build` successfully and verified the bundle completed. 
- Attempted to produce a Playwright screenshot (`npx playwright screenshot`) and to install Chromium (`npx playwright install chromium`), but browser download failed due to CDN `403 Forbidden`, so a preview image could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0934cddd948324b984488c77065424)