### PR TITLE
Phase 2: HttpOnly ctr_auth cookie + WebSocket ticket endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,9 @@ This repository uses this file for all developer tasks. The rules below apply to
 - Preserve the undo/redo stacks maintained by `pushUndo`, `undoProjectChange`, and `redoProjectChange`. Ensure new mutations capture diffs through these helpers so change history stays accurate.
 
 ## Backend Security Requirements
-- Server authentication in `server.mjs` relies on scrypt password hashing (`hashPassword` / `verifyPassword`), `FileSessionStore` persistence, and session records containing both bearer tokens and CSRF tokens. Retain these mechanisms when modifying auth flows.
-- Authenticated routes must continue to require a `Bearer` token header and enforce the `x-csrf-token` timing-safe comparison before mutating state.
+- Server authentication in `server.mjs` relies on scrypt password hashing (`hashPassword` / `verifyPassword`), `FileSessionStore` persistence, and session records containing both session tokens and CSRF tokens. Retain these mechanisms when modifying auth flows.
+- Authenticated routes accept either the HttpOnly `ctr_auth` cookie (preferred for browser clients) or a legacy `Authorization: Bearer` header during the deprecation window. Either path must still enforce the `x-csrf-token` timing-safe comparison before mutating state.
+- WebSocket upgrades cannot carry cookies, so browsers exchange the cookie session for a short-lived single-use ticket via `POST /ws/ticket` and pass `ticket.<hex>` in the `Sec-WebSocket-Protocol` header. Preserve this flow when changing the collaboration server.
 - The `/projects` endpoints are guarded by rate limiting. Keep rate limiting active for any new persistence routes.
 - HTTPS enforcement (via the `enforceHttps` option) is required in production deployments. New middleware must not bypass or weaken this redirect.
 

--- a/account.js
+++ b/account.js
@@ -51,17 +51,15 @@ function init() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${auth.token}`,
           'X-CSRF-Token': auth.csrfToken
         },
         body: JSON.stringify({ currentPassword, newPassword })
       });
       const body = await res.json().catch(() => ({}));
       if (res.ok) {
-        if (body.token && body.csrfToken && body.expiresAt) {
+        if (body.csrfToken && body.expiresAt) {
           auth = {
             ...auth,
-            token: body.token,
             csrfToken: body.csrfToken,
             expiresAt: body.expiresAt,
           };

--- a/auth.js
+++ b/auth.js
@@ -94,8 +94,10 @@ async function login(e) {
       body: JSON.stringify({ username, password })
     });
     if (res.ok) {
-      const { token, csrfToken, expiresAt, role } = await res.json();
-      setAuthContextState({ token, csrfToken, expiresAt, user: username, role: role || null });
+      const { csrfToken, expiresAt, role } = await res.json();
+      // The session token rides in the HttpOnly ctr_auth cookie set by the
+      // server; we only persist the CSRF secret and metadata for the UI.
+      setAuthContextState({ csrfToken, expiresAt, user: username, role: role || null });
       window.location.href = 'index.html';
       return;
     }

--- a/library.html
+++ b/library.html
@@ -206,9 +206,7 @@
     async function cloudGet() {
       const auth = authState();
       if (!auth) return null;
-      const res = await fetch('/api/v1/library', {
-        headers: { 'Authorization': `Bearer ${auth.token}` },
-      });
+      const res = await fetch('/api/v1/library');
       if (res.status === 404) return { notFound: true };
       if (!res.ok) return null;
       return res.json();
@@ -224,7 +222,6 @@
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${auth.token}`,
           'X-Csrf-Token': auth.csrfToken,
         },
         body: JSON.stringify(body),
