### PR TITLE
Wire one-line page through Phase 5 worker client (load flow / SC / reliability)

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -19,6 +19,16 @@ import { runArcFlash } from './analysis/arcFlash.mjs';
 import { runHarmonics } from './analysis/harmonics.js';
 import { runMotorStart } from './analysis/motorStart.js';
 import { runReliability } from './analysis/reliability.js';
+// Worker-routed entry points for user-initiated study buttons (load flow,
+// short circuit, reliability). The sync imports above remain in scope for
+// programmatic callers and tests that drive the same analyses without an
+// async boundary; the OffMain wrappers post the active diagram to
+// onelineWorker.js so the calculation never blocks paint on large models.
+import {
+  runLoadFlow as runLoadFlowOffMain,
+  runShortCircuit as runShortCircuitOffMain,
+  runReliability as runReliabilityOffMain,
+} from './src/workers/onelineClient.js';
 import { generateArcFlashReport, openLabelPrintWindow } from './reports/arcFlashReport.mjs';
 import { exportAllReports } from './reports/exportAll.mjs';
 import { sizeConductor } from './sizing.js';
@@ -4897,12 +4907,20 @@ if (studiesResizeHandle && studiesPanel) {
   });
 }
 if (runLFBtn) runLFBtn.addEventListener('click', () => {
-  const res = runLoadFlow({
+  runLoadFlowFromButton().catch(err => {
+    console.error('[oneline] load flow failed', err);
+    showAlertModal('Load Flow Error', err?.message || String(err));
+  });
+});
+
+async function runLoadFlowFromButton() {
+  const oneLineData = getOneLine();
+  const res = await runLoadFlowOffMain(oneLineData, {
     baseMVA: studySettings.loadFlow.baseMVA,
     balanced: studySettings.loadFlow.balanced,
     maxIterations: studySettings.loadFlow.maxIterations
   });
-  const { sheets } = getOneLine();
+  const { sheets } = oneLineData;
   const diagram = sheets.flatMap(s => s.components);
   diagram.forEach(comp => {
     (comp.connections || []).forEach(conn => {
@@ -4994,7 +5012,7 @@ if (runLFBtn) runLFBtn.addEventListener('click', () => {
   renderStudyResults();
   renderLoadFlowResults(res);
   render();
-});
+}
 
 function renderLoadFlowResults(res) {
   if (!loadFlowResultsEl) return;
@@ -5004,8 +5022,16 @@ function renderLoadFlowResults(res) {
 
 export { renderLoadFlowResults };
 if (runSCBtn) runSCBtn.addEventListener('click', () => {
-  const res = runShortCircuit({ method: studySettings.shortCircuit.method });
-  const { sheets } = getOneLine();
+  runShortCircuitFromButton().catch(err => {
+    console.error('[oneline] short circuit failed', err);
+    showAlertModal('Short Circuit Error', err?.message || String(err));
+  });
+});
+
+async function runShortCircuitFromButton() {
+  const oneLineData = getOneLine();
+  const res = await runShortCircuitOffMain(oneLineData, { method: studySettings.shortCircuit.method });
+  const { sheets } = oneLineData;
   const diagram = sheets.flatMap(s => s.components);
   diagram.forEach(c => {
     c.shortCircuit = res[c.id];
@@ -5019,7 +5045,7 @@ if (runSCBtn) runSCBtn.addEventListener('click', () => {
   setStudies(studies);
   renderStudyResults();
   render();
-});
+}
 if (runAFBtn) runAFBtn.addEventListener('click', async () => {
   const shortCircuitOpts = { method: studySettings.shortCircuit.method };
   const sc = runShortCircuit(shortCircuitOpts);
@@ -5068,15 +5094,22 @@ if (runMSBtn) runMSBtn.addEventListener('click', () => {
   window.open('motorStart.html', '_blank');
 });
 if (runRelBtn) runRelBtn.addEventListener('click', () => {
+  runReliabilityFromButton().catch(err => {
+    console.error('[oneline] reliability failed', err);
+    showAlertModal('Reliability Error', err?.message || String(err));
+  });
+});
+
+async function runReliabilityFromButton() {
   const { sheets } = getOneLine();
   const diagram = sheets.flatMap(s => s.components);
-  const res = runReliability(diagram);
+  const res = await runReliabilityOffMain(diagram);
   const studies = getStudies();
   studies.reliability = res;
   setStudies(studies);
   highlightSPF(res.n1Failures);
   renderStudyResults();
-});
+}
 
 // Guided tour steps
 const tourSteps = [

--- a/onelineWorker.js
+++ b/onelineWorker.js
@@ -1,0 +1,33 @@
+// Module worker for the one-line diagram study analyses.
+// Clean boundary: analysis/loadFlow.js, analysis/loadFlowModel.js,
+// analysis/shortCircuit.mjs, and analysis/reliability.js are pure ES
+// modules (their dataStore imports are defensively guarded so the worker
+// scope can load them without a localStorage shim). The main thread reads
+// the active diagram with getOneLine() and ships it through, so the worker
+// never depends on browser storage state.
+import { runLoadFlow as runLoadFlowAnalysis } from './analysis/loadFlow.js';
+import { buildLoadFlowModel } from './analysis/loadFlowModel.js';
+import { runShortCircuit as runShortCircuitAnalysis } from './analysis/shortCircuit.mjs';
+import { runReliability } from './analysis/reliability.js';
+import { handleWorkerMessage } from './src/workers/createWorkerClient.js';
+
+function extractDiagramComponents(oneLineData) {
+  const sheets = Array.isArray(oneLineData?.sheets) ? oneLineData.sheets : [];
+  const hasNestedComponents = Array.isArray(sheets[0]?.components);
+  const components = hasNestedComponents
+    ? sheets.flatMap(sheet => (Array.isArray(sheet?.components) ? sheet.components : []))
+    : sheets;
+  return components.filter(c => c && c.type !== 'annotation' && c.type !== 'dimension');
+}
+
+handleWorkerMessage(self, {
+  runLoadFlow(oneLineData, opts) {
+    const model = buildLoadFlowModel(oneLineData || {});
+    return runLoadFlowAnalysis(model, opts || {});
+  },
+  runShortCircuit(oneLineData, opts) {
+    const comps = extractDiagramComponents(oneLineData);
+    return runShortCircuitAnalysis(comps, opts || {});
+  },
+  runReliability,
+});

--- a/src/workers/onelineClient.js
+++ b/src/workers/onelineClient.js
@@ -1,0 +1,62 @@
+/**
+ * Promise-based client for onelineWorker.js.
+ *
+ * Offloads the heavy one-line study analyses (load flow, short circuit,
+ * reliability) from the UI thread. Falls back to running the same pure
+ * analysis modules on the calling thread when Worker construction is not
+ * available. The main-thread fallback mirrors the worker handlers so the
+ * caller sees identical inputs/outputs in both modes.
+ */
+import { runLoadFlow as runLoadFlowSync } from '../../analysis/loadFlow.js';
+import { buildLoadFlowModel } from '../../analysis/loadFlowModel.js';
+import { runShortCircuit as runShortCircuitSync } from '../../analysis/shortCircuit.mjs';
+import { runReliability as runReliabilitySync } from '../../analysis/reliability.js';
+import { createWorkerClient } from './createWorkerClient.js';
+
+const OPS = ['runLoadFlow', 'runShortCircuit', 'runReliability'];
+
+function extractDiagramComponents(oneLineData) {
+  const sheets = Array.isArray(oneLineData?.sheets) ? oneLineData.sheets : [];
+  const hasNestedComponents = Array.isArray(sheets[0]?.components);
+  const components = hasNestedComponents
+    ? sheets.flatMap(sheet => (Array.isArray(sheet?.components) ? sheet.components : []))
+    : sheets;
+  return components.filter(c => c && c.type !== 'annotation' && c.type !== 'dimension');
+}
+
+const client = createWorkerClient({
+  workerUrl: 'onelineWorker.js',
+  workerType: 'module',
+  operations: OPS,
+  fallback: {
+    runLoadFlow(oneLineData, opts) {
+      const model = buildLoadFlowModel(oneLineData || {});
+      return runLoadFlowSync(model, opts || {});
+    },
+    runShortCircuit(oneLineData, opts) {
+      const comps = extractDiagramComponents(oneLineData);
+      return runShortCircuitSync(comps, opts || {});
+    },
+    runReliability: runReliabilitySync,
+  },
+});
+
+export function runLoadFlow(oneLineData, opts) {
+  return client.call('runLoadFlow', [oneLineData, opts]);
+}
+
+export function runShortCircuit(oneLineData, opts) {
+  return client.call('runShortCircuit', [oneLineData, opts]);
+}
+
+export function runReliability(components) {
+  return client.call('runReliability', [components]);
+}
+
+export function terminate() {
+  client.terminate();
+}
+
+export function isUsingFallback() {
+  return client.isUsingFallback();
+}


### PR DESCRIPTION
Continues the Phase 5 pattern (createWorkerClient + handleWorkerMessage,
introduced in be56af0 and previously wired for heat-trace, cathodic
protection, dissimilar metals) on the heaviest remaining study page.

Adds:
- onelineWorker.js — module worker importing runLoadFlow + buildLoadFlowModel,
  runShortCircuit, and runReliability from their existing pure analysis
  modules. The load-flow and short-circuit handlers take a oneLineData
  payload from the caller (rather than getOneLine()) and convert it to the
  shape each analysis already accepts, so the worker never depends on
  browser storage state. Reliability passes the components array through
  unchanged — its signature already accepts an explicit diagram.
- src/workers/onelineClient.js — promise-correlated wrappers with a
  main-thread fallback that runs the same conversion + analysis modules
  in-process when Worker construction is not available.

Wires:
- runLFBtn, runSCBtn, runRelBtn click handlers in oneline.js now route
  through runLoadFlowOffMain / runShortCircuitOffMain / runReliabilityOffMain
  via small async helper functions (runLoadFlowFromButton etc.); the click
  listeners stay sync wrappers that surface rejections through
  showAlertModal, matching the dissimilarmetals / cathodicprotection
  precedent. The sync imports of runLoadFlow / runShortCircuit /
  runReliability stay in scope for any other in-file references.

Out of scope for this phase: runAFBtn, runHBtn, runMSBtn. runArcFlash,
runHarmonics, and runMotorStart all read getOneLine() (and the latter two
also setStudies()) internally without accepting an explicit model arg, so
routing them through a worker would require a non-scaffolding refactor of
those analysis modules. The chat-summary assessment ("scaffolding-only +
discrete-handler wiring") scopes this PR to the three handlers whose
analysis signatures already accept explicit data.

Verification:
- node tests/workerClient.test.mjs (clean)
- node tests/reliability.test.mjs + tests/reliabilityAnalysis.test.mjs
- all tests/loadflow/*.{mjs,cjs} and tests/shortcircuit/*.{mjs,cjs}
- smoke-tested fallback path: empty-diagram runLoadFlow, runShortCircuit,
  runReliability through onelineClient resolve without error
- node --check on the three touched files