### PR TITLE
Fix URL-triggered storage wipe in one-line E2E helper

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -45,12 +45,7 @@ function setReadyWhen(selector, attrName, id, timeoutMs = 25000) {
 
 function suppressResumeIfE2E() {
   if (!E2E) return;
-  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
-  const qs = new URLSearchParams(location.search);
-  const shouldClear = qs.has('e2e_reset');
-  if (shouldClear) {
-    try { localStorage.clear(); sessionStorage.clear(); } catch {}
-  }
+  // Never clear user storage from URL-controlled flags on production pages.
   // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 


### PR DESCRIPTION
### Motivation
- The one-line startup path invoked an E2E helper that used a URL query flag to call `localStorage.clear()` and `sessionStorage.clear()`, allowing an attacker-supplied `?e2e`/`?e2e_reset` link to wipe same-origin auth/project data. 
- The intent of this change is to remove any URL-controlled global storage-clear behavior from production pages while keeping E2E-only UI signaling for tests.

### Description
- Removed the URL-driven storage-clearing behavior from `suppressResumeIfE2E()` in `oneline.js` so production startup will not call `localStorage.clear()` or `sessionStorage.clear()`.
- Preserved E2E gating for resume modal behavior and left tests able to opt into explicit actions via test-only flows rather than automatic origin-wide clears.
- Change is minimal and scoped to the inline E2E helpers in `oneline.js` to avoid affecting other storage or persistence APIs.

### Testing
- Ran `npm test` and the full test suite completed successfully with no regressions reported. 
- Ran `npm run build` and the production build completed successfully. 
- Attempted an automated Playwright page screenshot to produce a preview image but browser binary installation failed in this environment (download blocked), so no screenshot was generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a225bd4988324b9241b6148a824b8)