### PR TITLE
fix(oneline): guard manufacturer model dropdown lookup against prototype keys

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -1104,7 +1104,7 @@ const transformerConnectionOptions = [
   'Open Delta',
   'Open Wye'
 ];
-const manufacturerModels = {
+const manufacturerModels = Object.freeze({
   ABB: ['MNS', 'SafeGear'],
   Siemens: ['SB1', 'S6'],
   GE: ['EntelliGuard', 'Spectra'],
@@ -1112,7 +1112,14 @@ const manufacturerModels = {
   Caterpillar: ['XQ125', 'C175'],
   Cummins: ['C900', 'QSK60'],
   Generac: ['G2000', 'Industrial']
-};
+});
+const manufacturerOptions = Object.keys(manufacturerModels);
+
+function getManufacturerModels(manu) {
+  if (!Object.hasOwn(manufacturerModels, manu)) return [];
+  const models = manufacturerModels[manu];
+  return Array.isArray(models) ? models : [];
+}
 
 function createTuningField(name, label, type, help) {
   return {
@@ -8896,11 +8903,11 @@ function selectComponent(compOrId) {
           return { ...f, type: 'select', options: thermalRatings };
         }
         if (f.name === 'manufacturer') {
-          return { ...f, type: 'select', options: Object.keys(manufacturerModels) };
+          return { ...f, type: 'select', options: manufacturerOptions };
         }
         if (f.name === 'model') {
-          const manu = targetComp.manufacturer || Object.keys(manufacturerModels)[0];
-          return { ...f, type: 'select', options: manufacturerModels[manu] || [] };
+          const manu = targetComp.manufacturer || manufacturerOptions[0];
+          return { ...f, type: 'select', options: getManufacturerModels(manu) };
         }
         if (
           targetComp.type === 'transformer'
@@ -10420,7 +10427,7 @@ function selectComponent(compOrId) {
 
     if (manufacturerInput && modelInput) {
       const updateModels = () => {
-        const models = manufacturerModels[manufacturerInput.value] || [];
+        const models = getManufacturerModels(manufacturerInput.value);
         modelInput.innerHTML = '';
         models.forEach(m => {
           const o = document.createElement('option');
@@ -10431,7 +10438,7 @@ function selectComponent(compOrId) {
         });
       };
       manufacturerInput.addEventListener('change', updateModels);
-      if (!manufacturerInput.value) manufacturerInput.value = Object.keys(manufacturerModels)[0];
+      if (!manufacturerInput.value) manufacturerInput.value = manufacturerOptions[0];
       updateModels();
     }
 


### PR DESCRIPTION
### Motivation

- Prevent a client-side crash in the component property editor when imported diagrams set `manufacturer` to an inherited object key such as `__proto__` or `constructor`.
- Ensure dropdown `options` are always a real array so the renderer's `(f.options || []).forEach(...)` usage cannot throw a `TypeError`.

### Description

- Hardened `manufacturerModels` handling in `oneline.js` by wrapping the map in `Object.freeze(...)` and adding a cached `manufacturerOptions` list for the manufacturer select default.
- Added a safe helper `getManufacturerModels(manu)` that returns `[]` unless `Object.hasOwn(manufacturerModels, manu)` is true and the value is an array via `Array.isArray(...)`.
- Replaced direct lookups with `manufacturerOptions` and `getManufacturerModels(...)` in schema generation and the runtime manufacturer-change handler so only validated arrays are used as select `options`.

### Testing

- Ran the full test suite with `npm test` and all automated tests passed.
- Built the project with `npm run build` and the build completed successfully.
- Attempted to produce an updated browser preview via Playwright (`npx playwright screenshot ...`) but browser binaries could not be downloaded in this environment (upstream 403), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f66842508324940c782e996afa6c)