### PR TITLE
Fix numeric generation detection for transient stability

### DIFF
--- a/analysis/contingency.mjs
+++ b/analysis/contingency.mjs
@@ -103,6 +103,8 @@ function voltageStatus(vm, min, max) {
 function getGenerationKw(bus) {
   if (!bus || typeof bus !== 'object') return 0;
 
+  if (Number.isFinite(bus.generation)) return bus.generation;
+
   if (bus.generation && typeof bus.generation === 'object') {
     const kw = bus.generation.kw ?? bus.generation.kW;
     if (Number.isFinite(kw)) return kw;

--- a/tests/contingency.test.mjs
+++ b/tests/contingency.test.mjs
@@ -239,6 +239,22 @@ describe('runContingency — transient stability coupling', () => {
     assert.strictEqual(contingencies[0].transientStability.checked, true);
   });
 
+  it('with checkTransientStability:true and numeric bus.generation, checked is true', () => {
+    const model = {
+      buses: [
+        { id: 'G1', label: 'Gen Bus', Vm: 1.02, Va: 0, generation: 2000, connections: [] },
+        { id: 'B2', label: 'Load Bus', Vm: 1.0, Va: 0, connections: [] },
+      ],
+      branches: [{ id: 'L1', name: 'Line 1', type: 'line' }],
+    };
+    const { contingencies } = runContingency(model, {
+      checkTransientStability: true,
+      generatorInertiaH: 5.0,
+      baseMVA: 100,
+    });
+    assert.strictEqual(contingencies[0].transientStability.checked, true);
+  });
+
   it('treats Pg in kW consistently with generation.kw', () => {
     const pgModel = {
       buses: [


### PR DESCRIPTION
### Motivation
- Restore generator detection for buses whose `generation` is a numeric kW value so transient-stability checks are not silently skipped for legacy or numeric-form projects.

### Description
- Treat numeric `bus.generation` as kW in `getGenerationKw` in `analysis/contingency.mjs` and add a focused regression test in `tests/contingency.test.mjs` that verifies `transientStability.checked === true` when `generation` is numeric.

### Testing
- Ran `npm test`, which completed successfully and exercised the updated `tests/contingency.test.mjs` test; ran `npm run build`, which also completed successfully; attempted an automated Playwright screenshot to produce a preview image but browser download failed so no preview image could be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bd17a8c883248cedcc4c8c180872)