### PR TITLE
Harden DXF serializer against untrusted value injection

### DIFF
--- a/exporters/simpleDxf.js
+++ b/exporters/simpleDxf.js
@@ -3,12 +3,34 @@ export class Drawing {
     this.entities = [];
   }
 
+  sanitizeText(value, fallback = '') {
+    const text = String(value ?? '');
+    const normalized = text.replace(/[\r\n\u0000-\u001F\u007F]/g, ' ').trim();
+    return normalized || fallback;
+  }
+
+  toFiniteNumber(value, fallback = 0) {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : fallback;
+  }
+
   drawText(x, y, height, value, rotation = 0) {
-    this.entities.push(`0\nTEXT\n8\n0\n10\n${x}\n20\n${y}\n30\n0\n40\n${height}\n1\n${value}\n50\n${rotation}`);
+    const safeX = this.toFiniteNumber(x);
+    const safeY = this.toFiniteNumber(y);
+    const safeHeight = this.toFiniteNumber(height, 1);
+    const safeValue = this.sanitizeText(value, 'Component');
+    const safeRotation = this.toFiniteNumber(rotation);
+    this.entities.push(`0\nTEXT\n8\n0\n10\n${safeX}\n20\n${safeY}\n30\n0\n40\n${safeHeight}\n1\n${safeValue}\n50\n${safeRotation}`);
   }
 
   drawLine3d(x1, y1, z1, x2, y2, z2) {
-    this.entities.push(`0\nLINE\n8\n0\n10\n${x1}\n20\n${y1}\n30\n${z1}\n11\n${x2}\n21\n${y2}\n31\n${z2}`);
+    const safeX1 = this.toFiniteNumber(x1);
+    const safeY1 = this.toFiniteNumber(y1);
+    const safeZ1 = this.toFiniteNumber(z1);
+    const safeX2 = this.toFiniteNumber(x2);
+    const safeY2 = this.toFiniteNumber(y2);
+    const safeZ2 = this.toFiniteNumber(z2);
+    this.entities.push(`0\nLINE\n8\n0\n10\n${safeX1}\n20\n${safeY1}\n30\n${safeZ1}\n11\n${safeX2}\n21\n${safeY2}\n31\n${safeZ2}`);
   }
 
   toDxfString() {


### PR DESCRIPTION
### Motivation
- The hand-written DXF serializer emitted caller-controlled values directly into newline-delimited DXF group records, which allowed imported component fields (e.g. `subtype`) or non-numeric coordinates to inject additional DXF entities or produce malformed records.
- The fix centralizes input validation at the serializer boundary to prevent entity injection while preserving existing exporter behavior.

### Description
- Added `sanitizeText` and `toFiniteNumber` helpers to `exporters/simpleDxf.js` to normalize text and coerce numeric fields before serialization.
- Updated `drawText` to strip control/newline characters from text payloads and coerce `x`, `y`, `height`, and `rotation` to finite numbers before emitting DXF records.
- Updated `drawLine3d` to coerce all coordinate inputs to finite numbers before emitting DXF records.
- No caller-side changes were required; all existing DXF export paths continue to call the serializer and now benefit from the sanitization.

### Testing
- Ran `npm test` and the full test suite completed successfully with all assertions passing.
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a webpage preview with Playwright, but installing Chromium failed due to Playwright CDN download returning HTTP 403, so a preview screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0d7e23a88324b836bb3f4610b2e7)