### PR TITLE
Include standalone breaker custom VA in panel totals

### DIFF
--- a/src/panelSchedule.js
+++ b/src/panelSchedule.js
@@ -1080,7 +1080,7 @@ export function calculatePanelTotals(panelId) {
 
   const breakerDetails = ensureBreakerDetails(panel);
 
-  return loads.reduce((acc, l) => {
+  const totals = loads.reduce((acc, l) => {
     const span = getLoadBreakerSpan(l, panel, circuitCount);
     const startCircuit = span.length ? span[0] : null;
     const cKva = parseFloat(l.kva) || 0;
@@ -1125,6 +1125,40 @@ export function calculatePanelTotals(panelId) {
     acc.demandKva += (parsed - (dKva * 1000)) / 1000;
     return acc;
   }, { connectedKva: 0, connectedKw: 0, demandKva: 0, demandKw: 0 });
+
+  breakerStarts.forEach(startCircuit => {
+    const matchedLoad = loads.find(l => {
+      const span = getLoadBreakerSpan(l, panel, circuitCount);
+      return span.length && span[0] === startCircuit;
+    });
+    if (matchedLoad) return;
+
+    const detail = breakerDetails[String(startCircuit)];
+    if (!detail || detail.loadVaPerPhase == null) return;
+
+    if (detail.loadVaPerPhase && typeof detail.loadVaPerPhase === "object" && !Array.isArray(detail.loadVaPerPhase)) {
+      const block = getBreakerBlock(panel, startCircuit);
+      const span = block ? getBlockCircuits(panel, block, circuitCount) : [startCircuit];
+      span.forEach(slot => {
+        const phase = getPhaseLabel(panel, slot);
+        const slotBlock = getBreakerBlock(panel, slot);
+        const phaseKey = getPhaseLoadKey(phase, slotBlock);
+        const rawValue = phaseKey ? detail.loadVaPerPhase[phaseKey] : null;
+        const parsed = parseFloat(rawValue);
+        if (!Number.isFinite(parsed) || parsed < 0) return;
+        totals.connectedKva += parsed / 1000;
+        totals.demandKva += parsed / 1000;
+      });
+      return;
+    }
+
+    const parsed = parseFloat(detail.loadVaPerPhase);
+    if (!Number.isFinite(parsed) || parsed < 0) return;
+    totals.connectedKva += parsed / 1000;
+    totals.demandKva += parsed / 1000;
+  });
+
+  return totals;
 }
 
 const COLUMN_HEADERS = {


### PR DESCRIPTION
### Motivation
- `calculatePanelTotals` previously only applied breaker `loadVaPerPhase` overrides when iterating assigned loads, which caused manually configured breakers that have custom per-phase VA but no associated load record to be omitted from connected/demand totals.
- The UI and storage flows allow entering a custom load label and per-phase VA directly on a breaker start, so totals must account for those standalone breaker overrides to avoid under-reporting panel connected/demand values.

### Description
- Preserve the existing load-based reduction but store its result in `totals` and then iterate `breakerStarts` to find starts that have no matched load and apply `breakerDetails.loadVaPerPhase` for those starts.  
- Handle both per-phase object `loadVaPerPhase` and scalar `loadVaPerPhase` values using the same phase-key resolution (`getPhaseLoadKey`) and validation as used for assigned loads.  
- Skip any breaker start that already has a matched load to avoid double-counting and keep previous override behavior intact.  
- Change is localized to `src/panelSchedule.js` in the `calculatePanelTotals` function and adds minimal logic to accumulate standalone-breaker VA into the previously computed totals.

### Testing
- Ran the test suite with `npm test` and it completed successfully.  
- Built the distribution with `npm run build` and it completed successfully.  
- Attempted an automated headless screenshot with `npx playwright screenshot` to produce a preview image but it failed because the Playwright browser binary is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4d6255bc83249c642574335db1d1)