### PR TITLE
Prevent schema-less component props from overwriting internal fields

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -566,7 +566,12 @@ function setNestedComponentValue(comp, path = [], rawValue, type) {
 
 function inferSchemaFromProps(props, path = []) {
   const schema = [];
+  const reservedTopLevelFieldNames = new Set([
+    'id', 'type', 'subtype', 'x', 'y', 'width', 'height', 'rotation', 'flipped', 'label',
+    'ports', 'connections', 'meta', 'svg', 'icon', 'scheduleLinks', 'props'
+  ]);
   Object.entries(props || {}).forEach(([key, value]) => {
+    if (!path.length && reservedTopLevelFieldNames.has(key)) return;
     const currentPath = [...path, key];
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       schema.push(...inferSchemaFromProps(value, currentPath));
@@ -9304,6 +9309,11 @@ function selectComponent(compOrId) {
     };
 
     const applyFieldFromForm = (target, field, formData) => {
+      const reservedTopLevelFieldNames = new Set([
+        'id', 'type', 'subtype', 'x', 'y', 'width', 'height', 'rotation', 'flipped', 'label',
+        'ports', 'connections', 'meta', 'svg', 'icon', 'scheduleLinks', 'props'
+      ]);
+      if (reservedTopLevelFieldNames.has(field.name) && typeof field.setValue !== 'function') return;
       const hasPropKey = !!(
         target
         && target.props


### PR DESCRIPTION
### Motivation
- Imported diagrams can include unknown components whose `props` are attacker-controlled and were being turned into editable form fields, allowing reserved top-level keys like `connections` or `id` to be overwritten and corrupt editor state. 
- The change restores the previous defensive behavior by preventing inferred fields from exposing or writing to internal component fields while preserving nested prop editing where safe.

### Description
- Skip reserved top-level component keys when building a fallback schema by adding a `reservedTopLevelFieldNames` filter inside `inferSchemaFromProps` so keys like `connections`, `id`, `x`, and `type` are not turned into top-level editable fields. 
- Add a defensive guard in `applyFieldFromForm` that ignores form writes to reserved top-level field names when there is no explicit `setValue` handler, preventing direct assignment to internal component properties.

### Testing
- Ran the test suite with `npm test` and it passed successfully. 
- Built the distribution with `npm run build` and the build completed successfully. 
- Attempted a Playwright screenshot (`npx playwright screenshot ...`) but it failed because Playwright browser binaries are not installed in this environment, so browser-based verification was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0bb65aac83248d1caeeb5e48082a)