### PR TITLE
Fix stale study cache override when resolving one-line attributes

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -4305,6 +4305,12 @@ function resolveComponentAttribute(comp, key) {
     return value;
   }
   const segments = key.split('.');
+  let value = getNestedValue(comp, segments);
+  if (value !== undefined) return value;
+  if (comp.props && typeof comp.props === 'object') {
+    value = getNestedValue(comp.props, segments);
+    if (value !== undefined) return value;
+  }
   const resolver = studyAttributeResolvers[segments[0]];
   if (resolver) {
     const base = resolver(comp);
@@ -4312,12 +4318,6 @@ function resolveComponentAttribute(comp, key) {
       const studyValue = getNestedValue(base, segments.slice(1));
       if (studyValue !== undefined) return studyValue;
     }
-  }
-  let value = getNestedValue(comp, segments);
-  if (value !== undefined) return value;
-  if (comp.props && typeof comp.props === 'object') {
-    value = getNestedValue(comp.props, segments);
-    if (value !== undefined) return value;
   }
   return undefined;
 }


### PR DESCRIPTION
### Motivation
- Prevent cached `studyResults` from taking precedence over study values embedded in a loaded project's one-line components because `studyResults` is stored separately and is not synchronized with project import/export, which can show stale safety-relevant outputs.

### Description
- Reordered the lookup in `resolveComponentAttribute` (in `oneline.js`) to check the loaded component's nested fields (`comp` then `comp.props`) before consulting `studyAttributeResolvers` / `cachedStudyResults`, restoring component-first precedence for namespaced attributes.

### Testing
- Ran the full test suite with `npm test` and it passed.
- Built the application with `npm run build` and the build completed successfully.
- Attempted to capture a local webpage preview using Playwright (`npx playwright screenshot`), but the browser download failed with a 403 so a screenshot could not be generated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5ec22094832492e2ea213ad81c3d)