### PR TITLE
Restore cable CSV weight field for safe pull checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ All coordinates are in **feet**. Inside width and tray depth are in **inches**. 
 Cables can be imported with these column headers:
 
 ```
-tag,from_tag,to_tag,cable_type,conductors,conductor_size,cable_od,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
+tag,from_tag,to_tag,cable_type,conductors,conductor_size,cable_od,weight,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
 ```
 
 Start and end coordinates use **feet**. Cable OD is in **inches**. See `examples/cables_template.csv` for a template.

--- a/app.mjs
+++ b/app.mjs
@@ -348,6 +348,7 @@ async function initializeApp() {
         ['to_tag','end_tag'],
         'cable_type','conductors','conductor_size',
         ['cable_od','diameter'],
+        ['weight','weight_lb_ft'],
         'allowed_cable_group','start_x','start_y','start_z','end_x','end_y','end_z'
     ];
 
@@ -2762,6 +2763,7 @@ const openDuctbankRoute = (dbId, conduitId) => {
                     c.conductors !== undefined ? c.conductors : '',
                     c.conductor_size || '',
                     c.diameter !== undefined ? c.diameter : '',
+                    c.weight !== undefined ? c.weight : '',
                     c.allowed_cable_group || '',
                     c.start[0], c.start[1], c.start[2],
                     c.end[0], c.end[1], c.end[2]
@@ -2790,7 +2792,7 @@ const openDuctbankRoute = (dbId, conduitId) => {
                 conductors:parseInt(t.conductors)||0,
                 conductor_size:t.conductor_size||'#12 AWG',
                 diameter:parseFloat(t.cable_od||t.diameter)||0,
-                weight:parseFloat(t.weight)||0,
+                weight:parseFloat(t.weight||t.weight_lb_ft)||0,
                 allowed_cable_group:t.allowed_cable_group||'',
                 start:[parseFloat(t.start_x)||0,parseFloat(t.start_y)||0,parseFloat(t.start_z)||0],
                 end:[parseFloat(t.end_x)||0,parseFloat(t.end_y)||0,parseFloat(t.end_z)||0],

--- a/examples/cables_template.csv
+++ b/examples/cables_template.csv
@@ -1,3 +1,3 @@
-tag,from_tag,to_tag,cable_type,conductors,conductor_size,cable_od,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
-CABLE-1,START1,END1,Power,3,500 kcmil,1.5,HV,0,0,0,40,0,0
-CABLE-2,START2,END2,Control,2,#12 AWG,0.5,LV,0,0,10,40,0,10
+tag,from_tag,to_tag,cable_type,conductors,conductor_size,cable_od,weight,allowed_cable_group,start_x,start_y,start_z,end_x,end_y,end_z
+CABLE-1,START1,END1,Power,3,500 kcmil,1.5,1.20,HV,0,0,0,40,0,0
+CABLE-2,START2,END2,Control,2,#12 AWG,0.5,0.25,LV,0,0,10,40,0,10


### PR DESCRIPTION
### Motivation
- A prior change removed the `weight` column from the canonical cable CSV format causing imports to set `weight` to `0` and thereby silently suppress pull-tension/sidewall-pressure checks.
- The goal is to restore the weight field to prevent data loss on export/import round trips and to keep routing safety calculations meaningful.

### Description
- Reintroduced `['weight','weight_lb_ft']` into `cableTemplateHeaders` so `weight` is part of the canonical import/export schema in `app.mjs`.
- Updated CSV export in `app.mjs` to include `c.weight` so exported files preserve cable weight for re-imports.
- Made import robust by accepting either `weight` or `weight_lb_ft` with `weight: parseFloat(t.weight||t.weight_lb_ft)||0` to preserve backward compatibility.
- Synchronized user-facing docs and templates by restoring the `weight` column in `README.md` and `examples/cables_template.csv` with sample values.

### Testing
- Ran `npm test` and the full test suite completed successfully (all tests passed).
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a preview screenshot with `npx playwright screenshot` but browser binaries could not be downloaded in this environment (Playwright install failed with a 403), so a runtime page preview image could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0ebba6708324a475fcdddf588594)