@@ -398,7 +395,6 @@
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${auth.token}`,
           'X-Csrf-Token': auth.csrfToken,
         },
         body: '{}',

--- a/oidc-relay.html
+++ b/oidc-relay.html
@@ -18,7 +18,6 @@
     import { setAuthContextState } from './projectStorage.js';
 
     const params = new URLSearchParams(window.location.search);
-    const token = params.get('token');
     const csrfToken = params.get('csrfToken');
     const expiresAt = Number(params.get('expiresAt'));
     const user = params.get('user');
@@ -26,11 +25,14 @@
 
     const statusMsg = document.getElementById('status-msg');
 
-    if (!token || !csrfToken || !Number.isFinite(expiresAt)) {
+    // The session bearer token is delivered via the HttpOnly ctr_auth cookie
+    // set on the OIDC callback response — it is intentionally absent from the
+    // URL. Only non-secret metadata is relayed through query parameters.
+    if (!csrfToken || !Number.isFinite(expiresAt)) {
       statusMsg.textContent = 'Sign-in failed: missing session parameters. Redirecting to login…';
       setTimeout(() => { window.location.href = 'login.html?error=oidc_relay_invalid'; }, 2000);
     } else {
-      setAuthContextState({ token, csrfToken, expiresAt, user });
+      setAuthContextState({ csrfToken, expiresAt, user });
       if (role) {
         localStorage.setItem('ctr-user-role', role);
       }

--- a/projectStorage.js
+++ b/projectStorage.js
@@ -826,10 +826,12 @@ export function clearConduitCache() {
 }
 
 export function getAuthContextState() {
-  const token = readRawStorage(AUTH_TOKEN_KEY);
   const csrfToken = readRawStorage(AUTH_CSRF_KEY);
   const expiresRaw = readRawStorage(AUTH_EXPIRES_KEY);
-  if (!token || !csrfToken || !expiresRaw) return null;
+  // The bearer token is no longer stored client-side — it lives in the
+  // HttpOnly ctr_auth cookie. Auth context is defined by having a fresh CSRF
+  // secret and a non-expired session.
+  if (!csrfToken || !expiresRaw) return null;
   const expiresAt = Number.parseInt(expiresRaw, 10);
   if (!Number.isFinite(expiresAt)) {
     clearAuthContextState();
@@ -841,7 +843,7 @@ export function getAuthContextState() {
   }
   const user = readRawStorage(AUTH_USER_KEY);
   const role = readRawStorage(AUTH_ROLE_KEY);
-  return { token, csrfToken, expiresAt, user: user || null, role: role || null };
+  return { csrfToken, expiresAt, user: user || null, role: role || null };
 }
 
 const SESSION_WARNING_MS = 5 * 60 * 1000; // warn 5 minutes before expiry
@@ -882,11 +884,13 @@ function scheduleSessionTimers(expiresAt) {
   }, msUntilExpiry);
 }
 
-export function setAuthContextState({ token, csrfToken, expiresAt, user, role }) {
-  if (!token || !csrfToken) return;
+export function setAuthContextState({ csrfToken, expiresAt, user, role } = {}) {
+  if (!csrfToken) return;
   const expiresValue = Number(expiresAt);
   if (!Number.isFinite(expiresValue)) return;
-  writeRawStorage(AUTH_TOKEN_KEY, token);
+  // AUTH_TOKEN_KEY is intentionally cleared: the session token now lives in
+  // an HttpOnly cookie and must not be readable from JS-accessible storage.
+  writeRawStorage(AUTH_TOKEN_KEY, null);
   writeRawStorage(AUTH_CSRF_KEY, csrfToken);
   writeRawStorage(AUTH_EXPIRES_KEY, String(expiresValue));
   if (user === undefined || user === null) {

--- a/server.mjs
+++ b/server.mjs
@@ -706,6 +706,13 @@ class FileSessionStore {
     if (changed) await this.#persist();
   }
 
+  async revokeSession(token) {
+    if (!this.sessions.has(token)) return false;
+    this.sessions.delete(token);
+    await this.#persist();
+    return true;
+  }
+
   async get(token) {
     await this.#pruneExpired();
     const session = this.sessions.get(token);
@@ -837,6 +844,23 @@ export async function createApp(options = {}) {
   const oidcStateStore = new Map();
   const OIDC_STATE_TTL_MS = 10 * 60 * 1000;
   let oidcDiscoveryCache = null;
+
+  // Session cookie used by browser clients. The Authorization header is still
+  // accepted during a deprecation window so scripted API consumers and legacy
+  // browser builds keep working.
+  const AUTH_COOKIE_NAME = 'ctr_auth';
+
+  // WebSocket upgrade tickets — short-lived, single-use, bound to a session.
+  // Issued via POST /ws/ticket (authenticated + CSRF protected). Used because
+  // cookies cannot be transmitted through the WebSocket subprotocol header.
+  const WS_TICKET_TTL_MS = 30_000;
+  const wsTicketStore = new Map(); // ticket -> { sessionToken, username, expiresAt }
+  function pruneWsTickets() {
+    const now = Date.now();
+    for (const [t, entry] of wsTicketStore) {
+      if (!entry || entry.expiresAt <= now) wsTicketStore.delete(t);
+    }
+  }
 
   let users = {};
   try {
@@ -1042,6 +1066,53 @@ export async function createApp(options = {}) {
 
   // Stricter rate limit for auth endpoints to prevent brute-force attacks.
   const authRateLimiter = createRateLimiter({ windowMs: rateLimitWindowMs, max: 20 });
+  // Cookie helpers (shared by auth, refresh, logout, OIDC). Defined here so the
+  // /login handler and the auth middleware below can use them.
+  function serializeCookie(name, value, attrs = {}) {
+    const parts = [`${name}=${encodeURIComponent(value)}`];
+    if (attrs.maxAge !== undefined) parts.push(`Max-Age=${Math.floor(Number(attrs.maxAge))}`);
+    if (attrs.path) parts.push(`Path=${attrs.path}`);
+    if (attrs.httpOnly) parts.push('HttpOnly');
+    if (attrs.secure) parts.push('Secure');
+    if (attrs.sameSite) parts.push(`SameSite=${attrs.sameSite}`);
+    return parts.join('; ');
+  }
+  function getCookieValue(req, cookieName) {
+    const header = req.headers.cookie;
+    if (!header || typeof header !== 'string') return null;
+    for (const entry of header.split(';')) {
+      const [rawName, ...rest] = entry.trim().split('=');
+      if (rawName !== cookieName) continue;
+      try {
+        return decodeURIComponent(rest.join('='));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+  function isRequestSecure(req) {
+    return Boolean(req.secure || req.headers['x-forwarded-proto'] === 'https');
+  }
+  function setAuthCookie(req, res, token, ttlMs) {
+    res.setHeader('Set-Cookie', serializeCookie(AUTH_COOKIE_NAME, token, {
+      path: '/',
+      maxAge: Math.floor((ttlMs || sessionStore.ttlMs) / 1000),
+      httpOnly: true,
+      secure: isRequestSecure(req),
+      sameSite: 'Lax',
+    }));
+  }
+  function clearAuthCookie(req, res) {
+    res.setHeader('Set-Cookie', serializeCookie(AUTH_COOKIE_NAME, '', {
+      path: '/',
+      maxAge: 0,
+      httpOnly: true,
+      secure: isRequestSecure(req),
+      sameSite: 'Lax',
+    }));
+  }
+
   app.use('/login', authRateLimiter);
   app.use('/signup', authRateLimiter);
   app.use('/session/refresh', authRateLimiter);
@@ -1116,15 +1187,23 @@ export async function createApp(options = {}) {
       await saveUsers();
 
       const session = await sessionStore.createSession(trimmedUser);
+      setAuthCookie(req, res, session.token, sessionStore.ttlMs);
       appendAuditEntry(auditLogFile, { actor: trimmedUser, action: 'LOGIN', entityType: 'session' }).catch(() => {});
       res.json({ ...session, role: getUserRole(trimmedUser) });
     })
   );
 
+  // Authentication: accept the HttpOnly ctr_auth cookie first, falling back to
+  // the legacy Authorization: Bearer header during the deprecation window for
+  // scripted API consumers.
   const auth = asyncHandler(async (req, res, next) => {
-    const header = req.headers.authorization || '';
-    const [scheme, token] = header.split(' ');
-    if (scheme !== 'Bearer' || !token) {
+    let token = getCookieValue(req, AUTH_COOKIE_NAME);
+    if (!token) {
+      const header = req.headers.authorization || '';
+      const [scheme, headerToken] = header.split(' ');
+      if (scheme === 'Bearer' && headerToken) token = headerToken;
+    }
+    if (!token) {
       res.status(401).json({ error: 'Unauthorized' });
       return;
     }
@@ -1207,10 +1286,44 @@ export async function createApp(options = {}) {
     asyncHandler(async (req, res) => {
       const newSession = await sessionStore.refreshSession(req.authToken);
       if (!newSession) {
+        clearAuthCookie(req, res);
         res.status(401).json({ error: 'Session not eligible for refresh' });
         return;
       }
+      setAuthCookie(req, res, newSession.token, sessionStore.ttlMs);
       res.json(newSession);
+    })
+  );
+
+  // Local-account logout: revoke this session and clear the auth cookie.
+  app.post(
+    '/logout',
+    auth,
+    csrfProtection,
+    asyncHandler(async (req, res) => {
+      await sessionStore.revokeSession(req.authToken);
+      clearAuthCookie(req, res);
+      appendAuditEntry(auditLogFile, { actor: req.username, action: 'LOGOUT', entityType: 'session' }).catch(() => {});
+      res.json({ loggedOut: true });
+    })
+  );
+
+  // Mint a single-use, short-lived ticket the browser can pass through the
+  // WebSocket subprotocol header (cookies cannot be sent that way).
+  app.post(
+    '/ws/ticket',
+    auth,
+    csrfProtection,
+    asyncHandler(async (req, res) => {
+      pruneWsTickets();
+      const ticket = crypto.randomBytes(32).toString('hex');
+      const expiresAt = Date.now() + WS_TICKET_TTL_MS;
+      wsTicketStore.set(ticket, {
+        sessionToken: req.authToken,
+        username: req.username,
+        expiresAt,
+      });
+      res.json({ ticket, expiresAt });
     })
   );
 
@@ -1298,6 +1411,7 @@ export async function createApp(options = {}) {
       users[req.username].password = await hashPassword(newPassword);
       await saveUsers();
       const session = await sessionStore.createSession(req.username);
+      setAuthCookie(req, res, session.token, sessionStore.ttlMs);
       res.json({ message: 'Password changed successfully.', ...session });
     })
   );
@@ -1865,29 +1979,6 @@ When answering queries:
   function base64urlEncode(buf) {
     return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
   }
-  function serializeCookie(name, value, attrs = {}) {
-    const parts = [`${name}=${encodeURIComponent(value)}`];
-    if (attrs.maxAge !== undefined) parts.push(`Max-Age=${Math.floor(Number(attrs.maxAge))}`);
-    if (attrs.path) parts.push(`Path=${attrs.path}`);
-    if (attrs.httpOnly) parts.push('HttpOnly');
-    if (attrs.secure) parts.push('Secure');
-    if (attrs.sameSite) parts.push(`SameSite=${attrs.sameSite}`);
-    return parts.join('; ');
-  }
-  function getCookieValue(req, cookieName) {
-    const header = req.headers.cookie;
-    if (!header || typeof header !== 'string') return null;
-    for (const entry of header.split(';')) {
-      const [rawName, ...rest] = entry.trim().split('=');
-      if (rawName !== cookieName) continue;
-      try {
-        return decodeURIComponent(rest.join('='));
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }
 
   async function getOidcDiscovery(issuer) {
     if (oidcDiscoveryCache) return oidcDiscoveryCache;
@@ -2067,11 +2158,13 @@ When answering queries:
       await saveUsers();
 
       const session = await sessionStore.createSession(username);
+      setAuthCookie(req, res, session.token, sessionStore.ttlMs);
       appendAuditEntry(auditLogFile, { actor: username, action: 'LOGIN', entityType: 'session' }).catch(() => {});
 
-      // Relay token to the browser via a minimal HTML page that saves to localStorage.
+      // Relay the non-secret session metadata (csrfToken, expiresAt, user, role)
+      // through a minimal HTML page. The session token itself rides in the
+      // HttpOnly cookie set above, so it never enters the URL.
       const relayParams = new URLSearchParams({
-        token: session.token,
         csrfToken: session.csrfToken,
         expiresAt: String(session.expiresAt),
         user: username,
@@ -2088,6 +2181,7 @@ When answering queries:
     asyncHandler(async (req, res) => {
       appendAuditEntry(auditLogFile, { actor: req.username, action: 'LOGOUT', entityType: 'session' }).catch(() => {});
       await sessionStore.revokeUserSessions(req.username);
+      clearAuthCookie(req, res);
       res.json({ loggedOut: true });
     })
   );
@@ -2120,6 +2214,24 @@ When answering queries:
     if (typeof protocolHeader !== 'string') return false;
 
     const protocols = protocolHeader.split(',').map((value) => value.trim()).filter(Boolean);
+
+    // Preferred path: single-use ticket minted via POST /ws/ticket. Cookies
+    // cannot be sent through the subprotocol header, so browsers exchange the
+    // cookie session for a short-lived ticket here.
+    const ticketProtocol = protocols.find((value) => value.startsWith('ticket.')) || '';
+    if (ticketProtocol) {
+      pruneWsTickets();
+      const ticket = ticketProtocol.slice('ticket.'.length);
+      if (!ticket || !/^[0-9a-fA-F]+$/.test(ticket)) return false;
+      const entry = wsTicketStore.get(ticket);
+      if (!entry) return false;
+      wsTicketStore.delete(ticket); // single-use
+      if (entry.expiresAt <= Date.now()) return false;
+      const session = await sessionStore.get(entry.sessionToken);
+      return Boolean(session);
+    }
+
+    // Legacy path (deprecated): auth.<base64-token> + csrf.<hex>.
     const authProtocol = protocols.find((value) => value.startsWith('auth.')) || '';
     const csrfProtocol = protocols.find((value) => value.startsWith('csrf.')) || '';
     if (!authProtocol || !csrfProtocol) return false;

--- a/site.js
+++ b/site.js
@@ -2798,17 +2798,17 @@ globalThis.showSelfCheckModal=showSelfCheckModal;
       if (!auth) return; // only start when logged in
       if (window.localStorage?.getItem('ctrEnableCollaboration') !== 'true') return;
       const projectId = (window.currentProjectId || '').trim();
+      // The CollabClient reads the cookie-backed session via the ticket endpoint,
+      // so we only pass the projectId/username here.
       initCollaboration({
         projectId,
         username: auth.user,
-        authToken: auth.token,
-        csrfToken: auth.csrfToken,
       });
     }
     startCollab();
     // Re-init when project changes (project manager fires storage events)
     window.addEventListener('storage', (e) => {
-      if (e.key === 'currentProjectId' || e.key === 'authToken') {
+      if (e.key === 'currentProjectId' || e.key === 'authCsrfToken') {
         stopCollaboration();
         startCollab();
       }

--- a/src/admin.js
+++ b/src/admin.js
@@ -4,9 +4,8 @@ import { mountPersistentNavigation } from './components/navigation.js';
 const ROLE_OPTIONS = ['read-only', 'reviewer', 'engineer', 'admin'];
 
 function authHeaders() {
-  const { token, csrfToken } = getAuthContextState() ?? {};
+  const { csrfToken } = getAuthContextState() ?? {};
   return {
-    Authorization: `Bearer ${token}`,
     'X-CSRF-Token': csrfToken,
     'Content-Type': 'application/json',
   };
@@ -29,9 +28,7 @@ async function loadUsers() {
   const tbody = document.getElementById('users-tbody');
   tbody.innerHTML = '<tr><td colspan="7" class="table-empty">Loading…</td></tr>';
   try {
-    const res = await fetch('/api/v1/admin/users', {
-      headers: { Authorization: authHeaders().Authorization },
-    });
+    const res = await fetch('/api/v1/admin/users');
     if (res.status === 403) {
       tbody.innerHTML = '<tr><td colspan="7" class="table-empty table-error">Access denied. Admin role required.</td></tr>';
       return;
@@ -130,9 +127,7 @@ async function loadAuditLog() {
   params.set('limit', String(Math.min(limit, 500)));
 
   try {
-    const res = await fetch(`/api/v1/admin/audit-log?${params}`, {
-      headers: { Authorization: authHeaders().Authorization },
-    });
+    const res = await fetch(`/api/v1/admin/audit-log?${params}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const { entries, total } = await res.json();
     lastAuditEntries = entries;
