### PR TITLE
Wire cathodic-protection and dissimilar-metals pages through Phase 5 worker clients

### DIFF
--- a/cathodicprotection.js
+++ b/cathodicprotection.js
@@ -11,6 +11,16 @@ import { computeDistributionBySegment, parseZoneResistivityValues } from './src/
 import { evaluateCriteriaChecks } from './src/studies/cp/criteriaChecks.js';
 import { evaluateInterferenceAssessment, parseMitigationActions } from './src/studies/cp/interferenceAssessment.js';
 import { COATING_MODEL_TYPES, parseConditionFactorValues, resolveCoatingModel } from './src/studies/cp/coatingModel.js';
+// Worker-routed entry points for the user-initiated calculate action.
+// Hot paths (normalizeSavedStudy recomputes triggered by mouse/keyboard handlers
+// and comparison toggles) still use the sync imports above so per-event latency
+// is not gated on postMessage.
+import {
+  computeDistributionBySegment as computeDistributionBySegmentOffMain,
+  resolveCoatingModel as resolveCoatingModelOffMain,
+  evaluateCriteriaChecks as evaluateCriteriaChecksOffMain,
+  evaluateInterferenceAssessment as evaluateInterferenceAssessmentOffMain,
+} from './src/workers/cathodicProtectionClient.js';
 import { initCpLayoutCanvas } from './src/cpLayoutCanvas.js';
 import { initCpProfiles } from './src/cpProfiles.js';
 
@@ -191,18 +201,8 @@ export function calculatePredictedDesignLife(installedMassKg, anodeCapacityAhPer
   return (installedMassKg * anodeCapacityAhPerKg * utilizationFactor * designFactor) / (requiredCurrentA * 8760);
 }
 
