### PR TITLE
fix: prevent crashes from non-string imported analysis fields

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -416,7 +416,8 @@ export async function runArcFlash(options = {}) {
     const de = Number.isFinite(depthRaw) && depthRaw > 0 ? depthRaw : 508;
     const sizeFactor = Math.cbrt((h * w * de) / (508 * 508 * 508)) || 1;
     const time = clearingTime(comp, Ibf, devices, protectiveComp, sc, protectiveDevice);
-    const cfg = (comp.electrode_config || 'VCB').toUpperCase();
+    const cfgCandidate = comp.electrode_config ?? 'VCB';
+    const cfg = typeof cfgCandidate === 'string' ? cfgCandidate.toUpperCase() : 'VCB';
     const voltageSettingRaw = firstParsedNumeric(comp.kV, comp.baseKV, comp.prefault_voltage);
     const V = Number.isFinite(voltageSettingRaw) && voltageSettingRaw > 0 ? voltageSettingRaw : 0.48;
     const rawIa = Ibf > 0 && time > 0

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -792,7 +792,10 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     }
 
     const prefaultKV = computePrefaultKV(comp, comps, compMap, voltageCache) || 1;
-    const method = (comp.method || opts.method || (prefaultKV > 1 ? 'IEC' : 'ANSI')).toUpperCase();
+    const methodCandidate = comp.method ?? opts.method ?? (prefaultKV > 1 ? 'IEC' : 'ANSI');
+    const method = typeof methodCandidate === 'string'
+      ? methodCandidate.toUpperCase()
+      : (prefaultKV > 1 ? 'IEC' : 'ANSI');
 
     let entry;
     if (method === 'IEC') {

--- a/tests/arcflash/arcFlashExample.test.cjs
+++ b/tests/arcflash/arcFlashExample.test.cjs
@@ -51,7 +51,17 @@ global.localStorage = {
       assert.strictEqual(af.upstreamDevice, 'ABB Tmax T3 160A');
       const today = new Date().toISOString().split('T')[0];
       assert.strictEqual(af.studyDate, today);
+
+      setOneLine({ activeSheet: 0, sheets: [{ name: 'S2', components: [
+        { id: 'BUS2', kV: 0.48, z1: { r: 0, x: 0.05 }, z2: { r: 0, x: 0.05 }, z0: { r: 0, x: 0.05 },
+          sources: [{ z1: { r: 0, x: 0.02 }, z2: { r: 0, x: 0.02 }, z0: { r: 0, x: 0.02 } }],
+          enclosure: 'Box', gap: 32, working_distance: 455, electrode_config: { bad: true } }
+      ] }] });
+      const hardened = await runArcFlash();
+      assert(hardened.BUS2, 'arc flash result should be produced for non-string electrode config');
+      assert(Number.isFinite(hardened.BUS2.incidentEnergy), 'incident energy should be numeric');
     });
+
   });
 })();
 

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -350,5 +350,30 @@ global.localStorage = {
       assert.strictEqual(bus.ups.rated_kva, 500);
       assert.strictEqual(bus.ups.runtime_battery_min, 15);
     });
+    it('falls back to derived method when component method is non-string', () => {
+      setOneLine({
+        activeSheet: 0,
+        sheets: [{
+          name: 'Method type hardening',
+          components: [
+            {
+              id: 'busBadMethod',
+              type: 'bus',
+              subtype: 'Bus',
+              kV: 4.16,
+              method: { bad: true },
+              z1: { r: 0, x: 0.15 },
+              z2: { r: 0, x: 0.15 },
+              z0: { r: 0, x: 0.15 }
+            }
+          ]
+        }]
+      });
+      const res = runShortCircuit();
+      assert(res.busBadMethod, 'bus result should be produced');
+      assert.strictEqual(res.busBadMethod.method, 'IEC');
+      assert(res.busBadMethod.threePhaseKA > 0, 'analysis should complete');
+    });
+
   });
 })();


### PR DESCRIPTION
### Motivation
- Imported one-line projects only validated `oneLine` as an array and allowed nested component properties to be attacker-controlled, which caused `.toUpperCase()` calls in analysis to throw `TypeError` for non-string `method` or `electrode_config` values. 
- The change prevents client-side availability failures in short-circuit and arc-flash studies when processing untrusted or malformed project JSON.

### Description
- Guard `method` selection in `analysis/shortCircuit.mjs` by checking the candidate's type and only calling `.toUpperCase()` on strings, otherwise falling back to the derived default (`IEC`/`ANSI`).
- Guard `electrode_config` handling in `analysis/arcFlash.mjs` by checking the candidate's type and only calling `.toUpperCase()` on strings, otherwise falling back to `'VCB'`.
- Add regression tests exercising non-string `method` and non-string `electrode_config` in `tests/shortcircuit/shortCircuit.test.cjs` and `tests/arcflash/arcFlashExample.test.cjs` to ensure analysis completes.

### Testing
- Ran `npm test` and all automated tests completed successfully including the new regression cases that verify analysis no longer throws on non-string inputs. 
- Ran `npm run build` and the project built successfully. 
- Attempted to produce a visual preview via Playwright (`npx playwright install` / headless Chromium screenshot) but browser binaries could not be downloaded in this environment (HTTP 403), so a screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f79e10048324bd99cd7127a2b41a)