### PR TITLE
fix: sanitize DXF export text and numeric coordinates

### DIFF
--- a/exporters/dxf.js
+++ b/exporters/dxf.js
@@ -1,11 +1,22 @@
 import { Drawing } from './simpleDxf.js';
 
+function sanitizeDXFText(value) {
+  const text = String(value ?? '');
+  const withoutControls = text.replace(/[\r\n\u0000-\u001F\u007F]/g, ' ').trim();
+  return withoutControls || 'Component';
+}
+
+function toFiniteNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
 function buildDXF(components = []) {
   const d = new Drawing();
   components.forEach(c => {
-    const x = c.x || 0;
-    const y = c.y || 0;
-    const name = c.subtype || 'Component';
+    const x = toFiniteNumber(c.x);
+    const y = toFiniteNumber(c.y);
+    const name = sanitizeDXFText(c.subtype || 'Component');
     d.drawText(x, y, 5, name);
   });
   return d.toDxfString();


### PR DESCRIPTION
### Motivation
- The DXF exporter placed untrusted component `subtype` strings and raw numeric fields directly into line-oriented DXF output, allowing CR/LF/control-character injection and non-finite coordinate values to corrupt exported DXF deliverables.

### Description
- Add `sanitizeDXFText` to strip CR/LF and ASCII control characters from text written into DXF records and to coerce empty/invalid text to a safe default (`'Component'`).
- Add `toFiniteNumber` to coerce coordinate-like fields to finite `Number` values with a `0` fallback. 
- Use the new helpers inside `buildDXF` so `drawText` receives only sanitized strings and finite numeric coordinates while preserving filenames and export behavior.

### Testing
- Ran `npm test` and the project test suite completed successfully. 
- Ran `npm run build` and the bundling/build step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e807d21483249b84c0c0fc5884ac)