### PR TITLE
Clamp imported custom component bounds to prevent DoS payloads

### DIFF
--- a/custom-components.js
+++ b/custom-components.js
@@ -63,6 +63,20 @@ const MIN_COMPONENT_WIDTH = Number(widthInput?.min) || 20;
 const MAX_COMPONENT_WIDTH = Number(widthInput?.max) || 600;
 const MIN_COMPONENT_HEIGHT = Number(heightInput?.min) || 20;
 const MAX_COMPONENT_HEIGHT = Number(heightInput?.max) || 400;
+const MAX_PORTS_PER_SIDE = Math.max(
+  0,
+  Number(portTopInput?.max) || Number(portRightInput?.max) || Number(portBottomInput?.max) || Number(portLeftInput?.max) || 12
+);
+const ALLOWED_CATEGORIES = new Set([
+  'equipment',
+  'sources',
+  'protection',
+  'load',
+  'bus',
+  'cable',
+  'links',
+  'annotations'
+]);
 let iconCanvasSize = { width: ICON_CANVAS_SIZE, height: ICON_CANVAS_SIZE };
 
 let textStyleState = {
@@ -1112,6 +1126,11 @@ function sanitizeNumber(input, fallback) {
   return Number.isFinite(value) ? value : fallback;
 }
 
+function sanitizePortCount(input) {
+  const total = Math.max(0, Math.floor(Number(input) || 0));
+  return Math.min(total, MAX_PORTS_PER_SIDE);
+}
+
 function clearPropertyRows() {
   propertyList.innerHTML = '';
 }
@@ -1473,10 +1492,17 @@ function normalizeImportedComponent(raw) {
   const type = String(raw.type || raw.category || '').trim() || 'equipment';
   if (!subtype) return null;
   const label = String(raw.label || subtype);
-  const category = String(raw.category || '').trim() || type;
-  const width = sanitizeNumber(raw.width, 80);
-  const height = sanitizeNumber(raw.height, 40);
-  const counts = raw.portCounts || inferPortCounts(raw.ports || [], width, height);
+  const rawCategory = String(raw.category || '').trim().toLowerCase();
+  const category = ALLOWED_CATEGORIES.has(rawCategory) ? rawCategory : categorySelect?.value || 'equipment';
+  const width = Math.min(Math.max(sanitizeNumber(raw.width, DEFAULT_COMPONENT_WIDTH), MIN_COMPONENT_WIDTH), MAX_COMPONENT_WIDTH);
+  const height = Math.min(Math.max(sanitizeNumber(raw.height, DEFAULT_COMPONENT_HEIGHT), MIN_COMPONENT_HEIGHT), MAX_COMPONENT_HEIGHT);
+  const importedCounts = raw.portCounts || inferPortCounts(raw.ports || [], width, height);
+  const counts = {
+    top: sanitizePortCount(importedCounts.top),
+    right: sanitizePortCount(importedCounts.right),
+    bottom: sanitizePortCount(importedCounts.bottom),
+    left: sanitizePortCount(importedCounts.left)
+  };
   const defaultRotation = normalizeRotationValue(raw.defaultRotation);
   const props = raw.props && typeof raw.props === 'object' ? raw.props : {};
   const properties = Array.isArray(raw.properties)

--- a/oneline.js
+++ b/oneline.js
@@ -501,6 +501,17 @@ function categoryForType(t) {
   }
 }
 
+const PALETTE_CATEGORIES = new Set([
+  'equipment',
+  'sources',
+  'protection',
+  'load',
+  'bus',
+  'cable',
+  'links',
+  'annotations'
+]);
+
 function isProtectionComponent(comp) {
   if (!comp || typeof comp !== 'object') return false;
   const subtypeMeta = componentMeta[comp.subtype];
@@ -1632,7 +1643,10 @@ async function loadComponentLibrary() {
       }
     }
     const resolvedType = definition.type || baseType;
-    const category = definition.category || categoryForType(resolvedType);
+    const requestedCategory = typeof definition.category === 'string' ? definition.category.trim().toLowerCase() : '';
+    const category = PALETTE_CATEGORIES.has(requestedCategory)
+      ? requestedCategory
+      : categoryForType(resolvedType);
     const icon = resolveIconSource(definition.icon, definition.symbol);
     const ports = normalizePortsForCategory(category, definition.ports, resolvedType, subtype);
     const defaultRotation = normalizeRotation(


### PR DESCRIPTION
### Motivation
- The custom component import path trusted attacker-controlled `portCounts`, `width`/`height`, and `category` values which could cause unbounded port materialization and persistent malformed categories that degrade availability.  
- The UI already enforces sensible bounds for dimensions, ports, and a finite set of palette categories; imports must respect the same invariants.  
- Make a minimal, targeted fix that prevents large-memory or infinite-loop allocations while preserving valid import behavior.

### Description
- In `custom-components.js` add import-time guards: define `MAX_PORTS_PER_SIDE` and `ALLOWED_CATEGORIES`, add `sanitizePortCount()` and clamp imported `width`/`height` to the UI `MIN`/`MAX` bounds.  
- Update `normalizeImportedComponent()` to whitelist `category`, clamp dimensions, and cap each side's `portCounts` before calling `buildPorts()` so attacker-controlled counts cannot trigger huge loops/allocations.  
- In `oneline.js` add `PALETTE_CATEGORIES` and coerce/validate incoming definition categories during `registerDefinition()` so stored/legacy malformed definitions cannot create arbitrary palette categories.  
- The change is intentionally minimal and keeps existing component shape/serialization but enforces the UI's same limits at import/load time.

### Testing
- Ran the full test suite with `npm test` and the suite completed successfully (all automated tests passed).  
- Ran `npm run build` and the build completed successfully (non-fatal Rollup warnings unrelated to the fix were present).  
- Attempted an automated Playwright page screenshot to produce a preview but the environment failed to download Chromium (`npx playwright install chromium` returned HTTP 403), so an in-repo browser preview could not be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0cf5f57083249a84d01c067ac885)