### PR TITLE
Fix integer kV normalization in load-flow and one-line voltage resolution

### DIFF
--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -943,21 +943,23 @@ function cloneBusComponent(comp) {
 function resolveBusBaseKV(comp) {
   if (!comp || typeof comp !== 'object') return null;
   const direct = [
-    comp.baseKV,
-    comp.kV,
-    comp.kv,
-    comp.nominalVoltage,
-    comp.nominal_voltage,
-    comp.prefault_voltage,
-    comp.voltage,
-    comp.volts,
-    comp.props?.baseKV,
-    comp.props?.voltage,
-    comp.parameters?.baseKV,
-    comp.parameters?.voltage
+    { value: comp.baseKV, asKV: true },
+    { value: comp.kV, asKV: true },
+    { value: comp.kv, asKV: true },
+    { value: comp.nominalVoltage, asKV: true },
+    { value: comp.nominal_voltage, asKV: true },
+    { value: comp.prefault_voltage, asKV: true },
+    { value: comp.voltage, asKV: false },
+    { value: comp.volts, asKV: false },
+    { value: comp.props?.baseKV, asKV: true },
+    { value: comp.props?.voltage, asKV: false },
+    { value: comp.parameters?.baseKV, asKV: true },
+    { value: comp.parameters?.voltage, asKV: false }
   ];
   for (const candidate of direct) {
-    const base = toBaseKV(candidate);
+    const base = candidate.asKV
+      ? toBaseKV({ kV: candidate.value })
+      : toBaseKV({ voltage: candidate.value });
     if (Number.isFinite(base) && base > 0) return base;
   }
   const volts = normalizeVoltageToVolts(comp?.props?.operating_voltage ?? comp?.cable?.operating_voltage);

--- a/oneline.js
+++ b/oneline.js
@@ -13461,7 +13461,7 @@ function resolveComponentVoltageVolts(comp, options = {}) {
     if (!container || typeof container !== 'object') continue;
     for (const key of directKeys) {
       if (!(key in container)) continue;
-      const resolved = normalizeVoltageToVolts(container[key]);
+      const resolved = normalizeVoltageToVolts({ [key]: container[key] });
       if (resolved !== null && Number.isFinite(resolved) && resolved > 0) {
         return resolved;
       }
@@ -13472,7 +13472,7 @@ function resolveComponentVoltageVolts(comp, options = {}) {
     if (!container || typeof container !== 'object') continue;
     for (const key of baseKeys) {
       if (!(key in container)) continue;
-      const base = toBaseKV(container[key]);
+      const base = toBaseKV({ kV: container[key] });
       if (Number.isFinite(base) && base > 0) {
         return base * 1000;
       }

--- a/tests/loadflow/baseKvHintRegression.test.mjs
+++ b/tests/loadflow/baseKvHintRegression.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildLoadFlowModel } from '../../analysis/loadFlowModel.js';
+
+function findBus(model, id) {
+  return model.buses.find(bus => bus.id === id);
+}
+
+describe('load-flow base kV numeric hints', () => {
+  it('preserves integer baseKV values as kV for bus modeling', () => {
+    const oneLine = {
+      activeSheet: 0,
+      sheets: [{
+        components: [
+          { id: 'source', type: 'bus', busType: 'slack', baseKV: 13, connections: [{ target: 'load' }] },
+          { id: 'load', type: 'bus', busType: 'PQ', baseKV: 13, connections: [{ target: 'source' }] }
+        ],
+        connections: []
+      }]
+    };
+
+    const model = buildLoadFlowModel(oneLine);
+    assert.equal(findBus(model, 'source')?.baseKV, 13);
+    assert.equal(findBus(model, 'load')?.baseKV, 13);
+  });
+});


### PR DESCRIPTION
### Motivation
- A recent voltage normalization change lost field-name hints when numeric kV fields (e.g., `baseKV`, `kV`) were passed as bare numbers, causing integer kV values to be interpreted as volts and producing 1000×-scale errors in load-flow and validation calculations.
- Preserve semantic unit context for fields that are already known to be kV so bus base voltages and validation comparisons are computed correctly.

### Description
- Update `resolveBusBaseKV` in `analysis/loadFlowModel.js` to preserve unit hints by passing semantic candidates as `{ kV: value }` or `{ voltage: value }` to the voltage helpers so integers like `13` are interpreted as kV when coming from `baseKV`-style fields.
- Update `resolveComponentVoltageVolts` in `oneline.js` to pass container key hints into `normalizeVoltageToVolts` (wrap as `{ [key]: value }`) and to call `toBaseKV({ kV: ... })` for base-voltage keys so validation and comparisons retain kV semantics.
- Add regression test `tests/loadflow/baseKvHintRegression.test.mjs` that asserts `buildLoadFlowModel` preserves integer `baseKV` values (e.g., `13` remains `13` kV) to prevent future regressions.

### Testing
- Ran the new regression with `node --test tests/loadflow/baseKvHintRegression.test.mjs` and it passed.
- Ran `node analysis/loadFlowModel.test.mjs` to validate related load-flow behavior and it passed.
- Ran the full test suite via `npm test` and `npm run build`, both completed successfully in this environment.
- Attempted to produce a webpage preview screenshot via Playwright, but `npx playwright install chromium` failed due to CDN HTTP 403, so an automated screenshot could not be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b19751ae88324848c6c7058730617)