### PR TITLE
Fix missing-project load state reset regression

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -767,9 +767,8 @@ export function loadProject(projectId, scenario = getCurrentScenarioNameState())
   if (!projectId) return false;
   try {
     const rawPayload = readSavedProject(projectId);
-    if (!rawPayload) return false;
     const payload = rawPayload || {};
-    const migrated = wasSavedProjectMigrated(projectId);
+    const migrated = rawPayload ? wasSavedProjectMigrated(projectId) : false;
     const equipment = payload.equipment;
     const panels = payload.panels;
     const loads = payload.loads;
@@ -799,7 +798,7 @@ export function loadProject(projectId, scenario = getCurrentScenarioNameState())
       setOneLine(oneLine || { activeSheet: 0, sheets: [] }, scenario);
     }
     if (migrated) saveProject(projectId, scenario);
-    return true;
+    return !!rawPayload;
   } catch (e) {
     console.error('Failed to load project', e);
     return false;


### PR DESCRIPTION
### Motivation
- A recent change made `loadProject` return early when a saved project record was missing, which prevented the code paths that clear in-memory project sections from running and allowed stale data to be saved under newly selected or attacker-chosen project IDs, breaking project isolation.

### Description
- Restored the missing-project reset behavior in `dataStore.mjs` so section setters run even when `readSavedProject` returns null, preventing stale state from leaking into a new project context.
- Guarded migration persistence by computing `migrated` only when a real saved payload exists (`migrated = rawPayload ? wasSavedProjectMigrated(projectId) : false`).
- Preserved the function return contract by returning `!!rawPayload` so callers can still detect "project not found" while state is safely reset.

### Testing
- Ran `npm test`, and the test suite completed successfully (all automated tests passed).
- Ran `npm run build`, and the build completed successfully.
- Attempted automated Playwright screenshot/install to produce a preview image, but Playwright browser installation failed due to remote CDN download returning HTTP 403, so a preview screenshot could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0bb8342c832486ec1fddcf860e48)