### PR TITLE
Restore early return in `loadProject` to prevent destructive missing-project loads

### DIFF
--- a/dataStore.mjs
+++ b/dataStore.mjs
@@ -767,8 +767,9 @@ export function loadProject(projectId, scenario = getCurrentScenarioNameState())
   if (!projectId) return false;
   try {
     const rawPayload = readSavedProject(projectId);
-    const payload = rawPayload || {};
-    const migrated = rawPayload ? wasSavedProjectMigrated(projectId) : false;
+    if (!rawPayload) return false;
+    const payload = rawPayload;
+    const migrated = wasSavedProjectMigrated(projectId);
     const equipment = payload.equipment;
     const panels = payload.panels;
     const loads = payload.loads;


### PR DESCRIPTION
### Motivation
- `loadProject()` previously proceeded with an empty payload when a saved project was not found, which caused in-memory/localStorage-backed working state to be partially cleared while leaving stale `loads` intact. 
- Because `site.js` calls `loadProject()` from arbitrary URL hashes and ignores its return value, a crafted same-origin hash could wipe a user's active unsaved project data.

### Description
- Reintroduced an early guard so `loadProject` immediately returns `false` when `readSavedProject(projectId)` is falsy and no setters run. 
- Kept existing behavior for valid saved projects unchanged by only calling `wasSavedProjectMigrated` and the normal setter path when a real payload exists.

### Testing
- Ran the full unit/test suite with `npm test`, and it completed successfully. 
- Ran `npm run build` to ensure the distribution build still succeeds, and the build completed successfully. 
- Attempted to capture an automated page preview with Playwright (`npx playwright screenshot`), but browser installation failed due to external download restrictions (Chromium download returned HTTP 403), so the preview image could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5ec0cc9c8324b45cf9c1198cc7ba)