### PR TITLE
Harden one-line study attribute resolution

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -417,12 +417,10 @@ let cachedStudyResults = getStudies();
 const studyAttributeResolvers = {
   arcFlash: comp => {
     if (!comp) return null;
-    if (comp.arcFlash && typeof comp.arcFlash === 'object') return comp.arcFlash;
     return cachedStudyResults?.arcFlash?.[comp.id] || null;
   },
   shortCircuit: comp => {
     if (!comp) return null;
-    if (comp.shortCircuit && typeof comp.shortCircuit === 'object') return comp.shortCircuit;
     return cachedStudyResults?.shortCircuit?.[comp.id] || null;
   },
   reliability: comp => {
@@ -4218,19 +4216,19 @@ function resolveComponentAttribute(comp, key) {
     return value;
   }
   const segments = key.split('.');
+  const resolver = studyAttributeResolvers[segments[0]];
+  if (resolver) {
+    const base = resolver(comp);
+    if (base && typeof base === 'object') {
+      const studyValue = getNestedValue(base, segments.slice(1));
+      if (studyValue !== undefined) return studyValue;
+    }
+  }
   let value = getNestedValue(comp, segments);
   if (value !== undefined) return value;
   if (comp.props && typeof comp.props === 'object') {
     value = getNestedValue(comp.props, segments);
     if (value !== undefined) return value;
-  }
-  const resolver = studyAttributeResolvers[segments[0]];
-  if (resolver) {
-    const base = resolver(comp);
-    if (base && typeof base === 'object') {
-      value = getNestedValue(base, segments.slice(1));
-      if (value !== undefined) return value;
-    }
   }
   return undefined;
 }


### PR DESCRIPTION
### Motivation
- Prevent imported or stale component-embedded `arcFlash.*` and `shortCircuit.*` fields from overriding computed study results shown on one-line diagrams to protect integrity of safety-relevant labels.

### Description
- Change `studyAttributeResolvers` to read authoritative values from `studyResults` (`getStudies()`) and stop trusting component-embedded `arcFlash`/`shortCircuit` objects; and reorder dotted-key resolution so study namespaces (e.g. `arcFlash.*`, `shortCircuit.*`, `reliability.*`) are resolved from cached study results before falling back to component/`props` nested fields.

### Testing
- Ran the full test suite with `npm test` and the build with `npm run build`, both completed successfully; an attempt to capture a browser preview with Playwright failed due to inability to download Chromium in this environment (Playwright binary download returned 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0cf9ebdc83248e8ccb9757ed2a85)