### PR TITLE
Mitigate deep nested load parsing stack overflow

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -836,78 +836,106 @@ function deriveReactiveFromPF(kw, record) {
   return kvarMag * sign;
 }
 
+const MAX_PQ_TRAVERSAL_NODES = 20000;
+
 function sumPQ(value) {
   if (value === null || value === undefined) {
     return { kw: 0, kvar: 0 };
   }
-  if (typeof value === 'number') {
-    return { kw: toNumber(value), kvar: 0 };
-  }
-  if (Array.isArray(value)) {
-    return value.reduce((acc, item) => {
-      const { kw, kvar } = sumPQ(item);
-      return { kw: acc.kw + kw, kvar: acc.kvar + kvar };
-    }, { kw: 0, kvar: 0 });
-  }
-  if (typeof value !== 'object') {
-    return { kw: 0, kvar: 0 };
-  }
-  let kw = 0;
-  let kvar = 0;
-  let hasDirect = false;
-  const directKw = value.kw ?? value.kW ?? value.P ?? value.p;
-  const directKvar = value.kvar ?? value.kVAr ?? value.Q ?? value.q;
-  if (directKw !== undefined) {
-    const added = toNumber(directKw);
-    if (added) hasDirect = true;
-    kw += added;
-  }
-  const kvarProvided = directKvar !== undefined;
-  const kvarAuthoritative = isReactiveAuthoritative(value, kvarProvided);
-  if (kvarProvided && kvarAuthoritative) {
-    const added = toNumber(directKvar);
-    if (added) hasDirect = true;
-    kvar += added;
-  }
-  if (value.watts !== undefined) {
-    const added = toNumber(value.watts, 0.001);
-    if (added) hasDirect = true;
-    kw += added;
-  }
-  if (value.hp !== undefined) {
-    const added = toNumber(value.hp, 0.746);
-    if (added) hasDirect = true;
-    kw += added;
-  }
-  if ((!kvarAuthoritative || !kvarProvided) && kw) {
-    const derived = deriveReactiveFromPF(kw, value);
-    if (derived) {
-      kvar += derived;
-      hasDirect = true;
+  const stack = [value];
+  const visited = new WeakSet();
+  let visitedNodes = 0;
+  let totalKw = 0;
+  let totalKvar = 0;
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (current === null || current === undefined) continue;
+    if (typeof current === 'number') {
+      totalKw += toNumber(current);
+      continue;
+    }
+    if (typeof current !== 'object') continue;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    visitedNodes += 1;
+    if (visitedNodes > MAX_PQ_TRAVERSAL_NODES) break;
+
+    if (Array.isArray(current)) {
+      current.forEach(item => stack.push(item));
+      continue;
+    }
+
+    let localKw = 0;
+    let localKvar = 0;
+    let hasDirect = false;
+    const directKw = current.kw ?? current.kW ?? current.P ?? current.p;
+    const directKvar = current.kvar ?? current.kVAr ?? current.Q ?? current.q;
+    if (directKw !== undefined) {
+      const added = toNumber(directKw);
+      if (added) hasDirect = true;
+      localKw += added;
+    }
+    const kvarProvided = directKvar !== undefined;
+    const kvarAuthoritative = isReactiveAuthoritative(current, kvarProvided);
+    if (kvarProvided && kvarAuthoritative) {
+      const added = toNumber(directKvar);
+      if (added) hasDirect = true;
+      localKvar += added;
+    }
+    if (current.watts !== undefined) {
+      const added = toNumber(current.watts, 0.001);
+      if (added) hasDirect = true;
+      localKw += added;
+    }
+    if (current.hp !== undefined) {
+      const added = toNumber(current.hp, 0.746);
+      if (added) hasDirect = true;
+      localKw += added;
+    }
+    if ((!kvarAuthoritative || !kvarProvided) && localKw) {
+      const derived = deriveReactiveFromPF(localKw, current);
+      if (derived) {
+        localKvar += derived;
+        hasDirect = true;
+      }
+    }
+
+    totalKw += localKw;
+    totalKvar += localKvar;
+    if (!hasDirect) {
+      Object.keys(current).forEach(key => {
+        const child = current[key];
+        if (!child || typeof child !== 'object') return;
+        stack.push(child);
+      });
     }
   }
-  if (!hasDirect) {
-    Object.keys(value).forEach(key => {
-      const child = value[key];
-      if (!child || typeof child !== 'object') return;
-      const { kw: childKw, kvar: childKvar } = sumPQ(child);
-      kw += childKw;
-      kvar += childKvar;
-    });
-  }
-  return { kw, kvar };
+
+  return { kw: totalKw, kvar: totalKvar };
 }
 
 function resolvePhaseRecord(record, phase) {
   if (!record || typeof record !== 'object') return null;
   const variants = [phase, phase?.toLowerCase?.(), phase?.toUpperCase?.()];
-  for (const key of variants) {
-    if (!key) continue;
-    if (record[key] !== undefined) return record[key];
-  }
-  if (record.phases) {
-    const nested = resolvePhaseRecord(record.phases, phase);
-    if (nested) return nested;
+  const stack = [record];
+  const visited = new WeakSet();
+  let visitedNodes = 0;
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || typeof current !== 'object') continue;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    visitedNodes += 1;
+    if (visitedNodes > MAX_PQ_TRAVERSAL_NODES) return null;
+    for (const key of variants) {
+      if (!key) continue;
+      if (current[key] !== undefined) return current[key];
+    }
+    if (current.phases && typeof current.phases === 'object') {
+      stack.push(current.phases);
+    }
   }
   return null;
 }

