### PR TITLE
Fix load-flow shunt-loss double counting in branch losses

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -466,13 +466,15 @@ function solvePhase(buses, baseMVA, options = {}) {
       const ViPrime = div(Vi, t);
       const yShFrom = conn.shunt?.from ? toPerUnitY(conn.shunt.from, bus.baseKV || 1, baseMVA) : toComplex(0, 0);
       const yShTo = conn.shunt?.to ? toPerUnitY(conn.shunt.to, working[j].baseKV || 1, baseMVA) : toComplex(0, 0);
-      const Iij = add(mul(sub(ViPrime, Vj), y), mul(ViPrime, yShFrom));
+      const Iseries = mul(sub(ViPrime, Vj), y);
+      const Iij = add(Iseries, mul(ViPrime, yShFrom));
       const Sij = mul(Vi, conj(Iij));
       const scale = baseMVA * 1000; // convert per-unit results to kW/kvar
       const P = Sij.re * scale;
       const Q = Sij.im * scale;
       const Ipu = Math.hypot(Iij.re, Iij.im);
-      const Ipu2 = Ipu * Ipu;
+      const IseriesPu = Math.hypot(Iseries.re, Iseries.im);
+      const IseriesPu2 = IseriesPu * IseriesPu;
       const baseKV = bus.baseKV || working[j].baseKV || 1;
       const baseCurrentKA = baseKV ? baseMVA / (Math.sqrt(3) * baseKV) : 0;
       const currentKA = Ipu * baseCurrentKA;
@@ -481,8 +483,8 @@ function solvePhase(buses, baseMVA, options = {}) {
       const toKV = Vm[j] * (working[j].baseKV || 0);
       const dropKV = fromKV - toKV;
       const dropPct = fromKV ? (dropKV / fromKV) * 100 : 0;
-      const lossKW = Ipu2 * (Z.re || 0) * scale;
-      const lossKVAR = Ipu2 * (Z.im || 0) * scale;
+      const lossKW = IseriesPu2 * (Z.re || 0) * scale;
+      const lossKVAR = IseriesPu2 * (Z.im || 0) * scale;
       const ViPrimeMag2 = ViPrime.re * ViPrime.re + ViPrime.im * ViPrime.im;
       const VjMag2 = Vj.re * Vj.re + Vj.im * Vj.im;
       const shuntFromLossKW = ViPrimeMag2 * (yShFrom.re || 0) * scale;
@@ -1096,4 +1098,3 @@ export function runLoadFlow(modelOrOpts = {}, maybeOpts = {}) {
   });
   return combined;
 }
-


### PR DESCRIPTION
### Motivation
- A bug caused from-side shunt conductance to be counted twice in branch loss totals because series I²R losses were computed from the terminal current that included shunt current, and explicit shunt losses were then added again.
- The correct calculation is to compute series losses from the series branch current only and add shunt conductance losses separately so each shunt side is counted exactly once.

### Description
- Split terminal current into `Iseries` (series branch current) and `Iij` (terminal current including from-side shunt) in `analysis/loadFlow.js`.
- Compute series losses `lossKW` and `lossKVAR` from the magnitude of `Iseries` (`IseriesPu2`) instead of from the terminal current, while keeping `Iij` for flow and Sij calculations.
- Preserve the explicit per-side shunt loss additions so shunt conductance is still included once per side in branch totals.

### Testing
- Ran `npm test`, which exercised the test suite; the run showed the existing unrelated failure in `tests/serverSecurity.test.mjs` (assertion expecting `204` but received `401`) while the rest of the tests executed (majority passed).
- Ran `npm run build`, which completed successfully (Rollup reported unresolved-external warnings that predate this fix).
- Attempted to generate a browser preview screenshot with Playwright, but the environment lacks Playwright browser binaries so the preview could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1bf791908324aa91290c7fb6bbf6)