### PR TITLE
Validate and clamp oneLine.activeSheet to prevent oneline crash

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -509,6 +509,7 @@ export const removeEquipment = index => {
  * @returns {OneLineSheet[]}
  */
 export const getOneLine = (scenario = getCurrentScenarioNameState()) => {
+  const normalizeActiveSheet = value => (Number.isInteger(value) && value >= 0 ? value : 0);
   const data = read(KEYS.oneLine, {}, scenario);
   if (Array.isArray(data)) {
     // legacy array of components
@@ -516,7 +517,7 @@ export const getOneLine = (scenario = getCurrentScenarioNameState()) => {
   }
   if (data && Array.isArray(data.sheets)) {
     return {
-      activeSheet: data.activeSheet || 0,
+      activeSheet: normalizeActiveSheet(data.activeSheet),
       sheets: data.sheets.map(s => ({
         name: s.name,
         components: Array.isArray(s.components) ? s.components : [],
@@ -578,10 +579,11 @@ export const restoreRevision = (index, scenario = getCurrentScenarioNameState())
 };
 
 export const setOneLine = (data, scenario = getCurrentScenarioNameState()) => {
+  const normalizeActiveSheet = value => (Number.isInteger(value) && value >= 0 ? value : 0);
   const prev = getOneLine(scenario);
   if (Array.isArray(prev.sheets) && prev.sheets.length) addRevision(prev.sheets, scenario);
   const payload = {
-    activeSheet: data.activeSheet || 0,
+    activeSheet: normalizeActiveSheet(data.activeSheet),
     sheets: Array.isArray(data.sheets) ? data.sheets : []
   };
   write(KEYS.oneLine, payload, scenario);

--- a/oneline.js
+++ b/oneline.js
@@ -11612,7 +11612,8 @@ async function init() {
   });
   setItem('labelCounters', labelCounters);
 
-  activeSheet = Math.min(storedActive, sheets.length - 1);
+  const normalizedStoredActive = Number.isInteger(storedActive) ? storedActive : 0;
+  activeSheet = Math.min(Math.max(normalizedStoredActive, 0), sheets.length - 1);
   components = sheets[activeSheet].components;
   connections = sheets[activeSheet].connections;
   // Gap #51: load layers for the initial active sheet
@@ -14324,7 +14325,8 @@ async function __oneline_init() {
       connections: Array.isArray(s.connections) ? s.connections : [],
     }));
     if (!sheets.length) sheets = [{ name: 'Sheet 1', components: [], connections: [] }];
-    activeSheet = Math.min(remoteActiveSheet, sheets.length - 1);
+    const normalizedRemoteActive = Number.isInteger(remoteActiveSheet) ? remoteActiveSheet : 0;
+    activeSheet = Math.min(Math.max(normalizedRemoteActive, 0), sheets.length - 1);
     components = sheets[activeSheet].components;
     connections = sheets[activeSheet].connections;
     renderSheetTabs();


### PR DESCRIPTION
### Motivation
- Imported or persisted `oneLine.activeSheet` values could be negative, non-integer, or non-numeric and were used directly as array indices, causing a persistent client-side crash when the one-line page initialized. 
- The aim is to harden storage and initialization so attacker-controlled project JSON or corrupted localStorage cannot cause `sheets[activeSheet]` to be undefined and abort the page.

### Description
- Add a normalization helper to `getOneLine` and `setOneLine` in `dataStore.mjs` to ensure only non-negative integers are returned/persisted for `activeSheet` (defaults to `0` otherwise). 
- Clamp and normalize the stored `activeSheet` in `oneline.js` initialization to a safe range with both lower and upper bounds before dereferencing `sheets[activeSheet]`. 
- Apply the same integer-normalization and clamping to the collaboration remote-refresh (`ctr:remote-applied`) path to avoid runtime crashes from malformed remote state. 
- Changes are minimal and preserve existing behavior for valid inputs while preventing invalid/attacker-supplied indices from being used.

### Testing
- Ran the full automated test suite with `npm test` and all tests completed successfully. 
- Built the web assets with `npm run build` and the build completed successfully. 
- Attempted to capture a screenshot of `oneline.html` for a preview using Playwright, but browser download/install failed due to CDN access errors (Playwright install returned 403), so an automated webpage preview could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a048e9330832483d1a59cc59368d7)