### PR TITLE
Include connector components in reliability calculations

### DIFF
--- a/analysis/reliability.js
+++ b/analysis/reliability.js
@@ -4,20 +4,6 @@ function isVisualComponent(comp) {
   return comp ? VISUAL_TYPES.has(comp.type) : false;
 }
 
-function isConnectorComponent(comp) {
-  if (!comp) return false;
-  const type = (comp.type || '').toLowerCase();
-  if (!type) return false;
-  if (type.includes('link')) return true;
-  if (type.includes('cable')) return true;
-  if (type.includes('feeder')) return true;
-  if (type.includes('conductor')) return true;
-  if (type.includes('tap')) return true;
-  if (type.includes('splice')) return true;
-  return false;
-}
-
-
 function buildAdjacency(components = [], skipIds = new Set()) {
   const adj = new Map();
   components.forEach(c => {
@@ -54,7 +40,7 @@ function findConnected(startIds = [], adj = new Map()) {
 export function runReliability(components = []) {
   // Filter out non-operational components like dimensions or annotations
   const ops = components.filter(c => !isVisualComponent(c));
-  const eligible = ops.filter(c => !isConnectorComponent(c));
+  const eligible = ops;
   // Compute component availability and expected downtime per year
   const componentStats = {};
   const availMap = {};

--- a/tests/reliabilityAnalysis.test.mjs
+++ b/tests/reliabilityAnalysis.test.mjs
@@ -40,24 +40,24 @@ describe('runReliability - component filtering', () => {
     assert.ok(!('dim-1' in result.componentStats));
   });
 
-  it('excludes cable-type connectors from componentStats', () => {
+  it('includes cable-type connectors in componentStats', () => {
     const connectorTypes = ['cable', 'link', 'feeder', 'conductor', 'tap', 'splice'];
     for (const type of connectorTypes) {
       const components = [{ id: `conn-${type}`, type, mtbf: 1000, mttr: 10 }];
       const result = runReliability(components);
-      assert.ok(!(`conn-${type}` in result.componentStats),
-        `Expected ${type} to be excluded from componentStats`);
+      assert.ok((`conn-${type}` in result.componentStats),
+        `Expected ${type} to be included in componentStats`);
     }
   });
 
-  it('excludes connector types with mixed casing', () => {
+  it('includes connector types with mixed casing', () => {
     const components = [
       { id: 'cable-upper', type: 'CABLE', mtbf: 1000, mttr: 10 },
       { id: 'feeder-mixed', type: 'PowerFeeder', mtbf: 1000, mttr: 10 }
     ];
     const result = runReliability(components);
-    assert.ok(!('cable-upper' in result.componentStats));
-    assert.ok(!('feeder-mixed' in result.componentStats));
+    assert.ok('cable-upper' in result.componentStats);
+    assert.ok('feeder-mixed' in result.componentStats);
   });
 
   it('includes bus and breaker components in componentStats', () => {


### PR DESCRIPTION
### Motivation
- The prior change classified many operational parts (cable/feeder/link/etc.) as "connectors" and excluded them from availability, downtime, and N-1/N-2 calculations, which can hide real single-point failures in radial systems. 
- Restore correct reliability behavior by ensuring all non-visual operational components are considered in the analysis so connector-like items are not silently omitted.

### Description
- Removed the broad connector exclusion by deleting the connector classifier and making `eligible` equal to all non-visual operational components in `analysis/reliability.js` so cables/feeders/links are included in `componentStats` and contingency analysis. 
- Kept adjacency/graph logic unchanged so connectors continue to participate in topology while now also contributing their MTBF/MTTR to availability math. 
- Updated `tests/reliabilityAnalysis.test.mjs` to assert that connector-like types (including mixed-case type strings) are included in `componentStats`.

### Testing
- Ran the focused reliability unit tests with `node tests/reliabilityAnalysis.test.mjs`, which passed. 
- Ran `npm run build`, which completed successfully but emitted existing Rollup unresolved-dependency warnings. 
- Ran the full test suite with `npm test`; the suite largely passed but an unrelated existing server security test (`tests/serverSecurity.test.mjs`) failed at the assertion `401 !== 200` (failure unrelated to the reliability changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b10822adc8324b2bc8b8b2911ad77)