### PR TITLE
Limit one-line view attribute options to prevent menu DoS

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -300,6 +300,8 @@ const compWidth = 80;
 const compHeight = 40;
 const attributeLineHeight = 12;
 const viewAttributeStorageKey = 'diagramViewAttributes';
+const maxViewAttributeCount = 250;
+const maxViewAttributeLength = 128;
 const defaultPaletteWidth = 250;
 const minPaletteWidth = 100;
 const maxPaletteWidth = 600;
@@ -431,10 +433,38 @@ const studyAttributeResolvers = {
   }
 };
 
+function sanitizeViewAttributeKey(key) {
+  if (typeof key !== 'string') return '';
+  const normalized = key.trim();
+  if (!normalized || normalized.length > maxViewAttributeLength) return '';
+  return normalized;
+}
+
+function sanitizeViewAttributeList(keys) {
+  if (!Array.isArray(keys)) return [];
+  const seen = new Set();
+  const normalized = [];
+  for (const key of keys) {
+    const safeKey = sanitizeViewAttributeKey(key);
+    if (!safeKey || seen.has(safeKey)) continue;
+    seen.add(safeKey);
+    normalized.push(safeKey);
+    if (normalized.length >= maxViewAttributeCount) break;
+  }
+  normalized.sort();
+  return normalized;
+}
+
 const storedViewAttributes = getItem(viewAttributeStorageKey, []);
-const initialViewAttributes = Array.isArray(storedViewAttributes)
-  ? storedViewAttributes.filter(key => typeof key === 'string' && key.trim())
-  : [];
+const initialViewAttributes = sanitizeViewAttributeList(storedViewAttributes);
+if (Array.isArray(storedViewAttributes)) {
+  const needsPersistedCleanup =
+    storedViewAttributes.length !== initialViewAttributes.length ||
+    storedViewAttributes.some((key, idx) => key !== initialViewAttributes[idx]);
+  if (needsPersistedCleanup) {
+    setItem(viewAttributeStorageKey, initialViewAttributes);
+  }
+}
 let viewAttributes = new Set(initialViewAttributes);
 let attributeOptions = [];
 const attributeOptionsMap = new Map();
@@ -4354,8 +4384,8 @@ function openViewModal() {
         } else {
           viewAttributes.delete(option.key);
         }
-        const persisted = Array.from(viewAttributes);
-        persisted.sort();
+        const persisted = sanitizeViewAttributeList(Array.from(viewAttributes));
+        viewAttributes = new Set(persisted);
         setItem(viewAttributeStorageKey, persisted);
         updateViewButtonLabel();
         render();
@@ -4714,7 +4744,8 @@ function refreshAttributeOptions() {
   const registerOption = key => {
     if (!key) return null;
     if (attributeIgnoreKeys.has(key)) return null;
-    const normalized = String(key);
+    const normalized = sanitizeViewAttributeKey(key);
+    if (!normalized) return null;
     if (optionMap.has(normalized)) return optionMap.get(normalized);
     const override = attributeDisplayOverrides[normalized];
     const label = override?.label || formatAttributeLabel(normalized);
@@ -4838,6 +4869,7 @@ function refreshAttributeOptions() {
     registerStudyAttributes('reliability', mapped);
   }
 
+  viewAttributes = new Set(sanitizeViewAttributeList(Array.from(viewAttributes)));
   viewAttributes.forEach(key => registerOption(key));
 
   attributeOptions = Array.from(optionMap.values()).sort((a, b) => a.label.localeCompare(b.label));


### PR DESCRIPTION
### Motivation
- The one-line attribute view previously trusted persisted `diagramViewAttributes` and unbounded primitive component keys which could be crafted to cause excessive DOM creation and a client-side denial-of-service when the one-line page loads. 
- The change aims to harden the UI by bounding and sanitizing persisted attribute names so large or oversized attacker-controlled lists cannot exhaust browser resources while preserving normal feature behavior.

### Description
- Added `maxViewAttributeCount` (250) and `maxViewAttributeLength` (128) and implemented `sanitizeViewAttributeKey` and `sanitizeViewAttributeList` to normalize, deduplicate, and cap persisted keys. 
- Pruned and rewritten persisted `diagramViewAttributes` on load when the stored list exceeds the bounds or contains invalid entries so storage is self-healing. 
- Re-sanitized the `viewAttributes` set before persisting on user toggles and before registering options so runtime-selected attributes cannot bypass limits, and updated `registerOption`/`refreshAttributeOptions` to ignore invalid/oversized keys. 
- Changes are intentionally minimal and localized to `oneline.js` so existing import/storage flows and UI behaviors remain unchanged for normal data.

### Testing
- Ran the full automated test suite with `npm test` and all tests completed successfully. 
- Built the distribution with `npm run build` and the build completed successfully. 
- Attempted to capture a preview image by installing Playwright browsers, but the environment failed to download Chromium (CDN returned 403), so a runtime screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0cf614548324985b752ab914e6d2)