### PR TITLE
Expose listAppSettingKeys helper from projectStorage

### DIFF
--- a/docs/page-contract-audit.md
+++ b/docs/page-contract-audit.md
@@ -992,7 +992,7 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 - `settings.trayHardwareCatalogCustomProducts`
   - src/catalogBrowser.js:41 getTrayHardwareCatalogCustomProducts()
 - `traySchedule`
-  - src/trayhardwarebom.js:36 getTrays()
+  - src/trayhardwarebom.js:37 getTrays()
 
 **Detected Writes**
 - `settings.trayHardwareCatalogCustomProducts`
@@ -1263,9 +1263,9 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - src/seismicwindcombined.js:279 getCables()
+  - src/seismicwindcombined.js:281 getCables()
 - `traySchedule`
-  - src/seismicwindcombined.js:278 getTrays()
+  - src/seismicwindcombined.js:280 getTrays()
 
 **Detected Writes**
 - None
@@ -1423,7 +1423,7 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - procurementschedule.js:149 getCables()
+  - procurementschedule.js:147 getCables()
 
 **Detected Writes**
 - None

--- a/procurementschedule.js
+++ b/procurementschedule.js
@@ -1,5 +1,6 @@
 import { calculateProcurement, exportProcurementCSV, STANDARD_REEL_SIZES } from './analysis/cableProcurement.mjs';
 import { getCables } from './dataStore.mjs';
