### PR TITLE
Fix load-flow transformer tap defaulting regression

### DIFF
--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -226,33 +226,6 @@ function deriveTransformerImpedance(comp, fromRole, toRole, fromBus, toBus) {
   return impedance || null;
 }
 
-function computeExistingTapRatio(tap) {
-  if (tap === null || tap === undefined) return null;
-  if (typeof tap === 'number') return Number.isFinite(tap) ? tap : null;
-  if (typeof tap === 'object' && tap !== null) {
-    const ratio = parseNumeric(tap.ratio);
-    return ratio !== null ? ratio : null;
-  }
-  return null;
-}
-
-function deriveTransformerTap(comp, tap, fromRole, toRole, fromBus, toBus) {
-  if (!isTransformerComponent(comp)) return tap;
-  const fromKV = determineSideKV(comp, fromRole, fromBus);
-  const toKV = determineSideKV(comp, toRole, toBus);
-  if (!fromKV || !toKV || Math.abs(toKV) < 1e-9) return tap;
-  const desiredRatio = fromKV / toKV;
-  if (!Number.isFinite(desiredRatio) || desiredRatio <= 0) return tap;
-  const existingRatio = computeExistingTapRatio(tap);
-  if (existingRatio !== null && Math.abs(existingRatio - desiredRatio) < 1e-6) {
-    return tap;
-  }
-  if (tap && typeof tap === 'object' && tap !== null) {
-    return { ...tap, ratio: desiredRatio };
-  }
-  return { ratio: desiredRatio };
-}
-
 function toNumber(value, scale = 1) {
   const num = Number(value);
   return Number.isFinite(num) ? num * scale : 0;
@@ -1149,8 +1122,7 @@ export function buildLoadFlowModel(oneLine = {}) {
         }
       }
       const explicitTie = zeroImpedance;
-      let tap = cloneData(comp.tap);
-      tap = deriveTransformerTap(comp, tap, fromSide, toSide, fromBus, toBus);
+      const tap = cloneData(comp.tap);
       const shunt = cloneData(comp.shunt);
       const rating = comp.rating ?? comp.ampacity ?? comp.currentRating;
       const phases = comp.phases ? cloneData(comp.phases) : undefined;

--- a/tests/loadflow/transformerOrientation.test.mjs
+++ b/tests/loadflow/transformerOrientation.test.mjs
@@ -69,9 +69,8 @@ describe('Transformer orientation handling', () => {
     assert(branch, 'Transformer branch should be constructed');
     assert.strictEqual(branch.from, 'hv_bus', 'Transformer should orient from the primary bus');
     assert.strictEqual(branch.to, 'lv_bus', 'Transformer secondary should remain on the to side');
-    assert(branch.tap, 'Derived tap data should be present');
-    const expectedRatio = 13.8 / 0.48;
-    assert(Math.abs(branch.tap.ratio - expectedRatio) < 1e-6, 'Tap ratio should match the primary to secondary voltage ratio');
+    assert(branch.tap, 'Explicit tap data should be preserved');
+    assert(Math.abs(branch.tap.ratio - 1) < 1e-6, 'Tap ratio should remain the configured off-nominal value');
 
     const result = runLoadFlow(model, { baseMVA: 10, balanced: true });
     assert(result.converged, 'Load flow should converge with correctly oriented transformer');


### PR DESCRIPTION
### Motivation
- A recent change automatically derived transformer tap ratios from nameplate voltages and applied them to every transformer branch, which caused physical voltage ratios (e.g., 13.8/0.48 ≈ 28.75) to be treated as off-nominal per-unit taps and corrupted load-flow results.
- The intent of the change is to restore correct solver semantics by preserving only explicitly configured off-nominal tap values and avoid double-applying the physical transformer ratio in Y-bus assembly.

### Description
- Removed the helper logic that computed and forced a derived `tap.ratio` based on transformer side nameplate/base voltages in `analysis/loadFlowModel.js` (deleted `computeExistingTapRatio` and `deriveTransformerTap`).
- Stopped applying an automatically derived tap when building transformer branches by leaving `tap = cloneData(comp.tap)` unchanged (now `const tap = cloneData(comp.tap);`) so only explicit taps are used.
- Updated the transformer orientation regression test `tests/loadflow/transformerOrientation.test.mjs` to assert that explicit tap data is preserved (configured off-nominal value) rather than expecting an auto-derived nameplate ratio.
- Changes are minimal and localized to `analysis/loadFlowModel.js` and the affected test file to preserve existing behavior for projects that rely on explicit tap configuration.

### Testing
- Ran the full test suite with `npm test`, and the failing transformer-orientation assertion was resolved; the test suite completed successfully after updating the expectation (automated tests passed).
- Built the distribution with `npm run build`, which completed successfully and produced the expected `dist/` artifacts.
- Attempted to capture a preview via Playwright (`npx playwright screenshot ...`) but browser download/install failed due to network restrictions (Chromium download returned HTTP 403), so an automated screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4168fad883249f9c06002b9a67c9)