### PR TITLE
Fix one-line viewport to include computed diagram bounds

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -2726,6 +2726,29 @@ function applyDiagramZoom({ adjustScroll = false, previousZoom, focusPoint } = {
 }
 
 function updateDiagramViewport(bounds) {
+  let nextViewport = { ...STATIC_VIEWPORT_BOUNDS };
+  if (bounds && Number.isFinite(bounds.minX) && Number.isFinite(bounds.minY) &&
+      Number.isFinite(bounds.maxX) && Number.isFinite(bounds.maxY)) {
+    const rawWidth = bounds.maxX - bounds.minX;
+    const rawHeight = bounds.maxY - bounds.minY;
+    if (Number.isFinite(rawWidth) && Number.isFinite(rawHeight) && rawWidth >= 0 && rawHeight >= 0) {
+      const pad = 200;
+      const minWidth = STATIC_VIEWPORT_BOUNDS.width;
+      const minHeight = STATIC_VIEWPORT_BOUNDS.height;
+      const paddedWidth = rawWidth + pad * 2;
+      const paddedHeight = rawHeight + pad * 2;
+      const width = Math.max(minWidth, paddedWidth);
+      const height = Math.max(minHeight, paddedHeight);
+      const centerX = (bounds.minX + bounds.maxX) / 2;
+      const centerY = (bounds.minY + bounds.maxY) / 2;
+      nextViewport = {
+        minX: centerX - width / 2,
+        minY: centerY - height / 2,
+        width,
+        height
+      };
+    }
+  }
   if (needsInitialViewportCenter) {
     if (bounds && Number.isFinite(bounds.minX) && Number.isFinite(bounds.minY) &&
         Number.isFinite(bounds.maxX) && Number.isFinite(bounds.maxY)) {
@@ -2739,7 +2762,7 @@ function updateDiagramViewport(bounds) {
       pendingInitialCenter = getStaticViewportCenter();
     }
   }
-  diagramViewport = { ...STATIC_VIEWPORT_BOUNDS };
+  diagramViewport = nextViewport;
 }
 
 function updateZoomDisplay() {


### PR DESCRIPTION
### Motivation
- The one-line viewport was forced to a fixed `STATIC_VIEWPORT_BOUNDS`, which could hide imported components placed outside that static range while leaving them in the project data.
- The change restores a data-driven viewport so visible/scrollable SVG size reflects actual component extents while keeping a safe minimum size.

### Description
- Rewrote `updateDiagramViewport(bounds)` to compute a `nextViewport` from `bounds` when valid, using a padded content rectangle and clamping to `STATIC_VIEWPORT_BOUNDS` as a minimum size.
- The function preserves the existing initial-center logic (`pendingInitialCenter` / `needsInitialViewportCenter`) so first-render centering remains unchanged.
- The fix is minimal and does not alter or clamp imported component coordinates; it only adjusts the visual viewport to include computed bounds plus a 200-unit padding.
- Applied and committed the updated `oneline.js` change with the message "Fix one-line viewport to include diagram bounds".

### Testing
- Ran `npm test` and the full test suite completed successfully in this environment.
- Ran `npm run build` and the build completed successfully and produced updated bundles.
- Attempted to install Playwright browsers to capture a webpage preview, but `npx playwright install chromium` failed due to upstream CDN 403 responses, so a visual screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1971c2848324b511752746cc326d)