### PR TITLE
Phase 5: groundgrid solver → Worker + templatable client factory

### DIFF
--- a/cathodicProtectionWorker.js
+++ b/cathodicProtectionWorker.js
@@ -1,0 +1,27 @@
+// Module worker for cathodic protection distribution / criteria / interference
+// analysis. Clean boundary: src/studies/cp/* modules are pure ES modules
+// (no DOM globals) and are imported directly by the worker.
+import {
+  computeDistributionBySegment,
+  parseZoneResistivityValues,
+} from './src/studies/cp/distributionModel.js';
+import { evaluateCriteriaChecks } from './src/studies/cp/criteriaChecks.js';
+import {
+  evaluateInterferenceAssessment,
+  parseMitigationActions,
+} from './src/studies/cp/interferenceAssessment.js';
+import {
+  parseConditionFactorValues,
+  resolveCoatingModel,
+} from './src/studies/cp/coatingModel.js';
+import { handleWorkerMessage } from './src/workers/createWorkerClient.js';
+
+handleWorkerMessage(self, {
+  computeDistributionBySegment,
+  parseZoneResistivityValues,
+  evaluateCriteriaChecks,
+  evaluateInterferenceAssessment,
+  parseMitigationActions,
+  parseConditionFactorValues,
+  resolveCoatingModel,
+});

--- a/dissimilarMetalsWorker.js
+++ b/dissimilarMetalsWorker.js
@@ -1,0 +1,26 @@
+// Module worker for dissimilar-metals galvanic corrosion screening.
+// Clean boundary: the analysis primitives (estimateDissimilarMetalsRisk,
+// buildCorrosionTimelineState, and the report-shape helpers) are exported
+// from dissimilarmetals.js. That file guards its DOM bootstrap behind a
+// `typeof document !== 'undefined'` check, so importing it from a worker
+// loads the pure exports without touching the document.
+import {
+  estimateDissimilarMetalsRisk,
+  buildCorrosionTimelineState,
+  buildMitigationComparisonRows,
+  buildInspectionMilestones,
+  buildAssumptionRows,
+  buildResultSummary,
+  buildResultExportPayload,
+} from './dissimilarmetals.js';
+import { handleWorkerMessage } from './src/workers/createWorkerClient.js';
+
+handleWorkerMessage(self, {
+  estimateDissimilarMetalsRisk,
+  buildCorrosionTimelineState,
+  buildMitigationComparisonRows,
+  buildInspectionMilestones,
+  buildAssumptionRows,
+  buildResultSummary,
+  buildResultExportPayload,
+});

--- a/groundGridWorker.js
+++ b/groundGridWorker.js
@@ -1,0 +1,18 @@
+// Module worker for IEEE 80-2013 ground grid analysis.
+// Mirrors thermalWorker.js's shape: self.onmessage routes incoming messages
+// and self.postMessage sends results back. The clean boundary is
+// analysis/groundGrid.mjs, which is already pure — the worker just imports
+// it and dispatches by op name. Each reply carries the request id so the
+// client (src/workers/groundGridClient.js) can correlate concurrent calls.
+import {
+  analyzeGroundGrid,
+  analyzeGroundGridWithSoil,
+  analyzeIrregularGrid,
+} from './analysis/groundGrid.mjs';
+import { handleWorkerMessage } from './src/workers/createWorkerClient.js';
+
+handleWorkerMessage(self, {
+  analyzeGroundGrid,
+  analyzeGroundGridWithSoil,
+  analyzeIrregularGrid,
+});

--- a/groundgrid.js
+++ b/groundgrid.js
@@ -1,4 +1,4 @@
-import { analyzeGroundGrid, analyzeGroundGridWithSoil, analyzeIrregularGrid } from './analysis/groundGrid.mjs';
+import { analyzeGroundGrid, analyzeIrregularGrid } from './src/workers/groundGridClient.js';
 import { normalizePreviewGeometry } from './src/groundgridPreviewGeometry.js';
 import {
   buildGroundGridRecommendations,
@@ -698,7 +698,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateRodLayoutHint();
   }
 
