### PR TITLE
Fix hidden voltage override by prioritizing top-level component voltage

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13466,11 +13466,10 @@ function showToast(msg, linkText, linkHref) {
 function resolveComponentVoltageVolts(comp, options = {}) {
   if (!comp || typeof comp !== 'object') return null;
   const { includeOperatingVoltage = true } = options;
-  const containers = [];
+  const containers = [comp];
   if (comp.props && typeof comp.props === 'object') containers.push(comp.props);
   if (comp.parameters && typeof comp.parameters === 'object') containers.push(comp.parameters);
   if (comp.cable && typeof comp.cable === 'object') containers.push(comp.cable);
-  containers.push(comp);
   const primaryKeys = [
     'voltage',
     'volts',


### PR DESCRIPTION
### Motivation
- Prevent hidden nested voltage fields in `props`/`parameters`/`cable` from taking precedence over the top-level component voltage shown in the property editor, which could cause validation, tooltips, and derived cable operating voltages to reflect a different (potentially attacker-controlled) value.

### Description
- Update `resolveComponentVoltageVolts` in `oneline.js` to evaluate the top-level `comp` container before `comp.props`, `comp.parameters`, and `comp.cable`, preserving the existing key list and normalization logic; the change is minimal and confined to that function.

### Testing
- Ran `npm test` (full test suite) and `npm run build`, both completed successfully; attempted to capture a webpage preview with Playwright but the browser binary download failed (HTTP 403), so no screenshot could be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4046a5048324aa3d2df8ea1ccf3d)