### PR TITLE
Fix hidden motor arc-flash gap field

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -9010,7 +9010,7 @@ function selectComponent(compOrId) {
 
     if (targetComp.subtype === 'motor_load' || targetComp.subtype === 'motor') {
       schema = schema.filter(
-        f => !['conductor_type', 'cable_assembly', 'breaker_frame', 'conductor_assembly', 'gap'].includes(f.name)
+        f => !['conductor_type', 'cable_assembly', 'breaker_frame', 'conductor_assembly'].includes(f.name)
       );
     }
 
@@ -9150,7 +9150,7 @@ function selectComponent(compOrId) {
 
       if (targetComp.subtype === 'motor_load' || targetComp.subtype === 'motor') {
         baseFields = baseFields.filter(
-          f => !['gap', 'conductor_type', 'cable_assembly', 'breaker_frame', 'conductor_assembly'].includes(f.name)
+          f => !['conductor_type', 'cable_assembly', 'breaker_frame', 'conductor_assembly'].includes(f.name)
         );
       }
 


### PR DESCRIPTION
### Motivation
- Motor and motor_load components had the `gap` property removed from the property editor while the arc‑flash engine continued to read `comp.gap`, allowing persisted or imported hidden values to silently affect safety‑critical calculations.
- Restore UI control and visibility of the electrode gap so users can inspect and correct `gap` values that are consumed by arc‑flash analysis.

### Description
- Adjusted the one-line property editor in `oneline.js` to stop filtering out the `gap` field for `motor` and `motor_load` components, preserving existing conductor-related filters.
- No changes were made to the arc‑flash calculation logic; the fix only restores the editable form fields so the engine's use of `comp.gap` is visible and user‑editable.

### Testing
- Ran `npm test` and the full test suite completed successfully (including arc‑flash tests). 
- Ran `npm run build` and the build completed successfully (Rollup emitted unrelated externalization warnings). 
- Attempted to generate a UI preview screenshot via Playwright, but browser binaries could not be installed in this environment (Chromium download failed with HTTP 403), so a preview image could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a23920a908324be3e3375c126873a)