### PR TITLE
Harden nested property editor against prototype-pollution keys

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -554,18 +554,33 @@ function readNestedValue(holder, path = []) {
   if (!holder || typeof holder !== 'object') return undefined;
   let current = holder;
   for (const key of path) {
-    if (!current || typeof current !== 'object' || !(key in current)) return undefined;
+    if (
+      !current
+      || typeof current !== 'object'
+      || isUnsafeNestedPathSegment(key)
+      || !Object.prototype.hasOwnProperty.call(current, key)
+    ) {
+      return undefined;
+    }
     current = current[key];
   }
   return current;
 }
 
+function isUnsafeNestedPathSegment(segment) {
+  return segment === '__proto__' || segment === 'prototype' || segment === 'constructor';
+}
+
 function writeNestedValue(holder, path = [], value) {
   if (!holder || typeof holder !== 'object' || !path.length) return;
+  if (path.some(isUnsafeNestedPathSegment)) return;
   let current = holder;
   for (let i = 0; i < path.length - 1; i += 1) {
     const key = path[i];
-    if (!current[key] || typeof current[key] !== 'object') current[key] = {};
+    const next = current[key];
+    if (!Object.prototype.hasOwnProperty.call(current, key) || !next || typeof next !== 'object') {
+      current[key] = {};
+    }
     current = current[key];
   }
   current[path[path.length - 1]] = value;
@@ -611,6 +626,7 @@ function inferSchemaFromProps(props, path = []) {
   ]);
   Object.entries(props || {}).forEach(([key, value]) => {
     if (!path.length && reservedTopLevelFieldNames.has(key)) return;
+    if (isUnsafeNestedPathSegment(key)) return;
     const currentPath = [...path, key];
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       schema.push(...inferSchemaFromProps(value, currentPath));


### PR DESCRIPTION
### Motivation
- Prevent prototype-pollution via the recursive nested property editor that previously allowed attacker-controlled path segments (e.g. `__proto__`) to mutate `Object.prototype` when form fields were applied. 

### Description
- Add `isUnsafeNestedPathSegment` and block `__proto__`, `prototype`, and `constructor` when inferring nested schemas and when writing nested values. 
- Tighten `readNestedValue` to only traverse own-properties using `Object.prototype.hasOwnProperty.call` and to reject unsafe segments. 
- Harden `writeNestedValue` to reject paths containing unsafe segments and to create plain own-property objects when creating intermediate containers. 
- Skip unsafe keys in `inferSchemaFromProps` so malicious imported props cannot generate editable fields for prototype segments. 

### Testing
- Ran the full unit test suite with `npm test`, which completed successfully. 
- Built the distribution with `npm run build`, which completed successfully. 
- Attempted a Playwright-render screenshot to produce a visual preview, but browser installation failed in this environment (`npx playwright install chromium` returned HTTP 403), so no screenshot could be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4168f7788324b9f724ffab48e2b1)