### PR TITLE
fix: bound and sanitize panel circuit counts to prevent DoS

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -397,11 +397,20 @@ export const addRaceway = raceway => {
  * @returns {GenericRecord[]}
  */
 export const getPanels = () => read(KEYS.panels, []);
+
+const DEFAULT_PANEL_CIRCUIT_COUNT = 42;
+const MAX_PANEL_CIRCUITS = 512;
+
+function normalizePanelCircuitCount(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_PANEL_CIRCUIT_COUNT;
+  return Math.min(parsed, MAX_PANEL_CIRCUITS);
+}
 /**
  * @param {GenericRecord} panel
  */
 function ensurePanelFields(panel) {
-  return {
+  const normalized = {
     id: '',
     description: '',
     ref: '',
@@ -411,9 +420,11 @@ function ensurePanelFields(panel) {
     phases: '',
     notes: '',
     mainRating: '',
-    circuitCount: 42,
+    circuitCount: DEFAULT_PANEL_CIRCUIT_COUNT,
     ...panel
   };
+  normalized.circuitCount = normalizePanelCircuitCount(normalized.circuitCount);
+  return normalized;
 }
 /**
  * @param {GenericRecord[]} panels

--- a/exportPanelSchedule.js
+++ b/exportPanelSchedule.js
@@ -1,6 +1,9 @@
 import * as dataStore from './dataStore.mjs';
 import { showAlertModal } from './src/components/modal.js';
 
+const DEFAULT_PANEL_CIRCUIT_COUNT = 42;
+const MAX_PANEL_CIRCUITS = 512;
+
 function parsePositiveInt(value) {
   if (value == null) return null;
   const parsed = Number.parseInt(value, 10);
@@ -9,9 +12,9 @@ function parsePositiveInt(value) {
 
 function getPanelCircuitCount(panel) {
   const explicit = parsePositiveInt(panel?.circuitCount || panel?.circuit_count);
-  if (explicit) return explicit;
-  if (Array.isArray(panel?.breakers)) return panel.breakers.length;
-  return 42;
+  if (explicit) return Math.min(explicit, MAX_PANEL_CIRCUITS);
+  if (Array.isArray(panel?.breakers) && panel.breakers.length > 0) return Math.min(panel.breakers.length, MAX_PANEL_CIRCUITS);
+  return DEFAULT_PANEL_CIRCUIT_COUNT;
 }
 
 function getPanelSystem(panel) {

--- a/panelschedule.html
+++ b/panelschedule.html
@@ -115,7 +115,7 @@
               <label class="panel-info-compact">Main Device Rating (A) <input id="panel-main-rating" type="number" min="0"></label>
             </div>
             <div class="panel-info-tight-group panel-info-circuit-group">
-              <label>Number of Circuits <input id="panel-circuit-count" type="number" min="1"></label>
+              <label>Number of Circuits <input id="panel-circuit-count" type="number" min="1" max="512"></label>
               <label class="panel-info-compact">Branch Device Type
                 <select id="panel-branch-device-type">
                   <option value="breaker">Breakers</option>

--- a/src/panelSchedule.js
+++ b/src/panelSchedule.js
@@ -6,6 +6,9 @@ import { ensureFieldAssistiveText, showAlertModal, openModal } from "./component
 
 const projectId = typeof window !== "undefined" ? window.currentProjectId : undefined;
 
+const DEFAULT_PANEL_CIRCUIT_COUNT = 42;
+const MAX_PANEL_CIRCUITS = 512;
+
 function getPanelIdentifierCandidates(panel) {
   if (!panel) return [];
   return [panel.id, panel.ref, panel.panel_id, panel.tag]
@@ -269,9 +272,9 @@ function parsePositiveInt(value) {
 
 function getPanelCircuitCount(panel) {
   const explicit = parsePositiveInt(panel?.circuitCount);
-  if (explicit) return explicit;
-  if (Array.isArray(panel?.breakers)) return panel.breakers.length;
-  return 42;
+  if (explicit) return Math.min(explicit, MAX_PANEL_CIRCUITS);
+  if (Array.isArray(panel?.breakers) && panel.breakers.length > 0) return Math.min(panel.breakers.length, MAX_PANEL_CIRCUITS);
+  return DEFAULT_PANEL_CIRCUIT_COUNT;
 }
 
 function getPanelSystem(panel) {
@@ -2564,8 +2567,8 @@ window.addEventListener("DOMContentLoaded", () => {
     const circuitInvalid = Number.isFinite(circuitValue) ? circuitValue < 1 : false;
     markInvalid(circuitInput, circuitInvalid);
     if (circuitInvalid) {
-      fieldErrors.circuitCount = 'Use 1 or greater for number of circuits.';
-      hints.push('Number of circuits must be 1 or greater.');
+      fieldErrors.circuitCount = `Use between 1 and ${MAX_PANEL_CIRCUITS} for number of circuits.`;
+      hints.push(`Number of circuits must be between 1 and ${MAX_PANEL_CIRCUITS}.`);
     }
 
     const mainRating = mainInput ? Number.parseFloat(mainInput.value) : null;
@@ -2985,7 +2988,9 @@ window.addEventListener("DOMContentLoaded", () => {
 
   if (circuitInput) {
     circuitInput.addEventListener("input", () => {
-      const count = parseInt(circuitInput.value, 10) || 0;
+      const parsed = parseInt(circuitInput.value, 10) || 0;
+      const count = Math.max(1, Math.min(MAX_PANEL_CIRCUITS, parsed));
+      circuitInput.value = String(count);
       panel.circuitCount = count;
       if (!Array.isArray(panel.breakers)) panel.breakers = [];
       const loads = dataStore.getLoads();


### PR DESCRIPTION
### Motivation

- A persisted `panel.circuitCount` was trusted as a loop bound in rendering and XLSX export, allowing a crafted project to specify extremely large or non-finite values and cause browser/Node OOM or hang.  The change restores a safe fixed upper bound and normalizes imported values.

### Description

- Introduced `DEFAULT_PANEL_CIRCUIT_COUNT` (`42`) and `MAX_PANEL_CIRCUITS` (`512`) and added `normalizePanelCircuitCount` to `dataStore.mjs` so persisted/imported `circuitCount` values are coerced and clamped during `ensurePanelFields` normalization.
- Updated panel runtime logic in `src/panelSchedule.js` to clamp derived circuit counts via `getPanelCircuitCount`, clamp user input before resizing breaker arrays, and update validation messaging to reference the upper bound (`MAX_PANEL_CIRCUITS`).
- Hardened export logic in `exportPanelSchedule.js` to derive a safe circuit count via `getPanelCircuitCount` and prevent unbounded XLSX row generation.
- Added an HTML-level `max="512"` to the `panel-circuit-count` input in `panelschedule.html` to limit values coming from the UI.

### Testing

- Ran the test suite with `npm test` and all automated tests completed successfully (exit code `0`).
- Built the distribution with `npm run build` and the build completed successfully (exit code `0`).
- Attempted to generate a Playwright screenshot to produce a preview image, but `npx playwright install chromium` failed due to remote download `403 Forbidden`, so a runtime screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a06da6d2c83248ca2281eaf0c1214)