### PR TITLE
Fail-closed arc-flash on protective device library load failure

### DIFF
--- a/analysis/arcFlash.mjs
+++ b/analysis/arcFlash.mjs
@@ -285,7 +285,9 @@ async function loadDevices() {
         showAlertModal('Library Error', 'Protective device library failed to load. Arc flash analysis may be unavailable.');
       }
     }
-    deviceCache = [];
+    const loadErr = new Error('Protective device library failed to load');
+    loadErr.cause = err;
+    throw loadErr;
   }
   return deviceCache;
 }


### PR DESCRIPTION
### Motivation
- Prevent a safety-critical fail-open behavior where a failed dynamic import of the protective-device library leads to an empty device list and misleading arc-flash results computed from fallback clearing times.

### Description
- In `analysis/arcFlash.mjs` the `loadDevices()` catch path now throws a load error (with the original error attached as `cause`) after emitting the existing diagnostics/UI messages instead of caching an empty `deviceCache` and returning it.

### Testing
- Ran the full automated test suite with `npm test` and the command completed successfully in this environment. 
- Built the distribution with `npm run build` and the build completed successfully. 
- Attempted to capture a browser preview via Playwright but browser binaries could not be downloaded in this environment (Playwright download returned HTTP 403), so a screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0d7a82a08324ab7a7078b7412601)