### PR TITLE
fix: remove URL-triggered storage reset from e2e helper

### DIFF
--- a/e2e-helpers.js
+++ b/e2e-helpers.js
@@ -2,13 +2,8 @@ export const E2E = new URLSearchParams(location.search).get('e2e') === '1';
 
 export function suppressResumeIfE2E() {
   if (!E2E) return;
-  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
-  const qs = new URLSearchParams(location.search);
-  const shouldClear = qs.has('e2e_reset');
-  if (shouldClear) {
-    try { localStorage.clear(); sessionStorage.clear(); } catch {}
-  }
-  // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
+  // Never clear browser storage from URL-controlled E2E flags.
+  // Let tests control resume behavior via the modal buttons only.
 }
 
 // Show resume modal in E2E so tests can click the No button


### PR DESCRIPTION
### Motivation
- Prevent client-side data loss by removing URL-controlled storage-clearing behavior that allowed `?e2e`/`?e2e_reset` links to wipe same-origin `localStorage`/`sessionStorage` during normal page loads.

### Description
- Modify `e2e-helpers.js` to remove the storage-clearing path from `suppressResumeIfE2E()` while preserving E2E resume-modal orchestration (`forceShowResumeIfE2E` and `markReady`) so tests can still interact with the resume UI without destructive side effects.

### Testing
- Ran `npm test` (all tests passed) and `npm run build` (build succeeded); attempted `npx playwright screenshot` to produce a preview image but the Playwright browser binaries are not installed in this environment so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a20b09c048324aff2ee7a8d6bee46)