### PR TITLE
Fix validation report export to flatten one-line components

### DIFF
--- a/site.js
+++ b/site.js
@@ -1608,7 +1608,9 @@ function initSettings(){
           const headers=['sample'];
           const rows=[{sample:'demo'}];
           downloadCSV(headers,rows,'reports.csv');
-          const issues=runValidation(getOneLine().sheets,getStudies());
+          const oneLine=getOneLine();
+          const components=(oneLine?.sheets||[]).flatMap(sheet=>Array.isArray(sheet.components)?sheet.components:[]);
+          const issues=runValidation(components,getStudies());
           const vHeaders=['component','message'];
           const vRows=issues.length?issues:[{component:'-',message:'No issues'}];
           downloadCSV(vHeaders,vRows,'validation-report.csv');


### PR DESCRIPTION
### Motivation
- The site-level report export passed `getOneLine()` sheets directly into `runValidation`, but `getOneLine()` returns sheet objects with nested `components` while `runValidation` expects a flat array of component objects, causing validations to be skipped and incorrect "No issues" reports.

### Description
- Changed `site.js` export logic to call `oneLine = getOneLine()` and build `components = (oneLine?.sheets || []).flatMap(sheet => Array.isArray(sheet.components) ? sheet.components : [])` before calling `runValidation(components, getStudies())`.
- The fix is minimal and limited to the report export handler so editor behavior remains unchanged and validator expectations are met.

### Testing
- Ran `npm test` and the full test suite completed successfully.
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a preview screenshot with Playwright, but browser binaries could not be downloaded in this environment (Playwright download returned HTTP 403), so a preview image could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e8081d7c832491d987d446a0a8c3)