### PR TITLE
Avoid SI double-scaling in TCC numeric parsing

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -9177,16 +9177,9 @@ function parseNumeric(value) {
   const normalized = trimmed.replace(/,/g, '');
   const direct = Number(normalized);
   if (Number.isFinite(direct)) return direct;
-  const match = normalized.match(/^(-?\d+(?:\.\d+)?)(?:\s*([kKmM])(?:[a-zA-Z]*)?)?$/);
+  const match = normalized.match(/^(-?\d+(?:\.\d+)?)(?:\s*[a-zA-Z]+)?$/);
   if (!match) return null;
-  let num = Number(match[1]);
-  const prefix = match[2];
-  if (prefix) {
-    if (prefix === 'k' || prefix === 'K') num *= 1000;
-    else if (prefix === 'M') num *= 1e6;
-    else if (prefix === 'm') num *= 0.001;
-  }
-  return num;
+  return Number(match[1]);
 }
 
 function getNumericValue(comp, keys) {


### PR DESCRIPTION
### Motivation
- A recent change made `parseNumeric` apply SI-prefix multipliers for suffixes like `k`, `M`, or `m`, which caused downstream unit-specific logic (kV→V, kVA/MVA→VA/kVA, kW→W) to double-scale values and silently corrupt TCC overlay calculations for transformers and motors.

### Description
- Remove SI-prefix multiplier behavior from `parseNumeric` in `analysis/tcc.js` so it returns only the numeric magnitude while still accepting an optional trailing alphabetic unit token (e.g. `500kVA`, `13.8kV`) without applying multipliers, preserving existing caller-side unit conversions.

### Testing
- Ran the full test suite with `npm test` and the suite completed successfully (all automated tests passed).
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1248b4888324836d5d813021bb05)