-export function runCathodicProtectionAnalysis(input) {
-  const validationErrors = validateInputs(input);
-  if (validationErrors.length) {
-    throw new Error(validationErrors.join(' '));
-  }
-
-  const designCurrentDensityMaM2 = input.currentDensityMethod === 'manual'
-    ? input.manualCurrentDensityMaM2
-    : lookupCurrentDensity(input.assetType, input.moistureCategory, input.soilResistivityOhmM, input.soilPh, input.pipeMaterial);
-
-  const designCurrentDensityAperM2 = designCurrentDensityMaM2 / 1000;
-  const distributionModel = computeDistributionBySegment({
+function buildDistributionInput(input) {
+  return {
     anodeTypeSystem: input.anodeTypeSystem,
     numberOfAnodes: input.numberOfAnodes,
     anodeSpacingM: input.anodeSpacingM,
@@ -210,8 +210,18 @@ export function runCathodicProtectionAnalysis(input) {
     anodeBurialDepthM: input.anodeBurialDepthM,
     soilResistivityOhmM: input.soilResistivityOhmM,
     zoneResistivityOhmM: input.zoneResistivityOhmM
-  });
-  const coatingModel = resolveCoatingModel(input, { segmentCount: distributionModel.segments.length });
+  };
+}
+
+function composeCpAnalysisResult({
+  input,
+  designCurrentDensityMaM2,
+  distributionModel,
+  coatingModel,
+  criteriaCheckEvidence,
+  interferenceAssessment
+}) {
+  const designCurrentDensityAperM2 = designCurrentDensityMaM2 / 1000;
   const exposedAreaM2 = input.surfaceAreaM2 * coatingModel.effectiveFactor;
   const areaBasedRequiredCurrentA = calculateRequiredCurrent(exposedAreaM2, designCurrentDensityAperM2);
   const distributionAdjustedCurrentA = areaBasedRequiredCurrentA * distributionModel.globalAttenuationFactor;
@@ -233,8 +243,6 @@ export function runCathodicProtectionAnalysis(input) {
     input.designFactor,
     adjustedRequiredCurrentA
   );
-  const criteriaCheckEvidence = evaluateCriteriaChecks(input, CP_STANDARDS_PROFILE);
-  const interferenceAssessment = evaluateInterferenceAssessment(input);
   const measurementMetadataWarnings = Array.isArray(criteriaCheckEvidence?.measurementCorrections?.warnings)
     ? criteriaCheckEvidence.measurementCorrections.warnings
     : [];
@@ -282,6 +290,58 @@ export function runCathodicProtectionAnalysis(input) {
       distributionModel
     })
   };
+}
+
+export function runCathodicProtectionAnalysis(input) {
+  const validationErrors = validateInputs(input);
+  if (validationErrors.length) {
+    throw new Error(validationErrors.join(' '));
+  }
+
+  const designCurrentDensityMaM2 = input.currentDensityMethod === 'manual'
+    ? input.manualCurrentDensityMaM2
+    : lookupCurrentDensity(input.assetType, input.moistureCategory, input.soilResistivityOhmM, input.soilPh, input.pipeMaterial);
+
+  const distributionModel = computeDistributionBySegment(buildDistributionInput(input));
+  const coatingModel = resolveCoatingModel(input, { segmentCount: distributionModel.segments.length });
+  const criteriaCheckEvidence = evaluateCriteriaChecks(input, CP_STANDARDS_PROFILE);
+  const interferenceAssessment = evaluateInterferenceAssessment(input);
+
+  return composeCpAnalysisResult({
+    input,
+    designCurrentDensityMaM2,
+    distributionModel,
+    coatingModel,
+    criteriaCheckEvidence,
+    interferenceAssessment
+  });
+}
+
+async function runCathodicProtectionAnalysisOffMain(input) {
+  const validationErrors = validateInputs(input);
+  if (validationErrors.length) {
+    throw new Error(validationErrors.join(' '));
+  }
+
+  const designCurrentDensityMaM2 = input.currentDensityMethod === 'manual'
+    ? input.manualCurrentDensityMaM2
+    : lookupCurrentDensity(input.assetType, input.moistureCategory, input.soilResistivityOhmM, input.soilPh, input.pipeMaterial);
+
+  const distributionModel = await computeDistributionBySegmentOffMain(buildDistributionInput(input));
+  const coatingModel = await resolveCoatingModelOffMain(input, { segmentCount: distributionModel.segments.length });
+  const [criteriaCheckEvidence, interferenceAssessment] = await Promise.all([
+    evaluateCriteriaChecksOffMain(input, CP_STANDARDS_PROFILE),
+    evaluateInterferenceAssessmentOffMain(input),
+  ]);
+
+  return composeCpAnalysisResult({
+    input,
+    designCurrentDensityMaM2,
+    distributionModel,
+    coatingModel,
+    criteriaCheckEvidence,
+    interferenceAssessment
+  });
 }
 
 function buildCpProfileData({ input, adjustedRequiredCurrentA, distributionModel, measuredInstantOffPotentialMv, baseCoatingFactor }) {
@@ -1237,40 +1297,41 @@ bootstrapPage({
     event.preventDefault();
     const input = readFormInputs();
     if (!input) return;
-
-    try {
-      const result = runCathodicProtectionAnalysis(input);
-      errorsDiv.hidden = true;
-      errorsDiv.textContent = '';
-      const studies = getStudies();
-      const previousStudy = normalizeSavedStudy(studies.cathodicProtection);
-      const approval = getStudyApprovals().cathodicProtection || null;
-      const complianceRecord = createComplianceRecord(result, previousStudy, approval);
-      studies.cathodicProtection = {
-        ...result,
-        reportExport: buildReportExportData(result, approval),
-        cpLayout: cpLayoutCanvasController?.getState() || cpLayoutState,
-        timelineState: cpTimelineState,
-        compliance: complianceRecord.compliance,
-        complianceHistory: complianceRecord.complianceHistory
-      };
-      setStudies(studies);
-      renderResults(studies.cathodicProtection, resultsDiv);
-      cpLayoutCanvasController?.setAssessmentData(buildLayoutAssessmentPayload(studies.cathodicProtection));
-      renderComplianceStatusPanel(
-        compliancePanelEl,
-        studies.cathodicProtection.compliance.requiredChecks,
-        studies.cathodicProtection.compliance.lastEvaluatedAt,
-        studies.cathodicProtection.compliance
-      );
-      renderTimelinePanel(timelinePanelEl, studies.cathodicProtection, cpTimelineState);
-    } catch (error) {
+    runSubmitCalculation(input).catch(error => {
       const message = error instanceof Error ? error.message : 'Invalid cathodic protection inputs.';
       errorsDiv.hidden = false;
       errorsDiv.innerHTML = `<strong>Input validation error:</strong> ${escapeHtml(message)}`;
       showModal('Input Error', `<p>${escapeHtml(message)}</p>`, 'error');
-    }
+    });
   });
+
+  async function runSubmitCalculation(input) {
+    const result = await runCathodicProtectionAnalysisOffMain(input);
+    errorsDiv.hidden = true;
+    errorsDiv.textContent = '';
+    const studies = getStudies();
+    const previousStudy = normalizeSavedStudy(studies.cathodicProtection);
+    const approval = getStudyApprovals().cathodicProtection || null;
+    const complianceRecord = createComplianceRecord(result, previousStudy, approval);
+    studies.cathodicProtection = {
+      ...result,
+      reportExport: buildReportExportData(result, approval),
+      cpLayout: cpLayoutCanvasController?.getState() || cpLayoutState,
+      timelineState: cpTimelineState,
+      compliance: complianceRecord.compliance,
+      complianceHistory: complianceRecord.complianceHistory
+    };
+    setStudies(studies);
+    renderResults(studies.cathodicProtection, resultsDiv);
+    cpLayoutCanvasController?.setAssessmentData(buildLayoutAssessmentPayload(studies.cathodicProtection));
+    renderComplianceStatusPanel(
+      compliancePanelEl,
+      studies.cathodicProtection.compliance.requiredChecks,
+      studies.cathodicProtection.compliance.lastEvaluatedAt,
+      studies.cathodicProtection.compliance
+    );
+    renderTimelinePanel(timelinePanelEl, studies.cathodicProtection, cpTimelineState);
+  }
   },
 });
 

