### PR TITLE
Sanitize ZIP entry names to prevent Zip Slip in consolidated report export

### DIFF
--- a/reports/exportAll.mjs
+++ b/reports/exportAll.mjs
@@ -137,6 +137,18 @@ const crcTable = new Uint32Array(256).map((_, n) => {
   }
   return c >>> 0;
 });
+
+function sanitizeZipFileName(name, fallback = 'report') {
+  const raw = String(name || '');
+  const normalized = raw.replace(/\\/g, '/').split('/').pop() || '';
+  const stripped = normalized
+    .replace(/\.\.+/g, '.')
+    .replace(/[^a-zA-Z0-9._-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[_\.\-]+|[_\.\-]+$/g, '');
+  return stripped || fallback;
+}
+
 function crc32(buf) {
   let crc = -1;
   for (let i = 0; i < buf.length; i++) {
@@ -149,7 +161,8 @@ class SimpleZip {
   constructor() { this.entries = []; }
   file(name, data) {
     if (typeof data === 'string') data = new TextEncoder().encode(data);
-    this.entries.push({ name, data });
+    const safeName = sanitizeZipFileName(name);
+    this.entries.push({ name: safeName, data });
   }
   async generateAsync({ type = 'nodebuffer' } = {}) {
     const fileRecords = [];
@@ -246,8 +259,8 @@ export function buildReportZip(data = {}) {
   // Add CSVs for each section
   sections.forEach(sec => {
     const csv = toCSV(sec.headers, sec.rows);
-    const name = sec.title.toLowerCase().replace(/\s+/g, '_') + '.csv';
-    zip.file(name, csv);
+    const baseName = sanitizeZipFileName(sec.title.toLowerCase().replace(/\s+/g, '_'), 'analysis');
+    zip.file(`${baseName}.csv`, csv);
   });
 
   // Arc flash labels

--- a/tests/exportAllReports.test.cjs
+++ b/tests/exportAllReports.test.cjs
@@ -30,5 +30,17 @@ function it(name, fn){
       assert(files.includes('loadflow_analysis.csv'));
       assert(files.includes('Main_Switchboard.svg'));
     });
+
+    it('sanitizes zip entry names derived from untrusted keys', async () => {
+      const data = {
+        analyses: { '../../analysis_escape': [{ id: 'B1', Vm: 1 }] },
+        arcFlash: { 'BUS/../../outside': { incidentEnergy: 1, boundary: 2 } }
+      };
+      const zip = buildReportZip(data);
+      const files = Object.keys(zip.files);
+      assert(files.includes('analysis_escape_analysis.csv'));
+      assert(files.includes('BUS_._._outside.svg'));
+      assert(!files.some(name => name.includes('..') || name.includes('/') || name.includes('\\')));
+    });
   });
 })();


### PR DESCRIPTION
### Motivation
- The consolidated report export used untrusted analysis keys and arc-flash IDs as ZIP entry names, allowing path traversal (`../`, `/`, `\`) to be embedded in archive entries and enabling Zip Slip extraction risks. 
- A minimal, centralized sanitization is needed so generated archives cannot contain directory components or traversal tokens from user-controlled identifiers.

### Description
- Add `sanitizeZipFileName(name, fallback)` to `reports/exportAll.mjs` to normalize and strip directory/traversal characters and unsafe tokens before writing ZIP entries. 
- Apply the sanitizer in `SimpleZip.file(...)` so every ZIP member name is converted to a safe basename at the point of insertion. 
- Use the sanitizer when generating CSV section filenames (replace the prior raw `sec.title`->name logic) so analysis-derived CSV names cannot contain separators or `..`. 
- Add a regression test in `tests/exportAllReports.test.cjs` that builds a zip from traversal-like analysis keys and arc-flash IDs and asserts the resulting ZIP entry names contain no `..`, `/`, or `\` sequences.

### Testing
- Ran the full test suite with `npm test`, and the test run completed with the new regression verifying sanitized names (all unit tests passed in this environment). 
- Built the distributable with `npm run build`, which completed successfully. 
- Attempted a preview screenshot with Playwright (`npx playwright screenshot ...`) but browser download failed in this environment; `npx playwright install` returned HTTP 403 from the upstream CDN, so automated UI screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e8080ae48324bd779d080f69c107)