### PR TITLE
Fix negative slack percentage bypass in cable auto-sizing

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13418,7 +13418,8 @@ function buildCableSpecFromComponent(comp, allComps) {
   spec.conductors = outbound?.conductors || cable.conductors || '';
   const unitPerPx = diagramScale.unitPerPx || 1;
   const slackPctRaw = parseFloat(cable.slack_pct);
-  const slackMultiplier = Number.isFinite(slackPctRaw) ? (1 + (slackPctRaw / 100)) : 1;
+  const slackPct = Number.isFinite(slackPctRaw) ? Math.max(0, slackPctRaw) : 0;
+  const slackMultiplier = 1 + (slackPct / 100);
   const autoLen = (outbound?.length || 0) * unitPerPx * slackMultiplier;
   let finalLen = autoLen;
   if (cable.manual_length) {


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled negative `cable.slack_pct` from producing zero/negative effective cable lengths that can bypass voltage-drop and conductor-sizing checks by ensuring automatically derived lengths cannot be reduced below the physical baseline.

### Description
- Clamp the parsed `cable.slack_pct` to a minimum of `0` in `buildCableSpecFromComponent()` (in `oneline.js`) and compute the slack multiplier from that clamped value so existing non-negative slack behavior and manual lengths are preserved.

### Testing
- Ran `npm test` which completed successfully (all assertions passed). 
- Ran `npm run build` which completed successfully (Rollup emitted non-blocking unresolved-dependency warnings for external/optional modules). 
- Attempted to produce a headless browser preview with Playwright but browser download failed due to environment network restrictions, so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5ec1059883248ebeb33e3f706543)