--- a/dissimilarmetals.js
+++ b/dissimilarmetals.js
@@ -1,5 +1,14 @@
 import { getStudies, setStudies } from './dataStore.mjs';
 import { escapeHtml } from './src/htmlUtils.mjs';
+// Worker-routed entry points for user-initiated calculate / export actions.
+// Hot paths (the corrosion-timeline slider's `input` handler and per-row
+// renderMitigationComparison helpers inside renderResults) still call the
+// sync exports above so per-event latency is not gated on postMessage.
+import {
+  estimateDissimilarMetalsRisk as estimateDissimilarMetalsRiskOffMain,
+  buildResultSummary as buildResultSummaryOffMain,
+  buildResultExportPayload as buildResultExportPayloadOffMain,
+} from './src/workers/dissimilarMetalsClient.js';
 
 const MM_PER_YEAR_TO_MPY = 39.3701;
 
@@ -738,21 +747,23 @@ if (typeof document !== 'undefined') {
 
     form.addEventListener('submit', (event) => {
       event.preventDefault();
-      try {
-        const result = estimateDissimilarMetalsRisk(readFormInput());
-        const studies = getStudies();
-        studies.dissimilarMetals = result;
-        setStudies(studies);
-        errorsEl.hidden = true;
-        errorsEl.textContent = '';
-        renderResults(result, resultsEl);
-      } catch (error) {
+      runSubmitCalculation().catch(error => {
         const message = error instanceof Error ? error.message : 'Unable to evaluate galvanic corrosion risk.';
         errorsEl.hidden = false;
         errorsEl.textContent = message;
         showModal('Input Error', `<p>${escapeHtml(message)}</p>`, 'error');
-      }
+      });
     });
+
+    async function runSubmitCalculation() {
+      const result = await estimateDissimilarMetalsRiskOffMain(readFormInput());
+      const studies = getStudies();
+      studies.dissimilarMetals = result;
+      setStudies(studies);
+      errorsEl.hidden = true;
+      errorsEl.textContent = '';
+      renderResults(result, resultsEl);
+    }
   });
 }
 
