### PR TITLE
Limit WebSocket ticket minting

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -854,11 +854,23 @@ export async function createApp(options = {}) {
   // Issued via POST /ws/ticket (authenticated + CSRF protected). Used because
   // cookies cannot be transmitted through the WebSocket subprotocol header.
   const WS_TICKET_TTL_MS = 30_000;
+  const WS_TICKET_MAX_PER_SESSION = 5;
   const wsTicketStore = new Map(); // ticket -> { sessionToken, username, expiresAt }
-  function pruneWsTickets() {
-    const now = Date.now();
+  function pruneWsTickets(now = Date.now()) {
     for (const [t, entry] of wsTicketStore) {
       if (!entry || entry.expiresAt <= now) wsTicketStore.delete(t);
+    }
+  }
+  function enforceWsTicketSessionLimit(sessionToken) {
+    const sessionTickets = [];
+    for (const [ticket, entry] of wsTicketStore) {
+      if (entry?.sessionToken === sessionToken) sessionTickets.push([ticket, entry.expiresAt]);
+    }
+    if (sessionTickets.length < WS_TICKET_MAX_PER_SESSION) return;
+    sessionTickets.sort((a, b) => a[1] - b[1]);
+    const ticketsToRemove = sessionTickets.length - WS_TICKET_MAX_PER_SESSION + 1;
+    for (const [ticket] of sessionTickets.slice(0, ticketsToRemove)) {
+      wsTicketStore.delete(ticket);
     }
   }
 
@@ -1066,6 +1078,10 @@ export async function createApp(options = {}) {
 
   // Stricter rate limit for auth endpoints to prevent brute-force attacks.
   const authRateLimiter = createRateLimiter({ windowMs: rateLimitWindowMs, max: 20 });
+  const wsTicketRateLimiter = createRateLimiter({
+    windowMs: rateLimitWindowMs,
+    max: Math.min(Math.max(1, rateLimitMax), 20),
+  });
   // Cookie helpers (shared by auth, refresh, logout, OIDC). Defined here so the
   // /login handler and the auth middleware below can use them.
   function serializeCookie(name, value, attrs = {}) {
@@ -1118,6 +1134,7 @@ export async function createApp(options = {}) {
   app.use('/session/refresh', authRateLimiter);
   app.use('/forgot-password', authRateLimiter);
   app.use('/reset-password', authRateLimiter);
+  app.use('/ws/ticket', wsTicketRateLimiter);
 
   app.post(
     '/signup',
@@ -1316,6 +1333,7 @@ export async function createApp(options = {}) {
     csrfProtection,
     asyncHandler(async (req, res) => {
       pruneWsTickets();
+      enforceWsTicketSessionLimit(req.authToken);
       const ticket = crypto.randomBytes(32).toString('hex');
       const expiresAt = Date.now() + WS_TICKET_TTL_MS;
       wsTicketStore.set(ticket, {

--- a/tests/serverSecurity.test.mjs
+++ b/tests/serverSecurity.test.mjs
@@ -349,6 +349,19 @@ async function rateLimitScenario() {
       const limited = await fetch(`${baseUrl}/projects/demo`, { headers });
       assert.strictEqual(limited.status, 429);
     });
+
+    await check('rate limits WebSocket ticket minting', async () => {
+      const headers = {
+        Authorization: `Bearer ${session.token}`,
+        'X-CSRF-Token': session.csrfToken,
+      };
+      const first = await fetch(`${baseUrl}/ws/ticket`, { method: 'POST', headers });
+      const second = await fetch(`${baseUrl}/ws/ticket`, { method: 'POST', headers });
+      assert.strictEqual(first.status, 200);
+      assert.strictEqual(second.status, 200);
+      const limited = await fetch(`${baseUrl}/ws/ticket`, { method: 'POST', headers });
+      assert.strictEqual(limited.status, 429);
+    });
   } finally {
     await closeServer(server);
   }
@@ -792,6 +805,40 @@ async function wsTicketScenario() {
         },
       });
       assert.strictEqual(ok, false);
+    });
+
+    await check('/ws/ticket caps outstanding tickets per session', async () => {
+      const issued = [];
+      for (let i = 0; i < 6; i += 1) {
+        const res = await fetch(`${baseUrl}/ws/ticket`, {
+          method: 'POST',
+          headers: {
+            Cookie: `ctr_auth=${authCookie}`,
+            'X-CSRF-Token': session.csrfToken,
+          },
+        });
+        assert.strictEqual(res.status, 200);
+        const body = await res.json();
+        issued.push(body.ticket);
+      }
+
+      const validate = app.get('collabUpgradeValidator');
+      const oldest = await validate({
+        headers: {
+          origin: baseUrl,
+          host: `127.0.0.1:${port}`,
+          'sec-websocket-protocol': `ctr-collab, ticket.${issued[0]}`,
+        },
+      });
+      const newest = await validate({
+        headers: {
+          origin: baseUrl,
+          host: `127.0.0.1:${port}`,
+          'sec-websocket-protocol': `ctr-collab, ticket.${issued.at(-1)}`,
+        },
+      });
+      assert.strictEqual(oldest, false, 'oldest outstanding ticket was evicted');
+      assert.strictEqual(newest, true, 'newer ticket remains usable');
     });
   } finally {
     await closeServer(server);


### PR DESCRIPTION
### Motivation
- Prevent an authenticated low-privilege attacker from minting unbounded short-lived `/ws/ticket` entries that caused O(n) scans and unbounded memory/CPU growth.  

### Description
- Add a per-session outstanding-ticket cap `WS_TICKET_MAX_PER_SESSION = 5` and an `enforceWsTicketSessionLimit(sessionToken)` helper that evicts the oldest unused tickets for the session before minting a new one in `server.mjs`.  
- Add a dedicated rate limiter for the `/ws/ticket` route (`wsTicketRateLimiter`) and mount it on `app.use('/ws/ticket', ...)` to apply route-level throttling.  
- Call `pruneWsTickets()` and `enforceWsTicketSessionLimit(req.authToken)` before creating and storing a new ticket so existing single-use, short-lived behavior is preserved while bounding per-session outstanding tickets.  
- Add regression checks to `tests/serverSecurity.test.mjs` to verify `/ws/ticket` is rate-limited and that outstanding tickets per session are capped and evict the oldest entry.  

### Testing
- Ran `node tests/serverSecurity.test.mjs` and the server-security scenarios (including the new `/ws/ticket` checks) passed.  
- Ran `npm run build` successfully to ensure frontend artifacts still build.  
- Ran the full test runner (`npm test`) and observed an existing unrelated failure in the MCC lineup page shell test (`mcclineup.html missing bundled script`), so the full suite did not complete green in this environment.  
- Attempted to capture a preview screenshot via Playwright but `npx playwright install chromium` failed due to CDN download 403 errors, so no preview image could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db07ae85c832495250c9b14aa3b26)