### PR TITLE
fix: clear one-line revisions on project import

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -1051,6 +1051,7 @@ export function importProject(obj) {
   } else {
     setOneLine({ activeSheet: 0, sheets: [] });
   }
+  removeItem(REVISION_KEY);
 
   const reserved = new Set([...Object.values(KEYS), EXTRA_KEYS.mccLineups, REVISION_KEY, 'CTR_PROJECT_V1']);
   for (const key of keys()) {


### PR DESCRIPTION
### Motivation
- Prevent cross-project leakage of one-line revision history by removing any existing local `oneLineRevisions` immediately after applying imported one-line sheets, because reserving the revision key caused cleanup to skip it and left prior revisions accessible after import.

### Description
- Add an explicit `removeItem(REVISION_KEY);` call in `importProject()` immediately after `setOneLine(...)` to clear prior one-line revisions while preserving the reserved-key behavior for import/export.

### Testing
- Ran `npm test` which completed successfully. 
- Ran `npm run build` which completed successfully. 
- Attempted `npx playwright install chromium` to produce a preview screenshot but the browser download failed (HTTP 403), so the requested preview image could not be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5c9d76308324baaae9d3f71a13b4)