### PR TITLE
Wire heat-trace page through the Phase 5 worker client

### DIFF
--- a/heattracesizing.js
+++ b/heattracesizing.js
@@ -13,6 +13,15 @@ import {
   buildHeatTraceReport,
   renderHeatTraceReportHTML,
 } from './analysis/heatTraceReport.mjs';
+// Worker-routed entry points for user-initiated calculate / export actions.
+// Hot paths (live input recalc, sensitivity perturbation loops) still use the
+// sync imports above so per-keystroke latency is not gated on postMessage.
+import {
+  runHeatTraceSizingAnalysis as runHeatTraceSizingAnalysisOffMain,
+  buildLineList as buildLineListOffMain,
+  buildHeatTraceBOM as buildHeatTraceBOMOffMain,
+  buildControllerSchedule as buildControllerScheduleOffMain,
+} from './src/workers/heatTraceClient.js';
 import { getStudies, getStudyApprovals, setStudies } from './dataStore.mjs';
 import { getProjectState } from './projectStorage.js';
 import { initStudyApprovalPanel } from './src/components/studyApproval.js';
@@ -213,10 +222,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   form.addEventListener('submit', e => {
     e.preventDefault();
+    runSubmitCalculation().catch(err => {
+      console.error('[heattracesizing] calculate failed', err);
+      showModal('Calculation Error', `<p>${escHtml(err.message || String(err))}</p>`, 'error');
+    });
+  });
 
+  async function runSubmitCalculation() {
     let result;
     try {
-      result = runHeatTraceSizingAnalysis(readInputs());
+      result = await runHeatTraceSizingAnalysisOffMain(readInputs());
     } catch (err) {
       showModal('Input Error', `<p>${escHtml(err.message)}</p>`, 'error');
       return;
@@ -234,7 +249,7 @@ document.addEventListener('DOMContentLoaded', () => {
     renderSystemOverview(result);
     renderWorkspaceCharts(result);
     captureSensitivityBaseline(result);
-  });
+  }
 
   sensitivitySetBaselineButton?.addEventListener('click', () => {
     captureSensitivityBaseline(getLiveAnalysisResult() || getStudies().heatTraceSizing || null);
@@ -2493,7 +2508,7 @@ document.addEventListener('DOMContentLoaded', () => {
     downloadCsvData(headers, schedule, `heat-trace-controller-schedule-${new Date().toISOString().slice(0,10)}.csv`);
   }
 
-  function exportPackageXlsx() {
+  async function exportPackageXlsx() {
     if (typeof XLSX === 'undefined') {
       showModal('Library Error', '<p>XLSX library not loaded. Ensure the page is fully loaded and try again.</p>', 'error');
       return;
@@ -2501,9 +2516,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const circuits = getNormalizedCircuits();
     if (!circuits.length) { showModal('No Data', '<p>Add branch cases before exporting the package.</p>', 'info'); return; }
     const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
-    const lineRows = buildLineList(circuits, catalog);
-    const bom = buildHeatTraceBOM(lineRows);
-    const controllerSched = buildControllerSchedule(lineRows);
+    const lineRows = await buildLineListOffMain(circuits, catalog);
+    const bom = await buildHeatTraceBOMOffMain(lineRows);
+    const controllerSched = await buildControllerScheduleOffMain(lineRows);
     const wb = XLSX.utils.book_new();
 
     // Line List sheet
@@ -2547,7 +2562,12 @@ document.addEventListener('DOMContentLoaded', () => {
     exportLineListCsvButton?.addEventListener('click', exportLineListCsv);
     exportBomCsvButton?.addEventListener('click', exportBomCsv);
     exportControllerCsvButton?.addEventListener('click', exportControllerCsv);
-    exportPackageButton?.addEventListener('click', exportPackageXlsx);
+    exportPackageButton?.addEventListener('click', () => {
+      exportPackageXlsx().catch(err => {
+        console.error('[heattracesizing] package export failed', err);
+        showModal('Export Error', `<p>${escHtml(err.message || String(err))}</p>`, 'error');
+      });
+    });
     [productFilterType, productFilterVoltage, productFilterHazardous].forEach(el => {
       el?.addEventListener('change', renderCatalogTable);
     });


### PR DESCRIPTION
Phase 5 (be56af0) shipped src/workers/heatTraceClient.js +
heatTraceWorker.js as scaffolding but only groundgrid.js was wired to
its client. The heat-trace page kept calling the sync analysis modules
directly, so the scaffolding was unused.

This wires the two discrete user-initiated paths through the worker
client:

- Form submit ("Run Analysis"): runHeatTraceSizingAnalysis routes to
  the worker. The handler is restructured into runSubmitCalculation()
  so the addEventListener wrapper stays synchronous (preventDefault
  remains synchronous) while the body awaits the worker and surfaces
  rejections through showModal, matching groundgrid.js's pattern.
- Package XLSX export: buildLineList / buildHeatTraceBOM /
  buildControllerSchedule route to the worker. The click handler wraps
  the async function so a rejection surfaces an Export Error modal
  instead of becoming an unhandled rejection.

Hot paths (per-keystroke live recalc via getLiveAnalysisResult, the
sensitivity-perturbation loop in safeRunSensitivityCase, and the
branch-schedule / line-list / BOM / controller tab renderers) keep the
synchronous imports from analysis/heatTraceSizing.mjs and
analysis/heatTraceReport.mjs. Routing those through postMessage would
add round-trip latency to every input event and to every sensitivity
sweep step (~10 solver calls per rebuild), which is the opposite of
the desired UX. The two newly-routed paths are user-discrete clicks
where a microtask roundtrip is invisible.

The existing AT-HT acceptance lane covers form submit + package XLSX
export end-to-end and continues to pass against the new wiring.