### PR TITLE
fix: switch import scenario before applying imported data

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -1031,6 +1031,10 @@ export function importProject(obj) {
     };
   }
 
+  if (importScenario) {
+    switchScenario(importScenario);
+  }
+
   setDuctbanks(data.ductbanks);
   setConduits(data.conduits);
   setTrays(data.trays);
@@ -1061,7 +1065,6 @@ export function importProject(obj) {
       }
     }
   }
-  if (importScenario) switchScenario(importScenario);
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- Imported project data was being written under the currently active scenario because `write()` defaults to `getCurrentScenarioNameState()`, allowing a malicious import to overwrite the victim's active scenario before the UI switched to the imported scenario. 
- This change closes a data-integrity / security hole where `meta.scenario` was validated but the scenario switch was deferred until after all imported writes completed.

### Description
- Move `switchScenario(importScenario)` to immediately after project schema validation and before any imported setters are called in `importProject` inside `dataStore.mjs` so default writes target the imported scenario. 
- Preserve the existing `isValidScenarioName` validation and the `setScenarioListState` behavior; the change is limited to the timing of the scenario switch. 
- Keep all other import logic (schema repair prompting, settings reservation and `setItem` behavior) unchanged to minimize surface area of the fix.

### Testing
- Ran the full unit test suite with `npm test`, and all automated tests completed successfully. 
- Built the distribution with `npm run build`, and the build completed successfully. 
- Attempted to capture a UI preview via Playwright to produce a screenshot, but browser binary installation failed in this environment (`npx playwright install` returned 403), so no visual preview could be generated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4d61c0dc8324abe8c113059ae5b4)