### PR TITLE
Fail closed conservatively for missing short-circuit impedance

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -744,19 +744,19 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       if ((isConductorMissing || isTargetOfMissingCable) && comp?.id) {
         defaultedLowImpedanceComponents.set(
           comp.id,
-          `${comp?.type === 'busway' ? 'Busway' : 'Cable'} impedance incomplete; results defaulted to high resistance until impedance data is provided.`
+          `${comp?.type === 'busway' ? 'Busway' : 'Cable'} impedance incomplete; results defaulted to low impedance until impedance data is provided.`
         );
-        return { r: 1e6, x: 1e6 };
+        return { r: 1e-6, x: 1e-6 };
       }
       if (isProtectionComponent(comp) && comp?.id) {
         defaultedLowImpedanceComponents.set(
           comp.id,
-          'Protective device properties incomplete; results defaulted to high resistance until data is provided.'
+          'Protective device properties incomplete; results defaulted to low impedance until data is provided.'
         );
-        return { r: 1e6, x: 1e6 };
+        return { r: 1e-6, x: 1e-6 };
       }
       if (comp?.id) missingImpedanceComponents.add(comp.id);
-      return { r: 1e6, x: 1e6 };
+      return { r: 1e-6, x: 1e-6 };
     }
     return { r, x };
   };
@@ -832,7 +832,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     if (lowImpedanceWarning) {
       entry.warnings = [lowImpedanceWarning];
     } else if (missingImpedanceComponents.has(comp.id)) {
-      entry.warnings = ['Impedance data missing; results defaulted to high resistance until data is provided.'];
+      entry.warnings = ['Impedance data missing; results defaulted to low impedance until data is provided.'];
     }
 
     limitFaultByProtection(entry, comp, comps, compMap, protectiveLookupCache, scaledDeviceCache, tccSettings);


### PR DESCRIPTION
### Motivation
- A recent change replaced the missing-impedance fallback with a very high impedance (1e6 + j1e6), which made missing data produce near‑zero reported fault currents and understate arc‑flash hazards, so a conservative, fail‑closed behavior is required.

### Description
- Restored the conservative low‑impedance fallback in `analysis/shortCircuit.mjs` to `{ r: 1e-6, x: 1e-6 }` for zero/missing impedance cases used for cables/busways, protective devices, and generic missing impedance.
- Updated the associated warning strings to say "defaulted to low impedance" so messages match the fallback behavior.
- Changes are minimal and localized to `runShortCircuit()` so existing study flow, warning attachments (`entry.warnings`), and downstream consumers are preserved.

### Testing
- Ran the full automated test suite with `npm test` and all tests passed.
- Performed a production build with `npm run build` and the build succeeded.
- Attempted to generate a webpage preview screenshot with Playwright, but `npx playwright install chromium` failed due to CDN HTTP 403 responses in this environment, so a preview image could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a093300c85c83248baa1b0ec743bd70)