### PR TITLE
Restore Dijkstra priorities to fix non‑optimal routing (routeWorker.js)

### DIFF
--- a/routeWorker.js
+++ b/routeWorker.js
@@ -845,22 +845,17 @@ class CableRoutingSystem {
             }
         });
         
-        // 2. A* Search Algorithm
-        const heuristic = (node) =>
-            this.manhattanDistance(graph.nodes[node].point, graph.nodes['end'].point);
+        // 2. Dijkstra Search Algorithm
         const distances = {};
         const prev = {};
         Object.keys(graph.nodes).forEach(node => (distances[node] = Infinity));
         distances['start'] = 0;
 
         const pq = new MinHeap();
-        pq.push('start', heuristic('start'));
-        const visited = new Set();
+        pq.push('start', 0);
 
         while (!pq.isEmpty()) {
             const u = pq.pop();
-            if (visited.has(u)) continue;
-            visited.add(u);
             if (u === 'end') break;
 
             for (const v in graph.edges[u]) {
@@ -869,7 +864,7 @@ class CableRoutingSystem {
                 if (alt < distances[v]) {
                     distances[v] = alt;
                     prev[v] = { node: u, edge };
-                    pq.push(v, alt + heuristic(v));
+                    pq.push(v, alt);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- The routing search used an A* queue ordering with a Manhattan heuristic while tray edges are weighted by Euclidean distance and utilization multipliers, allowing the heuristic to overestimate and causing the algorithm to return suboptimal routes.

### Description
- Replaced the A* priority/heuristic flow in `routeWorker.js` with a Dijkstra-style priority ordering based solely on accumulated path cost (`alt`) to preserve optimality.
- Removed the Manhattan heuristic and the popped-node `visited` check used with A*, while keeping the existing path reconstruction and output format unchanged.
- The change is minimal and targeted to the search loop so other routing and weighting logic (projection nodes, tray edge weights, utilization multipliers) remain intact.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (exit 0).
- Built the project with `npm run build`, which completed successfully and produced the distribution artifacts.
- Attempted an automated page preview with `npx playwright screenshot` but browser binaries could not be downloaded in this environment (download returned HTTP 403), so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0b181fbc8324b26fbcdf45fdd121)