### PR TITLE
Fix support span weight calculation for conductor_size-only cables

### DIFF
--- a/analysis/supportSpan.mjs
+++ b/analysis/supportSpan.mjs
@@ -163,10 +163,12 @@ export function sumCableWeights(cables) {
     }
 
     // Otherwise look up in the built-in table
-    const conductors = cable.conductors != null ? String(cable.conductors) : null;
     const size = (cable.size ?? cable.conductor_size) != null
       ? String(cable.size ?? cable.conductor_size)
       : null;
+    const conductors = cable.conductors != null
+      ? String(cable.conductors)
+      : (size ? '3' : null);
     const key = conductors && size ? `${conductors}C-${size}` : null;
     const unitWeight = (key && CABLE_WEIGHT_LB_FT[key]) || 0;
     return total + qty * unitWeight;

--- a/tests/supportSpan.test.mjs
+++ b/tests/supportSpan.test.mjs
@@ -238,6 +238,12 @@ describe('sumCableWeights', () => {
     assert.strictEqual(sumCableWeights(cables), w);
   });
 
+  it('defaults missing conductors to 3 when conductor_size is present', () => {
+    const w = CABLE_WEIGHT_LB_FT['3C-500 kcmil'];
+    const cables = [{ conductor_size: '500 kcmil', quantity: 2 }];
+    assert.strictEqual(sumCableWeights(cables), w * 2);
+  });
+
   it('throws for negative explicit weight_lb_ft', () => {
     const cables = [{ weight_lb_ft: -2, quantity: 1 }];
     assert.throws(() => sumCableWeights(cables), /positive finite/);


### PR DESCRIPTION
### Motivation
- A recent change allowed `conductor_size` to be used for lookup but removed the prior default of `3` conductors when `conductors` was missing, causing conductor_size-only cables to be counted as zero weight in schedule-mode and silently under-report tray loads.

### Description
- Restore the prior behavior in `sumCableWeights` by defaulting `conductors` to `'3'` when a `size`/`conductor_size` is present so size-only cables contribute to the built-in weight lookup.
- Preserve existing validation for explicit `weight_lb_ft` and `quantity` inputs so negative/non-finite values still throw.
- Add a regression unit test in `tests/supportSpan.test.mjs` that verifies conductor_size-only cables contribute as `3C-<size>` entries and multiply by `quantity`.

### Testing
- Ran the test suite with `npm test` and all tests (including the new regression) completed successfully.
- Built the distribution with `npm run build` and the build completed successfully.
- Attempted to generate a webpage preview screenshot via Playwright, but browser installation failed due to external download errors (HTTP 403), so a visual preview could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bd17d77083249cbfd7a76ff3a2c4)