### PR TITLE
Enforce deliverable review gates

### DIFF
--- a/analysis/designBasis.mjs
+++ b/analysis/designBasis.mjs
@@ -448,7 +448,7 @@ export function buildDesignBasisReview(project = {}) {
   }
 
   const openGates = gates.filter(gate => gate.status !== 'reviewed');
-  const deliverableBlockers = openGates.filter(gate => gate.enforceOnDeliverables && (gate.blocking || gate.severity === 'critical'));
+  const deliverableBlockers = openGates.filter(gate => gate.enforceOnDeliverables);
 
   return {
     summary,

--- a/tests/projectWorkflowCore.test.mjs
+++ b/tests/projectWorkflowCore.test.mjs
@@ -307,12 +307,21 @@ const customReview = buildDesignBasisReview({
 assert(customReview.openGateCount > 0);
 assert(customReview.gates.some(gate => gate.id === 'protective-device-settings'));
 assert(customReview.gates.some(gate => gate.id === 'generated-record-review'));
+assert(customReview.gates.some(gate => gate.id === 'generated-record-review' && gate.enforceOnDeliverables && !gate.blocking));
+assert(customReview.gates.some(gate => gate.id === 'route-result-review' && gate.enforceOnDeliverables && !gate.blocking));
+assert(customReview.gates.some(gate => gate.id === 'study-result-review' && gate.enforceOnDeliverables && !gate.blocking));
+assert(customReview.deliverableBlockers.some(gate => gate.id === 'generated-record-review'));
+assert(customReview.deliverableBlockers.some(gate => gate.id === 'route-result-review'));
+assert(customReview.deliverableBlockers.some(gate => gate.id === 'study-result-review'));
 assert(customReview.deliverableBlockers.length > 0);
 
 const reviewedCustomReview = buildDesignBasisReview({
   designBasis: customDesignBasis,
   designGateApprovals: {
-    'protective-device-settings': { status: 'reviewed', reviewedBy: 'Electrical Lead', approvedAt: '2026-05-20T00:00:00.000Z' }
+    'protective-device-settings': { status: 'reviewed', reviewedBy: 'Electrical Lead', approvedAt: '2026-05-20T00:00:00.000Z' },
+    'generated-record-review': { status: 'reviewed', reviewedBy: 'Electrical Lead', approvedAt: '2026-05-20T00:00:00.000Z' },
+    'route-result-review': { status: 'reviewed', reviewedBy: 'Electrical Lead', approvedAt: '2026-05-20T00:00:00.000Z' },
+    'study-result-review': { status: 'reviewed', reviewedBy: 'Electrical Lead', approvedAt: '2026-05-20T00:00:00.000Z' }
   },
   equipment: [
     { tag: 'SWBD-201', voltage: '480', x: 0, y: 0 },
@@ -329,7 +338,7 @@ const reviewedCustomReview = buildDesignBasisReview({
 });
 
 assert.equal(reviewedCustomReview.deliverableBlockers.length, 0);
-assert(reviewedCustomReview.openGateCount > 0);
+assert.equal(reviewedCustomReview.openGateCount, 0);
 
 const flaggedCustomReview = buildDesignBasisReview({
   designBasis: customDesignBasis,


### PR DESCRIPTION
### Motivation

- Ensure that any review gate explicitly marked `enforceOnDeliverables` actually prevents report/export/snapshot issuance even if the gate is non-blocking or warning-severity, restoring integrity of configured review rules.

### Description

- Change `buildDesignBasisReview` in `analysis/designBasis.mjs` so `deliverableBlockers` includes every open gate with `enforceOnDeliverables` (previously required `blocking` or `severity === 'critical'`).
- Add/adjust assertions in `tests/projectWorkflowCore.test.mjs` to cover the non-blocking `generated-record-review`, `route-result-review`, and `study-result-review` gates and their presence in `deliverableBlockers`.
- Update the reviewed-review fixture expectations to require that those enforced gates must be reviewed before `deliverableBlockers` clears by adjusting the `openGateCount` assertion.

### Testing

- Ran the focused test file with `node tests/projectWorkflowCore.test.mjs`, which passed.
- Ran `npm run build`, which completed successfully and produced `dist` artifacts.
- Ran the full test runner with `npm test`, which still fails due to an unrelated existing test (`tests/mccLineupPage.test.cjs` about a missing bundled script) and is not caused by these changes.
- Attempted to capture a preview screenshot of `projectreport.html` via Playwright, but `npx playwright install chromium` failed due to CDN download `403 Forbidden`, so a preview image could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dbfdaf04c832497dc86b2bf3bea7d)