### PR TITLE
Fix panel category resolution for schedule logic

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13370,6 +13370,7 @@ async function init() {
 }
 
 function getCategory(c) {
+  if (c?.type === 'panel') return 'panel';
   return subtypeCategory[c.subtype] || c.type;
 }
 


### PR DESCRIPTION
### Motivation

- A recent change made `getCategory()` prefer palette-derived `subtypeCategory` over the component `type`, which misclassified built-in panel components as `equipment` and caused panels to be omitted from panel schedules and to lose `panelId` associations for downstream loads.
- The intent of this change is to restore reliable detection of `panel` instances for schedule reconciliation while preserving subtype-based category resolution for specialized loads.

### Description

- Updated `getCategory(c)` in `oneline.js` to return `'panel'` when `c?.type === 'panel'` before consulting `subtypeCategory` or `c.type`.
- This minimal change ensures palette-created panel instances (which have `type: 'panel'`) are recognized as panels while keeping the existing `subtypeCategory` lookup for specialized load categories.

### Testing

- Ran the full automated test suite via `npm test`, which completed successfully with all checks passing.
- Ran the build via `npm run build`, which completed successfully and produced `dist` artifacts (non-fatal bundler warnings only).
- Attempted to generate a UI preview screenshot with Playwright, but `npx playwright install chromium` failed due to CDN download returning HTTP 403, so a preview image could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6bbc026c832480e627e30432e63c)