### PR TITLE
fix: restore bus-filtering in short-circuit study nodes

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -684,7 +684,7 @@ function computePrefaultKV(comp, comps, compMap, cache, visited = new Set()) {
 
 /**
  * Symmetrical component short‑circuit engine with basic ANSI C37 and
- * IEC 60909 support. Each component is treated as a bus with sequence
+ * IEC 60909 support. Bus components are treated as study nodes with sequence
  * impedances back to the source. Optional `sources` allows multiple
  * upstream contributions. Components may specify:
  *   - `prefault_voltage` (line‑to‑line kV)
@@ -708,7 +708,8 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       : sheets;
     comps = comps.filter(c => c && c.type !== 'annotation' && c.type !== 'dimension');
   }
-  const buses = comps;
+  let buses = comps.filter(comp => comp?.subtype === 'Bus' || comp?.type === 'bus');
+  if (buses.length === 0) buses = comps;
   const compMap = new Map(comps.map(c => [c.id, c]));
   const impedanceCache = new Map();
   const voltageCache = new Map();


### PR DESCRIPTION
### Motivation
- Fix a regression in `runShortCircuit` that started treating every non-annotation component as a study node, which increased CPU-bound synchronous work reachable via the authenticated short-circuit endpoint and exposed non-bus fields (e.g. non-string `method`) to crash paths.

### Description
- Restore bus-first selection by setting `buses = comps.filter(comp => comp?.subtype === 'Bus' || comp?.type === 'bus')` and falling back to `comps` only when no buses exist, and update the nearby doc comment to match this behavior in `runShortCircuit`.

### Testing
- Ran the full test suite with `npm test` and all tests passed.
- Built the UI with `npm run build` and the build completed successfully; an attempted automated Playwright screenshot failed because the Chromium binary could not be downloaded in this environment (Playwright install returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4d6132a88324bfce5aacf4a87d23)