### PR TITLE
Fix transformer-prefault voltage inheritance by connection port

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -664,7 +664,15 @@ function computePrefaultKV(comp, comps, compMap, cache, visited = new Set()) {
   }
   const parent = findParentInfo(comp, comps, compMap, visited);
   if (parent?.component) {
-    const upstreamKV = computePrefaultKV(parent.component, comps, compMap, cache, visited);
+    const { component: upstream, connection, reversed } = parent;
+    let upstreamKV;
+    if (upstream.type === 'transformer' && connection) {
+      const portIndex = normalizePortIndex(reversed ? connection?.targetPort : connection?.sourcePort);
+      upstreamKV = toKV(getTransformerVoltageForPort(upstream, portIndex));
+    }
+    if (!upstreamKV) {
+      upstreamKV = computePrefaultKV(upstream, comps, compMap, cache, visited);
+    }
     cache.set(comp.id, upstreamKV);
     visited.delete(comp.id);
     return upstreamKV;


### PR DESCRIPTION
### Motivation
- Fix a logic error where a downstream bus or load without an explicit voltage could inherit a transformer's primary-side voltage regardless of which transformer port it was connected to, producing incorrect short-circuit and arc‑flash results.

### Description
- Change `computePrefaultKV` in `analysis/shortCircuit.mjs` to, when the upstream component is a transformer, resolve the prefault voltage using the actual connection port (`sourcePort`/`targetPort`, accounting for `reversed`) via `getTransformerVoltageForPort(portIndex)`, and only fall back to recursive `computePrefaultKV` when a port-specific voltage is not available.

### Testing
- Ran `npm test` (full test suite) which completed successfully and ran `npm run build` which produced the dist bundle; an attempted Playwright screenshot failed because `npx playwright install` could not download Chromium (HTTP 403) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0cf5f4e88324be7d2720285adbcb)