### PR TITLE
Fix omission of motor/static loads from synced load schedules

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13330,7 +13330,7 @@ async function init() {
 }
 
 function getCategory(c) {
-  return c.type || subtypeCategory[c.subtype];
+  return subtypeCategory[c.subtype] || c.type;
 }
 
 function formatLoadFlowCurrentValue(value) {


### PR DESCRIPTION
### Motivation
- Specialized load components using `type` values like `motor_load` and `static_load` were being omitted from synchronized load schedules because `getCategory(c)` returned `c.type` before consulting subtype metadata, so those devices were not recognized as category `load`.

### Description
- Update `getCategory` in `oneline.js` to `return subtypeCategory[c.subtype] || c.type;` so subtype-derived categories (e.g. `load`) are preferred while preserving the persisted `comp.type` value.

### Testing
- Ran the full test suite with `npm test`, which completed successfully.
- Ran the build with `npm run build`, which completed successfully.
- Attempted to capture a UI preview with `npx playwright screenshot` but Playwright browser download failed and `npx playwright install chromium` returned a 403, so the screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b14d7dbfc8324ab55aa0e697e7c4a)