### PR TITLE
Fix non-finite kvar from tiny power factor derivation

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -832,10 +832,14 @@ function deriveReactiveFromPF(kw, record) {
   const kwAbs = Math.abs(Number(kw) || 0);
   if (!kwAbs) return 0;
   const kva = kwAbs / pf.magnitude;
-  const kvarMag = Math.sqrt(Math.max(0, kva * kva - kwAbs * kwAbs));
-  if (!kvarMag) return 0;
+  if (!Number.isFinite(kva)) return 0;
+  const squaredDelta = kva * kva - kwAbs * kwAbs;
+  if (!Number.isFinite(squaredDelta) || squaredDelta <= 0) return 0;
+  const kvarMag = Math.sqrt(squaredDelta);
+  if (!Number.isFinite(kvarMag) || !kvarMag) return 0;
   const sign = resolveReactiveSign(record, pf.sign);
-  return kvarMag * sign;
+  const kvar = kvarMag * sign;
+  return Number.isFinite(kvar) ? kvar : 0;
 }
 
 const MAX_PQ_TRAVERSAL_NODES = 20000;

--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -396,10 +396,14 @@ function deriveReactiveFromPF(kw, record) {
   const kwAbs = Math.abs(Number(kw) || 0);
   if (!kwAbs) return 0;
   const kva = kwAbs / pf.magnitude;
-  const kvarMag = Math.sqrt(Math.max(0, kva * kva - kwAbs * kwAbs));
-  if (!kvarMag) return 0;
+  if (!Number.isFinite(kva)) return 0;
+  const squaredDelta = kva * kva - kwAbs * kwAbs;
+  if (!Number.isFinite(squaredDelta) || squaredDelta <= 0) return 0;
+  const kvarMag = Math.sqrt(squaredDelta);
+  if (!Number.isFinite(kvarMag) || !kvarMag) return 0;
   const sign = resolveReactiveSign(record, pf.sign);
-  return kvarMag * sign;
+  const kvar = kvarMag * sign;
+  return Number.isFinite(kvar) ? kvar : 0;
 }
 
 function addPQ(target, addition) {

--- a/tests/loadflow/sampleOnelineLoadFlow.test.mjs
+++ b/tests/loadflow/sampleOnelineLoadFlow.test.mjs
@@ -137,4 +137,29 @@ describe('Simple feeder load flow', () => {
     assert(loadBus, 'Load bus should be reported');
     assert(loadBus.Vm < 1, 'Load bus voltage should sag under reactive draw');
   });
+  it('ignores non-finite reactive derivation from extremely small power factors', () => {
+    const model = {
+      buses: [
+        { id: 'source', type: 'slack', baseKV: 13.8 },
+        { id: 'load', type: 'PQ', baseKV: 13.8, load: { kw: 1, pf: 1e-308 } }
+      ],
+      branches: [
+        {
+          id: 'feeder',
+          from: 'source',
+          to: 'load',
+          impedance: { r: 0.5, x: 0.9 }
+        }
+      ]
+    };
+
+    const result = runLoadFlow(model, { baseMVA: 1, balanced: true });
+    assert(result.converged, 'Load flow should converge');
+    assert(Number.isFinite(result.summary.totalLoadKVAR), 'Reactive summary should remain finite');
+    assert(Math.abs(result.summary.totalLoadKVAR) < 1e-9, 'Invalid PF-derived reactive demand should be ignored');
+    const source = result.sources.find(bus => bus.id === 'source');
+    assert(source, 'Source should be reported');
+    assert(Number.isFinite(source.Qg), 'Source reactive generation should remain finite');
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Very small power-factor inputs (e.g. pf ≈ 1e-308) could produce extremely large intermediate values in the PF→kvar derivation path and overflow to `Infinity`, allowing non-finite reactive demand to enter study results. 
- Non-finite kvar values were inconsistently handled downstream (solver normalization dropped them for equations while summaries and source Q could retain `Infinity`), creating a silent integrity issue in reported results.

### Description
- Added finite-value guards in `deriveReactiveFromPF` in `analysis/loadFlow.js` to validate `kva`, the squared delta, `kvarMag`, and the final signed `kvar`, returning 0 when intermediate/final values are non-finite or invalid. 
- Applied the same defensive checks to the duplicate derivation in `analysis/loadFlowModel.js` to prevent non-finite values during model extraction. 
- Added a regression test to `tests/loadflow/sampleOnelineLoadFlow.test.mjs` that uses an extremely small PF (`1e-308`) and verifies the load-flow still converges while reactive summaries and source Q remain finite.

### Testing
- Ran `npm test` and the full test suite, including the new regression case, which passed. 
- Ran `npm run build` which completed successfully and produced the distribution artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b469fe9948324bd822cd65552a9ff)