### PR TITLE
Harden load‑flow branch cloning against deep inputs

### DIFF
--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -777,20 +777,70 @@ function isBranchDevice(comp) {
   return false;
 }
 
+const MAX_CLONE_DEPTH = 200;
+const MAX_CLONE_NODES = 10000;
+
 export function cloneData(value) {
   if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) {
-    return value.map(cloneData);
-  }
-  if (typeof value === 'object') {
-    const out = {};
-    Object.keys(value).forEach(key => {
-      const val = value[key];
-      if (val !== undefined) out[key] = cloneData(val);
+  if (typeof value !== 'object') return value;
+
+  const root = Array.isArray(value) ? [] : {};
+  const seen = new WeakMap([[value, root]]);
+  const stack = [{ source: value, target: root, depth: 0 }];
+  let nodesVisited = 1;
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (!frame) continue;
+    if (frame.depth >= MAX_CLONE_DEPTH) {
+      throw new Error('Load-flow input exceeds maximum supported nesting depth.');
+    }
+    if (nodesVisited > MAX_CLONE_NODES) {
+      throw new Error('Load-flow input exceeds maximum supported object size.');
+    }
+
+    if (Array.isArray(frame.source)) {
+      frame.source.forEach(item => {
+        if (item === undefined) return;
+        if (item === null || typeof item !== 'object') {
+          frame.target.push(item);
+          return;
+        }
+        const existing = seen.get(item);
+        if (existing) {
+          frame.target.push(existing);
+          return;
+        }
+        const nextTarget = Array.isArray(item) ? [] : {};
+        frame.target.push(nextTarget);
+        seen.set(item, nextTarget);
+        stack.push({ source: item, target: nextTarget, depth: frame.depth + 1 });
+        nodesVisited += 1;
+      });
+      continue;
+    }
+
+    Object.keys(frame.source).forEach(key => {
+      const item = frame.source[key];
+      if (item === undefined) return;
+      if (item === null || typeof item !== 'object') {
+        frame.target[key] = item;
+        return;
+      }
+      const existing = seen.get(item);
+      if (existing) {
+        frame.target[key] = existing;
+        return;
+      }
+      const nextTarget = Array.isArray(item) ? [] : {};
+      frame.target[key] = nextTarget;
+      seen.set(item, nextTarget);
+      stack.push({ source: item, target: nextTarget, depth: frame.depth + 1 });
+      nodesVisited += 1;
     });
-    return out;
   }
-  return value;
+
+  return root;
 }
 
 function deriveLinearSegmentImpedance(comp) {

--- a/tests/loadflow/cloneDataSafety.test.mjs
+++ b/tests/loadflow/cloneDataSafety.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert';
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  \u2713', name);
+  } catch (err) {
+    console.log('  \u2717', name);
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+const { runLoadFlow } = await import('../../analysis/loadFlow.js');
+
+function buildDeepObject(depth) {
+  let node = { r: 0.01, x: 0.02 };
+  for (let i = 0; i < depth; i += 1) {
+    node = { nested: node };
+  }
+  return node;
+}
+
+describe('Load flow branch clone safety', () => {
+  it('rejects excessively nested branch payloads with a bounded error', () => {
+    const model = {
+      buses: [
+        { id: 'slack', type: 'slack', baseKV: 13.8 },
+        { id: 'load', type: 'PQ', baseKV: 13.8, load: { kw: 100, kvar: 20 } }
+      ],
+      branches: [
+        {
+          id: 'deep-1',
+          from: 'slack',
+          to: 'load',
+          impedance: buildDeepObject(600)
+        }
+      ]
+    };
+
+    assert.throws(
+      () => runLoadFlow(model, { baseMVA: 10, balanced: true }),
+      /maximum supported nesting depth/i
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent a client-side denial-of-service where deeply nested or cyclic branch data causes `RangeError: Maximum call stack size exceeded` during load‑flow processing by the recursive `cloneData` helper. 
- Ensure imported/shared projects and direct `model.branches` payloads cannot exhaust the JS call stack while preserving normal cloning behavior for typical inputs.

### Description
- Replaced the recursive `cloneData` implementation with an iterative, stack-driven cloner in `analysis/loadFlowModel.js` that avoids call‑stack recursion and supports cyclic/shared object graphs via a `WeakMap`.
- Added explicit safety limits (`MAX_CLONE_DEPTH` and `MAX_CLONE_NODES`) and surface errors when inputs exceed those bounds to fail fast and deterministically instead of crashing with a `RangeError`.
- Preserved cloning semantics for primitive, array, and object fields used by the load‑flow model (impedance, tap, shunt, phases) so existing behavior for normal projects is unchanged.
- Added a regression test `tests/loadflow/cloneDataSafety.test.mjs` that constructs a deeply nested branch impedance and asserts the load‑flow path throws a bounded error rather than causing a stack overflow.

### Testing
- Ran the full test suite with `npm test` and the new regression test `tests/loadflow/cloneDataSafety.test.mjs` executed as part of the suite and passed.
- Built the distribution with `npm run build` and the build completed successfully.
- The change is limited to `analysis/loadFlowModel.js` and the new test file `tests/loadflow/cloneDataSafety.test.mjs`, and the fix is covered by automated tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b163ea59483249674b8b7ddbb51fe)