### PR TITLE
Fix arc-flash protective-type false positives from substring matching

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -12,11 +12,10 @@ function isProtectiveComponent(component) {
   if (category === 'protection') return true;
   const subtype = typeof component.subtype === 'string' ? component.subtype.toLowerCase() : '';
   if (PROTECTIVE_TYPES.has(subtype)) return true;
-  if ([...PROTECTIVE_TYPES].some(token => subtype.includes(token))) return true;
   if (!component.type) return true;
   const type = typeof component.type === 'string' ? component.type.toLowerCase() : '';
   if (PROTECTIVE_TYPES.has(type)) return true;
-  return [...PROTECTIVE_TYPES].some(token => type.includes(token));
+  return false;
 }
 const FALLBACK_TYPES = new Set(['motor_load', 'static_load', 'load', 'panel', 'equipment', 'bus', 'cable', 'mcc']);
 const UPSTREAM_CANDIDATE_TYPES = new Set([


### PR DESCRIPTION
### Motivation
- The arc-flash detection logic could misclassify equipment such as `switchboard` as protective because substring checks treated any `type`/`subtype` containing tokens like `switch`/`breaker`/`fuse` as protective, allowing hidden `tccId` values to influence clearing time and PPE outcomes.

### Description
- Removed substring-based matching from `isProtectiveComponent` in `analysis/arcFlash.mjs` so only `category === 'protection'` or exact normalized protective tokens (`breaker`, `fuse`, `relay`, `recloser`, `contactor`, `switch`) are accepted. 
- Retained lowercase normalization for `type`/`subtype` so mixed-case protective values continue to match correctly.

### Testing
- Ran `npm test` and the test suite completed successfully. 
- Ran `npm run build` and the build completed successfully. 
- Attempted to capture a preview screenshot with Playwright but the required browser binaries are not installed in the environment, so a page preview could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e451fa7c8324a3fe7cffc00dec86)