### PR TITLE
Guard one-line worker results against stale diagrams

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -4906,6 +4906,18 @@ if (studiesResizeHandle && studiesPanel) {
     e.preventDefault();
   });
 }
+function getOneLineSheetsRevision(oneLineData) {
+  return JSON.stringify(Array.isArray(oneLineData?.sheets) ? oneLineData.sheets : []);
+}
+
+function assertOneLineSheetsUnchanged(expectedRevision, studyName) {
+  const currentOneLineData = getOneLine();
+  if (getOneLineSheetsRevision(currentOneLineData) !== expectedRevision) {
+    throw new Error(`${studyName} results were discarded because the one-line diagram changed while the study was running. Please rerun the study on the current diagram.`);
+  }
+  return currentOneLineData;
+}
+
 if (runLFBtn) runLFBtn.addEventListener('click', () => {
   runLoadFlowFromButton().catch(err => {
     console.error('[oneline] load flow failed', err);
@@ -4915,11 +4927,13 @@ if (runLFBtn) runLFBtn.addEventListener('click', () => {
 
 async function runLoadFlowFromButton() {
   const oneLineData = getOneLine();
+  const oneLineRevision = getOneLineSheetsRevision(oneLineData);
   const res = await runLoadFlowOffMain(oneLineData, {
     baseMVA: studySettings.loadFlow.baseMVA,
     balanced: studySettings.loadFlow.balanced,
     maxIterations: studySettings.loadFlow.maxIterations
   });
+  const currentOneLineData = assertOneLineSheetsUnchanged(oneLineRevision, 'Load flow');
   const { sheets } = oneLineData;
   const diagram = sheets.flatMap(s => s.components);
   diagram.forEach(comp => {
@@ -5004,7 +5018,7 @@ async function runLoadFlowFromButton() {
     if (typeof l.toKV === 'number') conn.voltage_to_v = formatVolts(l.toKV * 1000);
   });
   updateCableOperatingVoltages(diagram);
-  setOneLine({ activeSheet, sheets });
+  setOneLine({ activeSheet: currentOneLineData.activeSheet, sheets });
   const studies = getStudies();
   studies.loadFlow = res;
   setStudies(studies);
@@ -5030,7 +5044,9 @@ if (runSCBtn) runSCBtn.addEventListener('click', () => {
 
 async function runShortCircuitFromButton() {
   const oneLineData = getOneLine();
+  const oneLineRevision = getOneLineSheetsRevision(oneLineData);
   const res = await runShortCircuitOffMain(oneLineData, { method: studySettings.shortCircuit.method });
+  const currentOneLineData = assertOneLineSheetsUnchanged(oneLineRevision, 'Short circuit');
   const { sheets } = oneLineData;
   const diagram = sheets.flatMap(s => s.components);
   diagram.forEach(c => {
@@ -5039,7 +5055,7 @@ async function runShortCircuitFromButton() {
       conn.faultKA = res[conn.target]?.threePhaseKA;
     });
   });
-  setOneLine({ activeSheet, sheets });
+  setOneLine({ activeSheet: currentOneLineData.activeSheet, sheets });
   const studies = getStudies();
   studies.shortCircuit = res;
   setStudies(studies);
@@ -5101,9 +5117,12 @@ if (runRelBtn) runRelBtn.addEventListener('click', () => {
 });
 
 async function runReliabilityFromButton() {
-  const { sheets } = getOneLine();
+  const oneLineData = getOneLine();
+  const oneLineRevision = getOneLineSheetsRevision(oneLineData);
+  const { sheets } = oneLineData;
   const diagram = sheets.flatMap(s => s.components);
   const res = await runReliabilityOffMain(diagram);
+  assertOneLineSheetsUnchanged(oneLineRevision, 'Reliability');
   const studies = getStudies();
   studies.reliability = res;
   setStudies(studies);

--- a/tests/onelineStudyStaleResultGuards.test.mjs
+++ b/tests/onelineStudyStaleResultGuards.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const source = fs.readFileSync(path.join(repoRoot, 'oneline.js'), 'utf8');
+
+function getFunctionBody(name) {
+  const start = source.indexOf(`async function ${name}()`);
+  assert.notEqual(start, -1, `${name} should exist`);
+  const bodyStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}') depth -= 1;
+    if (depth === 0) return source.slice(bodyStart + 1, i);
+  }
+  assert.fail(`Unable to parse ${name}`);
+}
+
+assert.ok(source.includes('function assertOneLineSheetsUnchanged'), 'one-line study stale-result guard should exist');
+
+[
+  ['runLoadFlowFromButton', 'runLoadFlowOffMain', 'setOneLine'],
+  ['runShortCircuitFromButton', 'runShortCircuitOffMain', 'setOneLine'],
+  ['runReliabilityFromButton', 'runReliabilityOffMain', 'setStudies'],
+].forEach(([name, awaitedCall, writeCall]) => {
+  const body = getFunctionBody(name);
+  const revisionIndex = body.indexOf('const oneLineRevision = getOneLineSheetsRevision(oneLineData);');
+  const awaitIndex = body.indexOf(`await ${awaitedCall}`);
+  const guardIndex = body.indexOf('assertOneLineSheetsUnchanged(oneLineRevision');
+  const writeIndex = body.indexOf(writeCall);
+  assert.ok(revisionIndex !== -1 && revisionIndex < awaitIndex, `${name} should capture the one-line revision before awaiting worker results`);
+  assert.ok(guardIndex !== -1 && awaitIndex < guardIndex, `${name} should validate the one-line revision after worker results resolve`);
+  assert.ok(writeIndex !== -1 && guardIndex < writeIndex, `${name} should validate the one-line revision before writing results`);
+});


### PR DESCRIPTION
### Motivation
- Asynchronous worker-based studies (load-flow, short-circuit, reliability) introduced a race where handlers persisted a pre-await snapshot and could overwrite intervening edits or collaborator updates.

### Description
- Add `getOneLineSheetsRevision` and `assertOneLineSheetsUnchanged` helpers to snapshot and validate the one-line `sheets` payload before and after awaiting worker results in `oneline.js`.
- Update `runLoadFlowFromButton` and `runShortCircuitFromButton` to capture a revision before calling the off-main worker, assert the diagram is unchanged after the worker returns, and preserve the current persisted `activeSheet` when calling `setOneLine` with validated results.
- Update `runReliabilityFromButton` to capture/validate the revision surrounding the async reliability call and discard stale results instead of applying them to the UI state.
- Add `tests/onelineStudyStaleResultGuards.test.mjs` to assert each async study handler captures the revision before awaiting and validates it before writing results.

### Testing
- Ran `node tests/onelineStudyStaleResultGuards.test.mjs` which passed.
- Ran `node --check oneline.js` which reported no syntax issues.
- Ran `npm run build` which completed successfully and produced updated `dist` artifacts.
- Ran `npm test` (full suite); node tests exercised and passed for the changed logic, but the repository-wide test run reports an unrelated existing failure in `tests/mccLineupPage.test.cjs` (`mcclineup.html missing bundled script`).
- Attempted a page preview via `npx playwright screenshot http://127.0.0.1:4173/oneline.html` but Playwright browsers were not available in the environment; `npx playwright install chromium` failed due to a network/download 403, so no browser screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dab35d22c832486b06830be6779ff)