### PR TITLE
fix: prevent Bus subtype from suppressing non-Bus study results

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -941,8 +941,7 @@ export function runLoadFlow(modelOrOpts = {}, maybeOpts = {}) {
   let busComps;
   if (model && model.buses) {
     const usable = model.buses.filter(isUsableComponent);
-    let selected = usable.filter(isBusComponent);
-    if (selected.length === 0) selected = usable;
+    const selected = usable;
     const busMap = new Map();
     busComps = selected.map(bus => {
       const clone = { ...bus };
@@ -980,8 +979,7 @@ export function runLoadFlow(modelOrOpts = {}, maybeOpts = {}) {
     }
   } else if (Array.isArray(model)) {
     const usable = model.filter(isUsableComponent);
-    busComps = usable.filter(isBusComponent);
-    if (busComps.length === 0) busComps = usable;
+    busComps = usable;
   }
   const busIds = busComps.map(b => b.id);
   const phases = balanced ? ['balanced'] : ['A', 'B', 'C'];

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -700,8 +700,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       : sheets;
     comps = comps.filter(c => c && c.type !== 'annotation' && c.type !== 'dimension');
   }
-  let buses = comps.filter(c => c.subtype === 'Bus');
-  if (buses.length === 0) buses = comps;
+  const buses = comps;
   const compMap = new Map(comps.map(c => [c.id, c]));
   const impedanceCache = new Map();
   const voltageCache = new Map();

--- a/studies/shortCircuit.js
+++ b/studies/shortCircuit.js
@@ -13,8 +13,7 @@ function buildModel() {
   const comps = Array.isArray(sheets[0]?.components)
     ? sheets.flatMap(s => s.components)
     : sheets;
-  let buses = comps.filter(c => c.subtype === 'Bus');
-  if (buses.length === 0) buses = comps;
+  const buses = comps;
   return { buses };
 }
 


### PR DESCRIPTION
### Motivation
- A recent addition of a `Bus` subtype caused `runLoadFlow()` and `runShortCircuit()` to restrict analysis to components with `subtype === 'Bus'` when any Bus existed, which silently omits panels, loads, breakers, and equipment from engineering studies and can produce dangerously misleading results. 
- The change restores analysis semantics so one-line studies include all usable components by default, eliminating the attack/poisoning vector introduced by a minimal `Bus` entry.

### Description
- In `analysis/loadFlow.js` replaced the Bus-only selection with `selected = usable` and `busComps = usable` so the load-flow model is built from all usable components rather than only `subtype: 'Bus'` components. 
- In `analysis/shortCircuit.mjs` removed the `comps.filter(c => c.subtype === 'Bus')` restriction and now uses `const buses = comps;` so short-circuit calculations iterate over all eligible components. 
- In `studies/shortCircuit.js` adjusted `buildModel()` to return all one-line components (no Bus-only pre-filter) so the study harness passes a complete model to the engine. 
- All edits are minimal and preserve branch/connection handling and existing branch-to-bus mapping logic so normal explicit modelling continues to work.

### Testing
- Ran the full automated test suite with `npm test`; most tests completed successfully but there is an existing unrelated failure in `tests/serverSecurity.test.mjs` (assertion `401 !== 200`) that predates and is not caused by these changes. 
- Built the project with `npm run build` which completed successfully (rollup warnings about external deps are unchanged). 
- Attempted to produce a webpage preview screenshot via Playwright but the environment is missing browser binaries; running `npx playwright install` and then `npx playwright screenshot file:///workspace/CableTrayRoute/loadFlow.html /workspace/CableTrayRoute/artifacts/loadflow-preview.png` will generate the preview image at `/workspace/CableTrayRoute/artifacts/loadflow-preview.png` once browsers are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f79e23288324bd9cf12fc1651422)