### PR TITLE
Fix double-conversion of baseKV/kV values in TCC voltage paths

### DIFF
--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -8776,9 +8776,8 @@ function inferVoltage(comp) {
   const keys = ['voltage', 'volts', 'volts_secondary', 'volts_lv', 'volts_primary', 'volts_hv', 'prefault_voltage', 'baseKV', 'kV'];
   for (const key of keys) {
     const raw = getComponentValue(comp, key);
-    const num = parseNumeric(raw);
+    const num = parseVoltageValue(raw, key.toLowerCase().includes('kv'));
     if (!Number.isFinite(num) || num <= 0) continue;
-    if (key.toLowerCase().includes('kv')) return num * 1000;
     return num;
   }
   return null;
@@ -8939,8 +8938,11 @@ function resolveTransformerOperatingPoint(transformer, referenceVoltage, refPhas
     const kva = getNumericValue(transformer, ['kva', 'kva_base']);
     let volts = getNumericValue(transformer, ['volts_secondary', 'volts_primary', 'voltage', 'volts']);
     if (!Number.isFinite(volts)) {
-      const baseKv = getNumericValue(transformer, ['baseKV', 'kV']);
-      if (Number.isFinite(baseKv)) volts = baseKv * 1000;
+      const baseKv = getComponentValue(transformer, 'baseKV');
+      const kv = getComponentValue(transformer, 'kV');
+      const baseKvVolts = parseVoltageValue(baseKv, true);
+      const kvVolts = parseVoltageValue(kv, true);
+      volts = Number.isFinite(baseKvVolts) ? baseKvVolts : kvVolts;
     }
     if (Number.isFinite(kva) && Number.isFinite(volts)) {
       sides.push({ kva, volts, label: 'Secondary' });
@@ -9194,6 +9196,15 @@ function parseNumeric(value) {
   if (suffix === 'kv') return numeric * 1000;
   if (suffix === 'v') return numeric;
   return numeric;
+}
+
+
+function parseVoltageValue(value, isKilovoltField = false) {
+  const numeric = parseNumeric(value);
+  if (!Number.isFinite(numeric)) return null;
+  if (!isKilovoltField) return numeric;
+  if (typeof value === 'string' && /\bkv\b/i.test(value)) return numeric;
+  return numeric * 1000;
 }
 
 function getNumericValue(comp, keys) {


### PR DESCRIPTION
### Motivation
- A recent change made `parseNumeric` convert `"13.8 kV"` to volts, which caused callers that still assume kV-magnitude fields (e.g. `baseKV`/`kV`) to multiply again by 1000 and silently corrupt TCC calculations by 1000×. 
- The change restores correct behavior for voltage fields by centralizing how kV-labeled fields are interpreted so legacy numeric kV entries remain supported while suffixed strings are not double-converted.

### Description
- Added a focused helper `parseVoltageValue(value, isKilovoltField)` that interprets `kV`-suffixed strings as volts but treats numeric/legacy kV fields as kilovolt magnitudes to be converted once. 
- Updated `inferVoltage` to call `parseVoltageValue` (instead of blindly multiplying by 1000 for `kv` keys) so inferred voltages are normalized exactly once. 
- Updated the transformer operating-point fallback to extract `baseKV` and `kV` via `parseVoltageValue` so transformer `volts` and derived FLA/inrush/damage curves use the correct magnitude. 
- Left `parseNumeric` behavior intact and centralized the kV-specific logic in `parseVoltageValue` to minimize impact elsewhere.

### Testing
- Ran the full test suite with `npm test`, and all automated tests completed successfully. 
- Built the distribution with `npm run build`, which completed successfully. 
- Attempted to capture a runtime UI preview via Playwright screenshot, but browser binaries could not be downloaded in this environment so the screenshot step failed (Playwright install downloads returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7dbc34788324aae1fc166df1ffac)