### PR TITLE
fix: restrict Cable Schedule E2E reset to explicit localhost runs

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -13,9 +13,13 @@ function suppressResumeIfE2E() {
   if (!E2E) return;
   // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
   const qs = new URLSearchParams(location.search);
-  const shouldClear = qs.has('e2e_reset');
-  if (shouldClear) {
-    try { localStorage.clear(); sessionStorage.clear(); } catch {}
+  const shouldClear = qs.get('e2e_reset') === '1';
+  const isLocalE2EHost = /^(localhost|127\.0\.0\.1|\[::1\])$/i.test(location.hostname);
+  if (shouldClear && isLocalE2EHost) {
+    try {
+      localStorage.clear();
+      sessionStorage.clear();
+    } catch {}
   }
   // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }


### PR DESCRIPTION
### Motivation
- The Cable Schedule page previously cleared all origin `localStorage` and `sessionStorage` when the `e2e` flag and the presence of an `e2e_reset` query parameter were detected, allowing crafted production URLs to wipe client-side data and auth state. 
- The change aims to avoid accidental or malicious storage wipes while preserving intentional local E2E reset behavior for test runs.

### Description
- Updated `cableschedule.js` so the reset only fires when `?e2e_reset=1` (explicit value check) rather than mere presence of the parameter. 
- Added a localhost-only gate that restricts actual `localStorage.clear()` / `sessionStorage.clear()` to hosts matching `localhost`, `127.0.0.1`, or `[::1]`. 
- Preserved the existing E2E resume-modal and test flow outside the storage-clear guard; the change is limited to `suppressResumeIfE2E()` in `cableschedule.js`.

### Testing
- Ran `npm test` and the full test suite completed successfully. 
- Ran `npm run build` and the project built successfully. 
- Attempted to capture an automated Playwright screenshot for a preview but `npx playwright install` failed due to browser download restrictions in this environment (download 403), so headless browser verification could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a26a65e288324bd5bb25aa52b8b3d)