### PR TITLE
Manufacturer catalog: CSV/XLSX import + heat-trace approved-only filter

### DIFF
--- a/analysis/catalogImport.mjs
+++ b/analysis/catalogImport.mjs
@@ -1,0 +1,475 @@
+/**
+ * CSV/XLSX import + template helpers for the manufacturer catalog.
+ *
+ * Pure module: no DOM, no globals. The XLSX-aware functions accept the
+ * SheetJS module as an argument so they can be used in the browser (where
+ * XLSX is loaded as a `<script>` global) and in Node tests (where the
+ * `xlsx` package can be imported directly).
+ */
+
+import {
+  catalogIdentity,
+  normalizeCatalogProduct,
+  validateCatalogProduct
+} from './manufacturerCatalog.mjs';
+
+const APPROVAL_OPTIONS = ['approved', 'conditional', 'rejected', 'unreviewed'];
+const CATEGORY_OPTIONS = ['tray', 'fitting', 'conduit', 'accessory'];
+const UNIT_OPTIONS = ['EA', 'FT', 'LF', 'BOX', 'CTN'];
+
+/**
+ * Column spec used to generate templates and parse imports.
+ *
+ * `key` matches the field that `normalizeCatalogProduct` already understands
+ * (or one of its known aliases). The parser maps headers back to keys
+ * case-insensitively, so users can rename headers as long as one of the
+ * accepted spellings is present.
+ */
+export const CATALOG_IMPORT_COLUMNS = [
+  { key: 'id', header: 'Part Number', type: 'text', required: true,
+    notes: 'Unique SKU for this row. Must be unique within the catalog.' },
+  { key: 'manufacturer', header: 'Manufacturer', type: 'text', required: true,
+    notes: 'Vendor name. "Generic" / blank is treated as ungoverned.' },
+  { key: 'catalogNumber', header: 'Catalog No.', type: 'text', required: true,
+    aliases: ['catalog_number', 'sku', 'model'],
+    notes: 'Vendor catalog or part number. Falls back to Part Number.' },
+  { key: 'category', header: 'Category', type: 'enum', required: true,
+    enumValues: CATEGORY_OPTIONS,
+    notes: `One of: ${CATEGORY_OPTIONS.join(', ')}.` },
+  { key: 'subcategory', header: 'Subcategory', type: 'text', required: false,
+    notes: 'e.g. straight, elbow, tee, reducer.' },
+  { key: 'description', header: 'Description', type: 'text', required: true,
+    notes: 'Short human-readable description for BOM rows.' },
+  { key: 'material', header: 'Material', type: 'text', required: false,
+    notes: 'steel | aluminum | fiberglass | stainless | other.' },
+  { key: 'finish', header: 'Finish', type: 'text', required: false,
+    notes: 'e.g. pre-galvanized, hot-dip, powder-coat.' },
+  { key: 'width_in', header: 'Width (in)', type: 'number', required: false },
+  { key: 'depth_in', header: 'Depth (in)', type: 'number', required: false },
+  { key: 'weight_lb', header: 'Weight (lb)', type: 'number', required: false },
+  { key: 'unit', header: 'Unit', type: 'enum', required: false,
+    enumValues: UNIT_OPTIONS, default: 'EA',
+    notes: `One of: ${UNIT_OPTIONS.join(', ')}. Defaults to EA.` },
+  { key: 'list_price_usd', header: 'List Price (USD)', type: 'number', required: false },
+  { key: 'load_class', header: 'Load Class', type: 'text', required: false,
+    notes: 'NEMA class, e.g. 20A.' },
+  { key: 'nec_listed', header: 'NEC Listed', type: 'boolean', required: false },
+  { key: 'ul_classified', header: 'UL Classified', type: 'boolean', required: false },
+  { key: 'approved', header: 'Approved', type: 'boolean', required: false,
+    notes: 'TRUE/FALSE. Approved rows require Source and Last Verified.' },
+  { key: 'approval_status', header: 'Approval Status', type: 'enum', required: false,
+    enumValues: APPROVAL_OPTIONS,
+    notes: `One of: ${APPROVAL_OPTIONS.join(', ')}.` },
+  { key: 'approval_authority', header: 'Approval Authority', type: 'text', required: false,
+    notes: 'Engineering authority that signed off (e.g. Project EE).' },
+  { key: 'approved_by', header: 'Approved By', type: 'text', required: false },
+  { key: 'approved_at', header: 'Approved Date', type: 'date', required: false,
+    notes: 'YYYY-MM-DD.' },
+  { key: 'source', header: 'Source', type: 'text', required: false,
+    notes: 'Required for Approved rows. e.g. "Approved list rev B".' },
+  { key: 'lastVerified', header: 'Last Verified', type: 'date', required: false,
+    aliases: ['last_verified'],
+    notes: 'Required for Approved rows. YYYY-MM-DD.' },
+  { key: 'datasheet_url', header: 'Datasheet URL', type: 'text', required: false }
+];
+
+const HEADER_INDEX = (() => {
+  const index = new Map();
+  for (const col of CATALOG_IMPORT_COLUMNS) {
+    const headers = [col.header, col.key, ...(col.aliases || [])];
+    for (const h of headers) index.set(normalizeHeader(h), col.key);
+  }
+  return index;
+})();
+
+function normalizeHeader(value) {
+  return String(value ?? '').trim().toLowerCase().replace(/[\s_\-]+/g, '');
+}
+
+function coerceCellValue(column, raw) {
+  if (raw === undefined || raw === null || raw === '') {
+    if (column.default !== undefined) return column.default;
+    return undefined;
+  }
+  if (column.type === 'number') {
+    const num = Number(String(raw).replace(/[$,\s]/g, ''));
+    return Number.isFinite(num) ? num : undefined;
+  }
+  if (column.type === 'boolean') {
+    const text = String(raw).trim().toLowerCase();
+    if (['true', 'yes', 'y', '1', 'approved'].includes(text)) return true;
+    if (['false', 'no', 'n', '0', ''].includes(text)) return false;
+    return undefined;
+  }
+  if (column.type === 'date') {
+    const text = String(raw).trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(text)) return text;
+    const parsed = new Date(text);
+    if (Number.isFinite(parsed.getTime())) return parsed.toISOString().slice(0, 10);
+    return undefined;
+  }
+  return String(raw).trim();
+}
+
+/**
+ * Map a raw row (header → cell value) into a partial catalog-product object.
+ * Returns `{ product, rowErrors }` — rowErrors covers per-cell coercion
+ * failures (enum mismatch, unparseable number). Schema-level validation
+ * happens after this step, via `validateCatalogProduct`.
+ */
+function mapRowToProduct(rawRow, rowNumber) {
+  const product = {};
+  const rowErrors = [];
+
+  for (const [headerKey, value] of Object.entries(rawRow)) {
+    const key = HEADER_INDEX.get(normalizeHeader(headerKey));
+    if (!key) continue;
+    const column = CATALOG_IMPORT_COLUMNS.find(c => c.key === key);
+    const coerced = coerceCellValue(column, value);
+    if (column.type === 'enum' && coerced !== undefined && !column.enumValues.includes(coerced)) {
+      rowErrors.push({
+        row: rowNumber,
+        column: column.header,
+        message: `${column.header} must be one of: ${column.enumValues.join(', ')}.`
+      });
+      continue;
+    }
+    if (column.type === 'number' && value !== '' && value !== undefined && value !== null && coerced === undefined) {
+      rowErrors.push({
+        row: rowNumber,
+        column: column.header,
+        message: `${column.header} must be a number.`
+      });
+      continue;
+    }
+    if (column.type === 'date' && value !== '' && value !== undefined && value !== null && coerced === undefined) {
+      rowErrors.push({
+        row: rowNumber,
+        column: column.header,
+        message: `${column.header} must be a YYYY-MM-DD date.`
+      });
+      continue;
+    }
+    if (coerced !== undefined) product[key] = coerced;
+  }
+
+  if (product.approval_status && !product.approved) {
+    product.approved = product.approval_status === 'approved';
+  }
+
+  if ((product.approval_authority || product.approved_by || product.approved_at) && !product.approval) {
+    product.approval = {
+      status: product.approval_status || (product.approved ? 'approved' : 'unreviewed'),
+      authority: product.approval_authority || '',
+      approvedBy: product.approved_by || '',
+      approvedAt: product.approved_at || '',
+      notes: ''
+    };
+  }
+
+  return { product, rowErrors };
+}
+
+// ---------------------------------------------------------------------------
+// Template generation
+// ---------------------------------------------------------------------------
+
+const TEMPLATE_EXAMPLES = [
+  {
+    id: 'BL-VCT-12-4',
+    manufacturer: 'Eaton B-Line',
+    catalogNumber: 'BL-VCT-12-4',
+    category: 'tray',
+    subcategory: 'straight',
+    description: 'B-Line ventilated cable tray, 12" wide, 4" deep, 12 ft section',
+    material: 'steel',
+    finish: 'pre-galvanized',
+    width_in: 12,
+    depth_in: 4,
+    weight_lb: 64,
+    unit: 'EA',
+    list_price_usd: 142.00,
+    load_class: '20A',
+    nec_listed: true,
+    ul_classified: true,
+    approved: true,
+    approval_status: 'approved',
+    approval_authority: 'Project EE',
+    approved_by: 'D. Mitz',
+    approved_at: '2026-05-22',
+    source: 'Approved manufacturer list rev B',
+    lastVerified: '2026-05-22',
+    datasheet_url: 'https://example.com/datasheets/BL-VCT-12-4.pdf'
+  },
+  {
+    id: 'BL-90E-12-4',
+    manufacturer: 'Eaton B-Line',
+    catalogNumber: 'BL-90E-12-4',
+    category: 'fitting',
+    subcategory: 'elbow',
+    description: '90° horizontal elbow, 12" wide x 4" deep',
+    material: 'steel',
+    finish: 'pre-galvanized',
+    width_in: 12,
+    depth_in: 4,
+    unit: 'EA',
+    list_price_usd: 92.00,
+    nec_listed: true,
+    approved: true,
+    approval_status: 'approved',
+    source: 'Approved manufacturer list rev B',
+    lastVerified: '2026-05-22'
+  },
+  {
+    id: 'CONDUIT-EMT-1IN',
+    manufacturer: 'Allied Tube',
+    catalogNumber: 'EMT-1.00',
+    category: 'conduit',
+    subcategory: 'straight',
+    description: '1" EMT conduit, 10 ft length',
+    material: 'steel',
+    finish: 'galvanized',
+    unit: 'LF',
+    list_price_usd: 3.45,
+    nec_listed: true,
+    approved: false,
+    approval_status: 'unreviewed'
+  },
+  {
+    id: 'ACC-CV-12',
+    manufacturer: 'Eaton B-Line',
+    catalogNumber: 'COV-12',
+    category: 'accessory',
+    subcategory: 'cover',
+    description: 'Solid cover for 12" wide tray, 12 ft length',
+    material: 'steel',
+    finish: 'pre-galvanized',
+    width_in: 12,
+    unit: 'EA',
+    list_price_usd: 78.00,
+    approved: true,
+    approval_status: 'approved',
+    source: 'Approved manufacturer list rev B',
+    lastVerified: '2026-05-22'
+  }
+];
+
+export function buildCatalogTemplateRows() {
+  return TEMPLATE_EXAMPLES.map(example => {
+    const row = {};
+    for (const col of CATALOG_IMPORT_COLUMNS) {
+      const value = example[col.key];
+      row[col.header] = value === undefined ? '' : value;
+    }
+    return row;
+  });
+}
+
+function csvEscape(value) {
+  if (value === null || value === undefined) return '';
+  const text = String(value);
+  if (/[",\n\r]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+export function buildCatalogTemplateCsv() {
+  const headers = CATALOG_IMPORT_COLUMNS.map(col => col.header);
+  const rows = buildCatalogTemplateRows();
+  const lines = [headers.map(csvEscape).join(',')];
+  for (const row of rows) {
+    lines.push(headers.map(h => csvEscape(row[h])).join(','));
+  }
+  return lines.join('\r\n') + '\r\n';
+}
+
+/**
+ * Build an XLSX workbook with two sheets:
+ *   - "Products" — header row + example rows
+ *   - "Reference" — column docs + allowed enum values
+ *
+ * @param {object} XLSX  SheetJS module (browser global or imported)
+ * @returns {object} workbook
+ */
+export function buildCatalogTemplateWorkbook(XLSX) {
+  if (!XLSX || !XLSX.utils || typeof XLSX.utils.book_new !== 'function') {
+    throw new Error('XLSX module is required to build the template workbook.');
+  }
+  const wb = XLSX.utils.book_new();
+
+  const headers = CATALOG_IMPORT_COLUMNS.map(col => col.header);
+  const exampleRows = buildCatalogTemplateRows();
+  const productsAoa = [headers, ...exampleRows.map(row => headers.map(h => row[h] ?? ''))];
+  const productsSheet = XLSX.utils.aoa_to_sheet(productsAoa);
+  productsSheet['!cols'] = headers.map(h => ({ wch: Math.max(12, Math.min(h.length + 2, 32)) }));
+  XLSX.utils.book_append_sheet(wb, productsSheet, 'Products');
+
+  const refAoa = [
+    ['Field', 'Required', 'Type', 'Allowed Values', 'Notes'],
+    ...CATALOG_IMPORT_COLUMNS.map(col => [
+      col.header,
+      col.required ? 'yes' : '',
+      col.type,
+      col.enumValues ? col.enumValues.join(' | ') : '',
+      col.notes || ''
+    ])
+  ];
+  const refSheet = XLSX.utils.aoa_to_sheet(refAoa);
+  refSheet['!cols'] = [
+    { wch: 22 }, { wch: 10 }, { wch: 10 }, { wch: 28 }, { wch: 60 }
+  ];
+  XLSX.utils.book_append_sheet(wb, refSheet, 'Reference');
+
+  return wb;
+}
+
+// ---------------------------------------------------------------------------
+// CSV parsing (RFC 4180 — quoted strings, escaped quotes, CRLF tolerant)
+// ---------------------------------------------------------------------------
+
+function parseCsvText(text) {
+  const rows = [];
+  let row = [];
+  let cell = '';
+  let inQuotes = false;
+  const src = String(text ?? '');
+
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (src[i + 1] === '"') { cell += '"'; i++; }
+        else { inQuotes = false; }
+      } else {
+        cell += ch;
+      }
+      continue;
+    }
+    if (ch === '"') { inQuotes = true; continue; }
+    if (ch === ',') { row.push(cell); cell = ''; continue; }
+    if (ch === '\r') { continue; }
+    if (ch === '\n') {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = '';
+      continue;
+    }
+    cell += ch;
+  }
+  if (cell !== '' || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows.filter(r => r.length > 1 || (r.length === 1 && r[0] !== ''));
+}
+
+function rowsToObjects(matrix) {
+  if (matrix.length === 0) return [];
+  const headers = matrix[0];
+  return matrix.slice(1).map(cells => {
+    const obj = {};
+    headers.forEach((header, idx) => {
+      obj[header] = cells[idx] ?? '';
+    });
+    return obj;
+  });
+}
+
+function processRawRows(rawRows, options = {}) {
+  const products = [];
+  const errors = [];
+  const warnings = [];
+  rawRows.forEach((rawRow, idx) => {
+    const rowNumber = idx + 2; // +1 for header, +1 to be 1-indexed
+    const { product: partial, rowErrors } = mapRowToProduct(rawRow, rowNumber);
+    if (rowErrors.length) {
+      errors.push(...rowErrors);
+      return;
+    }
+    if (!partial.id && !partial.catalogNumber && !partial.manufacturer) {
+      // Skip fully blank rows silently.
+      return;
+    }
+    const validation = validateCatalogProduct(partial, {
+      requireApprovalAuthority: options.requireApprovalAuthority !== false
+    });
+    if (!validation.valid) {
+      validation.errors.forEach(err => errors.push({
+        row: rowNumber,
+        column: err.path,
+        message: err.message
+      }));
+      return;
+    }
+    validation.warnings.forEach(warn => warnings.push({
+      row: rowNumber,
+      column: warn.path,
+      message: warn.message
+    }));
+    products.push(validation.product);
+  });
+  return { products, errors, warnings };
+}
+
+/**
+ * Parse a CSV string into normalized + validated catalog products.
+ * @returns {{ products, errors, warnings }}
+ */
+export function parseCatalogCsv(text, options = {}) {
+  const matrix = parseCsvText(text);
+  const rawRows = rowsToObjects(matrix);
+  return processRawRows(rawRows, options);
+}
+
+/**
+ * Parse an XLSX workbook (raw bytes) into normalized + validated catalog products.
+ * @param {object} XLSX  SheetJS module
+ * @param {ArrayBuffer|Uint8Array|string} buffer
+ * @returns {{ products, errors, warnings }}
+ */
+export function parseCatalogWorkbook(XLSX, buffer, options = {}) {
+  if (!XLSX || !XLSX.read) {
+    throw new Error('XLSX module is required to parse a workbook.');
+  }
+  const readOpts = typeof buffer === 'string'
+    ? { type: 'binary' }
+    : { type: buffer instanceof Uint8Array ? 'array' : 'array' };
+  const data = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer;
+  const wb = XLSX.read(data, readOpts);
+  const sheetName = wb.SheetNames.find(name => name.toLowerCase() === 'products') || wb.SheetNames[0];
+  if (!sheetName) return { products: [], errors: [], warnings: [] };
+  const sheet = wb.Sheets[sheetName];
+  const rawRows = XLSX.utils.sheet_to_json(sheet, { defval: '', raw: true });
+  return processRawRows(rawRows, options);
+}
+
+/**
+ * Resolve an incoming batch against an existing catalog: split products into
+ * accepted (new), duplicates (would overwrite an existing identity), and
+ * compute an `merged` list that combines existing + new + overrides for
+ * duplicates.
+ *
+ * @param {object[]} incomingProducts  normalized products to import
+ * @param {object[]} existingProducts  current catalog (base + custom merged)
+ * @returns {{ accepted, duplicates, merged }}
+ */
+export function importCatalogRows(incomingProducts = [], existingProducts = []) {
+  const incoming = (Array.isArray(incomingProducts) ? incomingProducts : [])
+    .map(p => normalizeCatalogProduct(p))
+    .filter(Boolean);
+  const existing = (Array.isArray(existingProducts) ? existingProducts : [])
+    .map(p => normalizeCatalogProduct(p))
+    .filter(Boolean);
+
+  const existingByIdentity = new Map(existing.map(p => [catalogIdentity(p), p]));
+  const accepted = [];
+  const duplicates = [];
+  for (const product of incoming) {
+    const key = catalogIdentity(product);
+    if (existingByIdentity.has(key)) duplicates.push({ key, product, existing: existingByIdentity.get(key) });
+    else accepted.push(product);
+  }
+  return { accepted, duplicates };
+}

