### PR TITLE
Restore slack percentage in automatic cable length calculations

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13328,7 +13328,9 @@ function buildCableSpecFromComponent(comp, allComps) {
   spec.phases = phases.length ? phases.join(',') : formatCablePhases(cable);
   spec.conductors = outbound?.conductors || cable.conductors || '';
   const unitPerPx = diagramScale.unitPerPx || 1;
-  const autoLen = (outbound?.length || 0) * unitPerPx;
+  const slackPctRaw = parseFloat(cable.slack_pct);
+  const slackMultiplier = Number.isFinite(slackPctRaw) ? (1 + (slackPctRaw / 100)) : 1;
+  const autoLen = (outbound?.length || 0) * unitPerPx * slackMultiplier;
   let finalLen = autoLen;
   if (cable.manual_length) {
     const manual = parseFloat(cable.length);


### PR DESCRIPTION
### Motivation
- Reintroduce legacy behavior where `slack_pct` increases auto-calculated cable lengths so existing/imported projects keep their intended installation slack. 
- Prevent integrity regressions in voltage-drop and conductor sizing that arise when slack is silently ignored for non-manual lengths.

### Description
- Parse `cable.slack_pct` and compute a `slackMultiplier` in `buildCableSpecFromComponent` inside `oneline.js`.
- Apply `slackMultiplier` to the routed auto-length calculation (`autoLen`) before `finalLen` is determined.
- Preserve existing manual override behavior: `manual_length` still takes precedence and remains unchanged.
- The change is minimal and localized to `oneline.js` to restore prior length semantics without altering downstream sizing APIs.

### Testing
- Ran the full automated test suite with `npm test`, and it completed successfully.
- Performed a production build with `npm run build`, and it completed successfully.
- Attempted to capture an oneline page preview via Playwright; `npx playwright install chromium` failed in this environment due to remote browser download (HTTP 403), so a screenshot could not be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a239254608324a9f3518099529e1f)