### PR TITLE
Preserve voltage unit hints in oneline resolver

### DIFF
--- a/oneline.js
+++ b/oneline.js
@@ -17942,7 +17942,7 @@ function resolveComponentVoltageVolts(comp, options = {}) {
     if (!container || typeof container !== 'object') continue;
     for (const key of directKeys) {
       if (!(key in container)) continue;
-      const resolved = normalizeVoltageToVolts(container[key]);
+      const resolved = normalizeVoltageToVolts({ [key]: container[key] });
       if (resolved !== null && Number.isFinite(resolved) && resolved > 0) {
         return resolved;
       }

--- a/tests/transformerProperties.test.mjs
+++ b/tests/transformerProperties.test.mjs
@@ -148,3 +148,10 @@ const approxEqual = (a, b, tolerance = 1e-9) => {
   approxEqual(impedanceSci.r, impedanceNumeric.r, 1e-12);
   approxEqual(impedanceSci.x, impedanceNumeric.x, 1e-12);
 }
+
+// Unit-bearing voltage field names must guide numeric normalization.
+{
+  approxEqual(normalizeVoltageToVolts({ voltage_kv: 115 }), 115000, 1e-9);
+  approxEqual(normalizeVoltageToVolts({ voltage_v: 13.8 }), 13.8, 1e-9);
+  approxEqual(normalizeVoltageToVolts({ volts: 13.8 }), 13.8, 1e-9);
+}

--- a/utils/voltage.js
+++ b/utils/voltage.js
@@ -11,6 +11,13 @@ export function normalizeVoltageToVolts(raw) {
       const keys = [
         'voltage',
         'volts',
+        'voltage_v',
+        'voltage_kv',
+        'operating_voltage',
+        'rated_voltage',
+        'rated_volts',
+        'rated_voltage_kv',
+        'voltage_rating',
         'kv',
         'kV',
         'baseKV',


### PR DESCRIPTION
### Motivation
- Fix a regression where the one-line voltage resolver dropped the field-name unit hint (e.g. `voltage_kv`, `voltage_v`, `volts`) and could normalize numeric direct fields to the wrong scale, producing silent 1000× errors in downstream validation and calculations.

### Description
- Preserve direct field context by calling `normalizeVoltageToVolts({ [key]: container[key] })` in the one-line resolver so unit-bearing keys continue to guide normalization.
- Teach the shared normalizer about the one-line resolver's direct aliases by adding `voltage_v`, `voltage_kv`, `operating_voltage`, `rated_*`, and `voltage_rating` to the object-key scan list in `utils/voltage.js`.
- Add a small regression test to `tests/transformerProperties.test.mjs` that asserts numeric `{ voltage_kv: 115 }` resolves to `115000` volts while `{ voltage_v: 13.8 }` and `{ volts: 13.8 }` remain `13.8` volts.

### Testing
- Ran `node tests/transformerProperties.test.mjs` and the added regression assertions passed.
- Ran `npm run build` and the project build completed successfully.
- Ran `npm test` (full suite); node tests ran but an unrelated pre-existing failure surfaced in `tests/mccLineupPage.test.cjs` (`mcclineup.html missing bundled script`), so the full suite did not fully pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc84e56cc83249d1c013afe5a7c69)