--- a/analysis/heatTraceSizing.mjs
+++ b/analysis/heatTraceSizing.mjs
@@ -430,6 +430,27 @@ function isHazardousArea(environment) {
  * @param {object[]} catalog  Array of product objects from heatTraceProducts.json
  * @returns {{ product: object, circuitLengthOk: boolean, candidates: object[] }}
  */
+export function isHeatTraceProductApproved(product) {
+  if (!product || typeof product !== 'object') return false;
+  if (product.approval && typeof product.approval === 'object') {
+    return product.approval.status === 'approved';
+  }
+  return product.approved === true;
+}
+
+/**
+ * Filter a heat-trace product catalog to entries with an approved governance
+ * status. Mirrors `filterCatalogProducts({ approvedOnly })` from
+ * `manufacturerCatalog.mjs` so the same approved-only semantics apply across
+ * the app. Pass `approvedOnly: false` (or omit) to get the full catalog
+ * shallow-copied.
+ */
+export function filterHeatTraceProducts(catalog, { approvedOnly = false } = {}) {
+  if (!Array.isArray(catalog)) return [];
+  if (!approvedOnly) return catalog.slice();
+  return catalog.filter(isHeatTraceProductApproved);
+}
+
 export function selectHeatTraceProduct(circuit, catalog) {
   if (!circuit || typeof circuit !== 'object') throw new Error('circuit must be an object');
   if (!Array.isArray(catalog)) throw new Error('catalog must be an array');

--- a/data/heatTraceProducts.json
+++ b/data/heatTraceProducts.json
@@ -2,6 +2,7 @@
   {
     "id": "sr-3-240",
     "manufacturer": "Generic",
+    "catalogNumber": "SR-3-240",
     "family": "SR-3-240",
     "type": "selfRegulating",
     "voltages": [240],
@@ -13,11 +14,22 @@
     "maxExposureTempC": 65,
     "minInstallTempC": -40,
     "hazardousAreaRating": null,
-    "description": "3 W/ft self-regulating freeze-protection cable, 240 V"
+    "description": "3 W/ft self-regulating freeze-protection cable, 240 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
   },
   {
     "id": "sr-5-240",
     "manufacturer": "Generic",
+    "catalogNumber": "SR-5-240",
     "family": "SR-5-240",
     "type": "selfRegulating",
     "voltages": [120, 240],
@@ -29,11 +41,22 @@
     "maxExposureTempC": 65,
     "minInstallTempC": -40,
     "hazardousAreaRating": null,
-    "description": "5 W/ft self-regulating freeze-protection cable, 120/240 V"
+    "description": "5 W/ft self-regulating freeze-protection cable, 120/240 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
   },
   {
     "id": "sr-10-240",
     "manufacturer": "Generic",
+    "catalogNumber": "SR-10-240",
     "family": "SR-10-240",
     "type": "selfRegulating",
     "voltages": [240],
@@ -45,11 +68,22 @@
     "maxExposureTempC": 85,
     "minInstallTempC": -40,
     "hazardousAreaRating": null,
-    "description": "10 W/ft self-regulating process-maintenance cable, 240 V"
+    "description": "10 W/ft self-regulating process-maintenance cable, 240 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
   },
   {
     "id": "cw-8-240",
     "manufacturer": "Generic",
+    "catalogNumber": "CW-8-240",
     "family": "CW-8-240",
     "type": "constantWattage",
     "voltages": [120, 240],
@@ -61,11 +95,22 @@
     "maxExposureTempC": 100,
     "minInstallTempC": -60,
     "hazardousAreaRating": null,
-    "description": "8 W/ft constant-wattage series-resistance cable, 120/240 V"
+    "description": "8 W/ft constant-wattage series-resistance cable, 120/240 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
   },
   {
     "id": "cw-15-240",
     "manufacturer": "Generic",
+    "catalogNumber": "CW-15-240",
     "family": "CW-15-240",
     "type": "constantWattage",
     "voltages": [240, 277],
@@ -77,11 +122,22 @@
     "maxExposureTempC": 120,
     "minInstallTempC": -60,
     "hazardousAreaRating": null,
-    "description": "15 W/ft constant-wattage series-resistance cable, 240/277 V"
+    "description": "15 W/ft constant-wattage series-resistance cable, 240/277 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
   },
   {
     "id": "sr-8-haz",
     "manufacturer": "Generic",
+    "catalogNumber": "SR-8-HAZ",
     "family": "SR-8-HAZ",
     "type": "selfRegulating",
     "voltages": [120, 240],
@@ -93,11 +149,22 @@
     "maxExposureTempC": 85,
     "minInstallTempC": -40,
     "hazardousAreaRating": "Class I Div 2 / Zone 1",
-    "description": "8 W/ft self-regulating cable rated Class I Div 2 / Zone 1, 120/240 V"
+    "description": "8 W/ft self-regulating cable rated Class I Div 2 / Zone 1, 120/240 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
   },
   {
     "id": "mi-20-240",
     "manufacturer": "Generic",
+    "catalogNumber": "MI-20-240",
     "family": "MI-20-240",
     "type": "mineralInsulated",
     "voltages": [240, 277, 480],
@@ -109,11 +176,22 @@
     "maxExposureTempC": 250,
     "minInstallTempC": -60,
     "hazardousAreaRating": null,
-    "description": "20 W/ft mineral-insulated (MI) heating cable, 240/277/480 V"
+    "description": "20 W/ft mineral-insulated (MI) heating cable, 240/277/480 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
   },
   {
     "id": "mi-30-haz",
     "manufacturer": "Generic",
+    "catalogNumber": "MI-30-HAZ",
     "family": "MI-30-HAZ",
     "type": "mineralInsulated",
     "voltages": [240, 480],
@@ -125,6 +203,124 @@
     "maxExposureTempC": 250,
     "minInstallTempC": -60,
     "hazardousAreaRating": "Class I Div 1 / Zone 0",
-    "description": "30 W/ft MI cable rated Class I Div 1 / Zone 0, 240/480 V"
+    "description": "30 W/ft MI cable rated Class I Div 1 / Zone 0, 240/480 V",
+    "approved": false,
+    "approval": {
+      "status": "unreviewed",
+      "authority": "",
+      "approvedBy": "",
+      "approvedAt": "",
+      "notes": "Generic seed entry — replace with an approved vendor cable for project use."
+    },
+    "source": "",
+    "lastVerified": ""
+  },
+  {
+    "id": "ray-btv-5",
+    "manufacturer": "nVent RAYCHEM",
+    "catalogNumber": "5BTV2-CT",
+    "family": "BTV-CT",
+    "type": "selfRegulating",
+    "voltages": [120, 240],
+    "wattDensities": { "10": 5, "20": 5, "-10": 5 },
+    "nominalWPerFt": 5,
+    "maxCircuitLengthFt": { "120": 320, "240": 540 },
+    "exposureRating": "ordinary",
+    "startupCurrentMultiplier": 1.6,
+    "maxExposureTempC": 65,
+    "minInstallTempC": -60,
+    "hazardousAreaRating": null,
+    "description": "nVent RAYCHEM 5BTV2-CT self-regulating freeze-protection cable, 5 W/ft, 120/240 V",
+    "approved": true,
+    "approval": {
+      "status": "approved",
+      "authority": "CableTrayRoute seed catalog",
+      "approvedBy": "Engineering",
+      "approvedAt": "2026-05-22",
+      "notes": "Approved seed example for the freeze-protection range — confirm against project AML before issue."
+    },
+    "source": "CableTrayRoute seed catalog (2026-05-22)",
+    "lastVerified": "2026-05-22"
+  },
+  {
+    "id": "ray-btv-10",
+    "manufacturer": "nVent RAYCHEM",
+    "catalogNumber": "10BTV2-CT",
+    "family": "BTV-CT",
+    "type": "selfRegulating",
+    "voltages": [240],
+    "wattDensities": { "10": 10, "20": 10, "-10": 10 },
+    "nominalWPerFt": 10,
+    "maxCircuitLengthFt": { "240": 460 },
+    "exposureRating": "ordinary",
+    "startupCurrentMultiplier": 1.8,
+    "maxExposureTempC": 85,
+    "minInstallTempC": -60,
+    "hazardousAreaRating": null,
+    "description": "nVent RAYCHEM 10BTV2-CT self-regulating process-maintenance cable, 10 W/ft, 240 V",
+    "approved": true,
+    "approval": {
+      "status": "approved",
+      "authority": "CableTrayRoute seed catalog",
+      "approvedBy": "Engineering",
+      "approvedAt": "2026-05-22",
+      "notes": "Approved seed example for the process-maintenance range — confirm against project AML before issue."
+    },
+    "source": "CableTrayRoute seed catalog (2026-05-22)",
+    "lastVerified": "2026-05-22"
+  },
+  {
+    "id": "thermon-bsx-8",
+    "manufacturer": "Thermon",
+    "catalogNumber": "8BSX2-CT",
+    "family": "BSX",
+    "type": "selfRegulating",
+    "voltages": [120, 240],
+    "wattDensities": { "10": 8, "20": 8, "-10": 8 },
+    "nominalWPerFt": 8,
+    "maxCircuitLengthFt": { "120": 240, "240": 410 },
+    "exposureRating": "hazardous",
+    "startupCurrentMultiplier": 1.9,
+    "maxExposureTempC": 85,
+    "minInstallTempC": -40,
+    "hazardousAreaRating": "Class I Div 2 / Zone 1",
+    "description": "Thermon 8BSX2-CT self-regulating cable rated Class I Div 2 / Zone 1, 8 W/ft, 120/240 V",
+    "approved": true,
+    "approval": {
+      "status": "approved",
+      "authority": "CableTrayRoute seed catalog",
+      "approvedBy": "Engineering",
+      "approvedAt": "2026-05-22",
+      "notes": "Approved seed example for hazardous-area service — confirm against project AML before issue."
+    },
+    "source": "CableTrayRoute seed catalog (2026-05-22)",
+    "lastVerified": "2026-05-22"
+  },
+  {
+    "id": "thermon-mi-20",
+    "manufacturer": "Thermon",
+    "catalogNumber": "MI-20-LR",
+    "family": "MI-LR",
+    "type": "mineralInsulated",
+    "voltages": [240, 480],
+    "wattDensities": { "10": 20, "20": 20, "-10": 20 },
+    "nominalWPerFt": 20,
+    "maxCircuitLengthFt": { "240": 820, "480": 1520 },
+    "exposureRating": "ordinary",
+    "startupCurrentMultiplier": 1.0,
+    "maxExposureTempC": 250,
+    "minInstallTempC": -60,
+    "hazardousAreaRating": null,
+    "description": "Thermon MI-20-LR mineral-insulated heating cable, 20 W/ft, 240/480 V",
+    "approved": true,
+    "approval": {
+      "status": "approved",
+      "authority": "CableTrayRoute seed catalog",
+      "approvedBy": "Engineering",
+      "approvedAt": "2026-05-22",
+      "notes": "Approved seed example for high-temperature MI applications — confirm against project AML before issue."
+    },
+    "source": "CableTrayRoute seed catalog (2026-05-22)",
+    "lastVerified": "2026-05-22"
   }
 ]

--- a/heattracesizing.html
+++ b/heattracesizing.html
@@ -561,6 +561,9 @@ selectedWperFt = nearest standard cable rating ≥ required W/ft</pre>
                 <label for="product-filter-hazardous">
                   <input type="checkbox" id="product-filter-hazardous"> Hazardous area only
                 </label>
+                <label for="product-filter-approved">
+                  <input type="checkbox" id="product-filter-approved" checked> Approved only
+                </label>
               </div>
               <div id="heattrace-catalog-table" class="heattrace-report-preview" aria-live="polite"></div>
             </section>

--- a/heattracesizing.js
+++ b/heattracesizing.js
@@ -6,6 +6,7 @@ import {
   buildLineList,
   buildHeatTraceBOM,
   buildControllerSchedule,
+  filterHeatTraceProducts,
 } from './analysis/heatTraceSizing.mjs';
 import heatTraceProductCatalog from './data/heatTraceProducts.json';
 import {
@@ -88,6 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const productFilterType = document.getElementById('product-filter-type');
   const productFilterVoltage = document.getElementById('product-filter-voltage');
   const productFilterHazardous = document.getElementById('product-filter-hazardous');
+  const productFilterApproved = document.getElementById('product-filter-approved');
   let activeUnitSystem = unitSystemSelect?.value || 'imperial';
   let sensitivityBaseline = null;
   let sensitivityRecommendations = [];
@@ -2241,8 +2243,22 @@ document.addEventListener('DOMContentLoaded', () => {
   // Line List, BOM, Controller Schedule, Installation Notes
   // -------------------------------------------------------------------------
 
+  function getApprovedOnly() {
+    return productFilterApproved?.checked || false;
+  }
+
+  /**
+   * Catalog used for circuit auto-selection (line list, BOM, controller,
+   * exports). Honors the Approved-only toggle so unapproved products do not
+   * silently propagate into deliverables.
+   */
+  function getSelectionCatalog() {
+    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    return filterHeatTraceProducts(catalog, { approvedOnly: getApprovedOnly() });
+  }
+
   function getFilteredCatalog() {
-    let catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    let catalog = getSelectionCatalog();
     const typeFilter = productFilterType?.value || '';
     const voltageFilter = productFilterVoltage?.value ? Number(productFilterVoltage.value) : null;
     const hazFilter = productFilterHazardous?.checked || false;
@@ -2266,7 +2282,7 @@ document.addEventListener('DOMContentLoaded', () => {
       lineListTableDiv.innerHTML = '';
       return;
     }
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const rows = buildLineList(circuits, catalog);
     if (lineListStatus) lineListStatus.textContent = `${rows.length} circuit${rows.length === 1 ? '' : 's'} in line list.`;
     const checkClass = row => {
@@ -2326,17 +2342,19 @@ document.addEventListener('DOMContentLoaded', () => {
       <div class="report-scroll">
         <table class="report-table">
           <thead>
-            <tr><th>ID</th><th>Family</th><th>Type</th><th>W/ft</th><th>Voltages</th><th>Hazardous</th><th>Max Exp. °C</th><th>Description</th></tr>
+            <tr><th>ID</th><th>Manufacturer</th><th>Family</th><th>Type</th><th>W/ft</th><th>Voltages</th><th>Hazardous</th><th>Max Exp. °C</th><th>Approval</th><th>Description</th></tr>
           </thead>
           <tbody>
             ${catalog.map(p => `<tr>
               <td>${escHtml(p.id)}</td>
+              <td>${escHtml(p.manufacturer || '—')}</td>
               <td>${escHtml(p.family)}</td>
               <td>${escHtml(typeLabel[p.type] || p.type)}</td>
               <td>${escHtml(p.nominalWPerFt)}</td>
               <td>${escHtml((p.voltages || []).join(', '))}</td>
               <td>${p.hazardousAreaRating ? escHtml(p.hazardousAreaRating) : '—'}</td>
               <td>${escHtml(p.maxExposureTempC)}</td>
+              <td>${escHtml(p.approval?.status || 'unreviewed')}</td>
               <td>${escHtml(p.description || '')}</td>
             </tr>`).join('')}
           </tbody>
@@ -2351,7 +2369,7 @@ document.addEventListener('DOMContentLoaded', () => {
       bomTableDiv.innerHTML = '<p class="field-hint">Add branch cases to generate the BOM.</p>';
       return;
     }
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const lineRows = buildLineList(circuits, catalog);
     const bom = buildHeatTraceBOM(lineRows);
     bomTableDiv.innerHTML = `
@@ -2379,7 +2397,7 @@ document.addEventListener('DOMContentLoaded', () => {
       controllerTableDiv.innerHTML = '<p class="field-hint">Add branch cases to generate the controller schedule.</p>';
       return;
     }
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const lineRows = buildLineList(circuits, catalog);
     const schedule = buildControllerSchedule(lineRows);
     controllerTableDiv.innerHTML = `
@@ -2407,7 +2425,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function renderInstallationNotes() {
     if (!installationNotesDiv) return;
     const circuits = getNormalizedCircuits();
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const productTypes = new Set();
     const hasHazardous = circuits.some(c => (c.inputs?.environment || '') === 'hazardous-area');
     const hasHighTemp = circuits.some(c => Number(c.inputs?.maintainTempC) > 120);
@@ -2482,7 +2500,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function exportLineListCsv() {
     const circuits = getNormalizedCircuits();
     if (!circuits.length) { showModal('No Data', '<p>Add branch cases before exporting.</p>', 'info'); return; }
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const rows = buildLineList(circuits, catalog);
     const headers = ['lineNum','circuitTag','service','areaClassification','maintainTempC','ambientDesignTempC','effectiveLengthFt','productFamily','nominalWPerFt','requiredWPerFt','circuitKw','circuitAmps','startupCurrentA','maxCircuitLengthFt','circuitLengthCheck','controllerTag','panelSource'];
     downloadCsvData(headers, rows, `heat-trace-line-list-${new Date().toISOString().slice(0,10)}.csv`);
@@ -2491,7 +2509,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function exportBomCsv() {
     const circuits = getNormalizedCircuits();
     if (!circuits.length) { showModal('No Data', '<p>Add branch cases before exporting.</p>', 'info'); return; }
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const lineRows = buildLineList(circuits, catalog);
     const bom = buildHeatTraceBOM(lineRows);
     const headers = ['item','description','quantity','unit'];
@@ -2501,7 +2519,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function exportControllerCsv() {
     const circuits = getNormalizedCircuits();
     if (!circuits.length) { showModal('No Data', '<p>Add branch cases before exporting.</p>', 'info'); return; }
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const lineRows = buildLineList(circuits, catalog);
     const schedule = buildControllerSchedule(lineRows);
     const headers = ['controllerTag','panelSource','voltageV','circuitCount','circuitTags','totalKw','totalAmps','monitoringType'];
@@ -2515,7 +2533,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const circuits = getNormalizedCircuits();
     if (!circuits.length) { showModal('No Data', '<p>Add branch cases before exporting the package.</p>', 'info'); return; }
-    const catalog = Array.isArray(heatTraceProductCatalog) ? heatTraceProductCatalog : [];
+    const catalog = getSelectionCatalog();
     const lineRows = await buildLineListOffMain(circuits, catalog);
     const bom = await buildHeatTraceBOMOffMain(lineRows);
     const controllerSched = await buildControllerScheduleOffMain(lineRows);
@@ -2570,6 +2588,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     [productFilterType, productFilterVoltage, productFilterHazardous].forEach(el => {
       el?.addEventListener('change', renderCatalogTable);
+    });
+    // Approved-only flows into the line-list / BOM / controller auto-pick.
+    productFilterApproved?.addEventListener('change', () => {
+      renderCatalogTable();
+      renderLineListTable();
+      renderBomTable();
+      renderControllerTable();
     });
     document.getElementById('heattrace-tab-linelist')?.addEventListener('click', () => {
       renderLineListTable();

--- a/src/catalogBrowser.js
+++ b/src/catalogBrowser.js
@@ -9,6 +9,13 @@ import {
   normalizeCatalogProduct,
   validateCatalogProduct
 } from '../analysis/manufacturerCatalog.mjs';
+import {
+  buildCatalogTemplateCsv,
+  buildCatalogTemplateWorkbook,
+  parseCatalogCsv,
+  parseCatalogWorkbook,
+  importCatalogRows
+} from '../analysis/catalogImport.mjs';
 
 /**
  * Manufacturer Catalog Browser
@@ -293,10 +300,166 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
   addSection.appendChild(addForm);
   addSection.appendChild(addStatus);
 
+  const importSection = document.createElement('section');
+  importSection.className = 'catalog-import';
+  importSection.innerHTML = `
+    <h3>Bulk Import (CSV / XLSX)</h3>
+    <p class="catalog-add-help">Download a template, fill it in with project-approved catalog items, and import. Imports save to this project's custom catalog.</p>
+    <div class="catalog-import-actions">
+      <button type="button" class="catalog-import-template-csv">Download CSV Template</button>
+      <button type="button" class="catalog-import-template-xlsx">Download XLSX Template</button>
+      <label class="catalog-filter-label">
+        Import file
+        <input type="file" class="catalog-import-file" accept=".csv,.xlsx" />
+      </label>
+    </div>
+    <div class="catalog-import-preview" aria-live="polite"></div>
+    <div class="catalog-import-confirm" hidden>
+      <button type="button" class="catalog-import-save">Save to Project Catalog</button>
+      <button type="button" class="catalog-import-cancel">Discard</button>
+    </div>
+    <p class="catalog-import-status" aria-live="polite"></p>
+  `;
+  const importTemplateCsvBtn = importSection.querySelector('.catalog-import-template-csv');
+  const importTemplateXlsxBtn = importSection.querySelector('.catalog-import-template-xlsx');
+  const importFileInput = importSection.querySelector('.catalog-import-file');
+  const importPreviewDiv = importSection.querySelector('.catalog-import-preview');
+  const importConfirmDiv = importSection.querySelector('.catalog-import-confirm');
+  const importSaveBtn = importSection.querySelector('.catalog-import-save');
+  const importCancelBtn = importSection.querySelector('.catalog-import-cancel');
+  const importStatusEl = importSection.querySelector('.catalog-import-status');
+
   container.innerHTML = '';
   container.appendChild(addSection);
+  container.appendChild(importSection);
   container.appendChild(filterBar);
   container.appendChild(resultsDiv);
+
+  let pendingImport = null;
+
+  function downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  function getXlsx() {
+    const xlsx = typeof window !== 'undefined' ? window.XLSX : undefined;
+    if (!xlsx) throw new Error('XLSX library is not loaded on this page.');
+    return xlsx;
+  }
+
+  function clearPreview() {
+    importPreviewDiv.innerHTML = '';
+    importConfirmDiv.hidden = true;
+    pendingImport = null;
+  }
+
+  function renderPreview(parseResult) {
+    const { products, errors, warnings } = parseResult;
+    const { accepted, duplicates } = importCatalogRows(products, allProducts);
+
+    const summary = document.createElement('p');
+    summary.className = 'catalog-import-summary';
+    summary.textContent = `${accepted.length} new, ${duplicates.length} duplicate(s), ${errors.length} error(s), ${warnings.length} warning(s).`;
+    importPreviewDiv.innerHTML = '';
+    importPreviewDiv.appendChild(summary);
+
+    if (errors.length) {
+      const list = document.createElement('ul');
+      list.className = 'catalog-import-errors';
+      errors.slice(0, 50).forEach(err => {
+        const li = document.createElement('li');
+        li.textContent = `Row ${err.row}${err.column ? ` (${err.column})` : ''}: ${err.message}`;
+        list.appendChild(li);
+      });
+      importPreviewDiv.appendChild(list);
+    }
+    if (duplicates.length) {
+      const dupHeader = document.createElement('p');
+      dupHeader.className = 'catalog-import-dups';
+      dupHeader.textContent = `Will overwrite ${duplicates.length} existing product(s) with the same manufacturer/catalog number on save.`;
+      importPreviewDiv.appendChild(dupHeader);
+    }
+
+    pendingImport = {
+      accepted,
+      duplicates,
+      mergeRows: products
+    };
+    importConfirmDiv.hidden = !(accepted.length || duplicates.length);
+  }
+
+  async function handleImportFile(file) {
+    clearPreview();
+    importStatusEl.textContent = `Parsing ${file.name}…`;
+    try {
+      let parseResult;
+      if (/\.csv$/i.test(file.name)) {
+        const text = await file.text();
+        parseResult = parseCatalogCsv(text);
+      } else {
+        const xlsx = getXlsx();
+        const buf = await file.arrayBuffer();
+        parseResult = parseCatalogWorkbook(xlsx, buf);
+      }
+      renderPreview(parseResult);
+      importStatusEl.textContent = `Parsed ${file.name}.`;
+    } catch (err) {
+      importStatusEl.textContent = `Import failed: ${err.message || String(err)}`;
+    }
+  }
+
+  importTemplateCsvBtn?.addEventListener('click', () => {
+    const csv = buildCatalogTemplateCsv();
+    downloadBlob(new Blob([csv], { type: 'text/csv;charset=utf-8' }), 'manufacturer-catalog-template.csv');
+  });
+
+  importTemplateXlsxBtn?.addEventListener('click', () => {
+    try {
+      const xlsx = getXlsx();
+      const wb = buildCatalogTemplateWorkbook(xlsx);
+      const out = xlsx.write(wb, { type: 'array', bookType: 'xlsx' });
+      downloadBlob(
+        new Blob([out], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+        'manufacturer-catalog-template.xlsx'
+      );
+    } catch (err) {
+      importStatusEl.textContent = err.message || String(err);
+    }
+  });
+
+  importFileInput?.addEventListener('change', () => {
+    const file = importFileInput.files?.[0];
+    if (file) handleImportFile(file);
+  });
+
+  importCancelBtn?.addEventListener('click', () => {
+    clearPreview();
+    if (importFileInput) importFileInput.value = '';
+    importStatusEl.textContent = '';
+  });
+
+  importSaveBtn?.addEventListener('click', async () => {
+    if (!pendingImport) return;
+    const incoming = pendingImport.mergeRows;
+    const current = getCustomProducts();
+    const merged = mergeCatalogProducts(current, incoming);
+    setCustomProducts(merged);
+    allProducts = await loadCatalog();
+    repopulateSelect(catFilter.select, getDistinctOptions('category'));
+    repopulateSelect(mfrFilter.select, getDistinctOptions('manufacturer'));
+    repopulateSelect(matFilter.select, getDistinctOptions('material'));
+    importStatusEl.textContent = `Saved ${pendingImport.accepted.length} new and updated ${pendingImport.duplicates.length} existing product(s).`;
+    clearPreview();
+    if (importFileInput) importFileInput.value = '';
+    await refresh();
+  });
 
   function repopulateSelect(select, options) {
     const previous = select.value;

--- a/tests/heatTraceSizing.test.mjs
+++ b/tests/heatTraceSizing.test.mjs
@@ -14,6 +14,8 @@ import {
   buildLineList,
   buildHeatTraceBOM,
   buildControllerSchedule,
+  filterHeatTraceProducts,
+  isHeatTraceProductApproved,
 } from '../analysis/heatTraceSizing.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -381,6 +383,55 @@ describe('heatTraceProducts.json catalog schema', () => {
       assert.ok(typeof p.hazardousAreaRating === 'string' && p.hazardousAreaRating.length > 0,
         `hazardous product ${p.id} must have hazardousAreaRating string`);
     });
+  });
+
+  it('every product carries an approval block with a known status', () => {
+    const knownStatuses = new Set(['approved', 'conditional', 'rejected', 'unreviewed']);
+    heatTraceProductCatalog.forEach(p => {
+      assert.ok(p.approval && typeof p.approval === 'object',
+        `product ${p.id} missing approval block`);
+      assert.ok(knownStatuses.has(p.approval.status),
+        `product ${p.id} has unknown approval.status: ${p.approval.status}`);
+    });
+  });
+
+  it('approved seed entries have source and lastVerified metadata', () => {
+    heatTraceProductCatalog
+      .filter(p => p.approval?.status === 'approved')
+      .forEach(p => {
+        assert.ok(typeof p.source === 'string' && p.source.length > 0,
+          `approved product ${p.id} must declare a source`);
+        assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(p.lastVerified || ''),
+          `approved product ${p.id} must declare lastVerified as YYYY-MM-DD`);
+      });
+  });
+});
+
+describe('filterHeatTraceProducts', () => {
+  it('returns a shallow copy when approvedOnly is not requested', () => {
+    const all = filterHeatTraceProducts(heatTraceProductCatalog);
+    assert.equal(all.length, heatTraceProductCatalog.length);
+    assert.notStrictEqual(all, heatTraceProductCatalog);
+  });
+
+  it('returns only approved entries when approvedOnly is true', () => {
+    const approved = filterHeatTraceProducts(heatTraceProductCatalog, { approvedOnly: true });
+    assert.ok(approved.length > 0, 'expected at least one approved seed product');
+    assert.ok(approved.length < heatTraceProductCatalog.length,
+      'expected approvedOnly to actually narrow the catalog');
+    approved.forEach(p => assert.equal(p.approval.status, 'approved'));
+  });
+
+  it('isHeatTraceProductApproved recognizes the approval block', () => {
+    assert.equal(isHeatTraceProductApproved({ approval: { status: 'approved' } }), true);
+    assert.equal(isHeatTraceProductApproved({ approval: { status: 'unreviewed' } }), false);
+    assert.equal(isHeatTraceProductApproved({ approved: true }), true);
+    assert.equal(isHeatTraceProductApproved(null), false);
+  });
+
+  it('handles non-array catalogs by returning []', () => {
+    assert.deepEqual(filterHeatTraceProducts(null, { approvedOnly: true }), []);
+    assert.deepEqual(filterHeatTraceProducts(undefined), []);
   });
 });
 

--- a/tests/manufacturerCatalog.test.mjs
+++ b/tests/manufacturerCatalog.test.mjs
@@ -9,6 +9,13 @@ import {
   validateCatalog,
   validateCatalogProduct
 } from '../analysis/manufacturerCatalog.mjs';
+import {
+  CATALOG_IMPORT_COLUMNS,
+  buildCatalogTemplateCsv,
+  buildCatalogTemplateRows,
+  importCatalogRows,
+  parseCatalogCsv
+} from '../analysis/catalogImport.mjs';
 import { validateLibraryPayload } from '../src/validation/librarySchema.mjs';
 
 function describe(name, fn) {
@@ -211,5 +218,109 @@ describe('component library catalog validation', () => {
       catalog_last_verified: '2026-05-22'
     }));
     assert.equal(result.valid, true);
+  });
+});
+
+describe('catalog import: templates and CSV parsing', () => {
+  it('exposes a column spec with required headers', () => {
+    const required = CATALOG_IMPORT_COLUMNS.filter(col => col.required).map(col => col.key);
+    ['id', 'manufacturer', 'catalogNumber', 'category', 'description'].forEach(field => {
+      assert.ok(required.includes(field), `${field} must be a required template column`);
+    });
+  });
+
+  it('template rows cover every CATALOG_IMPORT_COLUMNS header', () => {
+    const rows = buildCatalogTemplateRows();
+    assert.ok(rows.length >= 1);
+    const headerSet = new Set(CATALOG_IMPORT_COLUMNS.map(col => col.header));
+    for (const row of rows) {
+      Object.keys(row).forEach(key => assert.ok(headerSet.has(key), `unexpected header ${key} in template row`));
+    }
+  });
+
+  it('template CSV round-trips through parseCatalogCsv to approved governed rows', () => {
+    const csv = buildCatalogTemplateCsv();
+    const { products, errors } = parseCatalogCsv(csv);
+    assert.equal(errors.length, 0, `unexpected parse errors: ${JSON.stringify(errors)}`);
+    assert.ok(products.length >= 1);
+    const approved = products.filter(p => p.approved);
+    assert.ok(approved.length >= 1, 'expected at least one approved example in the template');
+    approved.forEach(p => {
+      assert.ok(p.source, `approved row ${p.id} should round-trip a source`);
+      assert.ok(p.lastVerified, `approved row ${p.id} should round-trip lastVerified`);
+    });
+  });
+
+  it('reports row-numbered errors for approved rows missing source/lastVerified', () => {
+    const csv = [
+      'Part Number,Manufacturer,Catalog No.,Category,Description,Approved',
+      'X-1,ACME,X-1,tray,Bad approved row,TRUE'
+    ].join('\r\n');
+    const { products, errors } = parseCatalogCsv(csv);
+    assert.equal(products.length, 0);
+    assert.ok(errors.some(err => err.row === 2 && /source/i.test(err.message)));
+    assert.ok(errors.some(err => err.row === 2 && /lastVerified/i.test(err.message)));
+  });
+
+  it('rejects rows with invalid category enums', () => {
+    const csv = [
+      'Part Number,Manufacturer,Catalog No.,Category,Description',
+      'X-2,ACME,X-2,not-a-category,Some row'
+    ].join('\r\n');
+    const { errors } = parseCatalogCsv(csv);
+    assert.ok(errors.some(err => err.row === 2 && /Category/i.test(err.column)));
+  });
+
+  it('importCatalogRows splits incoming products into accepted vs duplicate by manufacturer/catalogNumber', () => {
+    const existing = [
+      normalizeCatalogProduct({
+        id: 'OLD',
+        manufacturer: 'ACME',
+        catalogNumber: 'TRAY-12',
+        category: 'tray',
+        description: 'Old',
+        approved: true,
+        source: 'Approved list',
+        lastVerified: '2026-05-22'
+      })
+    ];
+    const incoming = [
+      normalizeCatalogProduct({
+        id: 'NEW',
+        manufacturer: 'ACME',
+        catalogNumber: 'TRAY-24',
+        category: 'tray',
+        description: 'New approved tray',
+        approved: true,
+        source: 'Approved list',
+        lastVerified: '2026-05-22'
+      }),
+      normalizeCatalogProduct({
+        id: 'DUP',
+        manufacturer: 'ACME',
+        catalogNumber: 'TRAY-12',
+        category: 'tray',
+        description: 'Same identity, will overwrite OLD',
+        approved: true,
+        source: 'Approved list rev B',
+        lastVerified: '2026-05-22'
+      })
+    ];
+    const { accepted, duplicates } = importCatalogRows(incoming, existing);
+    assert.deepEqual(accepted.map(p => p.id), ['NEW']);
+    assert.equal(duplicates.length, 1);
+    assert.equal(duplicates[0].existing.id, 'OLD');
+  });
+
+  it('skips fully blank CSV rows', () => {
+    const csv = [
+      'Part Number,Manufacturer,Catalog No.,Category,Description',
+      ',,,,',
+      'X-3,ACME,X-3,tray,Real row'
+    ].join('\r\n');
+    const { products, errors } = parseCatalogCsv(csv);
+    assert.equal(errors.length, 0);
+    assert.equal(products.length, 1);
+    assert.equal(products[0].id, 'X-3');
   });
 });


### PR DESCRIPTION
Adds the remaining manufacturer-catalog deliverables on top of the existing
analysis/manufacturerCatalog.mjs governance layer:

- analysis/catalogImport.mjs: CSV/XLSX template builders, parsers, and
  importCatalogRows() that splits an incoming batch into accepted vs
  duplicate (by manufacturer/catalog-number identity). Reuses
  normalizeCatalogProduct and validateCatalogProduct for governance.
- src/catalogBrowser.js: Bulk Import section with Download CSV/XLSX
  template buttons, file picker, validation preview, and Save to Project
  Catalog (persists via the existing trayHardware custom-products
  dataStore slot).
- data/heatTraceProducts.json: every entry now carries an approval block,
  source, and lastVerified. Adds approved seed entries from nVent
  RAYCHEM and Thermon so the approved-only filter has signal at the
  common ratings.
- analysis/heatTraceSizing.mjs: new filterHeatTraceProducts /
  isHeatTraceProductApproved helpers that mirror the catalog approvedOnly
  semantics.
- heattracesizing.html + heattracesizing.js: "Approved only" checkbox
  (default on) next to the existing product filters. The toggle flows
  through the catalog table AND the line list / BOM / controller / CSV
  exports so unapproved cables can't silently propagate into
  deliverables. Catalog table gains Manufacturer and Approval columns.
- Tests cover the import template round-trip, row-numbered validation
  errors, duplicate detection, the new heat-trace approval metadata, and
  the filter helper edge cases.

TCC and routing approved-only filters are documented as follow-ups in
the plan file but out of scope per the user's prioritization.