### PR TITLE
fix: require cable selection when creating port-drag connections

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -12460,9 +12460,36 @@ async function init() {
           const toPort = hoverPort.port;
           const created = ensureConnection(fromComp, toComp, fromPort, toPort);
           if (created) {
-            pushHistory();
-            render();
-            save();
+            const createdConn = (fromComp.connections || []).find(conn =>
+              conn.target === toComp.id
+              && normalizePortIndex(conn.sourcePort) === normalizePortIndex(fromPort)
+              && normalizePortIndex(conn.targetPort) === normalizePortIndex(toPort)
+            );
+            const result = createdConn ? await chooseCable(fromComp, toComp, createdConn) : null;
+            if (!result) {
+              fromComp.connections = (fromComp.connections || []).filter(conn => conn !== createdConn);
+              render();
+              save();
+            } else if (createdConn) {
+              const updatedCable = { ...result.cable };
+              if (hasImpedance(result.cable)) updatedCable.impedance = { ...result.cable.impedance };
+              const resolvedPhases = parseCablePhases(result.phases ?? updatedCable);
+              updatedCable.phases = resolvedPhases.slice();
+              createdConn.cable = updatedCable;
+              createdConn.phases = resolvedPhases.slice();
+              createdConn.conductors = result.conductors;
+              if (result.impedance && typeof result.impedance === 'object') {
+                createdConn.impedance = { ...result.impedance };
+              } else if (hasImpedance(updatedCable)) {
+                createdConn.impedance = { ...updatedCable.impedance };
+              } else {
+                delete createdConn.impedance;
+              }
+              pushHistory();
+              render();
+              save();
+              markScheduleReconcilePending();
+            }
           }
         }
         connectSource = null;


### PR DESCRIPTION
### Motivation
- Port-drag connection creation previously persisted connections that lacked any `cable`/`phases`/`conductors`/`impedance` data, causing schedule/export to skip them and load-flow to fall back to empty impedance objects.

### Description
- Updated the port-drag mouseup flow in `oneline.js` so a newly created connection is immediately passed to `chooseCable(...)` before it is finalized.
- If the user cancels cable selection the transient connection is removed instead of being saved, and if selection succeeds the connection is populated with the chosen `cable`, normalized `phases`, `conductors`, and `impedance` (or `impedance` removed when not applicable).
- On successful cable assignment the code now records history, calls `save()`, and invokes `markScheduleReconcilePending()` so downstream schedules/exports and validation see the completed connection.

### Testing
- Ran the full test suite with `npm test` and all automated tests completed successfully (green).
- Built the distribution with `npm run build` and the build completed successfully.
- Attempted a headless browser screenshot to produce a preview image via Playwright, but `npx playwright install chromium` failed to download the browser binary in this environment (HTTP 403), so no runtime screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a048dd34c8324be8c8c51e6f98d4d)