### PR TITLE
Phase 4: extract cable-schedule I/O & print renderer + one-line validation passes

### DIFF
--- a/cableschedule.js
+++ b/cableschedule.js
@@ -17,6 +17,14 @@ import {
   READINESS_VOCABULARY,
   getContractReadinessCopy
 } from './src/workflowStatus.js';
+import {
+  isXlsxExportAvailable,
+  isXlsxImportAvailable,
+  readFirstSheet,
+  todayStamp,
+  writeAoaWorkbook
+} from './src/cable-schedule/io.js';
+import { renderCablePrintReport as renderCablePrintReportTo } from './src/cable-schedule/printReport.js';
 const { sizeToArea } = ampacity;
 const CABLE_READINESS_COPY = getContractReadinessCopy('cableschedule.html');
 
@@ -1453,29 +1461,24 @@ async function initCableSchedule() {
       const templatesForExport = this.templates.map(tpl =>
         filterTemplateFields(tpl, { keepLabel: true, keepTypicalId: true })
       );
-      if (typeof XLSX !== 'undefined' && XLSX && typeof XLSX.utils?.aoa_to_sheet === 'function') {
-        try {
-          const headerConfig = this.headerConfig;
-          const headerRow = headerConfig.map(cfg => cfg.header);
-          const rows = templatesForExport.map(tpl =>
-            headerConfig.map(({ key }) => {
-              if (key === 'label') return sanitizeTemplateFieldValue(tpl.label);
-              if (key === 'template_id') return sanitizeTemplateFieldValue(tpl.template_id);
-              return sanitizeTemplateFieldValue(tpl[key]);
-            })
-          );
-          const sheetData = [headerRow, ...rows];
-          const sheet = XLSX.utils.aoa_to_sheet(sheetData);
-          const workbook = XLSX.utils.book_new();
-          XLSX.utils.book_append_sheet(workbook, sheet, 'Cable Typicals');
-          const stamp = new Date().toISOString().split('T')[0];
-          XLSX.writeFile(workbook, `cable-typicals-${stamp}.xlsx`);
-          return;
-        } catch (err) {
-          console.error('Failed to export cable typicals to Excel', err);
-          showAlertModal('Export Error', 'Unable to export cable typicals to Excel.');
-          return;
-        }
+      if (isXlsxExportAvailable()) {
+        const headerConfig = this.headerConfig;
+        const headerRow = headerConfig.map(cfg => cfg.header);
+        const rows = templatesForExport.map(tpl =>
+          headerConfig.map(({ key }) => {
+            if (key === 'label') return sanitizeTemplateFieldValue(tpl.label);
+            if (key === 'template_id') return sanitizeTemplateFieldValue(tpl.template_id);
+            return sanitizeTemplateFieldValue(tpl[key]);
+          })
+        );
+        const result = writeAoaWorkbook([headerRow, ...rows], {
+          sheetName: 'Cable Typicals',
+          filename: `cable-typicals-${todayStamp()}.xlsx`
+        });
+        if (result.ok) return;
+        console.error('Failed to export cable typicals to Excel', result.error);
+        showAlertModal('Export Error', 'Unable to export cable typicals to Excel.');
+        return;
       }
       const payload = {
         version: 1,
@@ -1534,36 +1537,30 @@ async function initCableSchedule() {
         const isExcel = name.endsWith('.xlsx') || type.includes('spreadsheet');
         let candidates;
         if (isExcel) {
-          if (typeof XLSX === 'undefined' || !XLSX || typeof XLSX.read !== 'function' || !XLSX.utils || typeof XLSX.utils.sheet_to_json !== 'function') {
+          if (!isXlsxImportAvailable()) {
             console.error('Excel import requested but XLSX library is unavailable');
             showAlertModal('Import Error', 'Excel import is not supported in this environment.');
             resetInput();
             return;
           }
-          let workbook;
-          try {
-            const buffer = await file.arrayBuffer();
-            workbook = XLSX.read(buffer, { type: 'array' });
-          } catch (err) {
-            console.error('Failed to read cable typical Excel file', err);
-            showAlertModal('Import Error', 'Unable to import cable typicals. The Excel file could not be read.');
+          const buffer = await file.arrayBuffer();
+          const result = readFirstSheet(buffer);
+          if (!result.ok) {
+            if (result.code === 'no-sheets') {
+              showAlertModal('Import Error', 'No sheets were found in the selected file.');
+            } else {
+              if (result.error) console.error('Failed to read cable typical Excel file', result.error);
+              showAlertModal('Import Error', 'Unable to import cable typicals. The Excel file could not be read.');
+            }
             resetInput();
             return;
           }
-          const sheetName = workbook.SheetNames && workbook.SheetNames[0];
-          if (!sheetName) {
-            showAlertModal('Import Error', 'No sheets were found in the selected file.');
-            resetInput();
-            return;
-          }
-          const sheet = workbook.Sheets[sheetName];
-          const rows = XLSX.utils.sheet_to_json(sheet, { defval: '', raw: true });
-          if (!Array.isArray(rows) || rows.length === 0) {
+          if (!result.rows.length) {
             showAlertModal('Import Error', 'No cable typicals found in the selected file.');
             resetInput();
             return;
           }
-          candidates = rows
+          candidates = result.rows
             .map(row => this.normalizeExcelRow(row))
             .filter(Boolean);
         } else {
@@ -3069,25 +3066,24 @@ async function initCableSchedule() {
   };
   table.importXlsx = async function(file) {
     if (!file) return;
-    if (typeof XLSX === 'undefined' || !XLSX?.read || !XLSX?.utils?.sheet_to_json) {
+    if (!isXlsxImportAvailable()) {
       showAlertModal('Import Error', 'Excel import is not available in this environment.');
       return;
     }
-    let rows = [];
-    try {
-      const buffer = await file.arrayBuffer();
-      const workbook = XLSX.read(buffer, { type: 'array' });
-      const sheetName = workbook.SheetNames && workbook.SheetNames[0];
-      if (!sheetName) {
+    const buffer = await file.arrayBuffer();
+    const result = readFirstSheet(buffer);
+    if (!result.ok) {
+      if (result.code === 'unavailable') {
+        showAlertModal('Import Error', 'Excel import is not available in this environment.');
+      } else if (result.code === 'no-sheets') {
         showAlertModal('Import Error', 'No sheets were found in the selected file.');
-        return;
+      } else {
+        console.error('Failed to read cable import file', result.error);
+        showAlertModal('Import Error', 'Unable to read the selected Excel file.');
       }
-      rows = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName], { defval: '', raw: true });
-    } catch (err) {
-      console.error('Failed to read cable import file', err);
-      showAlertModal('Import Error', 'Unable to read the selected Excel file.');
       return;
     }
+    const rows = result.rows;
     if (!rows.length) {
       showAlertModal('Import Error', 'No cable rows were found in the selected file.');
       return;
@@ -3252,7 +3248,7 @@ async function initCableSchedule() {
     return value == null ? '' : value;
   };
   const exportCableReport = mode => {
-    if (typeof XLSX === 'undefined' || !XLSX?.utils) {
+    if (!isXlsxExportAvailable()) {
       showAlertModal('Export Error', 'Excel export is not available in this environment.');
       return;
     }
@@ -3263,52 +3259,26 @@ async function initCableSchedule() {
       reportColumns.map(col => col.label),
       ...reportRows.map(row => reportColumns.map(col => formatReportValue(row[col.key])))
     ];
-    const workbook = XLSX.utils.book_new();
-    const sheet = XLSX.utils.aoa_to_sheet(sheetData);
-    XLSX.utils.book_append_sheet(workbook, sheet, REPORT_MODE_LABELS[reportMode].slice(0, 31));
-    const stamp = new Date().toISOString().split('T')[0];
     const suffix = reportMode.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
-    XLSX.writeFile(workbook, `cable-schedule-${suffix}-${stamp}.xlsx`);
+    const result = writeAoaWorkbook(sheetData, {
+      sheetName: REPORT_MODE_LABELS[reportMode],
+      filename: `cable-schedule-${suffix}-${todayStamp()}.xlsx`
+    });
+    if (!result.ok) {
+      showAlertModal('Export Error', 'Excel export is not available in this environment.');
+    }
   };
   const renderCablePrintReport = mode => {
     const host = document.getElementById('cable-print-report');
     if (!host) return;
     const reportMode = REPORT_MODE_LABELS[mode] ? mode : 'visible';
-    const reportColumns = getReportColumns(reportMode);
-    const reportRows = getReportRows(reportMode);
-    host.innerHTML = '';
-    host.removeAttribute('aria-hidden');
-    const meta = document.createElement('div');
-    meta.className = 'print-report-meta';
-    const title = document.createElement('strong');
-    title.textContent = `Cable Schedule - ${REPORT_MODE_LABELS[reportMode]}`;
-    const generated = document.createElement('span');
-    generated.textContent = `Generated ${formatDateTime(new Date())}`;
-    meta.append(title, generated);
-    const tableEl = document.createElement('table');
-    tableEl.className = 'cable-print-table';
-    const thead = tableEl.createTHead();
-    const header = thead.insertRow();
-    reportColumns.forEach(col => {
-      const th = document.createElement('th');
-      th.textContent = col.label;
-      header.appendChild(th);
+    renderCablePrintReportTo(host, {
+      columns: getReportColumns(reportMode),
+      rows: getReportRows(reportMode),
+      modeLabel: REPORT_MODE_LABELS[reportMode],
+      formatValue: formatReportValue,
+      formatDateTime
     });
-    const tbody = tableEl.createTBody();
-    reportRows.forEach(row => {
-      const tr = tbody.insertRow();
-      reportColumns.forEach(col => {
-        const td = tr.insertCell();
-        td.textContent = formatReportValue(row[col.key]);
-      });
-    });
-    if (!reportRows.length) {
-      const tr = tbody.insertRow();
-      const td = tr.insertCell();
-      td.colSpan = Math.max(1, reportColumns.length);
-      td.textContent = 'No cable rows match this report.';
-    }
-    host.append(meta, tableEl);
   };
   const printCableReport = mode => {
     renderCablePrintReport(mode);

--- a/docs/page-contract-audit.md
+++ b/docs/page-contract-audit.md
@@ -306,7 +306,7 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 - Section: Workflow
 - Group: Planning
-- Source files: `ampacity.mjs`, `analysis/arcFlash.mjs`, `analysis/ctMetadata.mjs`, `analysis/harmonics.js`, `analysis/ibrModeling.mjs`, `analysis/iec60909.mjs`, `analysis/iecRelayCurves.mjs`, `analysis/loadFlow.js`, `analysis/loadFlowModel.js`, `analysis/loadFlowResultsRenderer.js`, `analysis/motorStart.js`, `analysis/ptVtMetadata.mjs`, `analysis/reliability.js`, `analysis/scheduleReconcile.mjs`, `analysis/shortCircuit.mjs`, `analysis/tccUtils.js`, `codes/iecTables.js`, `codes/necTables.js`, `componentLibrary.json`, `conductorProperties.mjs`, `conductorPropertiesData.mjs`, `data/conductor_properties.js`, `data/protectiveDevices.mjs`, `exporters/dxf.js`, `exporters/pdf.js`, `exporters/simpleDxf.js`, `oneline.js`, `reports/arcFlashReport.mjs`, `reports/exportAll.mjs`, `reports/labels.mjs`, `reports/reporting.mjs`, `sizing.js`, `src/crossProbe.js`, `src/lifecycle/pageBootstrap.js`, `src/voltageDrop.js`, `utils/cableImpedance.js`, `utils/cablePhases.js`, `utils/componentLabels.js`, `utils/transformerImpedance.js`, `utils/transformerProperties.js`, `utils/voltage.js`, `validation/rules.js`
+- Source files: `ampacity.mjs`, `analysis/arcFlash.mjs`, `analysis/ctMetadata.mjs`, `analysis/harmonics.js`, `analysis/ibrModeling.mjs`, `analysis/iec60909.mjs`, `analysis/iecRelayCurves.mjs`, `analysis/loadFlow.js`, `analysis/loadFlowModel.js`, `analysis/loadFlowResultsRenderer.js`, `analysis/motorStart.js`, `analysis/ptVtMetadata.mjs`, `analysis/reliability.js`, `analysis/scheduleReconcile.mjs`, `analysis/shortCircuit.mjs`, `analysis/tccUtils.js`, `codes/iecTables.js`, `codes/necTables.js`, `componentLibrary.json`, `conductorProperties.mjs`, `conductorPropertiesData.mjs`, `data/conductor_properties.js`, `data/protectiveDevices.mjs`, `exporters/dxf.js`, `exporters/pdf.js`, `exporters/simpleDxf.js`, `oneline.js`, `reports/arcFlashReport.mjs`, `reports/exportAll.mjs`, `reports/labels.mjs`, `reports/reporting.mjs`, `sizing.js`, `src/crossProbe.js`, `src/lifecycle/pageBootstrap.js`, `src/one-line/validation.js`, `src/voltageDrop.js`, `utils/cableImpedance.js`, `utils/cablePhases.js`, `utils/componentLabels.js`, `utils/transformerImpedance.js`, `utils/transformerProperties.js`, `utils/voltage.js`, `validation/rules.js`
 
 **Undocumented Reads**
 - None
@@ -321,27 +321,27 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 - None
 
 **Direct Browser Storage**
-- oneline.js:2733 sessionStorage.setItem(<dynamic>) - session-handoff: Temporary custom component editor prefill; not durable project state.
+- oneline.js:2734 sessionStorage.setItem(<dynamic>) - session-handoff: Temporary custom component editor prefill; not durable project state.
 
 **Detected Reads**
 - `cableSchedule`
-  - oneline.js:13339 getCables()
-  - oneline.js:15253 getCables()
-  - oneline.js:18573 getCables()
-  - oneline.js:4168 getCables()
-  - oneline.js:4285 getCables()
+  - oneline.js:13340 getCables()
+  - oneline.js:15254 getCables()
+  - oneline.js:18448 getCables()
+  - oneline.js:4169 getCables()
+  - oneline.js:4286 getCables()
   - ... 2 more
 - `equipment`
-  - oneline.js:13315 getEquipment()
-  - oneline.js:18570 getEquipment()
-  - oneline.js:4169 getEquipment()
-  - oneline.js:8744 getEquipment()
+  - oneline.js:13316 getEquipment()
+  - oneline.js:18445 getEquipment()
+  - oneline.js:4170 getEquipment()
+  - oneline.js:8745 getEquipment()
   - reports/exportAll.mjs:293 getEquipment()
 - `loadList`
-  - oneline.js:13323 getLoads()
-  - oneline.js:18572 getLoads()
-  - oneline.js:4166 getLoads()
-  - oneline.js:8745 getLoads()
+  - oneline.js:13324 getLoads()
+  - oneline.js:18447 getLoads()
+  - oneline.js:4167 getLoads()
+  - oneline.js:8746 getLoads()
 - `oneLineDiagram`
   - analysis/arcFlash.mjs:389 getOneLine()
   - analysis/harmonics.js:181 getOneLine()
@@ -350,57 +350,57 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
   - analysis/motorStart.js:82 getOneLine()
   - ... 11 more
 - `panelSchedule`
-  - oneline.js:13331 getPanels()
-  - oneline.js:18571 getPanels()
-  - oneline.js:4167 getPanels()
+  - oneline.js:13332 getPanels()
+  - oneline.js:18446 getPanels()
+  - oneline.js:4168 getPanels()
   - reports/exportAll.mjs:294 getPanels()
 - `settings.diagramDatablockConfig`
-  - oneline.js:17742 getItem(diagramDatablockConfig)
+  - oneline.js:17743 getItem(diagramDatablockConfig)
 - `settings.diagramScale`
-  - oneline.js:3264 getItem(diagramScale)
+  - oneline.js:3265 getItem(diagramScale)
 - `settings.diagramTitleBlock`
-  - oneline.js:17689 getItem(diagramTitleBlock)
+  - oneline.js:17690 getItem(diagramTitleBlock)
 - `settings.diagramZoom`
-  - oneline.js:3285 getItem(diagramZoom)
+  - oneline.js:3286 getItem(diagramZoom)
 - `settings.gistToken`
-  - oneline.js:18815 getItem(gistToken)
+  - oneline.js:18690 getItem(gistToken)
 - `settings.gridEnabled`
-  - oneline.js:3314 getItem(gridEnabled)
+  - oneline.js:3315 getItem(gridEnabled)
 - `settings.gridSize`
-  - oneline.js:3313 getItem(gridSize)
+  - oneline.js:3314 getItem(gridSize)
 - `settings.labelCounters`
-  - oneline.js:16056 getItem(labelCounters)
-  - oneline.js:5196 getItem(labelCounters)
+  - oneline.js:16057 getItem(labelCounters)
+  - oneline.js:5197 getItem(labelCounters)
 - `settings.labelPrefixes`
-  - oneline.js:5195 getItem(labelPrefixes)
+  - oneline.js:5196 getItem(labelPrefixes)
 - `settings.layersPanelOpen`
-  - oneline.js:16142 getItem(layersPanelOpen)
+  - oneline.js:16143 getItem(layersPanelOpen)
 - `settings.manufacturerDefaults`
-  - oneline.js:2629 getItem(manufacturerDefaults)
+  - oneline.js:2630 getItem(manufacturerDefaults)
 - `settings.oneLineDiagramFilterMode`
-  - oneline.js:3249 getItem(oneLineDiagramFilterMode)
+  - oneline.js:3250 getItem(oneLineDiagramFilterMode)
 - `settings.oneLineScheduleReconcilePending`
-  - oneline.js:3351 getItem(oneLineScheduleReconcilePending)
+  - oneline.js:3352 getItem(oneLineScheduleReconcilePending)
 - `settings.onelineTemplates`
-  - oneline.js:6207 migrateLegacyItem(..., onelineTemplates)
+  - oneline.js:6208 migrateLegacyItem(..., onelineTemplates)
 - `settings.orthogonalRouting`
-  - oneline.js:17666 getItem(orthogonalRouting)
+  - oneline.js:17667 getItem(orthogonalRouting)
 - `settings.studySettings`
-  - oneline.js:3309 getItem(studySettings)
+  - oneline.js:3310 getItem(studySettings)
 - `settings.symbolStandard`
-  - oneline.js:17675 getItem(symbolStandard)
+  - oneline.js:17676 getItem(symbolStandard)
 - `settings.tccSettings`
   - analysis/arcFlash.mjs:321 getItem(tccSettings)
   - analysis/shortCircuit.mjs:492 getItem(tccSettings)
 - `studyResults`
   - analysis/harmonics.js:416 getStudies()
   - analysis/motorStart.js:209 getStudies()
-  - oneline.js:18142 getStudies()
-  - oneline.js:18789 getStudies()
-  - oneline.js:3369 getStudies()
+  - oneline.js:18017 getStudies()
+  - oneline.js:18664 getStudies()
+  - oneline.js:3370 getStudies()
   - ... 12 more
 - `studyResults.arcFlash`
-  - oneline.js:5045 getStudies().arcFlash
+  - oneline.js:5046 getStudies().arcFlash
   - reports/exportAll.mjs:297 getStudies().arcFlash
 - `studyResults.duty`
   - validation/rules.js:666 studies.duty
@@ -412,97 +412,97 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Writes**
 - `cableSchedule`
-  - oneline.js:18589 setCables()
-  - oneline.js:4187 setCables()
-  - oneline.js:4295 setCables()
+  - oneline.js:18464 setCables()
+  - oneline.js:4188 setCables()
+  - oneline.js:4296 setCables()
 - `conduitSchedule`
-  - oneline.js:8653 addRaceway()
-  - oneline.js:9170 addRaceway()
+  - oneline.js:8654 addRaceway()
+  - oneline.js:9171 addRaceway()
 - `equipment`
-  - oneline.js:18586 setEquipment()
-  - oneline.js:4189 setEquipment()
+  - oneline.js:18461 setEquipment()
+  - oneline.js:4190 setEquipment()
 - `loadList`
-  - oneline.js:18588 setLoads()
-  - oneline.js:4183 setLoads()
+  - oneline.js:18463 setLoads()
+  - oneline.js:4184 setLoads()
 - `oneLineDiagram`
-  - oneline.js:11714 setOneLine()
-  - oneline.js:11906 setOneLine()
-  - oneline.js:4987 setOneLine()
-  - oneline.js:5014 setOneLine()
-  - oneline.js:5034 setOneLine()
+  - oneline.js:11715 setOneLine()
+  - oneline.js:11907 setOneLine()
+  - oneline.js:4988 setOneLine()
+  - oneline.js:5015 setOneLine()
+  - oneline.js:5035 setOneLine()
 - `panelSchedule`
-  - oneline.js:18587 setPanels()
-  - oneline.js:4185 setPanels()
+  - oneline.js:18462 setPanels()
+  - oneline.js:4186 setPanels()
 - `settings.diagramDatablockConfig`
-  - oneline.js:11644 setItem(diagramDatablockConfig)
+  - oneline.js:11645 setItem(diagramDatablockConfig)
 - `settings.diagramScale`
-  - oneline.js:11907 setItem(diagramScale)
-  - oneline.js:18924 setItem(diagramScale)
+  - oneline.js:11908 setItem(diagramScale)
+  - oneline.js:18799 setItem(diagramScale)
 - `settings.diagramTitleBlock`
-  - oneline.js:17724 setItem(diagramTitleBlock)
+  - oneline.js:17725 setItem(diagramTitleBlock)
 - `settings.diagramZoom`
-  - oneline.js:3789 setItem(diagramZoom)
-  - oneline.js:3827 setItem(diagramZoom)
-  - oneline.js:3913 setItem(diagramZoom)
-  - oneline.js:3951 setItem(diagramZoom)
+  - oneline.js:3790 setItem(diagramZoom)
+  - oneline.js:3828 setItem(diagramZoom)
+  - oneline.js:3914 setItem(diagramZoom)
+  - oneline.js:3952 setItem(diagramZoom)
 - `settings.gistToken`
-  - oneline.js:18817 setItem(gistToken)
+  - oneline.js:18692 setItem(gistToken)
 - `settings.gridEnabled`
-  - oneline.js:10962 setItem(gridEnabled)
+  - oneline.js:10963 setItem(gridEnabled)
 - `settings.gridSize`
-  - oneline.js:16433 setItem(gridSize)
+  - oneline.js:16434 setItem(gridSize)
 - `settings.labelCounters`
-  - oneline.js:16068 setItem(labelCounters)
-  - oneline.js:5205 setItem(labelCounters)
+  - oneline.js:16069 setItem(labelCounters)
+  - oneline.js:5206 setItem(labelCounters)
 - `settings.labelPrefixes`
-  - oneline.js:5391 setItem(labelPrefixes)
+  - oneline.js:5392 setItem(labelPrefixes)
 - `settings.layersPanelOpen`
-  - oneline.js:16148 setItem(layersPanelOpen)
-  - oneline.js:16155 setItem(layersPanelOpen)
+  - oneline.js:16149 setItem(layersPanelOpen)
+  - oneline.js:16156 setItem(layersPanelOpen)
 - `settings.manufacturerDefaults`
-  - oneline.js:5460 setItem(manufacturerDefaults)
+  - oneline.js:5461 setItem(manufacturerDefaults)
 - `settings.oneLineDiagramFilterMode`
-  - oneline.js:16444 setItem(oneLineDiagramFilterMode)
+  - oneline.js:16445 setItem(oneLineDiagramFilterMode)
 - `settings.oneLineScheduleReconcilePending`
-  - oneline.js:18418 setItem(oneLineScheduleReconcilePending)
+  - oneline.js:18293 setItem(oneLineScheduleReconcilePending)
 - `settings.onelineTemplates`
-  - oneline.js:6207 migrateLegacyItem(..., onelineTemplates)
-  - oneline.js:6215 setItem(onelineTemplates)
+  - oneline.js:6208 migrateLegacyItem(..., onelineTemplates)
+  - oneline.js:6216 setItem(onelineTemplates)
 - `settings.orthogonalRouting`
-  - oneline.js:17659 setItem(orthogonalRouting)
+  - oneline.js:17660 setItem(orthogonalRouting)
 - `settings.scenarios`
-  - oneline.js:18920 switchScenario()
+  - oneline.js:18795 switchScenario()
 - `settings.studySettings`
-  - oneline.js:3406 setItem(studySettings)
+  - oneline.js:3407 setItem(studySettings)
 - `settings.symbolStandard`
-  - oneline.js:17679 setItem(symbolStandard)
+  - oneline.js:17680 setItem(symbolStandard)
 - `studyResults`
   - analysis/harmonics.js:419 setStudies()
   - analysis/motorStart.js:212 setStudies()
-  - oneline.js:4990 setStudies()
-  - oneline.js:5017 setStudies()
-  - oneline.js:5038 setStudies()
+  - oneline.js:4991 setStudies()
+  - oneline.js:5018 setStudies()
+  - oneline.js:5039 setStudies()
   - ... 3 more
 - `studyResults.arcFlash`
-  - oneline.js:5037 studies.arcFlash
+  - oneline.js:5038 studies.arcFlash
 - `studyResults.duty`
   - validation/rules.js:666 studies.duty
 - `studyResults.harmonics`
   - analysis/harmonics.js:418 studies.harmonics
-  - oneline.js:5055 studies.harmonics
+  - oneline.js:5056 studies.harmonics
 - `studyResults.loadFlow`
-  - oneline.js:4989 studies.loadFlow
+  - oneline.js:4990 studies.loadFlow
 - `studyResults.motorStart`
   - analysis/motorStart.js:211 studies.motorStart
-  - oneline.js:5063 studies.motorStart
+  - oneline.js:5064 studies.motorStart
 - `studyResults.reliability`
-  - oneline.js:5073 studies.reliability
+  - oneline.js:5074 studies.reliability
 - `studyResults.shortCircuit`
-  - oneline.js:5016 studies.shortCircuit
-  - oneline.js:5036 studies.shortCircuit
+  - oneline.js:5017 studies.shortCircuit
+  - oneline.js:5037 studies.shortCircuit
 - `traySchedule`
-  - oneline.js:8653 addRaceway()
-  - oneline.js:9170 addRaceway()
+  - oneline.js:8654 addRaceway()
+  - oneline.js:9171 addRaceway()
 
 ### Demand Schedule (`demandschedule.html`)
 
@@ -538,7 +538,7 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 - Section: Workflow
 - Group: Cable
-- Source files: `ampacity.mjs`, `analysis/scheduleWorkflow.mjs`, `cableschedule.js`, `codes/iecTables.js`, `codes/necTables.js`, `conductorProperties.mjs`, `conductorPropertiesData.mjs`, `data/conductor_properties.js`, `sizing.js`, `src/cableschedule.js`, `src/crossProbe.js`, `src/lifecycle/pageBootstrap.js`, `src/voltageDrop.js`, `tableUtils.mjs`, `tour.js`, `utils/cablePhases.js`
+- Source files: `ampacity.mjs`, `analysis/scheduleWorkflow.mjs`, `cableschedule.js`, `codes/iecTables.js`, `codes/necTables.js`, `conductorProperties.mjs`, `conductorPropertiesData.mjs`, `data/conductor_properties.js`, `sizing.js`, `src/cable-schedule/io.js`, `src/cable-schedule/printReport.js`, `src/cableschedule.js`, `src/crossProbe.js`, `src/lifecycle/pageBootstrap.js`, `src/voltageDrop.js`, `tableUtils.mjs`, `tour.js`, `utils/cablePhases.js`
 
 **Undocumented Reads**
 - None
@@ -557,53 +557,53 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - cableschedule.js:2046 getCables()
+  - cableschedule.js:2043 getCables()
 - `conduitSchedule`
-  - cableschedule.js:71 getConduits()
+  - cableschedule.js:79 getConduits()
 - `ductbankSchedule`
-  - cableschedule.js:75 getDuctbanks()
+  - cableschedule.js:83 getDuctbanks()
 - `equipment`
-  - cableschedule.js:96 getEquipment()
+  - cableschedule.js:104 getEquipment()
 - `loadList`
-  - cableschedule.js:99 getLoads()
+  - cableschedule.js:107 getLoads()
 - `oneLineDiagram`
   - src/crossProbe.js:139 getOneLine()
   - src/crossProbe.js:152 getOneLine()
   - src/crossProbe.js:201 getOneLine()
 - `panelSchedule`
-  - cableschedule.js:102 getPanels()
-  - cableschedule.js:87 getPanels()
+  - cableschedule.js:110 getPanels()
+  - cableschedule.js:95 getPanels()
 - `settings.cableChangeLog`
-  - cableschedule.js:733 getCableChangeLog()
-  - cableschedule.js:734 getItem(settings.cableChangeLog)
+  - cableschedule.js:741 getCableChangeLog()
+  - cableschedule.js:742 getItem(settings.cableChangeLog)
 - `settings.cableTagSettings`
-  - cableschedule.js:660 getCableTagSettings()
-  - cableschedule.js:661 getItem(settings.cableTagSettings)
+  - cableschedule.js:668 getCableTagSettings()
+  - cableschedule.js:669 getItem(settings.cableTagSettings)
 - `settings.cableTemplates`
-  - cableschedule.js:1413 getCableTemplates()
-  - cableschedule.js:1656 getCableTemplates()
-  - cableschedule.js:633 getCableTemplates()
+  - cableschedule.js:1421 getCableTemplates()
+  - cableschedule.js:1653 getCableTemplates()
+  - cableschedule.js:641 getCableTemplates()
 - `traySchedule`
-  - cableschedule.js:70 getTrays()
+  - cableschedule.js:78 getTrays()
 
 **Detected Writes**
 - `cableSchedule`
-  - cableschedule.js:2359 setCables()
-  - cableschedule.js:2371 setCables()
-  - cableschedule.js:2385 setCables()
-  - cableschedule.js:2408 setCables()
+  - cableschedule.js:2356 setCables()
+  - cableschedule.js:2368 setCables()
+  - cableschedule.js:2382 setCables()
+  - cableschedule.js:2405 setCables()
 - `settings.cableChangeLog`
-  - cableschedule.js:740 setCableChangeLog()
-  - cableschedule.js:742 setItem(settings.cableChangeLog)
+  - cableschedule.js:748 setCableChangeLog()
+  - cableschedule.js:750 setItem(settings.cableChangeLog)
 - `settings.cableTagSettings`
-  - cableschedule.js:667 setCableTagSettings()
-  - cableschedule.js:669 setItem(settings.cableTagSettings)
+  - cableschedule.js:675 setCableTagSettings()
+  - cableschedule.js:677 setItem(settings.cableTagSettings)
 - `settings.cableTemplates`
-  - cableschedule.js:1161 setCableTemplates()
-  - cableschedule.js:1204 setCableTemplates()
-  - cableschedule.js:1423 setCableTemplates()
-  - cableschedule.js:1442 setCableTemplates()
-  - cableschedule.js:1613 setCableTemplates()
+  - cableschedule.js:1169 setCableTemplates()
+  - cableschedule.js:1212 setCableTemplates()
+  - cableschedule.js:1431 setCableTemplates()
+  - cableschedule.js:1450 setCableTemplates()
+  - cableschedule.js:1610 setCableTemplates()
   - ... 4 more
 
 ### Panel Schedule (`panelschedule.html`)

--- a/oneline.js
+++ b/oneline.js
@@ -23,6 +23,7 @@ import { generateArcFlashReport, openLabelPrintWindow } from './reports/arcFlash
 import { exportAllReports } from './reports/exportAll.mjs';
 import { sizeConductor } from './sizing.js';
 import { runValidation } from './validation/rules.js';
+import { runDiagramValidationPasses } from './src/one-line/validation.js';
 import { exportPDF } from './exporters/pdf.js';
 import { exportDXF, exportDWG } from './exporters/dxf.js';
 import { ensureFieldAssistiveText, openModal, showAlertModal } from './src/components/modal.js';
@@ -17996,140 +17997,14 @@ function validateDiagram(options = {}) {
   const svg = document.getElementById('diagram');
   if (!svg) return validationIssues;
 
-  const idMap = new Map();
-  const inbound = new Map();
-  components.forEach(c => {
-    if (c.type === 'dimension') return;
-    idMap.set(c.id, (idMap.get(c.id) || 0) + 1);
-    inbound.set(c.id, 0);
-  });
-
-  function phaseSet(val) {
-    if (Array.isArray(val)) return val.map(p => String(p).toUpperCase());
-    if (typeof val === 'number') {
-      if (val === 3) return ['A', 'B', 'C'];
-      if (val === 2) return ['A', 'B'];
-      if (val === 1) return ['A'];
-      return [];
-    }
-    if (typeof val === 'string') {
-      if (/^\d+$/.test(val.trim())) return phaseSet(parseInt(val, 10));
-      return val
-        .split(/[\s,]+/)
-        .map(p => p.trim().toUpperCase())
-        .filter(Boolean);
-    }
-    return [];
-  }
-
-  components.forEach(c => {
-    if (c.type === 'dimension') return;
-    (c.connections || []).forEach(conn => {
-      inbound.set(conn.target, (inbound.get(conn.target) || 0) + 1);
-      const target = components.find(t => t.id === conn.target);
-      if (target) {
-        const srcVolt = resolveConnectionVoltageVolts(c, conn, 'source');
-        const tgtVolt = resolveConnectionVoltageVolts(target, conn, 'target');
-        if (srcVolt !== null && tgtVolt !== null) {
-          const diff = Math.abs(srcVolt - tgtVolt);
-          const tolerance = Math.max(1, Math.min(srcVolt, tgtVolt) * 0.005);
-          if (diff > tolerance) {
-            const srcLabel = formatVoltage(srcVolt);
-            const tgtLabel = formatVoltage(tgtVolt);
-            validationIssues.push({
-              component: c.id,
-              target: target.id,
-              code: 'voltage-mismatch',
-              message: `Voltage mismatch with ${target.label || target.subtype || target.id} (${srcLabel} vs ${tgtLabel})`
-            });
-            validationIssues.push({
-              component: target.id,
-              target: c.id,
-              code: 'voltage-mismatch',
-              message: `Voltage mismatch with ${c.label || c.subtype || c.id} (${tgtLabel} vs ${srcLabel})`
-            });
-          }
-        }
-      }
-      if (target) {
-        const srcPh = phaseSet(c.phases);
-        const tgtPh = phaseSet(target.phases);
-        const connPh = conn.phases ? phaseSet(conn.phases) : null;
-        if (connPh && connPh.length) {
-          if (srcPh.length && !connPh.every(p => srcPh.includes(p))) {
-            validationIssues.push({
-              component: c.id,
-              target: target.id,
-              code: 'phase-mismatch',
-              message: `Phase mismatch with ${target.label || target.subtype || target.id}`
-            });
-          }
-          if (tgtPh.length && !connPh.every(p => tgtPh.includes(p))) {
-            validationIssues.push({
-              component: target.id,
-              target: c.id,
-              code: 'phase-mismatch',
-              message: `Phase mismatch with ${c.label || c.subtype || c.id}`
-            });
-          }
-        } else if (srcPh.length && tgtPh.length && !tgtPh.every(p => srcPh.includes(p))) {
-          validationIssues.push({
-            component: c.id,
-            target: target.id,
-            code: 'phase-mismatch',
-            message: `Phase mismatch with ${target.label || target.subtype || target.id}`
-          });
-          validationIssues.push({
-            component: target.id,
-            target: c.id,
-            code: 'phase-mismatch',
-            message: `Phase mismatch with ${c.label || c.subtype || c.id}`
-          });
-        }
-      }
-      const cableInfo = getCableForConnection(c, target, conn);
-      if (target && (!cableInfo?.tag || cableInfo?.provisional || conn.reviewStatus === 'assumed')) {
-        validationIssues.push({
-          component: c.id,
-          target: target.id,
-          connectionIndex: (c.connections || []).indexOf(conn),
-          code: 'provisional-cable',
-          message: `Cable details need review for ${getComponentTag(c) || c.id} to ${getComponentTag(target) || target.id}`
-        });
-      }
-    });
-  });
-
-  components.forEach(c => {
-    // Gap #48: sheet_link components are intentional terminators; exclude from unconnected check
-    if (c.type === 'dimension' || c.type === 'annotation' || c.type === 'sheet_link') return;
-    if ((c.connections || []).length + (inbound.get(c.id) || 0) === 0) {
-      validationIssues.push({ component: c.id, code: 'unconnected', message: 'Unconnected component' });
-    }
-    const key = scheduleKeyForComponent(c);
-    if (key && !hasResolvedScheduleLink(c)) {
-      validationIssues.push({ component: c.id, code: 'missing-schedule-link', message: 'Missing schedule link' });
-    }
-  });
-
-  components.forEach(c => {
-    if (c.type === 'dimension') return;
-    (c.connections || []).forEach(conn => {
-      const target = components.find(t => t.id === conn.target);
-      const cableInfo = getCableForConnection(c, target, conn);
-      if (cableInfo && cableInfo.sizing_warning) {
-        validationIssues.push({ component: c.id, code: 'sizing-warning', message: cableInfo.sizing_warning });
-      }
-    });
-  });
-
-  idMap.forEach((count, id) => {
-    if (count > 1) {
-      components.filter(c => c.id === id).forEach(c => {
-        validationIssues.push({ component: c.id, code: 'duplicate-id', message: `Duplicate ID "${id}"` });
-      });
-    }
-  });
+  validationIssues.push(...runDiagramValidationPasses(components, {
+    resolveConnectionVoltageVolts,
+    formatVoltage,
+    getCableForConnection,
+    getComponentTag,
+    scheduleKeyForComponent,
+    hasResolvedScheduleLink
+  }));
 
   // Gap #48 – Cross-sheet connector pairing validation (active sheet only)
   validateSheetLinks(sheets).forEach(issue => {

--- a/src/cable-schedule/io.js
+++ b/src/cable-schedule/io.js
@@ -1,0 +1,87 @@
+// CSV/XLSX I/O helpers for the Cable Schedule.
+//
+// These helpers wrap the SheetJS (XLSX) global in a way that is testable
+// outside the cableschedule.js initialization closure. Callers handle the
+// user-facing alerts; this module just returns success/failure results.
+
+function getXlsx() {
+  return typeof globalThis !== 'undefined' && globalThis.XLSX ? globalThis.XLSX : null;
+}
+
+/**
+ * Returns true when the SheetJS library exposes the export-side APIs we use.
+ */
+export function isXlsxExportAvailable() {
+  const xlsx = getXlsx();
+  return Boolean(xlsx && xlsx.utils && typeof xlsx.utils.aoa_to_sheet === 'function');
+}
+
+/**
+ * Returns true when the SheetJS library exposes the import-side APIs we use.
+ */
+export function isXlsxImportAvailable() {
+  const xlsx = getXlsx();
+  return Boolean(
+    xlsx
+      && typeof xlsx.read === 'function'
+      && xlsx.utils
+      && typeof xlsx.utils.sheet_to_json === 'function'
+  );
+}
+
+/**
+ * Read the first worksheet from an XLSX file buffer and return its rows.
+ *
+ * @param {ArrayBuffer|Uint8Array} buffer
+ * @returns {{ ok: true, rows: Array<object>, sheetName: string }
+ *          | { ok: false, code: 'unavailable' | 'no-sheets' | 'read-error',
+ *              error?: Error }}
+ */
+export function readFirstSheet(buffer) {
+  const xlsx = getXlsx();
+  if (!isXlsxImportAvailable()) return { ok: false, code: 'unavailable' };
+  let workbook;
+  try {
+    workbook = xlsx.read(buffer, { type: 'array' });
+  } catch (error) {
+    return { ok: false, code: 'read-error', error };
+  }
+  const sheetName = workbook.SheetNames && workbook.SheetNames[0];
+  if (!sheetName) return { ok: false, code: 'no-sheets' };
+  const rows = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName], {
+    defval: '',
+    raw: true
+  });
+  return { ok: true, rows: Array.isArray(rows) ? rows : [], sheetName };
+}
+
+/**
+ * Build and download a workbook from a sheet of rows-of-arrays data.
+ *
+ * @param {Array<Array<*>>} aoa - Rows-of-arrays (first row typically headers).
+ * @param {object} [options]
+ * @param {string} [options.sheetName] - Defaults to "Sheet1"; truncated to 31 chars.
+ * @param {string} [options.filename] - Output filename.
+ * @returns {{ ok: true } | { ok: false, code: 'unavailable' | 'write-error',
+ *           error?: Error }}
+ */
+export function writeAoaWorkbook(aoa, { sheetName = 'Sheet1', filename = 'export.xlsx' } = {}) {
+  const xlsx = getXlsx();
+  if (!isXlsxExportAvailable()) return { ok: false, code: 'unavailable' };
+  try {
+    const workbook = xlsx.utils.book_new();
+    const sheet = xlsx.utils.aoa_to_sheet(aoa);
+    xlsx.utils.book_append_sheet(workbook, sheet, String(sheetName).slice(0, 31));
+    xlsx.writeFile(workbook, filename);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, code: 'write-error', error };
+  }
+}
+
+/**
+ * Build a date-stamped filename suffix, e.g. "2026-05-25".
+ */
+export function todayStamp(date = new Date()) {
+  return date.toISOString().split('T')[0];
+}

--- a/src/cable-schedule/printReport.js
+++ b/src/cable-schedule/printReport.js
@@ -1,0 +1,85 @@
+// Pure DOM renderer for the Cable Schedule print/preview report.
+// Extracted from cableschedule.js so the HTML structure can be unit-tested
+// and reused outside the initCableSchedule closure.
+
+function defaultFormatValue(value) {
+  if (Array.isArray(value)) return value.join(', ');
+  return value == null ? '' : value;
+}
+
+function defaultFormatDateTime(value) {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+}
+
+/**
+ * Render the Cable Schedule print report into `host`.
+ *
+ * @param {HTMLElement} host - Container element. Will be cleared.
+ * @param {object} options
+ * @param {Array<{ key: string, label: string }>} options.columns
+ * @param {Array<object>} options.rows
+ * @param {string} options.modeLabel - Human-readable label for the report mode.
+ * @param {Date|string|number} [options.generatedAt] - Generation timestamp; defaults to now.
+ * @param {(value: any) => string} [options.formatValue]
+ * @param {(value: any) => string} [options.formatDateTime]
+ * @param {string} [options.emptyMessage]
+ */
+export function renderCablePrintReport(host, options = {}) {
+  if (!host) return;
+  const {
+    columns = [],
+    rows = [],
+    modeLabel = '',
+    generatedAt = new Date(),
+    formatValue = defaultFormatValue,
+    formatDateTime = defaultFormatDateTime,
+    emptyMessage = 'No cable rows match this report.'
+  } = options;
+
+  host.innerHTML = '';
+  host.removeAttribute('aria-hidden');
+
+  const meta = document.createElement('div');
+  meta.className = 'print-report-meta';
+  const title = document.createElement('strong');
+  title.textContent = `Cable Schedule - ${modeLabel}`;
+  const generated = document.createElement('span');
+  generated.textContent = `Generated ${formatDateTime(generatedAt)}`;
+  meta.append(title, generated);
+
+  const tableEl = document.createElement('table');
+  tableEl.className = 'cable-print-table';
+  const thead = tableEl.createTHead();
+  const header = thead.insertRow();
+  columns.forEach(col => {
+    const th = document.createElement('th');
+    th.textContent = col.label;
+    header.appendChild(th);
+  });
+
+  const tbody = tableEl.createTBody();
+  rows.forEach(row => {
+    const tr = tbody.insertRow();
+    columns.forEach(col => {
+      const td = tr.insertCell();
+      td.textContent = formatValue(row[col.key]);
+    });
+  });
+  if (!rows.length) {
+    const tr = tbody.insertRow();
+    const td = tr.insertCell();
+    td.colSpan = Math.max(1, columns.length);
+    td.textContent = emptyMessage;
+  }
+
+  host.append(meta, tableEl);
+}

--- a/src/one-line/validation.js
+++ b/src/one-line/validation.js
@@ -1,0 +1,173 @@
+// One-line diagram validation passes.
+//
+// Pure issue-collecting checks extracted from oneline.js#validateDiagram.
+// The caller still owns side effects (rendering the lint panel, applying SVG
+// markers, toasting), but the underlying topology + connection rules now live
+// here so they can be unit-tested and reused without booting the editor.
+
+/**
+ * Normalize a `phases` value (array, count, or delimited string) to a
+ * deduplicated, upper-cased letter set. Returns an empty array when no phases
+ * can be inferred.
+ */
+export function phaseSet(val) {
+  if (Array.isArray(val)) return val.map(p => String(p).toUpperCase());
+  if (typeof val === 'number') {
+    if (val === 3) return ['A', 'B', 'C'];
+    if (val === 2) return ['A', 'B'];
+    if (val === 1) return ['A'];
+    return [];
+  }
+  if (typeof val === 'string') {
+    if (/^\d+$/.test(val.trim())) return phaseSet(parseInt(val, 10));
+    return val
+      .split(/[\s,]+/)
+      .map(p => p.trim().toUpperCase())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+/**
+ * Run the topology + connection-rule passes against a diagram's components.
+ *
+ * @param {Array<object>} components - Components on the active sheet.
+ * @param {object} deps
+ * @param {(component: object, connection: object, role: 'source'|'target') => number|null} deps.resolveConnectionVoltageVolts
+ * @param {(volts: number) => string} deps.formatVoltage
+ * @param {(source: object, target: object|undefined, conn: object) => any} deps.getCableForConnection
+ * @param {(component: object) => string} deps.getComponentTag
+ * @param {(component: object) => string} deps.scheduleKeyForComponent
+ * @param {(component: object) => boolean} deps.hasResolvedScheduleLink
+ * @returns {Array<{ component: string, target?: string, code: string, message: string, connectionIndex?: number }>}
+ */
+export function runDiagramValidationPasses(components, deps) {
+  const {
+    resolveConnectionVoltageVolts,
+    formatVoltage,
+    getCableForConnection,
+    getComponentTag,
+    scheduleKeyForComponent,
+    hasResolvedScheduleLink
+  } = deps;
+  const issues = [];
+  const idMap = new Map();
+  const inbound = new Map();
+
+  components.forEach(c => {
+    if (c.type === 'dimension') return;
+    idMap.set(c.id, (idMap.get(c.id) || 0) + 1);
+    inbound.set(c.id, 0);
+  });
+
+  components.forEach(c => {
+    if (c.type === 'dimension') return;
+    (c.connections || []).forEach(conn => {
+      inbound.set(conn.target, (inbound.get(conn.target) || 0) + 1);
+      const target = components.find(t => t.id === conn.target);
+      if (target) {
+        const srcVolt = resolveConnectionVoltageVolts(c, conn, 'source');
+        const tgtVolt = resolveConnectionVoltageVolts(target, conn, 'target');
+        if (srcVolt !== null && tgtVolt !== null) {
+          const diff = Math.abs(srcVolt - tgtVolt);
+          const tolerance = Math.max(1, Math.min(srcVolt, tgtVolt) * 0.005);
+          if (diff > tolerance) {
+            const srcLabel = formatVoltage(srcVolt);
+            const tgtLabel = formatVoltage(tgtVolt);
+            issues.push({
+              component: c.id,
+              target: target.id,
+              code: 'voltage-mismatch',
+              message: `Voltage mismatch with ${target.label || target.subtype || target.id} (${srcLabel} vs ${tgtLabel})`
+            });
+            issues.push({
+              component: target.id,
+              target: c.id,
+              code: 'voltage-mismatch',
+              message: `Voltage mismatch with ${c.label || c.subtype || c.id} (${tgtLabel} vs ${srcLabel})`
+            });
+          }
+        }
+      }
+      if (target) {
+        const srcPh = phaseSet(c.phases);
+        const tgtPh = phaseSet(target.phases);
+        const connPh = conn.phases ? phaseSet(conn.phases) : null;
+        if (connPh && connPh.length) {
+          if (srcPh.length && !connPh.every(p => srcPh.includes(p))) {
+            issues.push({
+              component: c.id,
+              target: target.id,
+              code: 'phase-mismatch',
+              message: `Phase mismatch with ${target.label || target.subtype || target.id}`
+            });
+          }
+          if (tgtPh.length && !connPh.every(p => tgtPh.includes(p))) {
+            issues.push({
+              component: target.id,
+              target: c.id,
+              code: 'phase-mismatch',
+              message: `Phase mismatch with ${c.label || c.subtype || c.id}`
+            });
+          }
+        } else if (srcPh.length && tgtPh.length && !tgtPh.every(p => srcPh.includes(p))) {
+          issues.push({
+            component: c.id,
+            target: target.id,
+            code: 'phase-mismatch',
+            message: `Phase mismatch with ${target.label || target.subtype || target.id}`
+          });
+          issues.push({
+            component: target.id,
+            target: c.id,
+            code: 'phase-mismatch',
+            message: `Phase mismatch with ${c.label || c.subtype || c.id}`
+          });
+        }
+      }
+      const cableInfo = getCableForConnection(c, target, conn);
+      if (target && (!cableInfo?.tag || cableInfo?.provisional || conn.reviewStatus === 'assumed')) {
+        issues.push({
+          component: c.id,
+          target: target.id,
+          connectionIndex: (c.connections || []).indexOf(conn),
+          code: 'provisional-cable',
+          message: `Cable details need review for ${getComponentTag(c) || c.id} to ${getComponentTag(target) || target.id}`
+        });
+      }
+    });
+  });
+
+  components.forEach(c => {
+    // Gap #48: sheet_link components are intentional terminators; exclude from unconnected check
+    if (c.type === 'dimension' || c.type === 'annotation' || c.type === 'sheet_link') return;
+    if ((c.connections || []).length + (inbound.get(c.id) || 0) === 0) {
+      issues.push({ component: c.id, code: 'unconnected', message: 'Unconnected component' });
+    }
+    const key = scheduleKeyForComponent(c);
+    if (key && !hasResolvedScheduleLink(c)) {
+      issues.push({ component: c.id, code: 'missing-schedule-link', message: 'Missing schedule link' });
+    }
+  });
+
+  components.forEach(c => {
+    if (c.type === 'dimension') return;
+    (c.connections || []).forEach(conn => {
+      const target = components.find(t => t.id === conn.target);
+      const cableInfo = getCableForConnection(c, target, conn);
+      if (cableInfo && cableInfo.sizing_warning) {
+        issues.push({ component: c.id, code: 'sizing-warning', message: cableInfo.sizing_warning });
+      }
+    });
+  });
+
+  idMap.forEach((count, id) => {
+    if (count > 1) {
+      components.filter(c => c.id === id).forEach(c => {
+        issues.push({ component: c.id, code: 'duplicate-id', message: `Duplicate ID "${id}"` });
+      });
+    }
+  });
+
+  return issues;
+}


### PR DESCRIPTION
Carve three focused, testable modules out of the two largest root files
(cableschedule.js: 3434 lines, oneline.js: 19003 lines) per the Phase 4
"policy-driven, not big-bang" guidance. The root files keep their entry-point
shape; the extracted modules can now be exercised without booting the page.

- src/cable-schedule/io.js — SheetJS wrapper helpers:
  isXlsxExportAvailable(), isXlsxImportAvailable(), readFirstSheet(buffer),
  writeAoaWorkbook(aoa, { sheetName, filename }), todayStamp(). Replaces four
  inline copies of the same "is XLSX loaded?" + read/write boilerplate inside
  cableschedule.js (cable typicals export/import and the cable-schedule report
  export/import).

- src/cable-schedule/printReport.js — renderCablePrintReport(host, {
  columns, rows, modeLabel, formatValue, formatDateTime, emptyMessage }).
  Extracts the print-preview DOM builder from the initCableSchedule closure
  so the HTML structure can be unit-tested. The caller still owns mode →
  rows/columns selection.

- src/one-line/validation.js — runDiagramValidationPasses(components, deps)
  returns the issue array for all six inline rules previously embedded in
  oneline.js#validateDiagram: voltage mismatch, phase mismatch, provisional
  cable, unconnected/missing-schedule-link, sizing warning, duplicate ID.
  validateDiagram still owns side effects (lint panel, SVG markers, toast,
  validateSheetLinks, runValidation) but no longer carries the rule code.
  phaseSet() is exported alongside.

Net effect on the two root files: -155 source lines, replaced by three
~85–170 line modules that can be imported by future tests without `jsdom`
loading the entire page.

Regenerate docs/page-contract-audit.md (the audit test compares against
this file and the line-number/source-file references shift).

https://claude.ai/code/session_01BvAfy1ajp5xS7vPQibnEvh