### PR TITLE
fix: exclude one-line revisions from project export/import

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -890,7 +890,7 @@ export function exportProject() {
     mccLineups: getMccLineups(),
     settings: {}
   };
-  const reserved = new Set([...Object.values(KEYS), EXTRA_KEYS.mccLineups, 'CTR_PROJECT_V1']);
+  const reserved = new Set([...Object.values(KEYS), EXTRA_KEYS.mccLineups, REVISION_KEY, 'CTR_PROJECT_V1']);
   for (const key of keys()) {
     if (!reserved.has(key)) {
       project.settings[key] = getItem(key);
@@ -1029,7 +1029,7 @@ export function importProject(obj) {
     setOneLine({ activeSheet: 0, sheets: [] });
   }
 
-  const reserved = new Set([...Object.values(KEYS), EXTRA_KEYS.mccLineups, 'CTR_PROJECT_V1']);
+  const reserved = new Set([...Object.values(KEYS), EXTRA_KEYS.mccLineups, REVISION_KEY, 'CTR_PROJECT_V1']);
   for (const key of keys()) {
     if (!reserved.has(key) && !(data.settings && key in data.settings)) {
       removeItem(key);
@@ -1037,7 +1037,9 @@ export function importProject(obj) {
   }
   if (data.settings) {
     for (const [k, v] of Object.entries(data.settings)) {
-      setItem(k, v);
+      if (!reserved.has(k)) {
+        setItem(k, v);
+      }
     }
   }
   if (importScenario) switchScenario(importScenario);


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of historical one-line sheets by ensuring the internal `oneLineRevisions` storage key is not serialized into exported project `settings` or restored during import.

### Description
- Treat `REVISION_KEY` (`oneLineRevisions`) as a reserved internal key in `dataStore.mjs` so `exportProject()` skips it and `importProject()` never rehydrates it from `settings` (adds checks around reserved-key handling and skips `setItem` for reserved keys).

### Testing
- Ran the automated project checks: `npm test` completed successfully and `npm run build` completed successfully; Playwright-based screenshot/install failed due to browser download restrictions so no preview image could be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a02ffb1308324a228ce2b3a694110)