### PR TITLE
Normalize load 'watts' into 'kw' during load migration

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -631,6 +631,11 @@ function ensureLoadFields(load) {
     l.kw = l.power;
     delete l.power;
   }
+  const hasKw = typeof l.kw === 'string' ? l.kw.trim() !== '' : l.kw != null && l.kw !== '';
+  if ('watts' in l && !hasKw) {
+    const watts = Number.parseFloat(l.watts);
+    if (!Number.isNaN(watts)) l.kw = watts / 1000;
+  }
   return {
     id: '',
     ref: '',


### PR DESCRIPTION
### Motivation
- Recent component defaults provide static loads with a `watts` field while downstream schedules and reports read `kw`, so newly created Non-Motor Loads were silently counted as 0 kW and caused under-reporting in totals and exports.

### Description
- Add a normalization step in `ensureLoadFields` (`dataStore.mjs`) that, when `kw` is missing/blank, converts `watts` -> `kw` by dividing by 1000 and preserves the existing legacy `power -> kw` migration and any explicit `kw` values.

### Testing
- Ran `npm test` (full suite) and `npm run build`, both completed successfully; an automated Playwright headless screenshot attempt to produce a preview failed because the environment could not download the Chromium browser (HTTP 403), so no preview image was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a23925838832497eba7cd4eb49f64)