### PR TITLE
Include `trayCableMap` in `latestRouteResults` to fix DRC schema mismatch

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -224,11 +224,15 @@ async function initializeApp() {
     };
 
     const storeLatestRouteResults = (batchResults, meta = {}) => {
+        const hasValidMap = meta.trayCableMap
+            && typeof meta.trayCableMap === 'object'
+            && !Array.isArray(meta.trayCableMap);
         try {
             setItem('latestRouteResults', {
                 batchResults: Array.isArray(batchResults) ? batchResults : [],
                 source: 'optimalRoute',
                 updatedAt: new Date().toISOString(),
+                ...(hasValidMap ? { trayCableMap: meta.trayCableMap } : {}),
                 ...meta
             });
         } catch (error) {
@@ -3949,7 +3953,11 @@ const renderBatchResults = (results) => {
             const cache = getItem(cacheKey);
             if (cache) {
                 state.latestRouteData = cache.batchResults;
-                storeLatestRouteResults(cache.batchResults, { projectHash, source: 'optimalRouteCache' });
+                storeLatestRouteResults(cache.batchResults, {
+                    projectHash,
+                    source: 'optimalRouteCache',
+                    trayCableMap: cache.trayCableMap || {}
+                });
                 state.finalTrays = cache.finalTrays;
                 const resMap = new Map((cache.batchResults || []).map(r => [r.cable, r]));
                 state.cableList.forEach(c => {
@@ -4062,7 +4070,6 @@ const renderBatchResults = (results) => {
                     buildFieldSegmentCableMap(batchResults);
                     setCables(state.cableList);
                     state.latestRouteData = batchResults;
-                    storeLatestRouteResults(batchResults, { projectHash });
                     renderBatchResults(batchResults);
                     const nameMap = new Map(state.cableList.map(c => [c.name, c]));
                     state.trayCableMap = {};
@@ -4080,6 +4087,7 @@ const renderBatchResults = (results) => {
                             }
                         });
                     });
+                    storeLatestRouteResults(batchResults, { projectHash, trayCableMap: state.trayCableMap });
                     const cableMapForArea = new Map(state.cableList.map(c => [c.name, c.diameter]));
                     const cableMapForObj = new Map(state.cableList.map(c => [c.name, c]));
                     const tempSystem = new CableRoutingSystem({});
@@ -4283,7 +4291,6 @@ const renderBatchResults = (results) => {
         }
 
         state.latestRouteData = Array.from(resultMap.values()).sort((a,b) => a.index - b.index).map(v => v.row);
-        storeLatestRouteResults(state.latestRouteData, { source: 'optimalRouteRebalance' });
         buildFieldSegmentCableMap(state.latestRouteData);
 
         const nameMap = new Map(state.cableList.map(c => [c.name, c]));
@@ -4304,6 +4311,8 @@ const renderBatchResults = (results) => {
                 }
             });
         });
+
+        storeLatestRouteResults(state.latestRouteData, { source: 'optimalRouteRebalance', trayCableMap: state.trayCableMap });
 
         const finalUtilization = routingSystem.getTrayUtilization();
         const utilData = buildUtilizationRows(finalUtilization, trayData);


### PR DESCRIPTION
### Motivation
- A producer/consumer mismatch caused `designrulechecker.js` to ignore `batchResults` unless `latestRouteResults.trayCableMap` existed, but the router published `latestRouteResults` without the map in several flows.  
- As a result route-dependent DRC checks (voltage segregation, ampacity derating, data-cable segregation, unrouted cable detection) could be skipped or miscomputed.  
- The change restores a consistent schema so the DRC consumer always sees route topology when available.

### Description
- Updated `storeLatestRouteResults` in `app.mjs` to persist `trayCableMap` when a valid map is provided via `meta` by adding a `hasValidMap` check and including `trayCableMap` in the stored object.  
- On cache hits the cached `trayCableMap` is now passed into `storeLatestRouteResults` so `latestRouteResults` includes the cached topology.  
- For fresh route runs the code now publishes `latestRouteResults` only after `state.trayCableMap` is rebuilt and includes `trayCableMap` in the stored metadata.  
- For rebalanced routes the rebuilt `state.trayCableMap` is also published with `latestRouteResults` to avoid the same mismatch after rebalancing.

### Testing
- Ran `npm test`; the suite aborted on an existing unrelated assertion failure in `tests/serverSecurity.test.mjs` (`expected 409, got 401`), so full tests did not fully pass (failure unrelated to routing fix).  
- Ran `npm run build`; build completed successfully (pre-existing Rollup warnings about external deps were observed).  
- Attempted a Playwright screenshot of `designrulechecker.html` to produce a preview image, but `npx playwright install` failed due to browser download being blocked (HTTP 403) in this environment, so a runtime screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c04a85788324a5d3bf5d1b2f8815)