### PR TITLE
Harden motor torque curve parsing against malformed imported arrays

### DIFF
--- a/analysis/motorStart.js
+++ b/analysis/motorStart.js
@@ -13,7 +13,9 @@ function parseTorqueCurve(spec) {
   const pts = [];
   if (Array.isArray(spec)) {
     spec.forEach(p => {
+      if (typeof p !== 'string') return;
       const [s, t] = p.split(':');
+      if (s === undefined || t === undefined) return;
       pts.push({ s: Number(s), t: Number(t) });
     });
   } else if (typeof spec === 'string') {


### PR DESCRIPTION
### Motivation
- Prevent a client-side crash in the Motor Start analysis when imported/shared project JSON supplies malformed `load_torque_curve` arrays (for example `[null]`) that previously caused a `TypeError` by calling `.split(':')` on non-string entries.

### Description
- Add defensive validation in `analysis/motorStart.js` `parseTorqueCurve` to skip non-string array elements and skip array entries that do not contain both `speed:torque` parts, preserving existing behavior for valid curve inputs.

### Testing
- Ran `npm test` and the full test suite passed.
- Ran `npm run build` and the project build completed successfully (only unrelated, non-fatal Rollup warnings were present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b163c7e9c8324b569b1fb3c893362)