### PR TITLE
Fix ReDoS risk in short-circuit kV parsing

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -98,10 +98,12 @@ function parseNumeric(value) {
 function toKV(value) {
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();
-    const kvMatch = normalized.match(/([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)\s*k\s*v\b/);
-    if (kvMatch) {
-      const num = Number.parseFloat(kvMatch[1]);
-      return Number.isFinite(num) ? num : null;
+    if (normalized.includes('kv')) {
+      const kvMatch = normalized.match(/([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)\s*k\s*v\b/);
+      if (kvMatch) {
+        const num = Number.parseFloat(kvMatch[1]);
+        return Number.isFinite(num) ? num : null;
+      }
     }
   }
   const num = parseNumeric(value);

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -282,6 +282,35 @@ global.localStorage = {
       assert(Math.abs(bus.ibr.Ifault_A - 1323.0943668928928) < 1e-6, 'Fault contribution should match 0.48 kV base');
     });
 
+    it('handles long digit-only voltage labels without regex backtracking slowdowns', () => {
+      const longDigits = '9'.repeat(5000);
+      setOneLine({
+        activeSheet: 0,
+        sheets: [{
+          name: 'IBR long numeric label',
+          components: [
+            {
+              id: 'ibr1',
+              type: 'pv_inverter',
+              rated_kva: 1000,
+              rated_kv: 0.48,
+              voltage: longDigits,
+              connections: [{ target: 'bus1', sourcePort: 0, targetPort: 0 }]
+            },
+            { id: 'bus1', type: 'bus', subtype: 'Bus' }
+          ]
+        }]
+      });
+
+      const started = Date.now();
+      const res = runShortCircuit();
+      const elapsedMs = Date.now() - started;
+      const bus = res.bus1;
+      assert(bus && bus.ibr, 'IBR metadata should be attached');
+      assert(elapsedMs < 250, `long non-kV labels should parse quickly (elapsed ${elapsedMs} ms)`);
+      assert.strictEqual(bus.ibr.vLL_kV, 0.48, 'invalid long voltage input should fall back to rated_kv');
+    });
+
     it('falls back to rated_kv when IBR voltage parses to nonpositive values', () => {
       setOneLine({
         activeSheet: 0,


### PR DESCRIPTION
### Motivation

- Prevent a CPU denial-of-service vector caused by catastrophic regex backtracking in the kV parser when untrusted project-controlled voltage strings lack a `kv` token.
- Preserve the intended mixed-unit parsing behavior that prefers an explicit `kV` token when present while avoiding expensive evaluation on non-`kv` inputs.

### Description

- Add a fast guard in `toKV()` inside `analysis/shortCircuit.mjs` that checks `normalized.includes('kv')` before executing the mixed-unit regex; this prevents running the expensive regex on long digit-only strings.
- Add a focused regression test in `tests/shortcircuit/shortCircuit.test.cjs` that feeds a 5000-character digit-only `voltage` label and asserts the short-circuit run is quick and falls back to `rated_kv`.
- The change is minimal and keeps the existing numeric parsing fallback via `parseNumeric(value)` and the kV-to-kV normalization logic intact.

### Testing

- Ran `npm test` and the full test suite completed successfully, including the `short circuit engine` tests with the new regression case passing.
- Ran `npm run build` and the build completed successfully.
- The added test file is `tests/shortcircuit/shortCircuit.test.cjs` and the modified parser is `analysis/shortCircuit.mjs`, and both are exercised by the CI-local test run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4d2d1b708324ab635f48de478bf0)