### PR TITLE
Remove URL-triggered storage reset from cable schedule E2E hook

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -11,16 +11,7 @@ function markReady(flagName) {
 
 function suppressResumeIfE2E() {
   if (!E2E) return;
-  // Do NOT clear storage by default; only when ?e2e_reset=1 is present.
-  const qs = new URLSearchParams(location.search);
-  const shouldClear = qs.get('e2e_reset') === '1';
-  const isLocalE2EHost = /^(localhost|127\.0\.0\.1|\[::1\])$/i.test(location.hostname);
-  if (shouldClear && isLocalE2EHost) {
-    try {
-      localStorage.clear();
-      sessionStorage.clear();
-    } catch {}
-  }
+  // Never clear browser storage from URL parameters.
   // Do NOT auto-click resume buttons. Let tests click #resume-no-btn.
 }
 


### PR DESCRIPTION
### Motivation
- The unbundled `cableschedule.js` exposed an E2E-only `?e2e_reset` query parameter that could clear `localStorage`/`sessionStorage` when the page was loaded, creating an attacker-triggerable client-side data-loss/logout vector.

### Description
- Remove the URL-parameter-driven storage clear logic from `suppressResumeIfE2E()` in `cableschedule.js` while keeping the E2E resume-modal visibility behavior and `window.E2E` exposure for tests.

### Testing
- Ran `npm test` and all automated tests passed, and ran `npm run build` which completed successfully (Rollup unresolved-dependency warnings were present but non-fatal); an attempt to produce a Playwright screenshot for a preview image failed because Playwright could not download Chromium in this environment (HTTP 403), so no preview image could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b04524dcc83249ee03ec8bd311ebe)