### PR TITLE
Prevent duplicate component IDs from overwriting bus short‑circuit results

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -756,9 +756,17 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       : sheets;
     comps = comps.filter(c => c && c.type !== 'annotation' && c.type !== 'dimension');
   }
-  const busNodes = comps.filter(comp => comp?.subtype === 'Bus' || comp?.type === 'bus');
+  const isBusStudyNode = comp => comp?.subtype === 'Bus' || comp?.type === 'bus';
+  const busNodes = comps.filter(isBusStudyNode);
   const hasBusNodes = busNodes.length > 0;
-  const compMap = new Map(comps.map(c => [c.id, c]));
+  const compMap = new Map();
+  comps.forEach(comp => {
+    if (!comp?.id) return;
+    const existing = compMap.get(comp.id);
+    if (!existing || (isBusStudyNode(comp) && !isBusStudyNode(existing))) {
+      compMap.set(comp.id, comp);
+    }
+  });
   const impedanceCache = new Map();
   const voltageCache = new Map();
   const protectiveLookupCache = new Map();
@@ -828,8 +836,9 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
   };
 
   comps.forEach(comp => {
+    if (comp?.id && compMap.get(comp.id) !== comp) return;
     const baseZ = computeImpedance(comp, comps, compMap, impedanceCache);
-    const fallbackZ = (!hasBusNodes || comp?.subtype === 'Bus' || comp?.type === 'bus')
+    const fallbackZ = (!hasBusNodes || isBusStudyNode(comp))
       ? resolveUpstreamImpedance(comp, comps, compMap, impedanceCache)
       : null;
     let z1 = comp.z1 ? toImpedance(comp.z1) : baseZ;

--- a/tests/shortcircuit/shortCircuit.test.cjs
+++ b/tests/shortcircuit/shortCircuit.test.cjs
@@ -41,6 +41,34 @@ global.localStorage = {
       assert(Math.abs(b.asymKA - 45.86) < 0.1);
     });
 
+    it('preserves bus short-circuit results when a malformed model repeats a bus id on a later non-bus component', () => {
+      const res = runShortCircuit([
+        {
+          id: 'BUS-1',
+          type: 'bus',
+          subtype: 'Bus',
+          kV: 0.48,
+          z1: { r: 0, x: 0.01 },
+          z2: { r: 0, x: 0.01 },
+          z0: { r: 0, x: 0.01 }
+        },
+        {
+          id: 'BUS-1',
+          type: 'panel',
+          kV: 0.48,
+          z1: { r: 1000000, x: 1000000 },
+          z2: { r: 1000000, x: 1000000 },
+          z0: { r: 1000000, x: 1000000 }
+        }
+      ]);
+
+      const bus = res['BUS-1'];
+      assert(bus, 'duplicate id should still produce the bus result');
+      assert.strictEqual(Object.keys(res).length, 1, 'duplicate id should not create additional results');
+      assert(bus.threePhaseKA > 25, 'later duplicate non-bus component should not overwrite bus fault current');
+      assert(!bus.warnings, 'bus result should not inherit duplicate non-bus warnings');
+    });
+
     it('propagates transformer impedance from secondary data fields', () => {
       setOneLine({
         activeSheet: 0,


### PR DESCRIPTION
### Motivation
- Recent changes iterated every component when building short‑circuit results but still keyed results only by `id`, which allowed a later non‑bus component with a duplicate id to overwrite a true bus study entry and corrupt safety‑relevant outputs. 
- This change hardens the short‑circuit engine against malformed or attacker‑crafted projects that repeat ids by preferring bus study nodes when selecting the canonical component for a given id.

### Description
- Prefer bus study nodes when building the component lookup by using `isBusStudyNode` and only replacing an existing map entry if the new component is a bus and the existing entry is not. 
- Skip non‑canonical duplicate components during result generation by returning early when `compMap.get(comp.id) !== comp`, preventing later duplicates from writing `results[comp.id]`. 
- Add a regression unit test `tests/shortcircuit/shortCircuit.test.cjs` that exercises a model with a bus followed by a duplicate non‑bus component and asserts the bus short‑circuit result is preserved and not overwritten.

### Testing
- Ran the targeted short‑circuit tests with `node tests/shortcircuit/shortCircuit.test.cjs`, which passed including the new regression case. 
- Ran `npm run build` and `git diff --check`, both completed successfully. 
- Ran the full test suite with `npm test`; the short‑circuit fix is included but `npm test` surfaced an unrelated pre‑existing assertion failure in the MCC page tests (`mcclineup.html missing bundled script`), so the full suite did not complete green in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc452bdc08324b1184df4e32818eb)