### PR TITLE
Ignore untrusted component schema defaults when syncing schedules

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13717,7 +13717,7 @@ function buildScheduleDataFromDiagram() {
       const value = typeof f.getValue === 'function'
         ? f.getValue(c)
         : c[f.name];
-      fields[f.name] = value ?? f.default ?? fields[f.name] ?? '';
+      fields[f.name] = value ?? fields[f.name] ?? '';
     });
     return fields;
   };


### PR DESCRIPTION
### Motivation
- The schedule synchronization was applying untrusted component schema `default` values into load/equipment/panel rows, allowing a malicious user-supplied component library to silently modify calculation inputs and corrupt engineering schedules.

### Description
- Modify `oneline.js` schedule mapping to stop injecting schema defaults by replacing `fields[f.name] = value ?? f.default ?? fields[f.name] ?? '';` with `fields[f.name] = value ?? fields[f.name] ?? '';`, so only explicit component values or existing mapped fields are used.

### Testing
- Ran `npm test` and `npm run build`, both completed successfully, and an attempted `npx playwright screenshot` preview failed because the Playwright Chromium binary is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0b1830408324b9170f7a9a5f95cc)