--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -437,42 +437,61 @@ function addPQ(target, addition) {
   return out;
 }
 
+const MAX_PQ_TRAVERSAL_NODES = 20000;
+
 function extractPQ(source) {
   if (source === null || source === undefined) return null;
-  if (typeof source === 'number') {
-    const kw = toNumber(source);
-    return kw ? { kw, kvar: 0 } : null;
-  }
-  if (Array.isArray(source)) {
-    return source.reduce((acc, item) => addPQ(acc, extractPQ(item)), null);
-  }
-  if (typeof source !== 'object') return null;
-  let kw = toNumber(source.kw ?? source.kW ?? source.P ?? source.p);
-  kw += toNumber(source.watts, 0.001);
-  kw += toNumber(source.hp, 0.746);
-  const directKvar = source.kvar ?? source.kVAr ?? source.Q ?? source.q;
-  const kvarProvided = directKvar !== undefined;
-  const kvarAuthoritative = isReactiveAuthoritative(source, kvarProvided);
-  let kvar = 0;
-  if (kvarProvided && kvarAuthoritative) {
-    kvar += toNumber(directKvar);
-  }
-  if ((!kvarAuthoritative || !kvarProvided) && kw) {
-    const derived = deriveReactiveFromPF(kw, source);
-    if (derived) kvar += derived;
-  }
-  if (!kw && !kvar) {
-    let nested = null;
-    Object.keys(source).forEach(key => {
-      const child = source[key];
+  const stack = [source];
+  const visited = new WeakSet();
+  let visitedNodes = 0;
+  let total = null;
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (current === null || current === undefined) continue;
+    if (typeof current === 'number') {
+      const kw = toNumber(current);
+      if (kw) total = addPQ(total, { kw, kvar: 0 });
+      continue;
+    }
+    if (typeof current !== 'object') continue;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    visitedNodes += 1;
+    if (visitedNodes > MAX_PQ_TRAVERSAL_NODES) break;
+
+    if (Array.isArray(current)) {
+      current.forEach(item => stack.push(item));
+      continue;
+    }
+
+    let kw = toNumber(current.kw ?? current.kW ?? current.P ?? current.p);
+    kw += toNumber(current.watts, 0.001);
+    kw += toNumber(current.hp, 0.746);
+    const directKvar = current.kvar ?? current.kVAr ?? current.Q ?? current.q;
+    const kvarProvided = directKvar !== undefined;
+    const kvarAuthoritative = isReactiveAuthoritative(current, kvarProvided);
+    let kvar = 0;
+    if (kvarProvided && kvarAuthoritative) {
+      kvar += toNumber(directKvar);
+    }
+    if ((!kvarAuthoritative || !kvarProvided) && kw) {
+      const derived = deriveReactiveFromPF(kw, current);
+      if (derived) kvar += derived;
+    }
+    if (kw || kvar) {
+      total = addPQ(total, { kw, kvar });
+      continue;
+    }
+
+    Object.keys(current).forEach(key => {
+      const child = current[key];
       if (!child || typeof child !== 'object') return;
-      const pq = extractPQ(child);
-      if (pq) nested = addPQ(nested, pq);
+      stack.push(child);
     });
-    if (nested) return nested;
   }
-  if (!kw && !kvar) return null;
-  return { kw, kvar };
+
+  return total;
 }
 
 function isLoadDevice(comp) {

--- a/tests/loadflow/deepNestedLoadSafety.test.mjs
+++ b/tests/loadflow/deepNestedLoadSafety.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert';
+
+const { buildLoadFlowModel } = await import('../../analysis/loadFlowModel.js');
+const { runLoadFlow } = await import('../../analysis/loadFlow.js');
+
+function nestedLoad(depth) {
+  const root = {};
+  let cursor = root;
+  for (let i = 0; i < depth; i++) {
+    cursor.next = {};
+    cursor = cursor.next;
+  }
+  cursor.kw = 50;
+  return root;
+}
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  \u2713', name);
+  } catch (err) {
+    console.log('  \u2717', name);
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+describe('Load flow nested PQ parsing safety', () => {
+  it('handles deeply nested bus load objects without stack overflow', () => {
+    const model = {
+      buses: [
+        { id: 'source', type: 'slack', baseKV: 13.8 },
+        { id: 'load', type: 'PQ', baseKV: 13.8, load: nestedLoad(30000) }
+      ],
+      branches: [
+        { id: 'line1', from: 'source', to: 'load', impedance: { r: 0.1, x: 0.2 } }
+      ]
+    };
+
+    const result = runLoadFlow(model, { baseMVA: 10, balanced: true });
+    assert.strictEqual(typeof result.converged, 'boolean');
+  });
+
+  it('handles deeply nested component load objects when building model', () => {
+    const oneLine = {
+      sheets: [
+        {
+          components: [
+            { id: 'bus1', type: 'bus', subtype: 'Bus', position: { x: 0, y: 0 } },
+            { id: 'load1', type: 'load', subtype: 'generic_load', position: { x: 5, y: 0 }, load: nestedLoad(30000) }
+          ],
+          connections: [
+            { from: { component: 'bus1', port: 0 }, to: { component: 'load1', port: 0 } }
+          ]
+        }
+      ]
+    };
+
+    const model = buildLoadFlowModel(oneLine);
+    assert(Array.isArray(model.buses));
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent denial-of-service caused by unbounded recursion while aggregating PQ from attacker-controlled deeply nested load/generation objects that could trigger `RangeError: Maximum call stack size exceeded` during load-flow analysis and model building.
- Keep existing per-object direct-field precedence and reactive-derivation semantics while eliminating recursive traversal over arbitrary nested objects and arrays.

### Description
- Replace recursive `sumPQ`/`resolvePhaseRecord` in `analysis/loadFlow.js` with iterative stack-based traversals that use a `WeakSet` to track cycles and a `MAX_PQ_TRAVERSAL_NODES` budget to bound total visited nodes, preserving original direct-value and derived reactive logic.
- Replace recursive `extractPQ` in `analysis/loadFlowModel.js` with a similar iterative traversal that accumulates `kw`/`kvar` and avoids deep call stacks while preserving `addPQ` and direct-field behavior.
- Keep `extractPhasePQ` API behavior intact so `runLoadFlow` continues to call it for bus `load`/`generation` without changing higher-level logic.
- Add a regression test `tests/loadflow/deepNestedLoadSafety.test.mjs` that constructs 30,000-level nested objects to verify both direct `runLoadFlow` and `buildLoadFlowModel` paths no longer crash on deep nesting.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (all tests passed).
- Built distribution with `npm run build`, which completed successfully and produced expected artifacts.
- Executed the new regression `node tests/loadflow/deepNestedLoadSafety.test.mjs`, which passed and confirmed the fix prevents stack-overflow on deep nesting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b163dfeec832485e0cc3cdc6040cc)