### PR TITLE
fix(report): use route cache + conduits for report DRC

### DIFF
--- a/src/projectreport.js
+++ b/src/projectreport.js
@@ -179,21 +179,47 @@ function escAttr(s) {
 // Project data assembly
 // ---------------------------------------------------------------------------
 
+function getLatestRouteCacheState() {
+  const latestState = getItem('latestRouteResults', {}) || {};
+  if (latestState.trayCableMap && Object.keys(latestState.trayCableMap).length) {
+    return latestState;
+  }
+
+  for (const storage of [sessionStorage, localStorage]) {
+    for (const key of Object.keys(storage)) {
+      if (!key.includes('route-')) continue;
+      try {
+        const parsed = JSON.parse(storage.getItem(key));
+        if (parsed && parsed.trayCableMap) return parsed;
+      } catch {
+        // Skip malformed cache entries.
+      }
+    }
+  }
+
+  return latestState;
+}
+
 function loadProjectData() {
   const cables = getCables();
   const trays = getTrays();
-  const routeState = getItem('latestRouteResults', {}) || {};
+  const conduits = getConduits();
+  const routeState = getLatestRouteCacheState();
+  const routedCableNames = routeState.routedCableNames || (routeState.batchResults || [])
+    .filter(r => r.cable && r.status && r.status.includes('Routed'))
+    .map(r => r.cable);
   const drcRun = runDRC({
     trays,
+    conduits,
     cables,
     trayCableMap: routeState.trayCableMap || {},
-    routedCableNames: routeState.routedCableNames,
+    routedCableNames,
   });
 
   return {
     cables,
     trays,
-    conduits:  getConduits(),
+    conduits,
     ductbanks: getDuctbanks(),
     studies:   getStudies(),
     approvals: getStudyApprovals(),


### PR DESCRIPTION
### Motivation
- The report assembly ran the DRC engine against `latestRouteResults` which normally lacks the populated `trayCableMap` and did not pass `conduits`, causing route- and conduit-dependent checks (segregation, ampacity derating, conduit-fill, unrouted cables) to be suppressed in generated reports.

### Description
- Added `getLatestRouteCacheState()` in `src/projectreport.js` to prefer a populated `latestRouteResults.trayCableMap` and otherwise fall back to scanning `route-*` cache entries in `sessionStorage`/`localStorage` for the routed state.
- Updated `loadProjectData()` to include `conduits` when calling `runDRC()` and to derive `routedCableNames` from cached `batchResults` if an explicit set is not present.
- Passed the recovered `trayCableMap`, `routedCableNames`, and `conduits` into `runDRC()` so route- and conduit-dependent checks run against the same state used by the routing UI.

### Testing
- Ran the full test suite with `npm test`, and the tests completed successfully in this environment.
- Ran `npm run build`, which completed successfully though Rollup emitted existing unresolved-dependency warnings; build artifacts were produced.
- Attempted to capture a page preview with Playwright (`npx playwright screenshot`), but Playwright browser installation failed in this environment (download blocked with HTTP 403), so an automated screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c2fdb1cc83248698a043be93c504)