### PR TITLE
Move CAD import/export out of Optimal Route page header

### DIFF
--- a/optimalRoute.html
+++ b/optimalRoute.html
@@ -182,9 +182,6 @@
             <header class="page-header">
                 <h1>Optimal Route Planner</h1>
                 <p>Validate routing inputs, calculate cable paths, and review why each route was selected.</p>
-                <button id="import-cad-btn" onclick="document.getElementById('import-cad-input').click()">Import CAD</button>
-                <input type="file" id="import-cad-input" accept=".json,.ifc" style="display:none;" onchange="dataStore.importFromCad(this.files[0])">
-                <button id="export-cad-btn" onclick="dataStore.exportToCad('json')">Export CAD</button>
             </header>
             <details class="method-panel">
                 <summary>Method &amp; Assumptions</summary>
@@ -240,6 +237,13 @@
           <span>Source Data</span>
           <small>Raceway network, cable list, imports, and manual overrides</small>
         </summary>
+        <div class="table-controls route-cad-controls">
+            <div class="table-import-export">
+                <button id="import-cad-btn" onclick="document.getElementById('import-cad-input').click()">Import CAD</button>
+                <input type="file" id="import-cad-input" accept=".json,.ifc" style="display:none;" onchange="dataStore.importFromCad(this.files[0])">
+                <button id="export-cad-btn" onclick="dataStore.exportToCad('json')">Export CAD</button>
+            </div>
+        </div>
         <div class="route-source-data-grid">
       <section class="route-data-card">
                 <div class="route-card-heading">


### PR DESCRIPTION
The page header carried two ungrouped CAD buttons next to the H1, breaking
the house pattern where .page-header is title + description only (see
Cable Tray Fill, Raceway Schedule). Relocate Import/Export CAD into the
Source Data panel alongside the other import/export controls so the header
reads as a calm anchor and the page hierarchy is consistent with siblings.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RWbhu8FwpAt7o6dyH78RHj