### PR TITLE
Fix scientific-notation parsing for explicit transformer base kV

### DIFF
--- a/tests/transformerProperties.test.mjs
+++ b/tests/transformerProperties.test.mjs
@@ -123,3 +123,28 @@ const approxEqual = (a, b, tolerance = 1e-9) => {
   const volts = normalizeVoltageToVolts('4.16e3 V');
   approxEqual(volts, 4160, 1e-9);
 }
+
+// Scientific-notation explicit baseKV/prefault_voltage strings should parse as numeric kV.
+{
+  const baseFromKV = computeTransformerBaseKV({ baseKV: '4.8e-1' });
+  const baseFromPrefault = computeTransformerBaseKV({ prefault_voltage: '1.5e1' });
+  approxEqual(baseFromKV, 0.48, 1e-9);
+  approxEqual(baseFromPrefault, 15, 1e-9);
+
+  const impedanceSci = calculateTransformerImpedance({
+    kva: 2500,
+    percentZ: 6,
+    xrRatio: 10,
+    baseKV: '4.8e-1'
+  });
+  const impedanceNumeric = calculateTransformerImpedance({
+    kva: 2500,
+    percentZ: 6,
+    xrRatio: 10,
+    baseKV: 0.48
+  });
+  assert(impedanceSci, 'Impedance should be calculated for scientific-notation baseKV');
+  assert(impedanceNumeric, 'Impedance should be calculated for numeric baseKV');
+  approxEqual(impedanceSci.r, impedanceNumeric.r, 1e-12);
+  approxEqual(impedanceSci.x, impedanceNumeric.x, 1e-12);
+}

--- a/utils/transformerImpedance.js
+++ b/utils/transformerImpedance.js
@@ -16,6 +16,7 @@ function parseNumeric(raw) {
   return null;
 }
 
+const explicitKvNumericPattern = /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?$/;
 
 function parseExplicitBaseKV(raw) {
   if (raw === null || raw === undefined) return null;
@@ -23,8 +24,8 @@ function parseExplicitBaseKV(raw) {
   if (typeof raw === 'string') {
     const trimmed = raw.trim();
     if (!trimmed) return null;
-    if (/[a-zA-Z]/.test(trimmed)) return toBaseKV(trimmed);
-    return parseNumeric(trimmed);
+    if (explicitKvNumericPattern.test(trimmed)) return parseNumeric(trimmed);
+    return toBaseKV(trimmed);
   }
   return toBaseKV(raw);
 }

--- a/utils/transformerProperties.js
+++ b/utils/transformerProperties.js
@@ -2,6 +2,7 @@ import { normalizeVoltageToVolts, toBaseKV } from './voltage.js';
 import { calculateTransformerImpedance } from './transformerImpedance.js';
 
 const numberPattern = /[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/;
+const explicitKvNumericPattern = /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?$/;
 
 function getCandidateValue(record, key) {
   if (!record || typeof record !== 'object' || !key) return undefined;
@@ -94,8 +95,8 @@ function parseExplicitBaseKV(raw) {
   if (typeof raw === 'string') {
     const trimmed = raw.trim();
     if (!trimmed) return null;
-    if (/[a-zA-Z]/.test(trimmed)) return toBaseKV(trimmed);
-    return parseNumeric(trimmed);
+    if (explicitKvNumericPattern.test(trimmed)) return parseNumeric(trimmed);
+    return toBaseKV(trimmed);
   }
   return toBaseKV(raw);
 }


### PR DESCRIPTION
### Motivation
- A recent change routed any explicit `baseKV`/`prefault_voltage` string containing letters to the unit parser, which mistakenly treated the `e`/`E` exponent marker in scientific-notation strings as a unit and caused incorrect kV and impedance calculations.
- This commit fixes the regression so scientific-notation literals like `4.8e-1` and `1.5e1` are interpreted correctly as numeric kV values and do not get misrouted to the unit-aware parser.

### Description
- Added an `explicitKvNumericPattern` regex (`/^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?$/`) and use it to detect when the entire trimmed string is a numeric literal (including scientific notation).
- Updated `parseExplicitBaseKV` in `utils/transformerImpedance.js` and `utils/transformerProperties.js` to treat full-match numeric literals as direct numeric kV via `parseNumeric`, and route all other strings through `toBaseKV` so unit-suffixed inputs like `480 V` continue to work.
- Added regression tests in `tests/transformerProperties.test.mjs` verifying that scientific-notation explicit `baseKV`/`prefault_voltage` parse to the expected kV and that calculated impedance matches the equivalent numeric input.

### Testing
- Ran the test suite with `npm test` and all tests passed successfully.
- Built the distribution with `npm run build` and the build completed successfully.
- Attempted to capture a page preview via Playwright (`npx playwright screenshot ...`) but browser installation failed due to outbound download access (HTTP 403), so a screenshot/preview could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e45307e083248877ebfd9b029f51)