### PR TITLE
Prevent gist token from being serialized into shared project state

### DIFF
--- a/projectStorage.js
+++ b/projectStorage.js
@@ -278,6 +278,7 @@ const DERIVED_SYNC_KEYS = {
   ductbanks: 'ductbankSchedule',
   cableTypicals: 'cableTypicals'
 };
+const NON_EXPORTABLE_SETTING_KEYS = new Set(['gistToken']);
 const UNDO_COALESCE_WINDOW_MS = 200;
 const derivedStorageCache = new Map();
 const mutationCounters = new Map();
@@ -1274,6 +1275,19 @@ export function setProjectKey(key, value, options = {}) {
         try { storage.setItem(key, value); }
         catch (e) { handleStorageWriteError('project save failed', e); }
       }
+    }
+    return;
+  }
+  if (NON_EXPORTABLE_SETTING_KEYS.has(key)) {
+    if (!options.skipLocalStorage) {
+      const storage = getStorage();
+      trySetStorage(storage, key, value);
+    }
+    if (project.settings && Object.prototype.hasOwnProperty.call(project.settings, key)) {
+      const oldProject = cloneProject();
+      delete project.settings[key];
+      pushUndo(oldProject, { coalesceKey: `setProjectKey:${key}`, allowCoalesce: true });
+      persistProject({ changeSet: createChangeSet(['settings:other']), mutationType: `setProjectKey:${key}:redact` });
     }
     return;
   }


### PR DESCRIPTION
### Motivation
- A recent refactor mirrored arbitrary dataStore keys into `project.settings`, causing sensitive keys like the One-Line flow `gistToken` to be included in `CTR_PROJECT_V1` and exported/shared via project links or fallback JSON.
- The intent of this change is to prevent credentials stored for local-only flows from being copied into the unified project export while preserving existing local persistence behavior.

### Description
- Add `NON_EXPORTABLE_SETTING_KEYS` (currently containing `gistToken`) in `projectStorage.js` to identify settings that must never be exported.
- Short-circuit `setProjectKey()` for non-exportable keys so the value is still written to local storage via `trySetStorage()` but is not copied into `project.settings` or the exported project object.
- If a non-exportable key already exists inside `project.settings`, remove it, push an undo snapshot, and immediately persist a redacted project snapshot to purge the secret from persisted project state.
- Only `projectStorage.js` was modified and the change preserves undo behavior and local persistence for the blocked keys.

### Testing
- Ran the full test suite with `npm test`, which completed successfully.
- Built assets with `npm run build`, which completed successfully.
- Attempted to generate a page preview with Playwright (`npx playwright screenshot`), but browser installation failed in this environment (download returned HTTP 403), so a screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b05a8cc5c832498ce91f179d0f349)