### PR TITLE
Fix catalog approval boolean normalization

### DIFF
--- a/analysis/manufacturerCatalog.mjs
+++ b/analysis/manufacturerCatalog.mjs
@@ -379,7 +379,7 @@ export function buildBomCatalogFields(record = {}) {
     manufacturer: product.manufacturer || cleanText(record.manufacturer),
     catalogNumber: product.catalogNumber || cleanText(record.catalogNumber ?? record.catalog_number ?? record.part_number ?? record.model),
     model: cleanText(record.model ?? product.model),
-    approvedPart: Boolean(product.approved || record.approved_part || record.catalog_approved),
+    approvedPart: product.approved === true,
     approvalStatus: product.approval?.status || cleanText(record.approvalStatus ?? record.approval_status) || 'unreviewed',
     source: product.source || cleanText(record.catalog_source),
     lastVerified: product.lastVerified || cleanText(record.catalog_last_verified),

--- a/artifacts/catalog-approval-fix-preview.svg
+++ b/artifacts/catalog-approval-fix-preview.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f7fafc"/>
+      <stop offset="1" stop-color="#e6f0ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#1f2937" flood-opacity="0.16"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)"/>
+  <rect x="90" y="80" width="1260" height="740" rx="22" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="90" y="80" width="1260" height="78" rx="22" fill="#1f4e79"/>
+  <rect x="90" y="136" width="1260" height="22" fill="#1f4e79"/>
+  <text x="132" y="130" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#fff">CableTrayRoute — Cost Estimate Approval Preview</text>
+  <text x="132" y="205" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700" fill="#1f2937">Catalog approval status now follows normalized boolean parsing</text>
+  <text x="132" y="240" font-family="Inter, Arial, sans-serif" font-size="17" fill="#4b5563">Rows imported with approved_part: &quot;false&quot;, &quot;no&quot;, &quot;0&quot;, &quot;rejected&quot;, or &quot;unreviewed&quot; remain unapproved in BOM, estimating, submittal, and BIM export data.</text>
+  <rect x="132" y="288" width="1176" height="390" rx="12" fill="#f9fafb" stroke="#d1d5db"/>
+  <rect x="132" y="288" width="1176" height="54" rx="12" fill="#e5eef9"/>
+  <text x="160" y="322" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#243b53">Category</text>
+  <text x="330" y="322" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#243b53">ID</text>
+  <text x="500" y="322" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#243b53">Manufacturer</text>
+  <text x="750" y="322" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#243b53">Catalog No.</text>
+  <text x="1010" y="322" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#243b53">Approval</text>
+  <line x1="132" y1="342" x2="1308" y2="342" stroke="#d1d5db"/>
+  <text x="160" y="390" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">Cable</text>
+  <text x="330" y="390" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">C-CAT-FALSE</text>
+  <text x="500" y="390" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">Prysmian</text>
+  <text x="750" y="390" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">XHHW-4-FALSE</text>
+  <rect x="1005" y="365" width="154" height="36" rx="18" fill="#fee2e2" stroke="#fca5a5"/>
+  <text x="1032" y="389" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700" fill="#991b1b">Rejected</text>
+  <line x1="132" y1="424" x2="1308" y2="424" stroke="#e5e7eb"/>
+  <text x="160" y="472" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">Tray</text>
+  <text x="330" y="472" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">T-CAT</text>
+  <text x="500" y="472" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">Eaton B-Line</text>
+  <text x="750" y="472" font-family="Inter, Arial, sans-serif" font-size="18" fill="#111827">BL-VCT-12-4</text>
+  <rect x="1005" y="447" width="154" height="36" rx="18" fill="#dcfce7" stroke="#86efac"/>
+  <text x="1030" y="471" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700" fill="#166534">Approved</text>
+  <rect x="160" y="545" width="1096" height="88" rx="10" fill="#eff6ff" stroke="#bfdbfe"/>
+  <text x="190" y="582" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700" fill="#1e3a8a">Security fix</text>
+  <text x="190" y="615" font-family="Inter, Arial, sans-serif" font-size="17" fill="#1e40af">Raw string approval fields no longer override normalizeCatalogProduct(); only normalized approved === true becomes ApprovedPart.</text>
+  <text x="132" y="734" font-family="Inter, Arial, sans-serif" font-size="15" fill="#6b7280">Generated preview artifact: artifacts/catalog-approval-fix-preview.svg</text>
+</svg>

--- a/tests/costEstimate.test.mjs
+++ b/tests/costEstimate.test.mjs
@@ -102,6 +102,22 @@ describe('estimateCableCosts', () => {
     assert.strictEqual(items[0].approvedPart, true);
   });
 
