### PR TITLE
Reject oversized collaboration project IDs to prevent room collisions

### DIFF
--- a/src/collaborationServer.mjs
+++ b/src/collaborationServer.mjs
@@ -107,7 +107,14 @@ export function attachCollaborationServer(httpServer, wss, options = {}) {
 
       if (msg.type === 'join') {
         removeFromRoom();
-        currentProjectId = String(msg.projectId || '').slice(0, 200);
+        const requestedProjectId = String(msg.projectId || '');
+        if (requestedProjectId.length > 200) {
+          currentProjectId = null;
+          currentUsername = null;
+          ws.send(JSON.stringify({ type: 'error', message: 'Project ID too long' }));
+          return;
+        }
+        currentProjectId = requestedProjectId;
         currentUsername = String(msg.username || 'Anonymous').slice(0, 100);
         if (!rooms.has(currentProjectId)) rooms.set(currentProjectId, new Set());
         if (!seqCounters.has(currentProjectId)) seqCounters.set(currentProjectId, 0);

--- a/tests/collaborationServer.test.mjs
+++ b/tests/collaborationServer.test.mjs
@@ -193,6 +193,17 @@ describe('attachCollaborationServer — join', () => {
     assert.ok(newPresence[0].users.includes('bob'), 'presence should include bob');
     assert.ok(newPresence[0].users.includes('alice'), 'presence should still include alice');
   });
+
+  it('rejects project IDs longer than 200 characters', () => {
+    const { httpServer, wss } = setupServer();
+    const ws = connectClient(httpServer, wss);
+    const tooLongProjectId = `${'p'.repeat(200)}suffix`;
+    ws._receive({ type: 'join', projectId: tooLongProjectId, username: 'alice' });
+    const errors = ws.sentOfType('error');
+    assert.ok(errors.length >= 1, 'should receive error message for long project IDs');
+    assert.strictEqual(errors[errors.length - 1].message, 'Project ID too long');
+    assert.strictEqual(ws.sentOfType('sync').length, 0, 'should not join or receive sync');
+  });
 });
 
 describe('attachCollaborationServer — patch broadcast', () => {


### PR DESCRIPTION
### Motivation
- Fix a high-severity vulnerability where the server silently truncated `projectId` to 200 characters, causing distinct long IDs sharing the same prefix to be joined into the same collaboration room. 
- Prevent cross-project presence and patch leakage by ensuring room and sequence-counter keys use the exact original project ID. 
- Prefer explicit rejection of overlong IDs rather than silent aliasing to preserve data isolation and integrity.

### Description
- Replace the join-time truncation (`.slice(0, 200)`) with an explicit length check that rejects `projectId`s longer than 200 characters and responds with `{ type: 'error', message: 'Project ID too long' }`. 
- Preserve existing behavior for valid joins (username truncation still applied, rooms and `seqCounters` created and used normally). 
- Add a regression test `rejects project IDs longer than 200 characters` to `tests/collaborationServer.test.mjs` to ensure overlong IDs are rejected and do not receive a sync.

### Testing
- Ran `npm test` and the full test suite passed, including the new collaborationServer test. 
- Ran `npm run build` and the build completed successfully. 
- Attempted to capture a webpage preview with Playwright but browser binaries could not be downloaded in this environment (download failed with HTTP 403), so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f60908e4832484aaaca54ad000e1)