### PR TITLE
Fix scientific-notation voltage normalization

### DIFF
--- a/tests/transformerProperties.test.mjs
+++ b/tests/transformerProperties.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { calculateTransformerImpedance } from '../utils/transformerImpedance.js';
+import { normalizeVoltageToVolts } from '../utils/voltage.js';
 import {
   computeTransformerBaseKV,
   deriveTransformerBaseKV,
@@ -88,4 +89,10 @@ const approxEqual = (a, b, tolerance = 1e-9) => {
   assert(impedance, 'Impedance should be calculated for explicit baseKV');
   approxEqual(Number(impedance.r.toFixed(6)), 0.53732, 1e-6);
   approxEqual(Number(impedance.x.toFixed(6)), 5.373201, 1e-6);
+}
+
+// Scientific-notation voltage strings should normalize correctly in volts.
+{
+  const volts = normalizeVoltageToVolts('4.16e3 V');
+  approxEqual(volts, 4160, 1e-9);
 }

--- a/utils/voltage.js
+++ b/utils/voltage.js
@@ -33,7 +33,7 @@ export function normalizeVoltageToVolts(raw) {
     if (typeof value === 'string') {
       const trimmed = value.trim();
       if (!trimmed) return null;
-      const match = trimmed.match(/-?\d+(?:\.\d+)?/);
+      const match = trimmed.match(/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/);
       if (!match) return null;
       const num = Number(match[0]);
       if (!Number.isFinite(num)) return null;


### PR DESCRIPTION
### Motivation
- Resolve a data-corruption mismatch where transformer voltage strings in scientific/exponent notation (e.g. `4.16e3 V`) were validated by the numeric parser but then mis-normalized and written as incorrect inherited `baseKV` / `prefault_voltage` values during propagation.

### Description
- Update the string parsing in `normalizeVoltageToVolts` (`utils/voltage.js`) to accept scientific/exponent notation by using the regex `[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?` so it aligns with `parseVoltageNumber` behavior.
- Add a small regression assertion to `tests/transformerProperties.test.mjs` that verifies `normalizeVoltageToVolts('4.16e3 V')` returns `4160` to prevent future regressions.
- This change is minimal and preserves existing normalization heuristics and downstream formatting while ensuring inherited numeric base fields are computed correctly from exponent-form inputs.

### Testing
- Ran `node tests/transformerProperties.test.mjs` and the new assertion passed.
- Ran the full automated suite with `npm test` and it completed successfully.
- Ran `npm run build` and the build completed successfully.
- Attempted an automated Playwright screenshot to produce a UI preview, but browser download/install failed due to network/hosting restrictions (Playwright Chromium download returned HTTP 403), so no screenshot could be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b8e29f1c8324a42ca1cd482499d3)