### PR TITLE
Fix kV suffix conversion in TCC numeric parsing

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -9185,9 +9185,15 @@ function parseNumeric(value) {
   const normalized = trimmed.replace(/,/g, '');
   const direct = Number(normalized);
   if (Number.isFinite(direct)) return direct;
-  const match = normalized.match(/^(-?\d+(?:\.\d+)?)(?:\s*[a-zA-Z]+)?$/);
+  const match = normalized.match(/^(-?\d+(?:\.\d+)?)(?:\s*([a-zA-Z]+))?$/);
   if (!match) return null;
-  return Number(match[1]);
+  const numeric = Number(match[1]);
+  if (!Number.isFinite(numeric)) return null;
+  const suffix = (match[2] || '').toLowerCase();
+  if (!suffix) return numeric;
+  if (suffix === 'kv') return numeric * 1000;
+  if (suffix === 'v') return numeric;
+  return numeric;
 }
 
 function getNumericValue(comp, keys) {


### PR DESCRIPTION
### Motivation

- A recent change to the numeric parser stopped applying SI scaling for unit suffixes, causing valid strings like `13.8kV` to be interpreted as `13.8` (volts) and inflating TCC-derived currents by ~1000x. 
- The intent of this change is to remediate that regression for voltage fields used by TCC while avoiding reintroducing the previous kA double-scaling behavior for explicitly kA fields.

### Description

- Updated `parseNumeric` in `analysis/tcc.js` to capture an alphabetic suffix and to explicitly convert `kV` to volts (`numeric * 1000`) and preserve `V` as-is. 
- The parser still returns the leading numeric token for unknown suffixes to avoid broad behavioral changes elsewhere. 
- The change is localized to `analysis/tcc.js` and does not alter callers or other unit-handling logic.

### Testing

- Ran `npm run build` and the build completed successfully. 
- Ran the full automated test suite with `npm test`, which failed on an existing server security assertion in `tests/serverSecurity.test.mjs` (`401 !== 200`) that is unrelated to the parser fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6bb829108324b4f6ad5176f3005d)