### PR TITLE
Harden ideal-tie handling against forged idealTie flags

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -119,6 +119,12 @@ function describeComponentMetadata(meta = {}) {
   return null;
 }
 
+function isCableConnection(conn = {}) {
+  const type = String(conn.componentType || '').toLowerCase();
+  const subtype = String(conn.componentSubtype || '').toLowerCase();
+  return type === 'cable' || subtype.includes('cable');
+}
+
 /** Basic complex number helpers used by the load-flow solver */
 function toComplex(re = 0, im = 0) {
   return { re, im };
@@ -162,7 +168,7 @@ function buildYBus(buses, baseMVA) {
       if (j < 0) return;
       const Z = toPerUnitZ(conn.impedance || { r: 0, x: 0 }, bus.baseKV || 1, baseMVA);
       const mag2 = Z.re * Z.re + Z.im * Z.im;
-      let treatAsIdealTie = conn.idealTie === true;
+      let treatAsIdealTie = false;
       if (mag2 < MIN_COMPLEX_MAG) {
         warnings.push({
           type: 'zero_impedance_branch',
@@ -179,7 +185,7 @@ function buildYBus(buses, baseMVA) {
           connectionSide: conn.connectionSide,
           connectionConfig: conn.connectionConfig
         });
-        treatAsIdealTie = true;
+        treatAsIdealTie = isCableConnection(conn);
       }
       if (treatAsIdealTie) {
         conn.idealTie = true;
@@ -452,9 +458,9 @@ function solvePhase(buses, baseMVA, options = {}) {
       const Vj = toComplex(Vm[j] * Math.cos(Va[j]), Vm[j] * Math.sin(Va[j]));
       const Z = toPerUnitZ(conn.impedance || { r: 0, x: 0 }, bus.baseKV || 1, baseMVA);
       const mag2 = Z.re * Z.re + Z.im * Z.im;
-      let treatAsIdealTie = conn.idealTie === true;
+      let treatAsIdealTie = false;
       if (mag2 < MIN_COMPLEX_MAG) {
-        treatAsIdealTie = true;
+        treatAsIdealTie = isCableConnection(conn);
       }
       if (treatAsIdealTie) {
         conn.idealTie = true;
@@ -1002,8 +1008,7 @@ export function runLoadFlow(modelOrOpts = {}, maybeOpts = {}) {
           componentSubtype: branch.subtype,
           componentName: branch.name,
           componentLabel: branch.label,
-          componentRef: branch.ref,
-          idealTie: branch.idealTie === true
+          componentRef: branch.ref
         });
       });
     }
@@ -1057,8 +1062,7 @@ export function runLoadFlow(modelOrOpts = {}, maybeOpts = {}) {
           phases: conn.phases,
           componentPort: conn.componentPort,
           connectionSide: conn.connectionSide,
-          connectionConfig: conn.connectionConfig,
-          idealTie: conn.idealTie === true
+          connectionConfig: conn.connectionConfig
         }))
       };
     });


### PR DESCRIPTION
### Motivation
- Fix an integrity issue where an attacker-controlled `idealTie: true` flag in project JSON could cause non-zero-impedance branches to be treated as ideal ties and silently override declared impedance.
- Ensure ideal-tie behavior is only inferred for genuine zero-impedance cable components so load-flow results remain trustworthy.

### Description
- Add a small helper `isCableConnection(conn)` and use it to ensure ideal-tie logic only applies to connections that identify as cables in `analysis/loadFlow.js`.
- Start `treatAsIdealTie` as `false` in both the admittance-matrix (`buildYBus`) and line-flow calculations, and set it only when `mag2 < MIN_COMPLEX_MAG` and `isCableConnection(conn)` is true.
- Stop propagating raw `idealTie` flags from input `branches` and `connections` into the per-phase solver model in `runLoadFlow`, removing the hidden-field injection path from imported/shared JSON.
- Preserve the zero-impedance warning metadata while preventing non-cable/non-zero branches from being silently shorted.

### Testing
- Ran the full test suite with `npm test`; the suite exited non-zero due to an existing unrelated failure in `tests/serverSecurity.test.mjs` (`401 !== 200`), not caused by these changes.  The load-flow related tests (including `analysis/loadFlow.idealTie.test.mjs`) that exercise ideal-tie behavior passed during the run.
- Ran `npm run build` and the build completed successfully.
- Generated a project preview image artifact during validation: `tmp/homepage-audit-desktop.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b46a315648324ac72f60a73a2e323)