### PR TITLE
Fix panel totals reconciliation for custom breaker phase loads

### DIFF
--- a/src/panelSchedule.js
+++ b/src/panelSchedule.js
@@ -1045,23 +1045,37 @@ export function calculatePanelTotals(panelId) {
   const panels = dataStore.getPanels();
   const panel = findPanelByIdentifier(panels, panelId);
   const loads = dataStore.getLoads().filter(l => l.panelId === panelId);
-  const totals = loads.reduce((acc, l) => {
-    const cKva = parseFloat(l.kva) || 0;
-    const cKw = parseFloat(l.kw) || 0;
-    const dKva = parseFloat(l.demandKva) || cKva;
-    const dKw = parseFloat(l.demandKw) || cKw;
-    acc.connectedKva += cKva;
-    acc.connectedKw += cKw;
-    acc.demandKva += dKva;
-    acc.demandKw += dKw;
-    return acc;
-  }, { connectedKva: 0, connectedKw: 0, demandKva: 0, demandKw: 0 });
+  if (!panel) {
+    return loads.reduce((acc, l) => {
+      const cKva = parseFloat(l.kva) || 0;
+      const cKw = parseFloat(l.kw) || 0;
+      const dKva = parseFloat(l.demandKva) || cKva;
+      const dKw = parseFloat(l.demandKw) || cKw;
+      acc.connectedKva += cKva;
+      acc.connectedKw += cKw;
+      acc.demandKva += dKva;
+      acc.demandKw += dKw;
+      return acc;
+    }, { connectedKva: 0, connectedKw: 0, demandKva: 0, demandKw: 0 });
+  }
 
-  if (!panel) return totals;
+  const circuitCount = getPanelCircuitCount(panel);
+  const breakerStarts = new Set();
+  for (let circuit = 1; circuit <= circuitCount; circuit++) {
+    const block = getBreakerBlock(panel, circuit);
+    const start = block && Number.isFinite(Number(block.start)) ? Number(block.start) : circuit;
+    if (start >= 1 && start <= circuitCount) {
+      breakerStarts.add(start);
+    }
+  }
+
   const breakerDetails = ensureBreakerDetails(panel);
+  const customStarts = new Set();
   let customVaTotal = 0;
-  Object.values(breakerDetails).forEach(detail => {
+  breakerStarts.forEach(start => {
+    const detail = breakerDetails[String(start)];
     if (!detail || detail.loadVaPerPhase == null) return;
+    customStarts.add(start);
     if (detail.loadVaPerPhase && typeof detail.loadVaPerPhase === "object" && !Array.isArray(detail.loadVaPerPhase)) {
       Object.values(detail.loadVaPerPhase).forEach(value => {
         const parsed = parseFloat(value);
@@ -1076,6 +1090,23 @@ export function calculatePanelTotals(panelId) {
       customVaTotal += parsed;
     }
   });
+
+  const totals = loads.reduce((acc, l) => {
+    const span = getLoadBreakerSpan(l, panel, circuitCount);
+    const startCircuit = span.length ? span[0] : null;
+    if (startCircuit != null && customStarts.has(startCircuit)) {
+      return acc;
+    }
+    const cKva = parseFloat(l.kva) || 0;
+    const cKw = parseFloat(l.kw) || 0;
+    const dKva = parseFloat(l.demandKva) || cKva;
+    const dKw = parseFloat(l.demandKw) || cKw;
+    acc.connectedKva += cKva;
+    acc.connectedKw += cKw;
+    acc.demandKva += dKva;
+    acc.demandKw += dKw;
+    return acc;
+  }, { connectedKva: 0, connectedKw: 0, demandKva: 0, demandKw: 0 });
 
   if (customVaTotal > 0) {
     const customKva = customVaTotal / 1000;


### PR DESCRIPTION
### Motivation
- The panel totals calculation previously summed all assigned loads and then additively included every `breakerDetails.loadVaPerPhase` value, which could double-count breakers that also have assigned loads.
- Orphan or attacker-controlled `breakerDetails` entries outside the current panel circuit layout could inflate connected and demand kVA totals.
- The intent of the change is to treat per-breaker `loadVaPerPhase` entries as overrides for the assigned load on the same breaker start and to only consider breakerDetails that map to valid breaker starts.

### Description
- Update `calculatePanelTotals` in `src/panelSchedule.js` to early-return when a panel is not found while preserving prior totals behavior for that case via `loads.reduce`.
- Compute `circuitCount` and a set of valid breaker start indexes, then only accumulate `loadVaPerPhase` values for those valid starts and record `customStarts` as overrides.
- Skip assigned-load contributions whose breaker start is present in `customStarts`, and add the validated `customVaTotal` (converted to kVA) to connected and demand totals.

### Testing
- Ran `npm test` and the full test suite completed successfully with the existing assertions passing.
- Ran `npm run build` and the build completed successfully (with non-fatal warnings about external modules), producing `dist/` artifacts.
- Attempted `npx playwright install chromium` and a Playwright screenshot step but the browser download failed due to remote CDN access returning HTTP 403, so UI screenshot generation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bc0e1f00832488e19d138b33633b)