### PR TITLE
fix: compute short-circuit results for all components

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -708,8 +708,8 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       : sheets;
     comps = comps.filter(c => c && c.type !== 'annotation' && c.type !== 'dimension');
   }
-  let buses = comps.filter(comp => comp?.subtype === 'Bus' || comp?.type === 'bus');
-  if (buses.length === 0) buses = comps;
+  const busNodes = comps.filter(comp => comp?.subtype === 'Bus' || comp?.type === 'bus');
+  const hasBusNodes = busNodes.length > 0;
   const compMap = new Map(comps.map(c => [c.id, c]));
   const impedanceCache = new Map();
   const voltageCache = new Map();
@@ -779,9 +779,9 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     return { r, x };
   };
 
-  buses.forEach(comp => {
+  comps.forEach(comp => {
     const baseZ = computeImpedance(comp, comps, compMap, impedanceCache);
-    const fallbackZ = (comp?.subtype === 'Bus' || comp?.type === 'bus')
+    const fallbackZ = (!hasBusNodes || comp?.subtype === 'Bus' || comp?.type === 'bus')
       ? resolveUpstreamImpedance(comp, comps, compMap, impedanceCache)
       : null;
     let z1 = comp.z1 ? toImpedance(comp.z1) : baseZ;


### PR DESCRIPTION
### Motivation
- Restore safety-analysis integrity by ensuring `runShortCircuit()` produces short-circuit results keyed by every non-annotation component so downstream arc-flash and equipment-evaluation code can reliably lookup fault currents. 
- Prevent a fail-open scenario introduced by a bus-only study-node filter that caused non-bus protective devices and cables to be omitted from the short-circuit result map in mixed one-line models.

### Description
- Changed `analysis/shortCircuit.mjs` to iterate `comps` (all non-annotation components) rather than a filtered bus-only list so every component receives a short-circuit entry. 
- Introduced `busNodes` / `hasBusNodes` and adjusted the upstream-impedance fallback so existing bus-specific fallback behavior is preserved only when bus nodes are present. 
- Kept the rest of the short-circuit engine logic intact (impedance handling, IEC/ANSI branches, warnings, protection limiting, instrument transformer metadata, and result writes) so functional behavior is unchanged except for coverage of results by component id.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (all automated tests passed). 
- Built the distribution with `npm run build`, which succeeded and produced the `dist` artifacts. 
- Attempted to capture a webpage preview with Playwright (`npx playwright screenshot ...`) but browser installation failed due to external CDN/403 errors so an automated screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b715f947c83249f2ee3cbe591cb51)