### PR TITLE
Fix loadConduits fallback to use project schedule keys

### DIFF
--- a/site.js
+++ b/site.js
@@ -2184,8 +2184,24 @@ function loadConduits(){
     }
   }catch(e){ console.warn('loadConduits: cache read failed', e); }
   let ductbanks=[];let conduits=[];
-  try{ductbanks=getDuctbanks();}catch(e){ console.warn('loadConduits: getDuctbanks failed', e); }
-  try{conduits=getConduits();}catch(e){ console.warn('loadConduits: getConduits failed', e); }
+  try{
+    const raw=localStorage?.getItem('ductbankSchedule');
+    if(raw!=null){
+      const parsed=JSON.parse(raw);
+      ductbanks=Array.isArray(parsed)?parsed:[];
+    }else{
+      ductbanks=getDuctbanks();
+    }
+  }catch(e){ console.warn('loadConduits: ductbankSchedule read failed', e); }
+  try{
+    const raw=localStorage?.getItem('conduitSchedule');
+    if(raw!=null){
+      const parsed=JSON.parse(raw);
+      conduits=Array.isArray(parsed)?parsed:[];
+    }else{
+      conduits=getConduits();
+    }
+  }catch(e){ console.warn('loadConduits: conduitSchedule read failed', e); }
   const flattened=[];
   ductbanks=ductbanks.map(db=>{
     (db.conduits||[]).forEach(c=>{


### PR DESCRIPTION
### Motivation
- The `loadConduits()` fallback was reading scenario-prefixed storage via `getDuctbanks()` / `getConduits()`, which can return `base:*` settings data that does not match the visible project schedule and can silently corrupt routing inputs. 
- The change restores the original intent to prefer the project-mapped unprefixed schedule keys so routing uses the same schedule the UI displays.

### Description
- Updated `loadConduits()` in `site.js` to first read the unprefixed `ductbankSchedule` and `conduitSchedule` keys from `localStorage` and parse them when present. 
- If those unprefixed keys are absent, the function falls back to `getDuctbanks()` / `getConduits()` as before, preserving existing scenario-aware behavior. 
- Kept the existing cache check path and the downstream flattening logic that maps ductbank conduits into the `conduits` array.

### Testing
- Ran `npm test` and the automated test suite completed successfully. 
- Ran `npm run build` and the build completed successfully (Rollup unresolved-dependency warnings remain unchanged). 
- Attempted to capture a UI preview with Playwright but `npx playwright install` failed due to browser download (HTTP 403), so no screenshot could be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0ebb2f688324a3b6c74be07070d6)