### PR TITLE
Harden isSourceComponent to avoid crash on malformed component.type

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -643,10 +643,11 @@ function isBusComponent(c) {
 }
 
 function isSourceComponent(comp) {
-  if (!comp || comp.type === 'transformer') return false;
+  if (!comp) return false;
+  const type = typeof comp.type === 'string' ? comp.type.toLowerCase() : '';
+  if (type === 'transformer') return false;
   const category = resolveComponentCategory(comp);
   if (category === 'sources') return true;
-  const type = (comp.type || '').toLowerCase();
   return type === 'utility_source' || type === 'generator' || type === 'pv_inverter';
 }
 


### PR DESCRIPTION
### Motivation
- The one-line renderer could crash when `component.type` is a non-string value from imported/shared JSON because `.toLowerCase()` was called unguarded, enabling a client-side denial-of-service for malformed project data.

### Description
- Tightened `isSourceComponent` in `oneline.js` to early-return on falsy `comp` and to normalize `comp.type` only when `typeof comp.type === 'string'`, preserving transformer exclusion and existing source-type checks.
- The fix is minimal and localized to `oneline.js`, keeping prior detection semantics for valid component types.

### Testing
- Ran `npm test` (full suite) and it completed successfully.
- Ran `npm run build` and it completed successfully.
- Attempted an automated Playwright screenshot to produce a preview, but `npx playwright install` failed due to browser download being blocked (HTTP 403), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1da545d08324af5f07b5ba7d3bfc)