### PR TITLE
Fix panel totals undercount with partial custom breaker VA overrides

### DIFF
--- a/src/panelSchedule.js
+++ b/src/panelSchedule.js
@@ -1070,33 +1070,10 @@ export function calculatePanelTotals(panelId) {
   }
 
   const breakerDetails = ensureBreakerDetails(panel);
-  const customStarts = new Set();
-  let customVaTotal = 0;
-  breakerStarts.forEach(start => {
-    const detail = breakerDetails[String(start)];
-    if (!detail || detail.loadVaPerPhase == null) return;
-    customStarts.add(start);
-    if (detail.loadVaPerPhase && typeof detail.loadVaPerPhase === "object" && !Array.isArray(detail.loadVaPerPhase)) {
-      Object.values(detail.loadVaPerPhase).forEach(value => {
-        const parsed = parseFloat(value);
-        if (Number.isFinite(parsed) && parsed > 0) {
-          customVaTotal += parsed;
-        }
-      });
-      return;
-    }
-    const parsed = parseFloat(detail.loadVaPerPhase);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      customVaTotal += parsed;
-    }
-  });
 
-  const totals = loads.reduce((acc, l) => {
+  return loads.reduce((acc, l) => {
     const span = getLoadBreakerSpan(l, panel, circuitCount);
     const startCircuit = span.length ? span[0] : null;
-    if (startCircuit != null && customStarts.has(startCircuit)) {
-      return acc;
-    }
     const cKva = parseFloat(l.kva) || 0;
     const cKw = parseFloat(l.kw) || 0;
     const dKva = parseFloat(l.demandKva) || cKva;
@@ -1105,15 +1082,40 @@ export function calculatePanelTotals(panelId) {
     acc.connectedKw += cKw;
     acc.demandKva += dKva;
     acc.demandKw += dKw;
+
+    if (startCircuit == null || !breakerStarts.has(startCircuit)) {
+      return acc;
+    }
+
+    const detail = breakerDetails[String(startCircuit)];
+    if (!detail || detail.loadVaPerPhase == null) {
+      return acc;
+    }
+
+    if (detail.loadVaPerPhase && typeof detail.loadVaPerPhase === "object" && !Array.isArray(detail.loadVaPerPhase)) {
+      const connectedShare = span.length > 0 ? (cKva * 1000) / span.length : 0;
+      const demandShare = span.length > 0 ? (dKva * 1000) / span.length : 0;
+      span.forEach(slot => {
+        const phase = getPhaseLabel(panel, slot);
+        const block = getBreakerBlock(panel, slot);
+        const phaseKey = getPhaseLoadKey(phase, block);
+        const rawValue = phaseKey ? detail.loadVaPerPhase[phaseKey] : null;
+        const parsed = parseFloat(rawValue);
+        if (!Number.isFinite(parsed) || parsed < 0) return;
+        acc.connectedKva += (parsed - connectedShare) / 1000;
+        acc.demandKva += (parsed - demandShare) / 1000;
+      });
+      return acc;
+    }
+
+    const parsed = parseFloat(detail.loadVaPerPhase);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return acc;
+    }
+    acc.connectedKva += (parsed - (cKva * 1000)) / 1000;
+    acc.demandKva += (parsed - (dKva * 1000)) / 1000;
     return acc;
   }, { connectedKva: 0, connectedKw: 0, demandKva: 0, demandKw: 0 });
-
-  if (customVaTotal > 0) {
-    const customKva = customVaTotal / 1000;
-    totals.connectedKva += customKva;
-    totals.demandKva += customKva;
-  }
-  return totals;
 }
 
 const COLUMN_HEADERS = {


### PR DESCRIPTION
### Motivation
- `calculatePanelTotals` in `src/panelSchedule.js` previously skipped an entire assigned load whenever any `loadVaPerPhase` data existed for its breaker, which underreported connected/demand kVA and removed kW totals for partially-overridden or zero-valued phase entries.
- Partial per-phase overrides and attacker-controlled project snapshots can produce incorrect panel totals, so the calculation must preserve baseline contributions and apply only the custom VA adjustments.

### Description
- Update `calculatePanelTotals` in `src/panelSchedule.js` to always include each load's baseline `kVA`/`kW` and `demandKva`/`demandKw` before applying custom VA adjustments.
- When `loadVaPerPhase` is an object, apply per-phase parsed values as deltas relative to the baseline per-phase share, adding only the difference to `connectedKva` and `demandKva` while leaving `connectedKw` and `demandKw` intact.
- When `loadVaPerPhase` is a scalar, apply the whole-load parsed value as a delta to kVA totals and ignore invalid negative or non-finite custom values while allowing zero-valued overrides.
- Remove the prior `customStarts`-and-skip approach so loads with partial or zero-phase overrides no longer wipe out non-overridden phase contributions or kW totals.

### Testing
- Ran `npm test` and the full test suite completed successfully.
- Ran `npm run build` and the build finished successfully producing `dist/` artifacts.
- Attempted a Playwright-based page screenshot to produce a preview image but the environment could not download Playwright browser binaries, so the automated preview step failed (network/permission issue), not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e4531e9c83248bbee97dd0419857)