### PR TITLE
Validate persisted diagram scale before use

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -2201,7 +2201,21 @@ let connectSource = null;
 let tempConnection = null;
 let hoverPort = null;
 let selectedConnection = null;
-let diagramScale = getItem('diagramScale', { unitPerPx: 1, unit: 'in' });
+const DEFAULT_DIAGRAM_SCALE = Object.freeze({ unitPerPx: 1, unit: 'in' });
+const MIN_DIAGRAM_UNIT_PER_PX = 1e-6;
+const MAX_DIAGRAM_UNIT_PER_PX = 1e6;
+
+function normalizeDiagramScale(rawScale) {
+  const fallback = { ...DEFAULT_DIAGRAM_SCALE };
+  if (!rawScale || typeof rawScale !== 'object' || Array.isArray(rawScale)) return fallback;
+  const unitPerPx = Number(rawScale.unitPerPx);
+  if (!Number.isFinite(unitPerPx) || unitPerPx <= 0) return fallback;
+  const clampedUnitPerPx = Math.min(Math.max(unitPerPx, MIN_DIAGRAM_UNIT_PER_PX), MAX_DIAGRAM_UNIT_PER_PX);
+  const unit = typeof rawScale.unit === 'string' && rawScale.unit.trim() ? rawScale.unit.trim() : fallback.unit;
+  return { unitPerPx: clampedUnitPerPx, unit };
+}
+
+let diagramScale = normalizeDiagramScale(getItem('diagramScale', DEFAULT_DIAGRAM_SCALE));
 const DEFAULT_DIAGRAM_ZOOM = 1;
 const MIN_DIAGRAM_ZOOM = 0.25;
 const MAX_DIAGRAM_ZOOM = 4;
@@ -8234,7 +8248,7 @@ function save(notify = true) {
     connections = [];
   }
   setOneLine({ activeSheet, sheets: sheetData });
-  setItem('diagramScale', diagramScale);
+  setItem('diagramScale', normalizeDiagramScale(diagramScale));
   const issues = validateDiagram();
   if (issues.length === 0) {
     markScheduleReconcilePending();
@@ -14292,7 +14306,7 @@ async function importDiagram(data) {
     switchScenario(data.meta.scenario);
   }
   data = migrateDiagram(data);
-  diagramScale = data.scale || { unitPerPx: 1, unit: 'in' };
+  diagramScale = normalizeDiagramScale(data.scale);
   setItem('diagramScale', diagramScale);
   templates = data.templates || [];
   saveTemplates();


### PR DESCRIPTION
### Motivation
- Prevent crashes and data-integrity issues caused by trusting a persisted `diagramScale` value that can be `null`, non-object, or contain non-finite/negative `unitPerPx` coming from `localStorage` or imported project settings. 
- Malformed scales previously caused `TypeError` in rendering and could produce negative/invalid cable lengths that corrupt schedules. 
- Introduce a minimal, defensive validation layer so persisted/imported scale values cannot silently break rendering or downstream calculations.

### Description
- Add `normalizeDiagramScale(rawScale)` in `oneline.js` to validate the shape and numeric bounds and to return a safe fallback when invalid. 
- Enforce small/large bounds for `unitPerPx` (`MIN_DIAGRAM_UNIT_PER_PX` and `MAX_DIAGRAM_UNIT_PER_PX`) and canonicalize `unit` to a non-empty string. 
- Sanitize `diagramScale` at initialization, before persisting on save, and after importing diagrams so only validated values are written back to storage and used by renderer/sync code.

### Testing
- Ran the full unit test suite with `npm test`, which completed successfully. 
- Built the distribution with `npm run build`, which completed successfully. 
- Attempted an automated Playwright preview screenshot, but browser binaries could not be downloaded in the current environment (Playwright install failed with remote download `403`), so a headless-rendered preview could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0ebb84a88324a338eb180687dd37)