### PR TITLE
Fix arc-flash protective resolver stack overflow

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -162,27 +162,80 @@ function createProtectiveResolver(comps = []) {
     return parents;
   }
 
-  function visit(component, stack = new Set()) {
+  function visit(component) {
     if (!component?.id) return null;
     if (cache.has(component.id)) return cache.get(component.id);
-    if (stack.has(component.id)) {
-      cache.set(component.id, null);
-      return null;
-    }
-    stack.add(component.id);
-    let result = null;
-    if (component?.tccId && isProtectiveComponent(component)) {
-      result = component;
-    } else {
-      const parents = getParents(component);
-      for (const parent of parents) {
-        result = visit(parent.component, stack);
-        if (result) break;
+
+    const stack = [];
+    const active = new Set();
+    stack.push({ component, entered: false, parents: [], index: 0, result: null });
+
+    while (stack.length) {
+      const frame = stack[stack.length - 1];
+      const current = frame.component;
+      const currentId = current?.id;
+
+      if (!currentId) {
+        stack.pop();
+        continue;
       }
+
+      if (!frame.entered) {
+        if (cache.has(currentId)) {
+          const cached = cache.get(currentId);
+          stack.pop();
+          if (cached && stack.length && !stack[stack.length - 1].result) {
+            stack[stack.length - 1].result = cached;
+          }
+          continue;
+        }
+
+        if (active.has(currentId)) {
+          cache.set(currentId, null);
+          stack.pop();
+          continue;
+        }
+
+        frame.entered = true;
+        active.add(currentId);
+
+        if (current?.tccId && isProtectiveComponent(current)) {
+          frame.result = current;
+        } else {
+          frame.parents = getParents(current);
+        }
+      }
+
+      if (frame.result || frame.index >= frame.parents.length) {
+        active.delete(currentId);
+        cache.set(currentId, frame.result || null);
+        stack.pop();
+
+        if (frame.result && stack.length && !stack[stack.length - 1].result) {
+          stack[stack.length - 1].result = frame.result;
+        }
+        continue;
+      }
+
+      const nextParent = frame.parents[frame.index++]?.component;
+      const nextId = nextParent?.id;
+      if (!nextId) continue;
+
+      if (cache.has(nextId)) {
+        const cached = cache.get(nextId);
+        if (cached) frame.result = cached;
+        continue;
+      }
+
+      if (active.has(nextId)) {
+        cache.set(nextId, null);
+        continue;
+      }
+
+      stack.push({ component: nextParent, entered: false, parents: [], index: 0, result: null });
     }
-    stack.delete(component.id);
-    cache.set(component.id, result || null);
-    return result;
+
+    return cache.get(component.id) || null;
   }
 
   return {


### PR DESCRIPTION
### Motivation
- The protective-device resolver previously used an unbounded recursive `visit()` over project `connections`, which can be attacker-controlled and could trigger `RangeError: Maximum call stack size exceeded` on very deep one-line graphs, aborting arc-flash analysis and report generation.

### Description
- Replace the recursive `visit()` in `analysis/arcFlash.mjs` with an iterative depth-first traversal that uses an explicit stack to remove reliance on the JS call stack depth limits.
- Preserve the existing caching behavior via the `cache` map and maintain cycle detection by tracking active nodes and caching `null` for cyclic paths.
- Keep the `createProtectiveResolver()` / `findNearest()` external behavior unchanged so callers remain compatible.

### Testing
- Ran `npm test`, which completed successfully and exercised the arc-flash and reporting test suites.
- Ran `npm run build`, which completed successfully and produced the distribution artifacts.
- Attempted to capture a UI preview with Playwright, but `npx playwright install` failed to download Chromium in this environment (HTTP 403), so a screenshot preview could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09372449a48324a70cce64de59ea0e)