+  it('keeps string false catalog approvals unapproved in line items', () => {
+    const items = estimateCableCosts([
+      {
+        cable_tag: 'C-CAT-FALSE',
+        conductor_size: '4 AWG',
+        conductors: 3,
+        manufacturer: 'Prysmian',
+        catalog_number: 'XHHW-4-FALSE',
+        approved_part: 'false',
+        approval_status: 'rejected'
+      }
+    ], [{ cable: 'C-CAT-FALSE', total_length: '10' }]);
+    assert.strictEqual(items[0].approvedPart, false);
+    assert.strictEqual(items[0].approvalStatus, 'rejected');
+  });
+
   it('falls back to default price for unknown size', () => {
     const unknownCable = [{ cable_tag: 'X-1', conductor_size: 'UNKNOWN', conductors: 1 }];
     const unknownRoute = [{ cable: 'X-1', total_length: '100' }];

--- a/tests/manufacturerCatalog.test.mjs
+++ b/tests/manufacturerCatalog.test.mjs
@@ -164,6 +164,19 @@ describe('catalog warnings and downstream fields', () => {
     assert.equal(fields.approvedPart, true);
     assert.equal(fields.lastVerified, '2026-05-22');
   });
+
+  it('does not treat string false approval fields as approved BOM fields', () => {
+    ['false', 'no', '0', 'rejected', 'unreviewed'].forEach((approved_part) => {
+      const fields = buildBomCatalogFields({
+        manufacturer: 'ACME',
+        catalog_number: `P-${approved_part}`,
+        approved_part,
+        approval_status: approved_part === 'rejected' ? 'rejected' : 'unreviewed'
+      });
+      assert.equal(fields.approvedPart, false);
+      assert.notEqual(fields.approvalStatus, 'approved');
+    });
+  });
 });
 
 describe('component library catalog validation', () => {

--- a/tests/revitImporter.test.mjs
+++ b/tests/revitImporter.test.mjs
@@ -138,6 +138,22 @@ describe('exportRevit - raceway material', () => {
     assert.strictEqual(result.cables[0].CatalogNumber, 'XHHW-500');
     assert.strictEqual(result.cables[0].ApprovalStatus, 'unreviewed');
   });
+
+  it('exports string false catalog approvals as unapproved BIM fields', () => {
+    const result = exportRevit({
+      trays: [{
+        tray_id: 'T-REJECTED',
+        manufacturer: 'Eaton B-Line',
+        catalogNumber: 'BL-VCT-12-4-R',
+        approved_part: 'false',
+        approval_status: 'rejected'
+      }],
+      conduits: [],
+      cables: []
+    });
+    assert.strictEqual(result.trays[0].ApprovedPart, false);
+    assert.strictEqual(result.trays[0].ApprovalStatus, 'rejected');
+  });
 });
 
 describe('parseRevit - JSON string input', () => {


### PR DESCRIPTION
### Motivation
- Raw imported approval fields like `"false"`, `"no"`, or `"0"` were treated as truthy and caused unapproved parts to be labeled and exported as Approved, creating an integrity issue in BOM, estimating, submittal, and BIM exports.
- The intent is to rely only on the normalized boolean produced by `normalizeCatalogProduct()` so downstream flows reflect the true reviewed/approved state.

### Description
- Change `buildBomCatalogFields()` to set `approvedPart` using the normalized product boolean only via `approvedPart: product.approved === true` instead of `Boolean(product.approved || record.approved_part || record.catalog_approved)` in `analysis/manufacturerCatalog.mjs`.
- Add regression tests ensuring string-false approval inputs remain unapproved in BOM extraction, cost-line propagation, and Revit/BIM export by extending `tests/manufacturerCatalog.test.mjs`, `tests/costEstimate.test.mjs`, and `tests/revitImporter.test.mjs`.
- Add a preview SVG artifact `artifacts/catalog-approval-fix-preview.svg` illustrating corrected approval labels in the cost estimate UI export preview.

### Testing
- Ran targeted Node tests: `node tests/manufacturerCatalog.test.mjs && node tests/costEstimate.test.mjs && node tests/revitImporter.test.mjs`, and the added regression tests passed.
- Ran build with `npm run build` which completed successfully and produced updated `dist/` assets.
- Ran full test run `npm test`; the new approval-related tests passed but the existing unrelated MCC lineup page test (`mcclineup.html missing bundled script`) remains failing in the suite.
- Attempted `npx playwright install chromium` to capture a live screenshot but the download was blocked by Playwright CDN (`403 Forbidden`), so a static SVG preview was generated and committed as an artifact instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db3610ae88324a049d0d0b52610d6)