### PR TITLE
Restore unit-aware parsing for explicit transformer base kV fields

### DIFF
--- a/tests/transformerProperties.test.mjs
+++ b/tests/transformerProperties.test.mjs
@@ -89,3 +89,30 @@ const approxEqual = (a, b, tolerance = 1e-9) => {
   approxEqual(Number(impedance.r.toFixed(6)), 0.53732, 1e-6);
   approxEqual(Number(impedance.x.toFixed(6)), 5.373201, 1e-6);
 }
+
+
+// Explicit unit-suffixed baseKV/prefault_voltage fields must be parsed with units
+{
+  const baseKV = computeTransformerBaseKV({ baseKV: '480 V' });
+  approxEqual(baseKV, 0.48, 1e-9);
+
+  const impedanceFromBase = calculateTransformerImpedance({
+    kva: 2500,
+    percentZ: 6,
+    xrRatio: 10,
+    baseKV: '480 V'
+  });
+  const impedanceFromPrefault = calculateTransformerImpedance({
+    kva: 2500,
+    percentZ: 6,
+    xrRatio: 10,
+    prefault_voltage: '480 V'
+  });
+
+  assert(impedanceFromBase, 'Impedance should be calculated for unit-suffixed baseKV');
+  assert(impedanceFromPrefault, 'Impedance should be calculated for unit-suffixed prefault voltage');
+  approxEqual(Number(impedanceFromBase.r.toFixed(6)), 0.00055, 1e-6);
+  approxEqual(Number(impedanceFromBase.x.toFixed(6)), 0.0055, 1e-5);
+  approxEqual(Number(impedanceFromPrefault.r.toFixed(6)), 0.00055, 1e-6);
+  approxEqual(Number(impedanceFromPrefault.x.toFixed(6)), 0.0055, 1e-5);
+}

--- a/utils/transformerImpedance.js
+++ b/utils/transformerImpedance.js
@@ -1,4 +1,4 @@
-import { normalizeVoltageToVolts } from './voltage.js';
+import { normalizeVoltageToVolts, toBaseKV } from './voltage.js';
 
 function parseNumeric(raw) {
   if (raw === null || raw === undefined) return null;
@@ -16,6 +16,19 @@ function parseNumeric(raw) {
   return null;
 }
 
+
+function parseExplicitBaseKV(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    if (/[a-zA-Z]/.test(trimmed)) return toBaseKV(trimmed);
+    return parseNumeric(trimmed);
+  }
+  return toBaseKV(raw);
+}
+
 function resolveVoltageKV(inputs) {
   if (!inputs) return null;
   if (inputs.voltageKV !== undefined && inputs.voltageKV !== null) {
@@ -30,7 +43,7 @@ function resolveVoltageKV(inputs) {
     if (kv > 0) return kv;
   }
   if (inputs.baseKV !== undefined || inputs.prefault_voltage !== undefined) {
-    const kv = parseNumeric(inputs.baseKV ?? inputs.prefault_voltage);
+    const kv = parseExplicitBaseKV(inputs.baseKV ?? inputs.prefault_voltage);
     if (Number.isFinite(kv) && kv > 0) return kv;
   }
   return null;

--- a/utils/transformerProperties.js
+++ b/utils/transformerProperties.js
@@ -88,11 +88,23 @@ export function resolveTransformerXrRatio(record) {
   return pickNumeric(record, xrKeys);
 }
 
+function parseExplicitBaseKV(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    if (/[a-zA-Z]/.test(trimmed)) return toBaseKV(trimmed);
+    return parseNumeric(trimmed);
+  }
+  return toBaseKV(raw);
+}
+
 export function readTransformerBaseKV(record) {
   const baseKeys = ['baseKV', 'kV', 'kv', 'prefault_voltage'];
   for (const key of baseKeys) {
     const raw = getCandidateValue(record, key);
-    const kv = parseNumeric(raw);
+    const kv = parseExplicitBaseKV(raw);
     if (Number.isFinite(kv) && kv > 0) return kv;
   }
   return null;


### PR DESCRIPTION
### Motivation
- A recent change replaced unit-aware conversion with a numeric-only parser for explicit transformer base fields, causing strings like `"480 V"` to be treated as `480 kV` and producing huge impedance errors.
- The intent is to accept bare numeric kV values while preserving unit-aware handling for unit-suffixed inputs to avoid integrity/security regressions in engineering calculations.

### Description
- Introduces `parseExplicitBaseKV` in `utils/transformerProperties.js` and `utils/transformerImpedance.js` that delegates to `toBaseKV()` when the input contains alphabetic unit characters and falls back to numeric parsing for bare numbers.
- Replaces direct uses of `parseNumeric()` for explicit base keys (`baseKV`, `kV`, `kv`, `prefault_voltage`) with `parseExplicitBaseKV()` in `readTransformerBaseKV()` and transformer impedance voltage resolution.
- Adds regression tests in `tests/transformerProperties.test.mjs` that assert unit-suffixed inputs such as `baseKV: '480 V'` and `prefault_voltage: '480 V'` produce the expected `0.48 kV` base and correctly scaled impedance values.

### Testing
- Ran the full test suite with `npm test` and all automated tests completed successfully.
- Built the distribution with `npm run build` and the build completed successfully.
- Attempted to produce a webpage preview screenshot with Playwright, but browser binaries are not installed in this environment so the screenshot step failed (error: Playwright browsers not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b8e48f18832486b533ba9a8441f8)