### PR TITLE
Fix study attribute resolution precedence

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -6715,12 +6715,6 @@ function resolveComponentAttribute(comp, key) {
     return value;
   }
   const segments = key.split('.');
-  let value = getNestedValue(comp, segments);
-  if (value !== undefined) return value;
-  if (comp.props && typeof comp.props === 'object') {
-    value = getNestedValue(comp.props, segments);
-    if (value !== undefined) return value;
-  }
   const resolver = studyAttributeResolvers[segments[0]];
   if (resolver) {
     const base = resolver(comp);
@@ -6728,6 +6722,12 @@ function resolveComponentAttribute(comp, key) {
       const studyValue = getNestedValue(base, segments.slice(1));
       if (studyValue !== undefined) return studyValue;
     }
+  }
+  let value = getNestedValue(comp, segments);
+  if (value !== undefined) return value;
+  if (comp.props && typeof comp.props === 'object') {
+    value = getNestedValue(comp.props, segments);
+    if (value !== undefined) return value;
   }
   return undefined;
 }

--- a/tests/onelineStudyStaleResultGuards.test.mjs
+++ b/tests/onelineStudyStaleResultGuards.test.mjs
@@ -20,6 +20,76 @@ function getFunctionBody(name) {
   assert.fail(`Unable to parse ${name}`);
 }
 
+function getFunctionSource(name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} should exist`);
+  const bodyStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}') depth -= 1;
+    if (depth === 0) return source.slice(start, i + 1);
+  }
+  assert.fail(`Unable to parse ${name}`);
+}
+
+function getNestedValue(sourceValue, segments = []) {
+  let current = sourceValue;
+  for (const segment of segments) {
+    if (!current || typeof current !== 'object' || !(segment in current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+const resolveComponentAttribute = new Function(
+  'getNestedValue',
+  'studyAttributeResolvers',
+  `return ${getFunctionSource('resolveComponentAttribute')};`
+)(getNestedValue, {
+  arcFlash: comp => comp.studyResults?.arcFlash?.[comp.id] || null,
+  shortCircuit: comp => comp.studyResults?.shortCircuit?.[comp.id] || null,
+  reliability: comp => comp.studyResults?.reliability?.componentStats?.[comp.id] || null,
+});
+
+const importedComponent = {
+  id: 'PANEL-1',
+  reliability: { availability: 0.001, downtime: 8760 },
+  shortCircuit: { threePhaseKA: 0.02 },
+  arcFlash: { incidentEnergy: 0.03 },
+  props: {
+    reliability: { availability: 0.002 },
+    shortCircuit: { threePhaseKA: 0.04 },
+    arcFlash: { incidentEnergy: 0.05 },
+  },
+  studyResults: {
+    reliability: { componentStats: { 'PANEL-1': { availability: 0.990099, downtime: 87.6 } } },
+    shortCircuit: { 'PANEL-1': { threePhaseKA: 42.5 } },
+    arcFlash: { 'PANEL-1': { incidentEnergy: 18.7 } },
+  },
+};
+
+assert.equal(
+  resolveComponentAttribute(importedComponent, 'reliability.availability'),
+  0.990099,
+  'calculated reliability results should take precedence over imported component reliability fields',
+);
+assert.equal(
+  resolveComponentAttribute(importedComponent, 'shortCircuit.threePhaseKA'),
+  42.5,
+  'calculated short-circuit results should take precedence over imported component shortCircuit fields',
+);
+assert.equal(
+  resolveComponentAttribute(importedComponent, 'arcFlash.incidentEnergy'),
+  18.7,
+  'calculated arc-flash results should take precedence over imported component arcFlash fields',
+);
+assert.equal(
+  resolveComponentAttribute({ custom: { value: 12 } }, 'custom.value'),
+  12,
+  'non-study dotted component fields should still resolve from the component object',
+);
+
 assert.ok(source.includes('function assertOneLineSheetsUnchanged'), 'one-line study stale-result guard should exist');
 
 [


### PR DESCRIPTION
### Motivation

- Imported or stale component JSON fields were taking precedence over authoritative study results for dotted attributes (e.g., `reliability.availability`, `shortCircuit.threePhaseKA`, `arcFlash.incidentEnergy`), allowing displayed engineering outputs to be shadowed by untrusted project data.
- The change restores integrity to one-line attribute displays by ensuring calculated study results are used as the primary source for those study-related dotted attributes.

### Description

- Reordered `resolveComponentAttribute` so `studyAttributeResolvers` are consulted for dotted keys before reading nested `comp` or `comp.props` values, restoring study-result precedence for `arcFlash`, `shortCircuit`, and `reliability` attributes.
- Added a regression test `tests/onelineStudyStaleResultGuards.test.mjs` that extracts the `resolveComponentAttribute` implementation and asserts that study results override imported component fields while leaving non-study dotted lookups unchanged.
- No other behavior was modified; non-study dotted attributes still resolve from the component object and single-segment keys keep their original lookup order.

### Testing

- Ran `git diff --check` and the new unit check harness `node tests/onelineStudyStaleResultGuards.test.mjs`, both of which completed successfully and validated the precedence behavior.
- Ran `npm run build` which completed successfully and produced updated `dist` HTML/JS artifacts.
- Executed `npm test`; the test run surfaced an unrelated existing failure in `tests/mccLineupPage.test.cjs` (the page-shell test expects the literal `dist/mcclineup.js` while the built HTML references a hashed bundle), so the full suite did not finish green for reasons outside this change.
- Attempted a Playwright-based page screenshot to provide a preview, but the browser binary installation failed (Playwright CDN returned HTTP 403), so a rendered preview could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc848d42883248192c8ccde733976)