### PR TITLE
Fix breaker assignment validation to honor intrinsic load pole count

### DIFF
--- a/src/panelSchedule.js
+++ b/src/panelSchedule.js
@@ -974,13 +974,19 @@ export function assignLoadToBreaker(panelId, loadIndex, breaker) {
     return;
   }
   const blockSize = Number(block.size) && Number(block.size) > 0 ? Number(block.size) : 1;
+  const { breakerPoles: _ignoredBreakerPoles, ...loadWithoutBreakerPoles } = load || {};
+  const intrinsicRequiredPoles = Math.max(1, getLoadPoleCount(loadWithoutBreakerPoles, panel));
+  if (blockSize < intrinsicRequiredPoles) {
+    showAlertModal('Configuration Error', `Cannot assign load: selected breaker is ${blockSize}-pole but load requires ${intrinsicRequiredPoles} poles.`);
+    return;
+  }
   const loadWithBreaker = { ...load, breaker: startCircuit, breakerPoles: blockSize };
   const span = getLoadBreakerSpan(loadWithBreaker, panel, circuitCount);
   if (!span.length) {
     showAlertModal('Configuration Error', 'Unable to assign load: invalid breaker selection.');
     return;
   }
-  const requiredPoles = Math.max(blockSize, getLoadPoleCount(loadWithBreaker, panel));
+  const requiredPoles = Math.max(blockSize, intrinsicRequiredPoles);
   if (circuitCount && span[span.length - 1] > circuitCount) {
     showAlertModal('Configuration Error', `Breaker selection requires ${requiredPoles} spaces on the same side of the panel but exceeds the available circuits.`);
     return;


### PR DESCRIPTION
### Motivation
- Prevent incorrect acceptance of undersized breaker blocks for multi-pole loads by validating against the load's intrinsic pole/phase requirement rather than a mutated `breakerPoles` value.

### Description
- Update `src/panelSchedule.js` so `assignLoadToBreaker` computes `intrinsicRequiredPoles` from the load with `breakerPoles` excluded, rejects when the selected breaker `blockSize` is smaller, and uses `intrinsicRequiredPoles` when deriving `requiredPoles` and messaging.

### Testing
- Ran `npm test` and the full test suite completed successfully.
- Ran `npm run build` and the project built successfully.
- Attempted a Playwright screenshot to produce a UI preview but `npx playwright install` failed due to Chromium download returning HTTP 403, so the visual preview could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b05aaac0c8324a57b0c4af2a2e1f5)