### PR TITLE
Fix scientific-notation transformer voltage normalization mismatch

### DIFF
--- a/tests/transformerProperties.test.mjs
+++ b/tests/transformerProperties.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { calculateTransformerImpedance } from '../utils/transformerImpedance.js';
+import { normalizeVoltageToVolts } from '../utils/voltage.js';
 import {
   computeTransformerBaseKV,
   deriveTransformerBaseKV,
@@ -115,4 +116,10 @@ const approxEqual = (a, b, tolerance = 1e-9) => {
   approxEqual(Number(impedanceFromBase.x.toFixed(6)), 0.0055, 1e-5);
   approxEqual(Number(impedanceFromPrefault.r.toFixed(6)), 0.00055, 1e-6);
   approxEqual(Number(impedanceFromPrefault.x.toFixed(6)), 0.0055, 1e-5);
+}
+
+// Scientific-notation voltage strings should normalize correctly in volts.
+{
+  const volts = normalizeVoltageToVolts('4.16e3 V');
+  approxEqual(volts, 4160, 1e-9);
 }

--- a/utils/voltage.js
+++ b/utils/voltage.js
@@ -33,7 +33,7 @@ export function normalizeVoltageToVolts(raw) {
     if (typeof value === 'string') {
       const trimmed = value.trim();
       if (!trimmed) return null;
-      const match = trimmed.match(/-?\d+(?:\.\d+)?/);
+      const match = trimmed.match(/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/);
       if (!match) return null;
       const num = Number(match[0]);
       if (!Number.isFinite(num)) return null;


### PR DESCRIPTION
### Motivation
- Resolve a mismatch where exponent-form voltage strings (e.g. "4.16e3 V") were accepted by the voltage-number validator but normalized incorrectly by `normalizeVoltageToVolts`, which caused inherited `baseKV`/`prefault_voltage` corruption and silent downstream calculation errors.

### Description
- Update `normalizeVoltageToVolts` to parse scientific-notation numeric tokens using `/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/` and add a regression test in `tests/transformerProperties.test.mjs` asserting `normalizeVoltageToVolts('4.16e3 V') === 4160`.

### Testing
- Ran `npm test` (full test suite) and it passed; ran `npm run build` and it completed successfully; attempted a Playwright-based page screenshot/install for a preview but the browser download failed in this environment (HTTP 403), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bbc423548324a359fffcae2b6b4b)