### PR TITLE
Prefer operating/actual voltage for oneline validation

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13448,15 +13448,16 @@ function resolveComponentVoltageVolts(comp, options = {}) {
   if (comp.cable && typeof comp.cable === 'object') containers.push(comp.cable);
   containers.push(comp);
   const primaryKeys = [
-    'rated_voltage',
-    'rated_volts',
-    'voltage_rating',
     'voltage',
     'volts',
     'voltage_v',
-    'voltage_kv'
+    'voltage_kv',
+    'operating_voltage',
+    'rated_voltage',
+    'rated_volts',
+    'voltage_rating'
   ];
-  const directKeys = includeOperatingVoltage ? [...primaryKeys, 'operating_voltage'] : primaryKeys;
+  const directKeys = includeOperatingVoltage ? primaryKeys : primaryKeys.filter(key => key !== 'operating_voltage');
   for (const container of containers) {
     if (!container || typeof container !== 'object') continue;
     for (const key of directKeys) {


### PR DESCRIPTION
### Motivation
- The voltage resolver used by `validateDiagram()` prioritized rating fields (`rated_voltage`, `rated_volts`, `voltage_rating`) over actual/operating voltage, which could suppress true voltage mismatch issues and allow downstream schedule syncs to proceed from an invalid one-line diagram.

### Description
- Reordered the lookup keys in `resolveComponentVoltageVolts` (in `oneline.js`) so `voltage`, `volts`, `voltage_v`, `voltage_kv`, and `operating_voltage` are checked before `rated_voltage`, `rated_volts`, and `voltage_rating`, and preserved the `includeOperatingVoltage` flag by filtering out `operating_voltage` when requested.

### Testing
- Ran `npm test` (full suite invocation) and the tests completed successfully.
- Ran `npm run build` and the build completed successfully.
- Attempted to capture a browser preview with Playwright to produce a screenshot but it failed because Playwright browser binaries are not installed in the environment (requires `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b197820e08324a9912ee8239f4de5)