### PR TITLE
Fix mixed-unit kV parsing in short-circuit voltage normalization

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -98,9 +98,10 @@ function parseNumeric(value) {
 function toKV(value) {
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();
-    if (normalized.includes('kv')) {
-      const num = parseNumeric(value);
-      return num === null ? null : num;
+    const kvMatch = normalized.match(/([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)\s*k\s*v\b/);
+    if (kvMatch) {
+      const num = Number.parseFloat(kvMatch[1]);
+      return Number.isFinite(num) ? num : null;
     }
   }
   const num = parseNumeric(value);

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -256,6 +256,32 @@ global.localStorage = {
       assert(Math.abs(bus.ibr.Ifault_A - 3.0373644596497704) < 1e-9, 'Fault contribution should use 230 kV base');
     });
 
+
+    it('prefers the numeric token attached to kV in mixed-unit IBR voltage labels', () => {
+      setOneLine({
+        activeSheet: 0,
+        sheets: [{
+          name: 'IBR mixed units',
+          components: [
+            {
+              id: 'ibr1',
+              type: 'pv_inverter',
+              rated_kva: 1000,
+              voltage: '480 V (0.48 kV)',
+              connections: [{ target: 'bus1', sourcePort: 0, targetPort: 0 }]
+            },
+            { id: 'bus1', type: 'bus', subtype: 'Bus' }
+          ]
+        }]
+      });
+
+      const res = runShortCircuit();
+      const bus = res.bus1;
+      assert(bus && bus.ibr, 'IBR metadata should be attached');
+      assert(Math.abs(bus.ibr.vLL_kV - 0.48) < 1e-9, 'Mixed-unit label should resolve to the kV token');
+      assert(Math.abs(bus.ibr.Ifault_A - 1323.0943668928928) < 1e-6, 'Fault contribution should match 0.48 kV base');
+    });
+
     it('falls back to rated_kv when IBR voltage parses to nonpositive values', () => {
       setOneLine({
         activeSheet: 0,


### PR DESCRIPTION
### Motivation
- Mixed-unit voltage labels such as `480 V (0.48 kV)` were being misinterpreted because the normalization helper favored the first numeric token in the string, which could turn a volts value into an implicit kV value and silently corrupt short-circuit/IBR calculations. 
- The goal is to reliably honor explicit `kV` tokens in strings while preserving existing behavior for plain numeric and volt-style inputs.

### Description
- Change `toKV()` in `analysis/shortCircuit.mjs` to prefer the numeric token directly attached to a `kV` unit by matching `/([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)\s*k\s*v\b/` and parsing that capture. 
- Preserve the previous fallback behavior by using the existing `parseNumeric()` for non-`kV` strings and keep the `>100 ? /1000` heuristic for apparent-volt inputs. 
- Add a regression test in `tests/shortcircuit/shortCircuit.test.cjs` that exercises a mixed-unit label (`'480 V (0.48 kV)'`) and asserts `vLL_kV === 0.48` and the expected inverter fault contribution. 
- Files changed: `analysis/shortCircuit.mjs` and `tests/shortcircuit/shortCircuit.test.cjs`.

### Testing
- Ran the full test suite with `npm test`, and the short-circuit tests (and overall test run) passed. 
- Built the distribution with `npm run build`, and the build completed successfully. 
- Attempted to capture a preview screenshot with Playwright but browser installation failed due to network/CDN download `403` responses, so a preview image could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e4536f748324bc736493bfdb1630)