### PR TITLE
fix: harden cross-window storage key parsing

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -153,8 +153,10 @@ const crossWindowKeys = new Set([
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
   window.addEventListener('storage', e => {
     if (!e.key) return;
-    const [scenario, key] = e.key.split(':');
-    if (!key || scenario !== getCurrentScenarioNameState()) return;
+    const scenarioPrefix = `${getCurrentScenarioNameState()}:`;
+    if (!e.key.startsWith(scenarioPrefix)) return;
+    const key = e.key.slice(scenarioPrefix.length);
+    if (!key || key.includes(':')) return;
     if (!crossWindowKeys.has(key)) return;
     try {
       const val = e.newValue ? JSON.parse(e.newValue) : undefined;


### PR DESCRIPTION
### Motivation
- Prevent delimiter-confusion in cross-window `storage` event parsing that could allow crafted multi-colon keys to be misclassified as trusted scenario events and corrupt another tab's data.

### Description
- Replace the naive `e.key.split(':')` parsing with a strict scenario-prefix check using `getCurrentScenarioNameState()`, extract the exact suffix via `e.key.slice(...)`, and reject suffixes containing additional `:` characters so only exact per-scenario keys are accepted; a lightweight preview image was generated at `artifacts/security-fix-preview.ppm`.

### Testing
- Ran `npm test` and `npm run build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b04509d28832484509a1994d829e5)