@@ -1137,7 +1148,8 @@ function initResultActions(container, result) {
 
   copyButton?.addEventListener('click', async () => {
     try {
-      await copyTextToClipboard(buildResultSummary(result));
+      const summary = await buildResultSummaryOffMain(result);
+      await copyTextToClipboard(summary);
       setActionStatus(status, 'Summary copied.');
     } catch {
       setActionStatus(status, 'Copy failed. Download the JSON instead.');
@@ -1145,8 +1157,9 @@ function initResultActions(container, result) {
   });
 
   downloadButton?.addEventListener('click', () => {
-    downloadResultJson(result);
-    setActionStatus(status, 'JSON downloaded.');
+    downloadResultJson(result)
+      .then(() => setActionStatus(status, 'JSON downloaded.'))
+      .catch(() => setActionStatus(status, 'Download failed.'));
   });
 }
 
@@ -1170,8 +1183,8 @@ async function copyTextToClipboard(text) {
   }
 }
 
-function downloadResultJson(result) {
-  const payload = buildResultExportPayload(result);
+async function downloadResultJson(result) {
+  const payload = await buildResultExportPayloadOffMain(result);
   const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');


### PR DESCRIPTION
Phase 5 (be56af0) shipped *Worker.js + src/workers/*Client.js scaffolding
for four pages (groundgrid, heattracesizing, cathodicprotection,
dissimilarmetals), but only groundgrid.js was wired at the time. d8d93d6
then wired heattracesizing.js. This finishes the remaining two
scaffolded pages.

cathodicprotection.js:
- Form submit ("Calculate") now routes computeDistributionBySegment,
  resolveCoatingModel, evaluateCriteriaChecks, and evaluateInterference-
  Assessment through cathodicProtectionClient.js. The composition logic
  was extracted into a shared composeCpAnalysisResult helper so the new
  async runCathodicProtectionAnalysisOffMain mirrors the existing sync
  runCathodicProtectionAnalysis without duplicating the assembly step.
- The submit handler is split into a sync addEventListener wrapper that
  calls preventDefault, plus an async runSubmitCalculation() inner that
  awaits the worker. Rejections surface through the existing Input
  Error modal instead of becoming unhandled promise rejections.
- The exported runCathodicProtectionAnalysis still runs the four
  sub-routines synchronously, so normalizeSavedStudy recomputes (called
  from mouse / click / comparison-toggle handlers and tests) keep their
  microsecond response time.

dissimilarmetals.js:
- Form submit now routes estimateDissimilarMetalsRisk through
  dissimilarMetalsClient.js. JSON download routes
  buildResultExportPayload, and the copy-summary button routes
  buildResultSummary. The dissimilarMetalsClient import creates a
  benign import cycle with dissimilarmetals.js's exported function
  declarations; tests confirm the hoisted bindings resolve.
- Submit handler is split into sync wrapper + async runSubmitCalculation
  matching the heattracesizing precedent. Download handler awaits the
  off-main payload build and reports failures through the existing
  result-action status line.

Hot paths intentionally stay synchronous on both pages: the corrosion-
timeline slider's `input` handler calls buildCorrosionTimelineState
directly, and renderResults' renderMitigationComparison helper still
calls the sync buildMitigationComparisonRows (which itself drives
estimateDissimilarMetalsRisk repeatedly per row). Same for cathodic
protection's normalizeSavedStudy recomputes wired into hover / click /
comparison handlers. Routing those through postMessage would add a
round-trip to every input event, which is the opposite of the desired
UX. The newly-routed paths are all user-discrete actions where a
microtask roundtrip is invisible.

Verification:
- node tests/cathodicProtection.test.mjs
- node tests/dissimilarMetals.test.mjs
- node tests/workerClient.test.mjs
- npm run test:critical
- npm run build (verified locally; dist artifacts discarded)
- npm run check:dist-review (clean)