### PR TITLE
Restore kV parsing guard for unitless integer source/base voltages

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -9934,7 +9934,7 @@ function selectComponent(compOrId) {
       const parseKvValue = raw => {
         if (raw === null || raw === undefined) return null;
         const directKv = toBaseKV(raw);
-        if (Number.isFinite(directKv) && directKv > 0) return directKv;
+        if (Number.isFinite(directKv) && directKv > 0.2) return directKv;
         const numeric = parseNumericValue(raw);
         if (!Number.isFinite(numeric) || numeric <= 0) return null;
         if (numeric > 1000) return numeric / 1000;


### PR DESCRIPTION
### Motivation
- A recent change trusted any positive `toBaseKV()` result which caused unitless integer entries in kV-labelled fields (for example `13`) to be interpreted as volts and produce 0.013 kV, corrupting derived Thevenin MVA calculations.

### Description
- Reverted the `parseKvValue` acceptance condition in `oneline.js` to only accept `toBaseKV(raw)` when it is greater than `0.2`, allowing the numeric-kV fallback to correctly interpret unitless integers as kV.

### Testing
- Ran `npm test` (full suite) which completed successfully and `npm run build` which also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b8e27ecc8324aa8b2becdc6ec236)