### PR TITLE
fix: validate scenario names and defer import scenario switch

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -24,6 +24,7 @@ import {
   registerScenario,
   getCurrentScenarioNameState,
   setCurrentScenarioNameState,
+  isValidScenarioName,
   readScenarioValue,
   writeScenarioValue,
   removeScenarioValue,
@@ -981,10 +982,10 @@ export function exportToCad(fileType = 'json') {
  */
 export function importProject(obj) {
   const { meta, ...rest } = obj || {};
+  const importScenario = meta && isValidScenarioName(meta.scenario) ? meta.scenario : null;
   if (meta && Array.isArray(meta.scenarios)) {
     setScenarioListState(meta.scenarios);
   }
-  if (meta && meta.scenario) switchScenario(meta.scenario);
   let data = rest;
   const { valid, missing, extra } = validateProjectSchema(data);
   if (!valid) {
@@ -1039,6 +1040,7 @@ export function importProject(obj) {
       setItem(k, v);
     }
   }
+  if (importScenario) switchScenario(importScenario);
   return true;
 }
 

--- a/projectStorage.js
+++ b/projectStorage.js
@@ -372,9 +372,20 @@ function listPrefixedKeys(prefix) {
   return [...keys];
 }
 
+const SCENARIO_NAME_MAX_LENGTH = 64;
+const SCENARIO_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
+
 function sanitizeScenarioName(name) {
   if (typeof name !== 'string') return '';
-  return name.trim();
+  const trimmed = name.trim();
+  if (!trimmed) return '';
+  if (trimmed.length > SCENARIO_NAME_MAX_LENGTH) return '';
+  if (!SCENARIO_NAME_PATTERN.test(trimmed)) return '';
+  return trimmed;
+}
+
+export function isValidScenarioName(name) {
+  return sanitizeScenarioName(name) === name;
 }
 
 function ensureScenarioList(list) {

--- a/src/scenarios.js
+++ b/src/scenarios.js
@@ -1,4 +1,5 @@
 import { listScenarios, getCurrentScenario, switchScenario, cloneScenario, getOneLine, getRevisions, restoreRevision, getCablesForScenario } from '../dataStore.mjs';
+import { isValidScenarioName } from '../projectStorage.js';
 import { showAlertModal, openModal } from './components/modal.js';
 
 function ensureDefaults() {
@@ -177,6 +178,10 @@ function initScenarioUI() {
   dupBtn?.addEventListener('click', () => {
     const name = prompt('New scenario name');
     if (name) {
+      if (!isValidScenarioName(name)) {
+        showAlertModal('Invalid Scenario Name', 'Use 1-64 characters: letters, numbers, hyphen (-), or underscore (_).');
+        return;
+      }
       cloneScenario(name);
       populateSelect(select);
       select.value = name;


### PR DESCRIPTION
### Motivation

- The repository accepted arbitrary scenario names and used a colon-delimited `scenario:key` storage namespace, which allowed delimiter collisions (e.g. `base:secret`) and cross-scenario leakage.
- `importProject()` switched to the imported `meta.scenario` before schema validation, enabling a malicious `.ctr.json` to redirect writes into an attacker-chosen scenario prior to validation.

### Description

- Added strict scenario-name validation in `projectStorage.js` by implementing `sanitizeScenarioName()` with a 1–64 char limit and the pattern `^[A-Za-z0-9_-]+$`, and exported `isValidScenarioName` for callers.
- Updated `importProject()` in `dataStore.mjs` to only accept a validated `meta.scenario` and to defer calling `switchScenario()` until after the import data is validated and written, preventing pre-validation redirection.
- Updated the scenario duplication UI in `src/scenarios.js` to check `isValidScenarioName()` and show a modal error when the user-entered name is invalid before calling `cloneScenario()`/`switchScenario()`.
- Kept changes minimal and centralized validation so other flows that normalize scenario lists (`ensureScenarioList`) and storage enumeration use the same sanitizer.

### Testing

- Ran the full unit/test suite with `npm test`, and all tests passed.
- Built the project with `npm run build`, which completed successfully (Rollup warnings about external deps as before but no failures).
- Attempted to capture a preview screenshot using Playwright, but `npx playwright install chromium` failed due to Playwright browser download being blocked by the environment (HTTP 403), so no preview image could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e6890c3083248dd8daeb26599214)