### PR TITLE
fix(report): constrain report DRC route cache source and shape validation

### DIFF
--- a/src/projectreport.js
+++ b/src/projectreport.js
@@ -181,21 +181,18 @@ function escAttr(s) {
 
 function getLatestRouteCacheState() {
   const latestState = getItem('latestRouteResults', {}) || {};
-  if (latestState.trayCableMap && Object.keys(latestState.trayCableMap).length) {
-    return latestState;
+
+  const trayCableMap = latestState && typeof latestState === 'object'
+    ? latestState.trayCableMap
+    : null;
+
+  if (!trayCableMap || typeof trayCableMap !== 'object' || Array.isArray(trayCableMap)) {
+    return {};
   }
 
-  for (const storage of [sessionStorage, localStorage]) {
-    for (const key of Object.keys(storage)) {
-      if (!key.includes('route-')) continue;
-      try {
-        const parsed = JSON.parse(storage.getItem(key));
-        if (parsed && parsed.trayCableMap) return parsed;
-      } catch {
-        // Skip malformed cache entries.
-      }
-    }
-  }
+  const entries = Object.entries(trayCableMap);
+  if (!entries.length) return {};
+  if (!entries.every(([, cables]) => Array.isArray(cables))) return {};
 
   return latestState;
 }
@@ -205,7 +202,9 @@ function loadProjectData() {
   const trays = getTrays();
   const conduits = getConduits();
   const routeState = getLatestRouteCacheState();
-  const routedCableNames = routeState.routedCableNames || (routeState.batchResults || [])
+  const routedCableNames = Array.isArray(routeState.routedCableNames)
+    ? routeState.routedCableNames
+    : (routeState.batchResults || [])
     .filter(r => r.cable && r.status && r.status.includes('Routed'))
     .map(r => r.cable);
   const drcRun = runDRC({


### PR DESCRIPTION
### Motivation
- The report DRC previously fell back to scanning raw browser storage for any `route-*` key and trusted its `trayCableMap`, which allows a malicious imported project to plant forged route cache entries and alter or crash DRC results. 
- The change closes this trust-boundary bypass by limiting what route cache state the report will accept and validating its structure.

### Description
- Removed the fallback that scanned `sessionStorage`/`localStorage` for arbitrary `route-*` keys and made `getLatestRouteCacheState()` only consider the `latestRouteResults` payload. 
- Added structural checks in `getLatestRouteCacheState()` to ensure `trayCableMap` is an object, non-empty, and that every tray entry is an `Array`; otherwise it returns an empty route state. 
- Tightened `routedCableNames` handling so only an array in `routeState.routedCableNames` is trusted and otherwise `batchResults` is used via the existing derivation.

### Testing
- Ran the full test suite with `npm test`, which completed successfully. 
- Built the distribution with `npm run build`, which completed successfully though Rollup emitted existing unresolved dependency warnings. 
- Attempted to generate a preview screenshot with Playwright (`npx playwright screenshot ...`) but it failed because Playwright browser binaries are not installed in this environment, so a visual preview could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e2c01cc48324a16f26ba78b225ae)