### PR TITLE
Fix dangling bus links bypassing connectivity validation

### DIFF
--- a/validation/rules.js
+++ b/validation/rules.js
@@ -88,7 +88,7 @@ export function runValidation(components = [], studies = {}) {
   inbound.forEach((cnt, id) => {
     const comp = componentLookup.get(id);
     const outbound = Array.isArray(comp?.connections)
-      ? comp.connections.filter(conn => conn && conn.target).length
+      ? comp.connections.filter(conn => conn && componentLookup.has(conn.target)).length
       : 0;
     if (cnt === 0 && outbound === 0) {
       issues.push({ component: id, message: 'Unconnected bus' });


### PR DESCRIPTION
### Motivation
- Prevent dangling or nonexistent outbound `conn.target` values from suppressing the `Unconnected bus` validation warning so validation reports remain accurate.

### Description
- Update `validation/rules.js` so outbound connections are counted only when `componentLookup.has(conn.target)` is true, replacing the previous truthiness check that allowed dangling targets to be treated as valid.

### Testing
- Ran the full test suite with `npm test` and ran `npm run build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1da8011883248e026ea30d087842)