+import { listAppSettingKeys, readAppSetting } from './projectStorage.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   initSettings();
@@ -38,20 +39,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function loadRouteResults() {
-    // Check sessionStorage first, then localStorage — same pattern as pullcards.js
-    // TODO(Phase 4): expose a listAppSettingKeys(prefix) helper from projectStorage.js
-    // eslint-disable-next-line no-restricted-globals
-    for (const storage of [sessionStorage, localStorage]) {
-      for (const key of Object.keys(storage)) {
-        if (key.endsWith('routeCache') || key.includes('routeCache')) {
-          try {
-            const cached = JSON.parse(storage.getItem(key));
-            if (cached && Array.isArray(cached.batchResults) && cached.batchResults.length > 0) {
-              return cached.batchResults;
-            }
-          } catch { /* skip malformed entries */ }
+    // Route caches are written per-scenario (e.g. "base:routeCache") and may
+    // live in either session or local storage; listAppSettingKeys enumerates
+    // both (session first), so we no longer reach into storage globals directly.
+    for (const key of listAppSettingKeys()) {
+      if (!key.includes('routeCache')) continue;
+      try {
+        const cached = JSON.parse(readAppSetting(key));
+        if (cached && Array.isArray(cached.batchResults) && cached.batchResults.length > 0) {
+          return cached.batchResults;
         }
-      }
+      } catch { /* skip malformed entries */ }
     }
     return null;
   }

--- a/projectStorage.js
+++ b/projectStorage.js
@@ -1013,16 +1013,61 @@ export function getAuthRole() {
 }
 
 export function readAppSetting(key) {
-  return readRawStorage(key);
+  const value = readRawStorage(key);
+  if (value !== null && value !== undefined) return value;
+  // Some cross-page payloads (e.g. per-scenario routeCache entries) are written
+  // to sessionStorage by the routing flow. Fall back to it so callers do not
+  // have to reach into storage globals directly.
+  const session = getSessionStorage();
+  if (session) {
+    const sessionValue = safeGet(session, key);
+    if (sessionValue !== null && sessionValue !== undefined) return sessionValue;
+  }
+  return value;
 }
 
 export function writeAppSetting(key, value) {
   writeRawStorage(key, value);
 }
 
+// Enumerate the full keys (optionally limited to those starting with `prefix`)
+// that are visible to readAppSetting — across session, local, and in-memory
+// storage. Session keys are listed first so callers that prefer the live tab's
+// values encounter them ahead of persisted localStorage entries. Duplicate keys
+// present in more than one storage are returned once.
+export function listAppSettingKeys(prefix = '') {
+  const wanted = typeof prefix === 'string' ? prefix : String(prefix ?? '');
+  const keys = new Set();
+  const collect = storage => {
+    if (!storage) return;
+    try {
+      for (let i = 0; i < storage.length; i++) {
+        const key = storage.key(i);
+        if (key && key.startsWith(wanted)) keys.add(key);
+      }
+    } catch (e) {
+      console.warn('app setting enumerate failed', e);
+    }
+  };
+  collect(getSessionStorage());
+  collect(getStorage());
+  for (const key of memoryStorage.keys()) {
+    if (key.startsWith(wanted)) keys.add(key);
+  }
+  return [...keys];
+}
+
 function getStorage() {
   try {
     return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function getSessionStorage() {
+  try {
+    return typeof sessionStorage !== 'undefined' ? sessionStorage : null;
   } catch {
     return null;
   }
@@ -1612,6 +1657,9 @@ const api = {
   updateSessionPreferences,
   getThemePreference,
   setThemePreference,
+  readAppSetting,
+  writeAppSetting,
+  listAppSettingKeys,
   getConduitCache,
   setConduitCache,
   clearConduitCache,

--- a/tests/appSettingKeys.test.mjs
+++ b/tests/appSettingKeys.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+
+// Storage mock implementing the parts of the Web Storage API that
+// projectStorage enumerates (length / key) plus the usual accessors.
+function makeStorage() {
+  const map = new Map();
+  return {
+    get length() { return map.size; },
+    key(i) { return [...map.keys()][i] ?? null; },
+    getItem(k) { return map.has(k) ? map.get(k) : null; },
+    setItem(k, v) { map.set(k, String(v)); },
+    removeItem(k) { map.delete(k); },
+    clear() { map.clear(); },
+  };
+}
+
+globalThis.localStorage = makeStorage();
+globalThis.sessionStorage = makeStorage();
+globalThis.document = { baseURI: 'http://localhost/index.html' };
+globalThis.location = { href: 'http://localhost/index.html' };
+globalThis.window = {};
+
+const { listAppSettingKeys, readAppSetting, writeAppSetting } = await import('../projectStorage.js');
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log('  ✓', name);
+  } catch (err) {
+    console.error('  ✗', name);
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+console.log('listAppSettingKeys / readAppSetting fallback');
+
+globalThis.localStorage.setItem('base:routeCache', JSON.stringify({ batchResults: [{ cable: 'C1' }] }));
+sessionStorage.setItem('future:routeCache', JSON.stringify({ batchResults: [{ cable: 'C2' }] }));
+
+check('lists keys from both session and local storage', () => {
+  const keys = listAppSettingKeys();
+  assert.ok(keys.includes('base:routeCache'), 'localStorage key present');
+  assert.ok(keys.includes('future:routeCache'), 'sessionStorage key present');
+});
+
+check('filters keys by prefix', () => {
+  const keys = listAppSettingKeys('future:');
+  assert.ok(keys.includes('future:routeCache'));
+  assert.ok(!keys.includes('base:routeCache'));
+});
+
+check('lists session keys before local keys', () => {
+  const keys = listAppSettingKeys().filter(k => k.endsWith(':routeCache'));
+  assert.deepEqual(keys, ['future:routeCache', 'base:routeCache']);
+});
+
+check('dedupes keys present in more than one storage', () => {
+  globalThis.localStorage.setItem('dup:key', 'a');
+  sessionStorage.setItem('dup:key', 'b');
+  const keys = listAppSettingKeys('dup:');
+  assert.equal(keys.filter(k => k === 'dup:key').length, 1);
+});
+
+check('readAppSetting falls back to sessionStorage', () => {
+  const cached = JSON.parse(readAppSetting('future:routeCache'));
+  assert.equal(cached.batchResults[0].cable, 'C2');
+});
+
+check('readAppSetting prefers localStorage over sessionStorage', () => {
+  writeAppSetting('pref:key', 'local-value');
+  sessionStorage.setItem('pref:key', 'session-value');
+  assert.equal(readAppSetting('pref:key'), 'local-value');
+});
+
+check('readAppSetting returns null for missing keys', () => {
+  assert.equal(readAppSetting('does-not-exist'), null);
+});
+
+console.log('✓ listAppSettingKeys helper exposed from projectStorage');


### PR DESCRIPTION
Implements the Phase 4 TODO in procurementschedule.js: route-cache
discovery previously reached into sessionStorage/localStorage globals
directly (with a no-restricted-globals eslint-disable). Add a
listAppSettingKeys(prefix) helper to projectStorage.js that enumerates
session, local, and in-memory storage (session first, deduped), and
extend readAppSetting to fall back to sessionStorage so cross-page
payloads like per-scenario routeCache entries are readable through the
storage helpers.

loadRouteResults() now uses these helpers, removing its direct global
access. Adds unit coverage for the new helper and regenerates the page
contract audit for the shifted line numbers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PoyUmg284cf4JZSVkPjtJo