### PR TITLE
Fix reset token leakage in forgot-password logs

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1191,8 +1191,8 @@ export async function createApp(options = {}) {
         res.json({ message: 'If that account exists, a reset token has been generated.' });
         return;
       }
-      const resetToken = resetTokenStore.create(trimmedUser);
-      console.error(`[password-reset] Reset requested for "${trimmedUser}". Share token securely with the user: ${resetToken}`);
+      resetTokenStore.create(trimmedUser);
+      console.error(`[password-reset] Reset requested for "${trimmedUser}".`);
       res.json({ message: 'If that account exists, a reset token has been generated.' });
     })
   );


### PR DESCRIPTION
### Motivation
- Prevent sensitive bearer reset tokens from being written to logs so attackers with log access cannot perform account takeover via leaked reset tokens.

### Description
- Remove the raw `resetToken` from `/forgot-password` logging while preserving `resetTokenStore.create(trimmedUser)` and the existing user-facing response in `server.mjs`.

### Testing
- Ran `npm test` (all automated tests passed) and `npm run build` (build completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09088c32048324b8a783dfce4c3092)