### PR TITLE
fix: guard runValidation against malformed studies.duty entries

### DIFF
--- a/validation/rules.js
+++ b/validation/rules.js
@@ -663,7 +663,8 @@ export function runValidation(components = [], studies = {}) {
   });
 
   // TCC duty/coordination violations from studies
-  Object.entries(studies.duty || {}).forEach(([id, msgs = []]) => {
+  Object.entries(studies?.duty && typeof studies.duty === 'object' ? studies.duty : {}).forEach(([id, msgs]) => {
+    if (!Array.isArray(msgs)) return;
     msgs.forEach(msg => issues.push({ component: id, message: msg }));
   });
 


### PR DESCRIPTION
### Motivation
- Prevent `runValidation` from throwing `TypeError` when persisted `studyResults` contains malformed `duty` entries (non-array values) which can break one-line validation and page rendering.

### Description
- Add a defensive shape check in `validation/rules.js` so `studies.duty` is only iterated when it is object-like and each `msgs` value is an `Array`; non-array entries are ignored and valid payload behavior is preserved.

### Testing
- Ran `npm test` and the test suite completed successfully.
- Ran `npm run build` and the build completed successfully.
- Attempted `npx playwright install chromium` and `npx playwright screenshot` to produce a preview image but the browser download failed with HTTP 403, so the screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e807c31c8324ba5c628ba01d9025)