@@ -231,7 +226,7 @@ async function init() {
   const accessCheck = document.getElementById('admin-access-check');
   const adminContent = document.getElementById('admin-content');
 
-  if (!authState?.token) {
+  if (!authState) {
     accessCheck.innerHTML = '<p class="table-error">You must be signed in to access the admin panel. <a href="login.html">Sign in</a></p>';
     return;
   }

--- a/src/collaboration.js
+++ b/src/collaboration.js
@@ -25,21 +25,29 @@ const WS_URL = (() => {
   return `${proto}//${location.host}/ws/collab`;
 })();
 
-function buildWsProtocols() {
-  if (typeof TextEncoder === 'undefined') return ['ctr-collab'];
-  const auth = getAuthContextState();
-  const authToken = auth?.token || '';
-  const csrfToken = auth?.csrfToken || '';
+/**
+ * Request a short-lived single-use ticket from the server. Cookies cannot be
+ * sent through the WebSocket subprotocol header, so we trade the cookie-backed
+ * session for a ticket that the server validates on upgrade.
+ *
+ * @returns {Promise<string[]>} subprotocols including the ticket, or just
+ *   ['ctr-collab'] if no auth context is available.
+ */
+async function buildWsProtocols() {
   const protocols = ['ctr-collab'];
-
-  if (authToken) {
-    const encoded = btoa(String.fromCharCode(...new TextEncoder().encode(authToken)))
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/g, '');
-    protocols.push(`auth.${encoded}`);
+  const auth = getAuthContextState();
+  if (!auth?.csrfToken) return protocols;
+  try {
+    const res = await fetch('/ws/ticket', {
+      method: 'POST',
+      headers: { 'X-CSRF-Token': auth.csrfToken },
+    });
+    if (!res.ok) return protocols;
+    const { ticket } = await res.json();
+    if (ticket && /^[0-9a-fA-F]+$/.test(ticket)) protocols.push(`ticket.${ticket}`);
+  } catch {
+    // network failure — fall back to unauthenticated protocol; server will reject
   }
-  if (csrfToken) protocols.push(`csrf.${csrfToken}`);
   return protocols;
 }
 
@@ -68,13 +76,18 @@ export class CollabClient extends EventTarget {
   }
 
   /** Connect (or reconnect) to the collaboration server. */
-  connect() {
+  async connect() {
     if (this.#ws && this.#ws.readyState <= WebSocket.OPEN) return; // already connecting/open
     if (!WS_URL) return;
 
     this.#intentionalClose = false;
     this.#lastSeq = 0;
-    this.#ws = new WebSocket(WS_URL, buildWsProtocols());
+    const protocols = await buildWsProtocols();
+    // A second concurrent connect() may have raced ahead while we were
+    // fetching the ticket; bail if so.
+    if (this.#ws && this.#ws.readyState <= WebSocket.OPEN) return;
+    if (this.#intentionalClose) return;
+    this.#ws = new WebSocket(WS_URL, protocols);
 
     this.#ws.addEventListener('open', () => {
       this.#reconnectAttempt = 0;

--- a/src/fetchUtils.mjs
+++ b/src/fetchUtils.mjs
@@ -38,11 +38,11 @@ export async function fetchJson(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_M
 }
 
 /**
- * Fetch a URL with Bearer + CSRF auth headers and return the parsed JSON body.
- * Callers should pass the auth context object from getAuthContext().
+ * Fetch a URL using the HttpOnly session cookie for authentication and the
+ * caller-supplied CSRF token for the double-submit check.
  *
  * @param {string} url
- * @param {{ token: string, csrfToken: string }} auth
+ * @param {{ csrfToken: string }} auth
  * @param {RequestInit} [options]
  * @param {number} [timeoutMs]
  * @returns {Promise<unknown>}
@@ -51,7 +51,6 @@ export async function fetchAuthJson(url, auth, options = {}, timeoutMs = DEFAULT
     const { method = 'GET', body, ...rest } = options;
     const headers = {
         ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
-        'Authorization': `Bearer ${auth.token}`,
         'X-CSRF-Token': auth.csrfToken,
         ...rest.headers,
     };

--- a/src/projectManager.js
+++ b/src/projectManager.js
@@ -334,7 +334,6 @@ async function serverSaveProject(name) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${auth.token}`,
       'X-CSRF-Token': auth.csrfToken
     },
     body: JSON.stringify(exportProject())
@@ -348,7 +347,6 @@ async function serverLoadProject(name) {
   if (!auth) return false;
   const res = await fetch(`/projects/${encodeURIComponent(name)}`, {
     headers: {
-      'Authorization': `Bearer ${auth.token}`,
       'X-CSRF-Token': auth.csrfToken
     }
   });
@@ -466,7 +464,6 @@ async function requestSnapshotList(projectName) {
   if (!auth) throw new Error('Login required to manage snapshots.');
   const res = await fetch(`/projects/${encodeURIComponent(projectName)}/snapshots`, {
     headers: {
-      'Authorization': `Bearer ${auth.token}`,
       'X-CSRF-Token': auth.csrfToken
     }
   });
@@ -483,7 +480,6 @@ async function createSnapshot(projectName, mode) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${auth.token}`,
       'X-CSRF-Token': auth.csrfToken
     },
     body: JSON.stringify({ mode })
@@ -499,7 +495,6 @@ async function revokeSnapshot(projectName, snapshotId) {
   const res = await fetch(`/projects/${encodeURIComponent(projectName)}/snapshots/${encodeURIComponent(snapshotId)}`, {
     method: 'DELETE',
     headers: {
-      'Authorization': `Bearer ${auth.token}`,
       'X-CSRF-Token': auth.csrfToken
     }
   });
@@ -664,13 +659,12 @@ async function refreshSession() {
     const res = await fetch('/session/refresh', {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${auth.token}`,
         'X-CSRF-Token': auth.csrfToken
       }
     });
     if (!res.ok) return false;
-    const { token, csrfToken, expiresAt } = await res.json();
-    setAuthContextState({ token, csrfToken, expiresAt, user: auth.user });
+    const { csrfToken, expiresAt } = await res.json();
+    setAuthContextState({ csrfToken, expiresAt, user: auth.user, role: auth.role });
     return true;
   } catch (err) {
     console.warn('[projectManager] Auth token refresh failed:', err.message || err);
@@ -700,8 +694,17 @@ function initProjectManagerControls() {
       btn.textContent = getAuthContext() ? 'Logout' : 'Login';
     }
     updateLabel();
-    btn.addEventListener('click', () => {
-      if (getAuthContext()) {
+    btn.addEventListener('click', async () => {
+      const auth = getAuthContext();
+      if (auth) {
+        try {
+          await fetch('/logout', {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': auth.csrfToken }
+          });
+        } catch (err) {
+          console.warn('[projectManager] Logout request failed:', err?.message || err);
+        }
         clearAuthContext();
         updateLabel();
       } else {

--- a/tests/collaboration.test.mjs
+++ b/tests/collaboration.test.mjs
@@ -61,6 +61,9 @@ globalThis.location = { protocol: 'http:', host: 'localhost:3000' };
 globalThis.WebSocket = MockWebSocket;
 globalThis.setInterval = () => 0;
 globalThis.clearInterval = () => {};
+// No auth context in tests → buildWsProtocols() never calls fetch. Stubbing
+// fetch defensively in case the implementation changes.
+globalThis.fetch = async () => ({ ok: false, json: async () => ({}) });
 
 // Import AFTER stubs are in place
 const { CollabClient, renderPresenceBar } = await import('../src/collaboration.js');
@@ -69,7 +72,7 @@ const { CollabClient, renderPresenceBar } = await import('../src/collaboration.j
 // Helpers
 // ---------------------------------------------------------------------------
 
-function describe(name, fn) { console.log(name); fn(); }
+async function describe(name, fn) { console.log(name); await fn(); }
 function it(name, fn) {
   try { fn(); console.log('  \u2713', name); }
   catch (err) { console.error('  \u2717', name, err.message || err); process.exitCode = 1; }
@@ -88,38 +91,38 @@ function makeClient(opts = {}) {
   return new CollabClient({ projectId: opts.projectId || 'proj-1', username: opts.username || 'alice' });
 }
 
-function connectAndOpen(client) {
-  client.connect();
+async function connectAndOpen(client) {
+  await client.connect();
   const ws = MockWebSocket._instances.at(-1);
   ws._emit('open');
   return ws;
 }
 
 // ---------------------------------------------------------------------------
-describe('CollabClient — connect & join', () => {
-  it('creates a WebSocket and sends join on open', () => {
+await describe('CollabClient — connect & join', async () => {
+  await itAsync('creates a WebSocket and sends join on open', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     assert.ok(ws, 'WebSocket instance must exist');
     assert.ok(ws.sent.some(m => m.type === 'join' && m.projectId === 'proj-1' && m.username === 'alice'));
   });
 
-  it('second connect() call is a no-op while already open', () => {
+  await itAsync('second connect() call is a no-op while already open', async () => {
     reset();
     const client = makeClient();
-    connectAndOpen(client);
-    client.connect(); // should not create a second socket
+    await connectAndOpen(client);
+    await client.connect(); // should not create a second socket
     assert.strictEqual(MockWebSocket._instances.length, 1);
   });
 });
 
 // ---------------------------------------------------------------------------
-describe('CollabClient — presence', () => {
-  it('fires presence event with the user list from server', () => {
+await describe('CollabClient — presence', async () => {
+  await itAsync('fires presence event with the user list from server', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
 
     let received = null;
     client.onPresence(users => { received = users; });
@@ -130,11 +133,11 @@ describe('CollabClient — presence', () => {
 });
 
 // ---------------------------------------------------------------------------
-describe('CollabClient — remote patch', () => {
-  it('fires remotePatch with sender and patch payload', () => {
+await describe('CollabClient — remote patch', async () => {
+  await itAsync('fires remotePatch with sender and patch payload', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
 
     let detail = null;
     client.onRemotePatch(d => { detail = d; });
@@ -147,11 +150,11 @@ describe('CollabClient — remote patch', () => {
 });
 
 // ---------------------------------------------------------------------------
-describe('CollabClient — sendPatch', () => {
-  it('sends a patch message when connected', () => {
+await describe('CollabClient — sendPatch', async () => {
+  await itAsync('sends a patch message when connected', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     client.sendPatch({ cables: [{ id: 'C1' }] });
     const msg = ws.sent.find(m => m.type === 'patch');
     assert.ok(msg, 'patch message must be sent');
@@ -167,11 +170,11 @@ describe('CollabClient — sendPatch', () => {
 });
 
 // ---------------------------------------------------------------------------
-describe('CollabClient — disconnect', () => {
-  it('sends leave message and closes the socket', () => {
+await describe('CollabClient — disconnect', async () => {
+  await itAsync('sends leave message and closes the socket', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     client.disconnect();
     assert.ok(ws.sent.some(m => m.type === 'leave'), 'leave message must be sent');
     assert.strictEqual(ws.readyState, WS_CLOSED);
@@ -179,25 +182,25 @@ describe('CollabClient — disconnect', () => {
 });
 
 // ---------------------------------------------------------------------------
-describe('CollabClient — connected getter', () => {
-  it('returns true when socket is open', () => {
+await describe('CollabClient — connected getter', async () => {
+  await itAsync('returns true when socket is open', async () => {
     reset();
     const client = makeClient();
-    connectAndOpen(client);
+    await connectAndOpen(client);
     assert.strictEqual(client.connected, true);
   });
 
-  it('returns false after disconnect', () => {
+  await itAsync('returns false after disconnect', async () => {
     reset();
     const client = makeClient();
-    connectAndOpen(client);
+    await connectAndOpen(client);
     client.disconnect();
     assert.strictEqual(client.connected, false);
   });
 });
 
 // ---------------------------------------------------------------------------
-describe('renderPresenceBar', () => {
+await describe('renderPresenceBar', async () => {
   // Minimal element factory
   function makeEl() {
     const el = { textContent: '', className: '', _attrs: {} };
@@ -252,11 +255,11 @@ describe('renderPresenceBar', () => {
 });
 
 // ---------------------------------------------------------------------------
-describe('CollabClient — sequence numbers & conflict detection', () => {
-  it('includes baseSeq in sendPatch message', () => {
+await describe('CollabClient — sequence numbers & conflict detection', async () => {
+  await itAsync('includes baseSeq in sendPatch message', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     // Simulate server sync on join
     ws._message({ type: 'sync', seq: 5 });
     client.sendPatch({ cables: [] });
@@ -265,10 +268,10 @@ describe('CollabClient — sequence numbers & conflict detection', () => {
     assert.strictEqual(patchMsg.baseSeq, 5, 'baseSeq must reflect last known seq');
   });
 
-  it('updates lastSeq on sync message', () => {
+  await itAsync('updates lastSeq on sync message', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     ws._message({ type: 'sync', seq: 10 });
     // Send a patch — baseSeq should now be 10
     client.sendPatch({ foo: 1 });
@@ -276,20 +279,20 @@ describe('CollabClient — sequence numbers & conflict detection', () => {
     assert.strictEqual(patchMsg.baseSeq, 10);
   });
 
-  it('updates lastSeq on ack message', () => {
+  await itAsync('updates lastSeq on ack message', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     ws._message({ type: 'ack', seq: 3 });
     client.sendPatch({ bar: 2 });
     const patchMsg = ws.sent.find(m => m.type === 'patch');
     assert.strictEqual(patchMsg.baseSeq, 3);
   });
 
-  it('fires conflict event when incoming seq has a gap', () => {
+  await itAsync('fires conflict event when incoming seq has a gap', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     // Start at seq 2
     ws._message({ type: 'sync', seq: 2 });
 
@@ -303,10 +306,10 @@ describe('CollabClient — sequence numbers & conflict detection', () => {
     assert.strictEqual(conflict.gap, 2);
   });
 
-  it('does not fire conflict when seq is consecutive', () => {
+  await itAsync('does not fire conflict when seq is consecutive', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     ws._message({ type: 'sync', seq: 0 });
 
     let conflict = null;
@@ -316,10 +319,10 @@ describe('CollabClient — sequence numbers & conflict detection', () => {
     assert.strictEqual(conflict, null, 'no conflict for consecutive seq');
   });
 
-  it('includes seq in remotePatch event detail', () => {
+  await itAsync('includes seq in remotePatch event detail', async () => {
     reset();
     const client = makeClient();
-    const ws = connectAndOpen(client);
+    const ws = await connectAndOpen(client);
     ws._message({ type: 'sync', seq: 0 });
 
     let detail = null;

--- a/tests/oidc.test.mjs
+++ b/tests/oidc.test.mjs
@@ -143,6 +143,16 @@ function getCookieHeaderFromSetCookie(setCookieHeader) {
   return setCookieHeader.split(';')[0];
 }
 
+function getSetCookieValue(headers, cookieName) {
+  const list = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : [];
+  for (const entry of list) {
+    const first = entry.split(';')[0];
+    const [name, ...rest] = first.split('=');
+    if (name === cookieName) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -210,10 +220,11 @@ await check('/auth/oidc/callback with valid code provisions user and redirects t
   const location = r.headers.get('location');
   assert.ok(location.includes('oidc-relay.html'), `expected relay redirect, got ${location}`);
   const relayUrlObj = new URL(location, appBase);
-  assert.ok(relayUrlObj.searchParams.get('token'), 'token in relay URL');
+  assert.ok(!relayUrlObj.searchParams.get('token'), 'session token must not be relayed via URL');
   assert.ok(relayUrlObj.searchParams.get('csrfToken'), 'csrfToken in relay URL');
   assert.ok(relayUrlObj.searchParams.get('user'), 'user in relay URL');
   assert.equal(relayUrlObj.searchParams.get('role'), 'reviewer', 'JIT user defaults to reviewer role');
+  assert.ok(getSetCookieValue(r.headers, 'ctr_auth'), 'ctr_auth cookie set on callback');
   relayUrl = location;
 });
 
@@ -266,11 +277,11 @@ await check('JIT-provisioned user appears in admin users list', async () => {
   const r2 = await fetchNoFollow(`http://127.0.0.1:${p2}/auth/oidc/callback?code=stub_auth_code_abc123&state=${st}`, {
     headers: { Cookie: cookie },
   });
-  const relayParams = new URL(r2.headers.get('location'), `http://127.0.0.1:${p2}`).searchParams;
-  const token = relayParams.get('token');
+  const authCookieValue = getSetCookieValue(r2.headers, 'ctr_auth');
+  assert.ok(authCookieValue, 'ctr_auth cookie issued on callback');
 
   const adminR = await fetch(`http://127.0.0.1:${p2}/api/v1/admin/users`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Cookie: `ctr_auth=${authCookieValue}` },
   });
   assert.equal(adminR.status, 200);
   const body = await adminR.json();

--- a/tests/serverSecurity.test.mjs
+++ b/tests/serverSecurity.test.mjs
@@ -13,7 +13,7 @@ async function startServer(options) {
   return new Promise(resolve => {
     const server = app.listen(0, () => {
       const address = server.address();
-      resolve({ server, port: address.port });
+      resolve({ server, port: address.port, app });
     });
   });
 }
@@ -581,10 +581,229 @@ async function httpsRedirectScenario() {
   }
 }
 
+function getSetCookieValue(headers, cookieName) {
+  const list = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : [];
+  for (const entry of list) {
+    const first = entry.split(';')[0];
+    const [name, ...rest] = first.split('=');
+    if (name === cookieName) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+function getSetCookieAttributes(headers, cookieName) {
+  const list = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : [];
+  for (const entry of list) {
+    const [first, ...attrs] = entry.split(';').map(s => s.trim());
+    const [name] = first.split('=');
+    if (name === cookieName) return attrs.map(a => a.toLowerCase());
+  }
+  return null;
+}
+
+async function cookieAuthScenario() {
+  console.log('server security - HttpOnly auth cookie');
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ctr-cookie-'));
+  const { server, port } = await startServer({
+    dataDir: tmpDir,
+    tokenTtlMs: 60_000,
+    rateLimit: { windowMs: 60000, max: 100 },
+    enforceHttps: false,
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    const username = 'cookieuser';
+    const password = 'C00kieMonster!';
+
+    await fetch(`${baseUrl}/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+
+    let session;
+    let authCookie;
+    await check('/login sets HttpOnly ctr_auth cookie', async () => {
+      const res = await fetch(`${baseUrl}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      assert.strictEqual(res.status, 200);
+      session = await res.json();
+      authCookie = getSetCookieValue(res.headers, 'ctr_auth');
+      assert(authCookie, 'ctr_auth cookie set');
+      assert.strictEqual(authCookie, session.token, 'cookie carries the session token');
+      const attrs = getSetCookieAttributes(res.headers, 'ctr_auth');
+      assert(attrs.includes('httponly'), 'HttpOnly flag set');
+      assert(attrs.some(a => a === 'samesite=lax'), 'SameSite=Lax set');
+      assert(attrs.some(a => a.startsWith('path=/')), 'Path=/ set');
+    });
+
+    await check('cookie auth grants access without Authorization header', async () => {
+      const res = await fetch(`${baseUrl}/projects/cookieproj`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `ctr_auth=${authCookie}`,
+          'X-CSRF-Token': session.csrfToken,
+        },
+        body: JSON.stringify({ data: { v: 1 } }),
+      });
+      assert.strictEqual(res.status, 200, 'cookie-authenticated write succeeds');
+    });
+
+    await check('cookie auth still requires CSRF token on writes', async () => {
+      const res = await fetch(`${baseUrl}/projects/cookieproj`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `ctr_auth=${authCookie}`,
+        },
+        body: JSON.stringify({ data: { v: 2 } }),
+      });
+      assert.strictEqual(res.status, 403, 'missing CSRF rejected even with cookie');
+    });
+
+    await check('Authorization header still works during deprecation window', async () => {
+      const res = await fetch(`${baseUrl}/projects/cookieproj`, {
+        headers: {
+          Authorization: `Bearer ${session.token}`,
+        },
+      });
+      assert.strictEqual(res.status, 200, 'bearer header still accepted');
+    });
+
+    await check('/logout revokes session and clears cookie', async () => {
+      const res = await fetch(`${baseUrl}/logout`, {
+        method: 'POST',
+        headers: {
+          Cookie: `ctr_auth=${authCookie}`,
+          'X-CSRF-Token': session.csrfToken,
+        },
+      });
+      assert.strictEqual(res.status, 200);
+      const cleared = getSetCookieAttributes(res.headers, 'ctr_auth');
+      assert(cleared, 'cookie cleared on logout');
+      assert(cleared.some(a => a === 'max-age=0'), 'cookie cleared with Max-Age=0');
+
+      const followUp = await fetch(`${baseUrl}/projects/cookieproj`, {
+        headers: { Cookie: `ctr_auth=${authCookie}` },
+      });
+      assert.strictEqual(followUp.status, 401, 'revoked session rejected');
+
+      const headerFollowUp = await fetch(`${baseUrl}/projects/cookieproj`, {
+        headers: { Authorization: `Bearer ${session.token}` },
+      });
+      assert.strictEqual(headerFollowUp.status, 401, 'header path also rejected after logout');
+    });
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function wsTicketScenario() {
+  console.log('server security - WebSocket ticket endpoint');
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ctr-wsticket-'));
+  const { server, port, app } = await startServer({
+    dataDir: tmpDir,
+    tokenTtlMs: 60_000,
+    rateLimit: { windowMs: 60000, max: 100 },
+    enforceHttps: false,
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    const username = 'wsuser';
+    const password = 'WsTicket!42';
+
+    await fetch(`${baseUrl}/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    const loginRes = await fetch(`${baseUrl}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    const session = await loginRes.json();
+    const authCookie = getSetCookieValue(loginRes.headers, 'ctr_auth');
+
+    await check('/ws/ticket requires authentication', async () => {
+      const res = await fetch(`${baseUrl}/ws/ticket`, { method: 'POST' });
+      assert.strictEqual(res.status, 401);
+    });
+
+    await check('/ws/ticket requires CSRF token', async () => {
+      const res = await fetch(`${baseUrl}/ws/ticket`, {
+        method: 'POST',
+        headers: { Cookie: `ctr_auth=${authCookie}` },
+      });
+      assert.strictEqual(res.status, 403);
+    });
+
+    let ticket;
+    await check('/ws/ticket issues a short-lived ticket', async () => {
+      const res = await fetch(`${baseUrl}/ws/ticket`, {
+        method: 'POST',
+        headers: {
+          Cookie: `ctr_auth=${authCookie}`,
+          'X-CSRF-Token': session.csrfToken,
+        },
+      });
+      assert.strictEqual(res.status, 200);
+      const body = await res.json();
+      assert(body.ticket && /^[0-9a-f]+$/.test(body.ticket), 'ticket is hex-encoded');
+      assert(body.expiresAt > Date.now(), 'ticket has future expiry');
+      assert(body.expiresAt < Date.now() + 60_000, 'ticket TTL is short (< 60s)');
+      ticket = body.ticket;
+    });
+
+    await check('upgrade validator accepts ticket subprotocol (single-use)', async () => {
+      const validate = app.get('collabUpgradeValidator');
+      assert(typeof validate === 'function', 'validator registered');
+      const ok = await validate({
+        headers: {
+          origin: baseUrl,
+          host: `127.0.0.1:${port}`,
+          'sec-websocket-protocol': `ctr-collab, ticket.${ticket}`,
+        },
+      });
+      assert.strictEqual(ok, true, 'first use accepted');
+      const replay = await validate({
+        headers: {
+          origin: baseUrl,
+          host: `127.0.0.1:${port}`,
+          'sec-websocket-protocol': `ctr-collab, ticket.${ticket}`,
+        },
+      });
+      assert.strictEqual(replay, false, 'ticket is single-use');
+    });
+
+    await check('upgrade validator rejects bogus ticket', async () => {
+      const validate = app.get('collabUpgradeValidator');
+      const ok = await validate({
+        headers: {
+          origin: baseUrl,
+          host: `127.0.0.1:${port}`,
+          'sec-websocket-protocol': 'ctr-collab, ticket.deadbeefdeadbeef',
+        },
+      });
+      assert.strictEqual(ok, false);
+    });
+  } finally {
+    await closeServer(server);
+  }
+}
+
 (async () => {
   await authScenario();
   await rateLimitScenario();
   await sessionRefreshScenario();
   await passwordChangeScenario();
   await httpsRedirectScenario();
+  await cookieAuthScenario();
+  await wsTicketScenario();
 })();

--- a/tests/sessionExpiry.test.mjs
+++ b/tests/sessionExpiry.test.mjs
@@ -60,13 +60,17 @@ async function checkAsync(name, fn) {
 
 console.log('session expiry - timer and event dispatch');
 
-check('setAuthContextState persists token data', () => {
+check('setAuthContextState persists session metadata', () => {
   storage.clear();
-  setAuthContextState({ token: 'tok1', csrfToken: 'csrf1', expiresAt: Date.now() + 10000, user: 'alice' });
+  setAuthContextState({ csrfToken: 'csrf1', expiresAt: Date.now() + 10000, user: 'alice' });
   const state = getAuthContextState();
-  assert.strictEqual(state.token, 'tok1');
+  assert.ok(state, 'auth context present');
   assert.strictEqual(state.csrfToken, 'csrf1');
   assert.strictEqual(state.user, 'alice');
+  // The session token itself lives in the HttpOnly ctr_auth cookie, not
+  // in JS-accessible storage.
+  assert.strictEqual(state.token, undefined);
+  assert.strictEqual(storage.has('authToken'), false);
 });
 
 check('clearAuthContextState removes all auth keys', () => {
@@ -74,10 +78,10 @@ check('clearAuthContextState removes all auth keys', () => {
   assert.strictEqual(getAuthContextState(), null);
 });
 
-check('getAuthContextState returns null when token is expired', () => {
+check('getAuthContextState returns null when session is expired', () => {
   storage.clear();
-  setAuthContextState({ token: 'old', csrfToken: 'cs', expiresAt: Date.now() - 1, user: 'bob' });
-  // Clear timers immediately since we set an already-expired token
+  setAuthContextState({ csrfToken: 'cs', expiresAt: Date.now() - 1, user: 'bob' });
+  // Clear timers immediately since we set an already-expired session
   clearAuthContextState();
   const state = getAuthContextState();
   assert.strictEqual(state, null);
@@ -88,7 +92,7 @@ await checkAsync('fires session-expiring event when within warning window', asyn
   dispatched.length = 0;
   // expiresAt less than SESSION_WARNING_MS (5 min) away → warning fires immediately
   const expiresAt = Date.now() + 2000;
-  setAuthContextState({ token: 'tok2', csrfToken: 'csrf2', expiresAt, user: 'carol' });
+  setAuthContextState({ csrfToken: 'csrf2', expiresAt, user: 'carol' });
   // The warning should dispatch immediately (since we're within the 5-min window)
   await sleep(10);
   const warningEvent = dispatched.find(e => e.type === 'session-expiring');
@@ -102,7 +106,7 @@ await checkAsync('fires session-expired event when token TTL elapses', async () 
   storage.clear();
   dispatched.length = 0;
   const expiresAt = Date.now() + 80;
-  setAuthContextState({ token: 'tok3', csrfToken: 'csrf3', expiresAt, user: 'dave' });
+  setAuthContextState({ csrfToken: 'csrf3', expiresAt, user: 'dave' });
   await sleep(120);
   const expiredEvent = dispatched.find(e => e.type === 'session-expired');
   assert.ok(expiredEvent, 'session-expired event should be dispatched after TTL');
@@ -115,7 +119,7 @@ await checkAsync('clearAuthContextState cancels pending timers', async () => {
   storage.clear();
   dispatched.length = 0;
   const expiresAt = Date.now() + 80;
-  setAuthContextState({ token: 'tok4', csrfToken: 'csrf4', expiresAt, user: 'eve' });
+  setAuthContextState({ csrfToken: 'csrf4', expiresAt, user: 'eve' });
   // Immediately clear to cancel timers
   clearAuthContextState();
   await sleep(120);


### PR DESCRIPTION
Move browser sessions from a localStorage-stored bearer token to an HttpOnly
ctr_auth cookie set by the server on /login, /session/refresh, the OIDC
callback, and /account/change-password. The auth middleware accepts the
cookie or, during a deprecation window, the legacy Authorization: Bearer
header so scripted API consumers and existing tests keep working.

Add POST /logout that revokes the current session and clears the cookie,
and a new POST /ws/ticket endpoint that mints a short-lived single-use
ticket — required because cookies cannot ride the WebSocket subprotocol
header. The collaboration upgrade validator now accepts ticket.<hex> as the
preferred subprotocol while still honoring the legacy auth.<>/csrf.<> pair.

CSRF double-submit stays intact: setAuthContextState still persists the
CSRF secret and metadata in localStorage and every mutating client request
sends X-CSRF-Token. The session token itself is no longer written to
JS-accessible storage anywhere, including the OIDC relay query string.