-  function calculate() {
+  async function calculate() {
     resultsDiv.innerHTML = '';
 
     const imperial = getUnits() === 'imperial';
@@ -737,7 +737,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let r;
     try {
-      r = analyzeGroundGrid({
+      r = await analyzeGroundGrid({
         rho,
         gridLx,
         gridLy,
@@ -884,7 +884,12 @@ document.addEventListener('DOMContentLoaded', () => {
   if (form) {
     form.addEventListener('submit', e => {
       e.preventDefault();
-      calculate();
+      calculate().catch(err => {
+        console.error('[groundgrid] calculate failed', err);
+        if (resultsDiv) {
+          resultsDiv.innerHTML = `<p class="alert-error" role="alert">Error: ${err.message || err}</p>`;
+        }
+      });
     });
 
     form.addEventListener('input', handleFormStateChange);
@@ -1202,7 +1207,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById(id)?.addEventListener('change', updatePolygonPreview);
   });
 
-  document.getElementById('irregular-analyze-btn')?.addEventListener('click', () => {
+  document.getElementById('irregular-analyze-btn')?.addEventListener('click', async () => {
     syncPolygonFromTable();
     if (polygonVertices.length < 3) {
       const { showAlertModal } = window;
@@ -1221,7 +1226,7 @@ document.addEventListener('DOMContentLoaded', () => {
         tf: parseFloat(document.getElementById('irr-tf')?.value) || 0.5,
         bw: parseInt(document.getElementById('irr-bw')?.value, 10) || 70,
       };
-      irregularGridResult = analyzeIrregularGrid(params, soilFitResult);
+      irregularGridResult = await analyzeIrregularGrid(params, soilFitResult);
       latestAnalysisResult = irregularGridResult;
       renderIrrResults(irregularGridResult);
     } catch (err) {

--- a/heatTraceWorker.js
+++ b/heatTraceWorker.js
@@ -1,0 +1,27 @@
+// Module worker for heat-trace circuit sizing and reporting.
+// Clean boundary: analysis/heatTraceSizing.mjs + analysis/heatTraceReport.mjs
+// are pure ES modules with no DOM dependencies. The worker imports them
+// directly and routes each incoming request id back on its reply so the
+// client (src/workers/heatTraceClient.js) can correlate concurrent calls.
+import {
+  runHeatTraceSizingAnalysis,
+  selectHeatTraceProduct,
+  buildLineList,
+  buildHeatTraceBOM,
+  buildControllerSchedule,
+} from './analysis/heatTraceSizing.mjs';
+import {
+  buildHeatTraceBranchSchedule,
+  buildHeatTraceReport,
+} from './analysis/heatTraceReport.mjs';
+import { handleWorkerMessage } from './src/workers/createWorkerClient.js';
+
+handleWorkerMessage(self, {
+  runHeatTraceSizingAnalysis,
+  selectHeatTraceProduct,
+  buildLineList,
+  buildHeatTraceBOM,
+  buildControllerSchedule,
+  buildHeatTraceBranchSchedule,
+  buildHeatTraceReport,
+});

--- a/src/workers/cathodicProtectionClient.js
+++ b/src/workers/cathodicProtectionClient.js
@@ -1,0 +1,82 @@
+/**
+ * Promise-based client for cathodicProtectionWorker.js.
+ *
+ * Offloads distribution / criteria / interference computations from the UI
+ * thread. Falls back to running the same pure modules on the calling thread
+ * when Worker construction is not available.
+ */
+import {
+  computeDistributionBySegment as computeDistributionBySegmentSync,
+  parseZoneResistivityValues as parseZoneResistivityValuesSync,
+} from '../studies/cp/distributionModel.js';
+import { evaluateCriteriaChecks as evaluateCriteriaChecksSync } from '../studies/cp/criteriaChecks.js';
+import {
+  evaluateInterferenceAssessment as evaluateInterferenceAssessmentSync,
+  parseMitigationActions as parseMitigationActionsSync,
+} from '../studies/cp/interferenceAssessment.js';
+import {
+  parseConditionFactorValues as parseConditionFactorValuesSync,
+  resolveCoatingModel as resolveCoatingModelSync,
+} from '../studies/cp/coatingModel.js';
+import { createWorkerClient } from './createWorkerClient.js';
+
+const OPS = [
+  'computeDistributionBySegment',
+  'parseZoneResistivityValues',
+  'evaluateCriteriaChecks',
+  'evaluateInterferenceAssessment',
+  'parseMitigationActions',
+  'parseConditionFactorValues',
+  'resolveCoatingModel',
+];
+
+const client = createWorkerClient({
+  workerUrl: 'cathodicProtectionWorker.js',
+  workerType: 'module',
+  operations: OPS,
+  fallback: {
+    computeDistributionBySegment: computeDistributionBySegmentSync,
+    parseZoneResistivityValues: parseZoneResistivityValuesSync,
+    evaluateCriteriaChecks: evaluateCriteriaChecksSync,
+    evaluateInterferenceAssessment: evaluateInterferenceAssessmentSync,
+    parseMitigationActions: parseMitigationActionsSync,
+    parseConditionFactorValues: parseConditionFactorValuesSync,
+    resolveCoatingModel: resolveCoatingModelSync,
+  },
+});
+
+export function computeDistributionBySegment(input) {
+  return client.call('computeDistributionBySegment', [input]);
+}
+
+export function parseZoneResistivityValues(rawValue) {
+  return client.call('parseZoneResistivityValues', [rawValue]);
+}
+
+export function evaluateCriteriaChecks(input, standardsProfile) {
+  return client.call('evaluateCriteriaChecks', [input, standardsProfile]);
+}
+
+export function evaluateInterferenceAssessment(input) {
+  return client.call('evaluateInterferenceAssessment', [input]);
+}
+
+export function parseMitigationActions(rawInput) {
+  return client.call('parseMitigationActions', [rawInput]);
+}
+
+export function parseConditionFactorValues(rawValue) {
+  return client.call('parseConditionFactorValues', [rawValue]);
+}
+
+export function resolveCoatingModel(input, context) {
+  return client.call('resolveCoatingModel', [input, context]);
+}
+
+export function terminate() {
+  client.terminate();
+}
+
+export function isUsingFallback() {
+  return client.isUsingFallback();
+}

--- a/src/workers/createWorkerClient.js
+++ b/src/workers/createWorkerClient.js
@@ -1,0 +1,173 @@
+/**
+ * createWorkerClient — id-correlated promise wrapper for Web Workers.
+ *
+ * Each call assigns a monotonically increasing id and stores its resolver in a
+ * pending map. The worker echoes the id in its reply so multiple in-flight
+ * requests never collide. If the Worker constructor throws (e.g. the runtime
+ * has no Worker, or the URL is blocked), the client transparently falls back
+ * to running the analysis on the calling thread via the supplied fallback map.
+ *
+ * Usage (see groundGridClient.js for a concrete instantiation):
+ *
+ *   const client = createWorkerClient({
+ *     workerUrl: 'groundGridWorker.js',
+ *     workerType: 'module',
+ *     operations: ['analyzeGroundGrid', 'analyzeIrregularGrid'],
+ *     fallback: { analyzeGroundGrid, analyzeIrregularGrid },
+ *   });
+ *   const result = await client.call('analyzeGroundGrid', [params]);
+ */
+
+const DEFAULT_VERSION = '1';
+
+function resolveWorkerUrl(workerUrl) {
+  if (typeof window !== 'undefined' && window.CTR_VERSION) {
+    const sep = workerUrl.includes('?') ? '&' : '?';
+    return `${workerUrl}${sep}v=${encodeURIComponent(window.CTR_VERSION || DEFAULT_VERSION)}`;
+  }
+  return workerUrl;
+}
+
+export function createWorkerClient({
+  workerUrl,
+  workerType = 'module',
+  operations = [],
+  fallback = {},
+  WorkerCtor,
+} = {}) {
+  if (!workerUrl) throw new Error('createWorkerClient: workerUrl is required');
+
+  const Ctor = WorkerCtor
+    || (typeof Worker !== 'undefined' ? Worker : null);
+
+  let worker = null;
+  let usingFallback = false;
+  let nextId = 1;
+  const pending = new Map();
+
+  function rejectAll(err) {
+    for (const entry of pending.values()) entry.reject(err);
+    pending.clear();
+  }
+
+  function onMessage(event) {
+    const data = event && event.data;
+    if (!data || typeof data.id !== 'number') return;
+    const entry = pending.get(data.id);
+    if (!entry) return;
+    pending.delete(data.id);
+    if (data.type === 'error') {
+      entry.reject(new Error(data.error || 'Worker error'));
+    } else {
+      entry.resolve(data.result);
+    }
+  }
+
+  function onError(event) {
+    const message = (event && (event.message || event.reason)) || 'Worker crashed';
+    rejectAll(new Error(message));
+    if (worker) {
+      try { worker.terminate(); } catch (_) { /* ignore */ }
+    }
+    worker = null;
+    usingFallback = true;
+  }
+
+  function ensureWorker() {
+    if (usingFallback) return null;
+    if (worker) return worker;
+    if (!Ctor) {
+      usingFallback = true;
+      return null;
+    }
+    try {
+      const opts = workerType ? { type: workerType } : undefined;
+      worker = new Ctor(resolveWorkerUrl(workerUrl), opts);
+    } catch (err) {
+      console.warn(`[workerClient] failed to construct worker for ${workerUrl}, using fallback:`, err);
+      usingFallback = true;
+      worker = null;
+      return null;
+    }
+    worker.onmessage = onMessage;
+    worker.onerror = onError;
+    if (typeof worker.onmessageerror !== 'undefined') {
+      worker.onmessageerror = onError;
+    }
+    return worker;
+  }
+
+  async function call(op, args = []) {
+    if (operations.length && !operations.includes(op)) {
+      throw new Error(`Unknown worker operation: ${op}`);
+    }
+    const w = ensureWorker();
+    if (!w) {
+      const fn = fallback[op];
+      if (typeof fn !== 'function') {
+        throw new Error(`No worker or fallback available for ${op}`);
+      }
+      return fn(...args);
+    }
+    return new Promise((resolve, reject) => {
+      const id = nextId++;
+      pending.set(id, { resolve, reject });
+      try {
+        w.postMessage({ id, op, args });
+      } catch (err) {
+        pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  function terminate() {
+    if (worker) {
+      try { worker.terminate(); } catch (_) { /* ignore */ }
+    }
+    worker = null;
+    rejectAll(new Error('Worker terminated'));
+  }
+
+  function isUsingFallback() {
+    return usingFallback;
+  }
+
+  return { call, terminate, isUsingFallback };
+}
+
+/**
+ * Build the message-handler half of a worker. Mirrors thermalWorker.js's
+ * `self.onmessage = e => { ... }` shape but dispatches by op name into a
+ * map of pure analysis functions and tags each reply with the request id.
+ *
+ * Usage inside a worker file:
+ *
+ *   import { handleWorkerMessage } from './src/workers/createWorkerClient.js';
+ *   import { analyzeGroundGrid } from './analysis/groundGrid.mjs';
+ *   handleWorkerMessage(self, { analyzeGroundGrid });
+ */
+export function handleWorkerMessage(scope, handlers) {
+  if (!scope || typeof scope.postMessage !== 'function') {
+    throw new Error('handleWorkerMessage: scope must expose postMessage');
+  }
+  scope.onmessage = event => {
+    const data = event && event.data;
+    if (!data || typeof data.id !== 'number') return;
+    const { id, op, args } = data;
+    const handler = handlers[op];
+    if (typeof handler !== 'function') {
+      scope.postMessage({ id, type: 'error', error: `Unknown op: ${op}` });
+      return;
+    }
+    try {
+      const result = handler(...(args || []));
+      Promise.resolve(result).then(
+        value => scope.postMessage({ id, type: 'result', result: value }),
+        err => scope.postMessage({ id, type: 'error', error: err && err.message || String(err) }),
+      );
+    } catch (err) {
+      scope.postMessage({ id, type: 'error', error: err && err.message || String(err) });
+    }
+  };
+}

--- a/src/workers/dissimilarMetalsClient.js
+++ b/src/workers/dissimilarMetalsClient.js
@@ -1,0 +1,78 @@
+/**
+ * Promise-based client for dissimilarMetalsWorker.js.
+ *
+ * Offloads galvanic corrosion risk estimation and timeline construction
+ * from the UI thread. Falls back to running the same pure functions on
+ * the calling thread when Worker construction is not available.
+ */
+import {
+  estimateDissimilarMetalsRisk as estimateDissimilarMetalsRiskSync,
+  buildCorrosionTimelineState as buildCorrosionTimelineStateSync,
+  buildMitigationComparisonRows as buildMitigationComparisonRowsSync,
+  buildInspectionMilestones as buildInspectionMilestonesSync,
+  buildAssumptionRows as buildAssumptionRowsSync,
+  buildResultSummary as buildResultSummarySync,
+  buildResultExportPayload as buildResultExportPayloadSync,
+} from '../../dissimilarmetals.js';
+import { createWorkerClient } from './createWorkerClient.js';
+
+const OPS = [
+  'estimateDissimilarMetalsRisk',
+  'buildCorrosionTimelineState',
+  'buildMitigationComparisonRows',
+  'buildInspectionMilestones',
+  'buildAssumptionRows',
+  'buildResultSummary',
+  'buildResultExportPayload',
+];
+
+const client = createWorkerClient({
+  workerUrl: 'dissimilarMetalsWorker.js',
+  workerType: 'module',
+  operations: OPS,
+  fallback: {
+    estimateDissimilarMetalsRisk: estimateDissimilarMetalsRiskSync,
+    buildCorrosionTimelineState: buildCorrosionTimelineStateSync,
+    buildMitigationComparisonRows: buildMitigationComparisonRowsSync,
+    buildInspectionMilestones: buildInspectionMilestonesSync,
+    buildAssumptionRows: buildAssumptionRowsSync,
+    buildResultSummary: buildResultSummarySync,
+    buildResultExportPayload: buildResultExportPayloadSync,
+  },
+});
+
+export function estimateDissimilarMetalsRisk(input) {
+  return client.call('estimateDissimilarMetalsRisk', [input]);
+}
+
+export function buildCorrosionTimelineState(result, years) {
+  return client.call('buildCorrosionTimelineState', [result, years]);
+}
+
+export function buildMitigationComparisonRows(result) {
+  return client.call('buildMitigationComparisonRows', [result]);
+}
+
+export function buildInspectionMilestones(result) {
+  return client.call('buildInspectionMilestones', [result]);
+}
+
+export function buildAssumptionRows(result) {
+  return client.call('buildAssumptionRows', [result]);
+}
+
+export function buildResultSummary(result) {
+  return client.call('buildResultSummary', [result]);
+}
+
+export function buildResultExportPayload(result) {
+  return client.call('buildResultExportPayload', [result]);
+}
+
+export function terminate() {
+  client.terminate();
+}
+
+export function isUsingFallback() {
+  return client.isUsingFallback();
+}

--- a/src/workers/groundGridClient.js
+++ b/src/workers/groundGridClient.js
@@ -1,0 +1,47 @@
+/**
+ * Promise-based client for groundGridWorker.js.
+ *
+ * Offloads IEEE 80-2013 ground grid analysis from the UI thread. The same
+ * synchronous functions exported by analysis/groundGrid.mjs are mirrored
+ * here as async wrappers that resolve with the worker's reply. If the
+ * Worker constructor fails (older runtime, headless test) the calls
+ * transparently fall back to the pure analysis module on the calling
+ * thread, so callers don't have to branch.
+ */
+import {
+  analyzeGroundGrid as analyzeGroundGridSync,
+  analyzeGroundGridWithSoil as analyzeGroundGridWithSoilSync,
+  analyzeIrregularGrid as analyzeIrregularGridSync,
+} from '../../analysis/groundGrid.mjs';
+import { createWorkerClient } from './createWorkerClient.js';
+
+const client = createWorkerClient({
+  workerUrl: 'groundGridWorker.js',
+  workerType: 'module',
+  operations: ['analyzeGroundGrid', 'analyzeGroundGridWithSoil', 'analyzeIrregularGrid'],
+  fallback: {
+    analyzeGroundGrid: analyzeGroundGridSync,
+    analyzeGroundGridWithSoil: analyzeGroundGridWithSoilSync,
+    analyzeIrregularGrid: analyzeIrregularGridSync,
+  },
+});
+
+export function analyzeGroundGrid(params) {
+  return client.call('analyzeGroundGrid', [params]);
+}
+
+export function analyzeGroundGridWithSoil(params, soilModel) {
+  return client.call('analyzeGroundGridWithSoil', [params, soilModel]);
+}
+
+export function analyzeIrregularGrid(params, soilModel) {
+  return client.call('analyzeIrregularGrid', [params, soilModel]);
+}
+
+export function terminate() {
+  client.terminate();
+}
+
+export function isUsingFallback() {
+  return client.isUsingFallback();
+}

--- a/src/workers/heatTraceClient.js
+++ b/src/workers/heatTraceClient.js
@@ -1,0 +1,80 @@
+/**
+ * Promise-based client for heatTraceWorker.js.
+ *
+ * Offloads heat-trace sizing, BOM construction, and report assembly from
+ * the UI thread. Falls back to running the same pure analysis modules
+ * on the calling thread when Worker construction is not available.
+ */
+import {
+  runHeatTraceSizingAnalysis as runHeatTraceSizingAnalysisSync,
+  selectHeatTraceProduct as selectHeatTraceProductSync,
+  buildLineList as buildLineListSync,
+  buildHeatTraceBOM as buildHeatTraceBOMSync,
+  buildControllerSchedule as buildControllerScheduleSync,
+} from '../../analysis/heatTraceSizing.mjs';
+import {
+  buildHeatTraceBranchSchedule as buildHeatTraceBranchScheduleSync,
+  buildHeatTraceReport as buildHeatTraceReportSync,
+} from '../../analysis/heatTraceReport.mjs';
+import { createWorkerClient } from './createWorkerClient.js';
+
+const OPS = [
+  'runHeatTraceSizingAnalysis',
+  'selectHeatTraceProduct',
+  'buildLineList',
+  'buildHeatTraceBOM',
+  'buildControllerSchedule',
+  'buildHeatTraceBranchSchedule',
+  'buildHeatTraceReport',
+];
+
+const client = createWorkerClient({
+  workerUrl: 'heatTraceWorker.js',
+  workerType: 'module',
+  operations: OPS,
+  fallback: {
+    runHeatTraceSizingAnalysis: runHeatTraceSizingAnalysisSync,
+    selectHeatTraceProduct: selectHeatTraceProductSync,
+    buildLineList: buildLineListSync,
+    buildHeatTraceBOM: buildHeatTraceBOMSync,
+    buildControllerSchedule: buildControllerScheduleSync,
+    buildHeatTraceBranchSchedule: buildHeatTraceBranchScheduleSync,
+    buildHeatTraceReport: buildHeatTraceReportSync,
+  },
+});
+
+export function runHeatTraceSizingAnalysis(inputs) {
+  return client.call('runHeatTraceSizingAnalysis', [inputs]);
+}
+
+export function selectHeatTraceProduct(circuit, catalog) {
+  return client.call('selectHeatTraceProduct', [circuit, catalog]);
+}
+
+export function buildLineList(circuits, catalog) {
+  return client.call('buildLineList', [circuits, catalog]);
+}
+
+export function buildHeatTraceBOM(lineListRows) {
+  return client.call('buildHeatTraceBOM', [lineListRows]);
+}
+
+export function buildControllerSchedule(lineListRows) {
+  return client.call('buildControllerSchedule', [lineListRows]);
+}
+
+export function buildHeatTraceBranchSchedule(cases) {
+  return client.call('buildHeatTraceBranchSchedule', [cases]);
+}
+
+export function buildHeatTraceReport(payload) {
+  return client.call('buildHeatTraceReport', [payload]);
+}
+
+export function terminate() {
+  client.terminate();
+}
+
+export function isUsingFallback() {
+  return client.isUsingFallback();
+}

--- a/tests/workerClient.test.mjs
+++ b/tests/workerClient.test.mjs
@@ -1,0 +1,211 @@
+/**
+ * Tests for src/workers/createWorkerClient.js
+ *
+ * Validates the id-correlated promise wrapper and the worker-side dispatcher
+ * helper. A minimal Worker mock simulates round-trip postMessage so we can
+ * exercise concurrent calls, error propagation, and the main-thread fallback
+ * without spinning up a real Worker runtime.
+ */
+import assert from 'assert';
+import {
+  createWorkerClient,
+  handleWorkerMessage,
+} from '../src/workers/createWorkerClient.js';
+
+function describe(name, fn) { console.log(name); fn(); }
+function it(name, fn) {
+  try {
+    const result = fn();
+    if (result && typeof result.then === 'function') {
+      return result.then(
+        () => console.log('  ✓', name),
+        err => { console.error('  ✗', name, err && err.stack || err); process.exitCode = 1; },
+      );
+    }
+    console.log('  ✓', name);
+  } catch (err) {
+    console.error('  ✗', name, err && err.stack || err);
+    process.exitCode = 1;
+  }
+}
+
+// Minimal Worker stub: a postMessage on the client side is routed to a
+// handler scope; postMessage on the scope side is routed back as an
+// 'message' event on the client. This is the contract the real Worker
+// API exposes — sufficient to test id correlation end-to-end.
+function makeMockWorker(handlers) {
+  const fakeWorker = {
+    onmessage: null,
+    onerror: null,
+    postMessage(message) {
+      // Asynchronously invoke handler, mirroring real Worker semantics
+      queueMicrotask(() => scope.onmessage({ data: message }));
+    },
+    terminate() { fakeWorker.terminated = true; },
+    terminated: false,
+  };
+  const scope = {
+    onmessage: null,
+    postMessage(message) {
+      queueMicrotask(() => {
+        if (fakeWorker.onmessage) fakeWorker.onmessage({ data: message });
+      });
+    },
+  };
+  handleWorkerMessage(scope, handlers);
+  return { fakeWorker, scope };
+}
+
+describe('createWorkerClient — id-correlated promises', () => {
+  it('resolves a single call with the worker reply', async () => {
+    const { fakeWorker } = makeMockWorker({ add: (a, b) => a + b });
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: function MockWorker() { return fakeWorker; },
+      operations: ['add'],
+    });
+    const result = await client.call('add', [2, 3]);
+    assert.strictEqual(result, 5);
+  });
+
+  it('correlates concurrent calls by id', async () => {
+    const { fakeWorker } = makeMockWorker({
+      slow: () => new Promise(resolve => setTimeout(() => resolve('slow'), 20)),
+      fast: () => 'fast',
+    });
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: function MockWorker() { return fakeWorker; },
+      operations: ['slow', 'fast'],
+    });
+    const [slow, fast] = await Promise.all([
+      client.call('slow', []),
+      client.call('fast', []),
+    ]);
+    assert.strictEqual(slow, 'slow');
+    assert.strictEqual(fast, 'fast');
+  });
+
+  it('propagates errors thrown inside the worker handler', async () => {
+    const { fakeWorker } = makeMockWorker({
+      boom: () => { throw new Error('explode'); },
+    });
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: function MockWorker() { return fakeWorker; },
+      operations: ['boom'],
+    });
+    await assert.rejects(() => client.call('boom', []), /explode/);
+  });
+
+  it('rejects unknown operations from the client side', async () => {
+    const { fakeWorker } = makeMockWorker({ add: a => a });
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: function MockWorker() { return fakeWorker; },
+      operations: ['add'],
+    });
+    await assert.rejects(() => client.call('missing', []), /Unknown worker operation/);
+  });
+
+  it('rejects unknown operations from the worker side', async () => {
+    const { fakeWorker } = makeMockWorker({ add: a => a });
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: function MockWorker() { return fakeWorker; },
+      operations: [],
+    });
+    await assert.rejects(() => client.call('missing', []), /Unknown op/);
+  });
+
+  it('falls back to the main thread when WorkerCtor is missing', async () => {
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: null,
+      operations: ['add'],
+      fallback: { add: (a, b) => a + b },
+    });
+    const result = await client.call('add', [4, 5]);
+    assert.strictEqual(result, 9);
+    assert.strictEqual(client.isUsingFallback(), true);
+  });
+
+  it('falls back when WorkerCtor throws on construction', async () => {
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: function ThrowingWorker() { throw new Error('blocked'); },
+      operations: ['add'],
+      fallback: { add: (a, b) => a + b },
+    });
+    const result = await client.call('add', [10, 11]);
+    assert.strictEqual(result, 21);
+    assert.strictEqual(client.isUsingFallback(), true);
+  });
+
+  it('terminate() rejects all pending calls', async () => {
+    let scope;
+    const fakeWorker = {
+      onmessage: null,
+      onerror: null,
+      postMessage() { /* never reply */ },
+      terminate() {},
+    };
+    const client = createWorkerClient({
+      workerUrl: 'mock.js',
+      WorkerCtor: function MockWorker() { return fakeWorker; },
+      operations: ['hang'],
+    });
+    const pending = client.call('hang', []);
+    client.terminate();
+    await assert.rejects(() => pending, /Worker terminated/);
+  });
+});
+
+describe('handleWorkerMessage — worker-side dispatcher', () => {
+  it('echoes the request id on success replies', async () => {
+    const scope = {
+      onmessage: null,
+      posted: [],
+      postMessage(msg) { this.posted.push(msg); },
+    };
+    handleWorkerMessage(scope, { square: x => x * x });
+    scope.onmessage({ data: { id: 42, op: 'square', args: [9] } });
+    await new Promise(r => queueMicrotask(r));
+    await new Promise(r => queueMicrotask(r));
+    assert.strictEqual(scope.posted.length, 1);
+    assert.strictEqual(scope.posted[0].id, 42);
+    assert.strictEqual(scope.posted[0].type, 'result');
+    assert.strictEqual(scope.posted[0].result, 81);
+  });
+
+  it('echoes the request id on async handler errors', async () => {
+    const scope = {
+      onmessage: null,
+      posted: [],
+      postMessage(msg) { this.posted.push(msg); },
+    };
+    handleWorkerMessage(scope, {
+      fail: async () => { throw new Error('async-boom'); },
+    });
+    scope.onmessage({ data: { id: 7, op: 'fail', args: [] } });
+    // wait two ticks for the async handler to settle
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    assert.strictEqual(scope.posted.length, 1);
+    assert.strictEqual(scope.posted[0].id, 7);
+    assert.strictEqual(scope.posted[0].type, 'error');
+    assert.match(scope.posted[0].error, /async-boom/);
+  });
+
+  it('ignores malformed messages without an id', () => {
+    const scope = {
+      onmessage: null,
+      posted: [],
+      postMessage(msg) { this.posted.push(msg); },
+    };
+    handleWorkerMessage(scope, { noop: () => 'ok' });
+    scope.onmessage({ data: { op: 'noop' } }); // missing id
+    scope.onmessage({ data: null });
+    assert.strictEqual(scope.posted.length, 0);
+  });
+});


### PR DESCRIPTION
Clean boundary: analysis/groundGrid.mjs (already pure) — groundGridWorker.js
imports it directly and mirrors thermalWorker.js's self.onmessage shape.
src/workers/groundGridClient.js wraps the worker behind id-correlated
promises so concurrent calls don't collide, with a transparent main-thread
fallback when Worker construction is unavailable.

The same pattern (createWorkerClient + handleWorkerMessage) is reused for
heattracesizing, cathodicprotection, and dissimilarmetals — each gets a
*Worker.js at the root that imports its pure analysis modules plus a
src/workers/*Client.js with id-correlated promises.

groundgrid.js's calculate() and irregular-grid handler now await the
client; the form-submit handler catches rejected promises.

Includes tests/workerClient.test.mjs covering: round-trip, concurrent
id correlation, error propagation, main-thread fallback (no WorkerCtor
and throwing WorkerCtor), terminate() rejecting pending calls, and the
worker-side dispatcher echoing request ids on success/error.