### PR TITLE
Fix voltage field normalization regression in oneline resolver

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -13503,7 +13503,7 @@ function resolveComponentVoltageVolts(comp, options = {}) {
     if (!container || typeof container !== 'object') continue;
     for (const key of directKeys) {
       if (!(key in container)) continue;
-      const resolved = normalizeVoltageToVolts({ [key]: container[key] });
+      const resolved = normalizeVoltageToVolts(container[key]);
       if (resolved !== null && Number.isFinite(resolved) && resolved > 0) {
         return resolved;
       }


### PR DESCRIPTION
### Motivation
- Fix a regression that wrapped direct voltage fields as objects before normalization which caused supported keys like `rated_voltage`, `voltage_kv`, and `operating_voltage` to resolve to `null` and unintentionally suppress voltage mismatch validation.

### Description
- Restore prior behavior in `oneline.js` by passing the raw field value to `normalizeVoltageToVolts` (use `normalizeVoltageToVolts(container[key])`) inside `resolveComponentVoltageVolts`, so numeric and unit-suffixed values on direct keys are recognized.

### Testing
- Ran the full automated test suite with `npm test`, which completed successfully.
- Ran the build with `npm run build`, which completed successfully.
- Attempted to generate a page preview with Playwright (`npx playwright install chromium` / screenshot), but browser download failed (CDN 403) so the preview image could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b715f4aac8324bc83392813757bb1)