### PR TITLE
Fail closed when PQ traversal exceeds safety cap

### DIFF
--- a/analysis/loadFlow.js
+++ b/analysis/loadFlow.js
@@ -871,7 +871,9 @@ function sumPQ(value) {
     if (visited.has(current)) continue;
     visited.add(current);
     visitedNodes += 1;
-    if (visitedNodes > MAX_PQ_TRAVERSAL_NODES) break;
+    if (visitedNodes > MAX_PQ_TRAVERSAL_NODES) {
+      throw new RangeError(`Load-flow PQ data exceeds maximum supported nesting depth (${MAX_PQ_TRAVERSAL_NODES} object nodes).`);
+    }
 
     if (Array.isArray(current)) {
       current.forEach(item => stack.push(item));

--- a/analysis/loadFlowModel.js
+++ b/analysis/loadFlowModel.js
@@ -435,7 +435,9 @@ function extractPQ(source) {
     if (visited.has(current)) continue;
     visited.add(current);
     visitedNodes += 1;
-    if (visitedNodes > MAX_PQ_TRAVERSAL_NODES) break;
+    if (visitedNodes > MAX_PQ_TRAVERSAL_NODES) {
+      throw new RangeError(`Load-flow PQ data exceeds maximum supported nesting depth (${MAX_PQ_TRAVERSAL_NODES} object nodes).`);
+    }
 
     if (Array.isArray(current)) {
       current.forEach(item => stack.push(item));

--- a/tests/loadflow/deepNestedLoadSafety.test.mjs
+++ b/tests/loadflow/deepNestedLoadSafety.test.mjs
@@ -31,7 +31,7 @@ function it(name, fn) {
 }
 
 describe('Load flow nested PQ parsing safety', () => {
-  it('handles deeply nested bus load objects without stack overflow', () => {
+  it('rejects deeply nested bus load objects with a bounded error', () => {
     const model = {
       buses: [
         { id: 'source', type: 'slack', baseKV: 13.8 },
@@ -42,11 +42,13 @@ describe('Load flow nested PQ parsing safety', () => {
       ]
     };
 
-    const result = runLoadFlow(model, { baseMVA: 10, balanced: true });
-    assert.strictEqual(typeof result.converged, 'boolean');
+    assert.throws(
+      () => runLoadFlow(model, { baseMVA: 10, balanced: true }),
+      /maximum supported nesting depth/i
+    );
   });
 
-  it('handles deeply nested component load objects when building model', () => {
+  it('rejects deeply nested component load objects when building model', () => {
     const oneLine = {
       sheets: [
         {
@@ -61,7 +63,9 @@ describe('Load flow nested PQ parsing safety', () => {
       ]
     };
 
-    const model = buildLoadFlowModel(oneLine);
-    assert(Array.isArray(model.buses));
+    assert.throws(
+      () => buildLoadFlowModel(oneLine),
+      /maximum supported nesting depth/i
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent silent truncation of deeply nested load/generation PQ data that previously returned partial or zeroed totals when the traversal cap was exceeded.  
- Preserve the iterative traversal mitigation against recursive stack-overflow while ensuring integrity by surfacing a bounded error instead of continuing with incomplete totals.

### Description
- Change `sumPQ` in `analysis/loadFlow.js` to throw a bounded `RangeError` when `MAX_PQ_TRAVERSAL_NODES` is exceeded instead of breaking and returning partial totals.  
- Apply the same fail-closed behavior to `extractPQ` in `analysis/loadFlowModel.js` by throwing the same `RangeError` on traversal-cap overflow.  
- Update `tests/loadflow/deepNestedLoadSafety.test.mjs` to assert the new fail-closed behavior for `runLoadFlow` and `buildLoadFlowModel` when presented with excessively nested PQ payloads.  
- Make the minimal changes necessary to preserve existing traversal limits and stack-overflow protection while surfacing an explicit error on over-limit inputs.

### Testing
- Ran the full test suite with `npm test`, which completed successfully after the changes.  
- Built the distribution with `npm run build`, which completed successfully (Rollup produced non-blocking warnings about unresolved external deps).  
- Attempted a Playwright screenshot to generate the requested preview image, but browser binaries are not installed in this environment so the screenshot step failed; the code changes and tests were still validated by the CI-local `npm test` and `npm run build` runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6d6dd2d48324b52d39782c99d8ec)