### PR TITLE
Recompute study results for harmonics and motor-start charts

### DIFF
--- a/analysis/harmonics.js
+++ b/analysis/harmonics.js
@@ -362,9 +362,6 @@ export function frequencyScan({
 
 function ensureHarmonicResults() {
   const studies = getStudies();
-  if (studies?.harmonics && Object.keys(studies.harmonics).length) {
-    return studies.harmonics;
-  }
   const res = runHarmonics();
   studies.harmonics = res;
   setStudies(studies);

--- a/analysis/motorStart.js
+++ b/analysis/motorStart.js
@@ -200,9 +200,6 @@ export function runMotorStart() {
 
 function ensureMotorStartResults() {
   const studies = getStudies();
-  if (studies?.motorStart && Object.keys(studies.motorStart).length) {
-    return studies.motorStart;
-  }
   const res = runMotorStart();
   studies.motorStart = res;
   setStudies(studies);


### PR DESCRIPTION
### Motivation
- The harmonics and motor-start chart pages were trusting any non-empty `studyResults` cache and could skip recomputation, allowing imported or stale `studyResults` to spoof engineering outputs. 
- The change ensures charts always reflect the active one-line model so integrity-sensitive results (THD, motor sag) cannot be replaced by attacker-supplied settings during project import.

### Description
- Removed the cache-hit early-return in `ensureHarmonicResults()` so `runHarmonics()` is always executed and its results are then persisted via `setStudies()`.
- Removed the cache-hit early-return in `ensureMotorStartResults()` so `runMotorStart()` is always executed and its results are then persisted via `setStudies()`.
- Preserved the existing behavior of writing the freshly computed results back to the shared `studyResults` storage key so downstream consumers continue to read the latest computed values.

### Testing
- Ran the full automated test suite via `npm test`, and the run completed successfully (tests passed).
- Built distribution artifacts via `npm run build`, and the build completed successfully.
- Attempted to run a Playwright-driven page preview, but `npx playwright install chromium` failed in this environment due to remote CDN access (HTTP 403), so a browser screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b107cd7248324b85e244292cb3794)