### PR TITLE
fix(tcc): avoid selector interpolation for untrusted component UIDs

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -1224,10 +1224,19 @@ function buildAnnotationContextItems(datum) {
   ];
 }
 
+function findSettingsDeviceDiv(uid) {
+  if (!settingsDiv || uid === undefined || uid === null) return null;
+  const expected = String(uid);
+  const nodes = settingsDiv.querySelectorAll('.device-settings[data-uid]');
+  for (const node of nodes) {
+    if (node.dataset.uid === expected) return node;
+  }
+  return null;
+}
+
 function focusDeviceSettings(uid) {
   if (!settingsDiv || !uid) return;
-  const selectorValue = String(uid).replace(/"/g, '\\"');
-  const target = settingsDiv.querySelector(`.device-settings[data-uid="${selectorValue}"]`);
+  const target = findSettingsDeviceDiv(uid);
   if (!target) return;
   target.classList.add('device-settings-highlight');
   const removeHighlight = () => target.classList.remove('device-settings-highlight');
@@ -6733,8 +6742,7 @@ function gatherOverridesFromInputs(uid) {
   if (!settingsDiv) {
     return snapOverridesToOptions(entry.baseDevice, entry.overrideSource || {});
   }
-  const selectorValue = String(uid).replace(/"/g, '\\"');
-  const div = settingsDiv.querySelector(`.device-settings[data-uid="${selectorValue}"]`);
+  const div = findSettingsDeviceDiv(uid);
   if (!div) {
     return snapOverridesToOptions(entry.baseDevice, entry.overrideSource || {});
   }
@@ -7625,7 +7633,7 @@ function plot() {
 
   const updateDeviceInputs = entry => {
     if (!settingsDiv) return;
-    const div = settingsDiv.querySelector(`.device-settings[data-uid="${entry.selection.uid}"]`);
+    const div = findSettingsDeviceDiv(entry.selection.uid);
     if (!div) return;
     Object.entries(entry.overrides).forEach(([field, value]) => {
       const input = div.querySelector(`[data-field="${field}"]`);


### PR DESCRIPTION
### Motivation
- The TCC component catalog began building UIDs from `component.id` and later interpolating those UIDs into CSS attribute selectors, which allows imported component IDs with special characters to produce invalid selectors and throw a `DOMException` (availability impact). 
- The intent is to retain component-backed TCC entries while preventing attacker-controlled text from being used directly in `querySelector()` strings. 

### Description
- Add `findSettingsDeviceDiv(uid)` to `analysis/tcc.js` which locates `.device-settings` elements by inspecting `element.dataset.uid` instead of constructing a CSS selector from raw UID text. 
- Replace three vulnerable `querySelector` lookups in `focusDeviceSettings`, `gatherOverridesFromInputs`, and `updateDeviceInputs` to use `findSettingsDeviceDiv(uid)` so untrusted IDs are never interpolated into selector strings. 
- Preserve existing behavior and DOM focus/scroll logic while removing the selector-interpolation attack surface. 

### Testing
- Ran the automated test suite with `npm test`, which completed and reported passing tests. 
- Built the distribution with `npm run build`, which completed successfully and produced `dist/`. 
- Attempted to capture a page preview with Playwright (`npx playwright screenshot` / `npx playwright install chromium`), but browser installation failed due to CDN download `403` errors, so an automated screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b12499f408324957300bb9e872e4a)