### PR TITLE
Clamp one-line viewport bounds to prevent client-side DoS

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -2281,6 +2281,7 @@ const MAX_DIAGRAM_ZOOM = 4;
 const DEFAULT_VIEWPORT_WIDTH = 960;
 const DEFAULT_VIEWPORT_HEIGHT = 540;
 const STATIC_VIEWPORT_SCALE = 4;
+const MAX_DYNAMIC_VIEWPORT_SPAN = 50000;
 const STATIC_VIEWPORT_BOUNDS = {
   minX: -DEFAULT_VIEWPORT_WIDTH * STATIC_VIEWPORT_SCALE / 2,
   minY: -DEFAULT_VIEWPORT_HEIGHT * STATIC_VIEWPORT_SCALE / 2,
@@ -2754,16 +2755,20 @@ function updateDiagramViewport(bounds) {
       const minHeight = STATIC_VIEWPORT_BOUNDS.height;
       const paddedWidth = rawWidth + pad * 2;
       const paddedHeight = rawHeight + pad * 2;
-      const width = Math.max(minWidth, paddedWidth);
-      const height = Math.max(minHeight, paddedHeight);
+      const width = Math.min(MAX_DYNAMIC_VIEWPORT_SPAN, Math.max(minWidth, paddedWidth));
+      const height = Math.min(MAX_DYNAMIC_VIEWPORT_SPAN, Math.max(minHeight, paddedHeight));
       const centerX = (bounds.minX + bounds.maxX) / 2;
       const centerY = (bounds.minY + bounds.maxY) / 2;
-      nextViewport = {
-        minX: centerX - width / 2,
-        minY: centerY - height / 2,
-        width,
-        height
-      };
+      const minX = centerX - width / 2;
+      const minY = centerY - height / 2;
+      if (Number.isFinite(centerX) && Number.isFinite(centerY) && Number.isFinite(minX) && Number.isFinite(minY)) {
+        nextViewport = {
+          minX,
+          minY,
+          width,
+          height
+        };
+      }
     }
   }
   if (needsInitialViewportCenter) {


### PR DESCRIPTION
### Motivation
- Recent viewport logic trusted finite but unbounded diagram bounds and could propagate extremely large or non-finite values into the SVG `viewBox` and CSS sizes, causing browser availability problems. 
- The change introduces an upper bound and final finite checks so attacker-controlled coordinates cannot force oversized or non-finite viewport values.

### Description
- Introduce `MAX_DYNAMIC_VIEWPORT_SPAN = 50000` next to the existing viewport constants to cap dynamic viewport width/height. 
- In `updateDiagramViewport` clamp computed `width`/`height` with `Math.min(MAX_DYNAMIC_VIEWPORT_SPAN, ...)` so padded diagram spans cannot exceed the cap. 
- Compute `minX`/`minY` from the center and validate `Number.isFinite(centerX)`, `centerY`, `minX`, and `minY` before assigning `diagramViewport`, falling back to `STATIC_VIEWPORT_BOUNDS` when validation fails. 
- Preserve prior fallback behavior so static/default viewport is used when bounds are invalid or overflow occurs.

### Testing
- Ran `npm test` and the test suite completed successfully. 
- Ran `npm run build` and the project bundled successfully. 
- Attempted to produce a browser preview with `npx playwright install chromium` and `npx playwright screenshot ...` but the Playwright browser download is blocked in this environment (HTTP 403), so an automated screenshot could not be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6ffcc1f08324a2bd5b365b1d8bcd)