### PR TITLE
fix: persist cable schedule rows after derived field recalculation

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -2364,16 +2364,17 @@ async function initCableSchedule() {
     },
     onChange:() => {
       const before = tableData ? [...tableData] : [];
-      const data = table.getData();
-      suppressCablesUpdate = true;
-      dataStore.setCables(data); // auto-persist edits
-      suppressCablesUpdate = false;
-      tableData = data;
       markUnsaved();
       applySizingHighlight();
       applyReviewStatusHighlight();
       validateAllRows();
       updateBatchTypicalControls();
+
+      const data = table.getData();
+      suppressCablesUpdate = true;
+      dataStore.setCables(data); // auto-persist edits after recalculating derived fields
+      suppressCablesUpdate = false;
+      tableData = data;
 
       // Register undo/redo entry (skip during undo/redo restoration)
       if (!window.__isUndoRedoOp && window.__undoManager) {


### PR DESCRIPTION
### Motivation
- The auto-persist path was snapshotting `table.getData()` and calling `dataStore.setCables()` before derived sizing/validation fields were recomputed in the DOM, allowing stale or user-tampered calculated fields to be written to storage and included in exports. 
- Persisted cable rows are read by `exportProject()` and report/save flows, so stored stale calculation fields can propagate to cloud saves and schedule exports and affect project data integrity.

### Description
- Reordered the `onChange` handler in `cableschedule.js` so `markUnsaved()`, `applySizingHighlight()`, `applyReviewStatusHighlight()`, `validateAllRows()`, and `updateBatchTypicalControls()` run before taking the persistence snapshot. 
- After recalculation and validation the code now calls `table.getData()` and then `dataStore.setCables(data)` (still wrapped with `suppressCablesUpdate`) so the stored rows reflect the corrected DOM values. 
- Preserved existing undo/redo registration and the `suppressCablesUpdate` semantics so behavior and history remain unchanged. 
- This is a minimal ordering-only change limited to `cableschedule.js` to ensure persisted/exported cable rows match the UI.

### Testing
- Ran the test suite with `npm test` and the automated tests completed successfully. 
- Built the frontend with `npm run build` and the build completed successfully with unrelated Rollup warnings about external modules. 
- Attempted to generate a browser preview screenshot via Playwright (`npx playwright screenshot`), but `npx playwright install chromium` failed due to HTTP 403 when downloading browser binaries so an in-container screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b05a88fc883249827e07807c37a79)