### PR TITLE
Fix arc-flash protective type detection for mixed-case data

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -8,9 +8,15 @@ let deviceCache = null;
 const PROTECTIVE_TYPES = new Set(['breaker', 'fuse', 'relay', 'recloser', 'contactor', 'switch']);
 function isProtectiveComponent(component) {
   if (!component || typeof component !== 'object') return false;
-  if (component.category === 'protection') return true;
+  const category = typeof component.category === 'string' ? component.category.toLowerCase() : '';
+  if (category === 'protection') return true;
+  const subtype = typeof component.subtype === 'string' ? component.subtype.toLowerCase() : '';
+  if (PROTECTIVE_TYPES.has(subtype)) return true;
+  if ([...PROTECTIVE_TYPES].some(token => subtype.includes(token))) return true;
   if (!component.type) return true;
-  return PROTECTIVE_TYPES.has(component.type);
+  const type = typeof component.type === 'string' ? component.type.toLowerCase() : '';
+  if (PROTECTIVE_TYPES.has(type)) return true;
+  return [...PROTECTIVE_TYPES].some(token => type.includes(token));
 }
 const FALLBACK_TYPES = new Set(['motor_load', 'static_load', 'load', 'panel', 'equipment', 'bus', 'cable', 'mcc']);
 const UPSTREAM_CANDIDATE_TYPES = new Set([


### PR DESCRIPTION
### Motivation
- A recent hardening change made the protective-device classifier exact-match lowercase `component.type`, which rejected common mixed-case imports like `Breaker` or descriptive subtypes and caused TCC-backed devices to fall back to an unsafe default clearing time.
- The intent is to retain the protection-category hardening while restoring recognition of protective devices expressed with mixed case or descriptive subtypes so TCC lookups and clearing-time math remain accurate.

### Description
- Normalized `component.category`, `component.subtype`, and `component.type` to lowercase in `isProtectiveComponent` in `analysis/arcFlash.mjs` before comparisons. 
- Added checks that accept protective tokens in `subtype` and `type` using both exact membership in `PROTECTIVE_TYPES` and substring matching to handle values like `Main Breaker` or `breaker`. 
- Preserved the original fallback behavior that treats components without a `type` as protective and preserved the `category === 'protection'` short-circuit. 

### Testing
- Ran the full test suite with `npm test`, which completed successfully. 
- Built the distribution with `npm run build`, which completed successfully. 
- Attempted to generate a Playwright screenshot preview (required browser download), but `npx playwright install chromium` failed due to remote download being blocked (HTTP 403), so an automated page preview could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b7990bd48324943f4fa7515af1f3)