### PR TITLE
Harden short-circuit/TCC parsing and cable-typical import limits

### DIFF
--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -146,10 +146,14 @@ function parseNumeric(value) {
 function toKV(value) {
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();
-    const kvMatch = normalized.match(/([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)\s*k\s*v\b/);
-    if (kvMatch) {
-      const num = Number.parseFloat(kvMatch[1]);
-      return Number.isFinite(num) ? num : null;
+    // Cheap pre-check avoids running the backtracking-prone regex on long
+    // non-kV strings (e.g. a 5000-digit label), which is a DoS vector.
+    if (normalized.includes('kv')) {
+      const kvMatch = normalized.match(/([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)\s*k\s*v\b/);
+      if (kvMatch) {
+        const num = Number.parseFloat(kvMatch[1]);
+        return Number.isFinite(num) ? num : null;
+      }
     }
   }
   const num = parseNumeric(value);

--- a/analysis/tcc.js
+++ b/analysis/tcc.js
@@ -10060,21 +10060,35 @@ function renderOneLinePreview(componentId) {
     HARD_MAX_PREVIEW_COMPONENTS,
     Math.max(20, neighborCount, sameSheetSelections.length + 5)
   );
-  const addUnique = (list, id) => {
+  // Bound how much of the neighbor set we traverse so a pathological
+  // high-degree node cannot freeze the preview render. Anything beyond the
+  // bound could never be displayed (maxComponents is the hard ceiling).
+  const MAX_PREVIEW_NEIGHBORS = Math.max(maxComponents * 3, sameSheetSelections.length + 5);
+  const boundedNeighbors = [];
+  for (const id of neighborSet) {
+    if (!componentMap.has(id)) continue;
+    boundedNeighbors.push(id);
+    if (boundedNeighbors.length >= MAX_PREVIEW_NEIGHBORS) break;
+  }
+
+  const addUnique = (list, seen, id) => {
     if (!id) return;
     if (!componentMap.has(id)) return;
-    if (list.includes(id)) return;
+    if (seen.has(id)) return;
+    seen.add(id);
     list.push(id);
   };
 
   const orderedTargets = [];
-  addUnique(orderedTargets, componentId);
-  neighborSet.forEach(id => addUnique(orderedTargets, id));
+  const orderedTargetSet = new Set();
+  addUnique(orderedTargets, orderedTargetSet, componentId);
+  boundedNeighbors.forEach(id => addUnique(orderedTargets, orderedTargetSet, id));
 
   const prioritizedTargets = [];
-  addUnique(prioritizedTargets, componentId);
-  neighborSet.forEach(id => addUnique(prioritizedTargets, id));
-  sameSheetSelections.forEach(id => addUnique(prioritizedTargets, id));
+  const prioritizedTargetSet = new Set();
+  addUnique(prioritizedTargets, prioritizedTargetSet, componentId);
+  boundedNeighbors.forEach(id => addUnique(prioritizedTargets, prioritizedTargetSet, id));
+  sameSheetSelections.forEach(id => addUnique(prioritizedTargets, prioritizedTargetSet, id));
 
   const availableTargets = prioritizedTargets.length ? prioritizedTargets : orderedTargets;
   if (!availableTargets.length) {
@@ -10847,10 +10861,12 @@ function inferVoltage(comp) {
   const keys = ['voltage', 'volts', 'volts_secondary', 'volts_lv', 'volts_primary', 'volts_hv', 'prefault_voltage', 'baseKV', 'kV'];
   for (const key of keys) {
     const raw = getComponentValue(comp, key);
-    const num = parseNumeric(raw);
-    if (!Number.isFinite(num) || num <= 0) continue;
-    if (key.toLowerCase().includes('kv')) return num * 1000;
-    return num;
+    // parseVoltageFieldValue scales kV-keyed fields to volts once, but skips
+    // the scaling when the raw value already carries a kV/V unit suffix —
+    // avoiding the 1000× double-conversion on inputs like "13.8 kV".
+    const volts = parseVoltageFieldValue(raw, key);
+    if (!Number.isFinite(volts) || volts <= 0) continue;
+    return volts;
   }
   return null;
 }

--- a/cableschedule.js
+++ b/cableschedule.js
@@ -561,6 +561,20 @@ async function initCableSchedule() {
   };
 
   const cloneTemplates = templates => (Array.isArray(templates) ? templates.map(t => JSON.parse(JSON.stringify(t))) : []);
+  // Bounds for cable-typical imports to keep a hostile/oversized file from
+  // exhausting memory or freezing the UI during parsing/merge.
+  const MAX_TEMPLATE_IMPORT_FILE_BYTES = 5 * 1024 * 1024;
+  const MAX_TEMPLATE_IMPORT_COUNT = 5000;
+  const MAX_TEMPLATE_IMPORT_FIELD_LENGTH = 2048;
+  const truncateImportedTemplateValues = (input = {}) => {
+    const out = {};
+    Object.entries(input || {}).forEach(([key, value]) => {
+      out[key] = typeof value === 'string'
+        ? value.slice(0, MAX_TEMPLATE_IMPORT_FIELD_LENGTH)
+        : value;
+    });
+    return out;
+  };
   const sanitizeTemplateFieldValue = value => {
     if (value == null) return '';
     if (Array.isArray(value)) {
@@ -1532,6 +1546,11 @@ async function initCableSchedule() {
           resetInput();
           return;
         }
+        if (typeof file.size === 'number' && file.size > MAX_TEMPLATE_IMPORT_FILE_BYTES) {
+          showAlertModal('Import Error', 'The selected file is too large to import. Please choose a file smaller than 5 MB.');
+          resetInput();
+          return;
+        }
         const name = (file.name || '').toLowerCase();
         const type = (file.type || '').toLowerCase();
         const isExcel = name.endsWith('.xlsx') || type.includes('spreadsheet');
@@ -1565,6 +1584,11 @@ async function initCableSchedule() {
             .filter(Boolean);
         } else {
           const text = await file.text();
+          if (text.length > MAX_TEMPLATE_IMPORT_FILE_BYTES) {
+            showAlertModal('Import Error', 'The selected file is too large to import. Please choose a file smaller than 5 MB.');
+            resetInput();
+            return;
+          }
           let parsed;
           try {
             parsed = JSON.parse(text);
@@ -1583,6 +1607,11 @@ async function initCableSchedule() {
           resetInput();
           return;
         }
+        if (candidates.length > MAX_TEMPLATE_IMPORT_COUNT) {
+          showAlertModal('Import Error', `The selected file contains too many cable typicals to import (limit ${MAX_TEMPLATE_IMPORT_COUNT}).`);
+          resetInput();
+          return;
+        }
         const existingIds = new Set(
           (this.templates || [])
             .map(tpl => tpl && tpl.template_id)
@@ -1590,6 +1619,7 @@ async function initCableSchedule() {
         );
         const imported = candidates
           .map(tpl => filterTemplateFields(tpl, { keepLabel: true, keepTypicalId: true }))
+          .map(tpl => truncateImportedTemplateValues(tpl))
           .map(tpl => {
             const copy = { ...tpl };
             copy.template_id = copy.template_id || generateTemplateId();

--- a/server.mjs
+++ b/server.mjs
@@ -2486,6 +2486,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.a
     const { WebSocketServer } = await import('ws');
     attachCollaborationServer(server, new WebSocketServer({ noServer: true }), {
       validateUpgrade: app.get('collabUpgradeValidator'),
+      maxMessageBytes: 64 * 1024,
     });
   } catch {
     // ws not installed — collaboration disabled; app still works fine

--- a/src/collaborationServer.mjs
+++ b/src/collaborationServer.mjs
@@ -24,6 +24,9 @@
  */
 export function attachCollaborationServer(httpServer, wss, options = {}) {
   const validateUpgrade = typeof options.validateUpgrade === 'function' ? options.validateUpgrade : null;
+  // Cap incoming frame size so an authenticated client cannot exhaust memory
+  // (or amplify a broadcast) with an oversized patch payload.
+  const maxMessageBytes = Number(options.maxMessageBytes) > 0 ? Number(options.maxMessageBytes) : 64 * 1024;
   // projectId → Set of { ws, username }
   const rooms = new Map();
   // projectId → monotonically increasing sequence counter
@@ -92,6 +95,11 @@ export function attachCollaborationServer(httpServer, wss, options = {}) {
     }
 
     ws.on('message', (data) => {
+      const size = typeof data === 'string' ? Buffer.byteLength(data) : (data?.length ?? 0);
+      if (size > maxMessageBytes) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Message too large' }));
+        return;
+      }
       let msg;
       try {
         msg = JSON.parse(data.toString());

--- a/tests/collaborationServer.test.mjs
+++ b/tests/collaborationServer.test.mjs
@@ -298,6 +298,39 @@ describe('attachCollaborationServer — close event', () => {
   });
 });
 
+describe('attachCollaborationServer — message size cap', () => {
+  it('rejects frames larger than maxMessageBytes without broadcasting', () => {
+    const httpServer = new MockHttpServer();
+    const wss = new MockWss();
+    attachCollaborationServer(httpServer, wss, { maxMessageBytes: 50 });
+
+    const alice = connectClient(httpServer, wss);
+    alice._receive({ type: 'join', projectId: 'proj1', username: 'alice' });
+    const bob = connectClient(httpServer, wss);
+    bob._receive({ type: 'join', projectId: 'proj1', username: 'bob' });
+
+    const bobPrevCount = bob.sent.length;
+    // Oversized patch: comfortably exceeds the 50-byte cap.
+    alice._emit('message', Buffer.from(JSON.stringify({
+      type: 'patch', projectId: 'proj1', username: 'alice', patch: { blob: 'x'.repeat(200) }
+    })));
+
+    const errors = alice.sentOfType('error');
+    assert.strictEqual(errors[errors.length - 1].message, 'Message too large');
+    const bobPatches = bob.sent.slice(bobPrevCount).filter(m => m.type === 'patch');
+    assert.strictEqual(bobPatches.length, 0, 'oversized patch should not be broadcast');
+  });
+
+  it('allows frames within maxMessageBytes', () => {
+    const httpServer = new MockHttpServer();
+    const wss = new MockWss();
+    attachCollaborationServer(httpServer, wss, { maxMessageBytes: 64 * 1024 });
+    const ws = connectClient(httpServer, wss);
+    ws._receive({ type: 'ping' });
+    assert.deepStrictEqual(ws.lastSent(), { type: 'pong' });
+  });
+});
+
 describe('attachCollaborationServer — invalid JSON', () => {
   it('sends error for malformed JSON', () => {
     const { httpServer, wss } = setupServer();


### PR DESCRIPTION
Triage of the open codex/aardvark security PR backlog. Applies the three
fixes that are still reachable on main (the battery, capacitor, differential,
icon-SVG, and scientific-notation voltage fixes were already merged):

- shortCircuit.toKV: gate the backtracking-prone kV regex behind a cheap
  `includes('kv')` pre-check so long non-kV labels can't trigger a ReDoS
  slowdown (PR #1762).
- tcc.inferVoltage: route kV-keyed fields through the existing
  parseVoltageFieldValue helper, fixing the 1000x double-conversion on
  unit-suffixed inputs like "13.8 kV" (PR #1795).
- tcc.renderOneLinePreview: bound neighbor-set traversal and switch dedup to
  a Set, so a pathological high-degree node can't freeze the preview render
  with O(n^2) work (PR #1669).
- cableschedule import: enforce file-size, candidate-count, and per-field
  length limits on cable-typical imports to prevent oversized-file DoS
  (PRs #1678/#1679).