### PR TITLE
Improve Design Coach action queue

### DIFF
--- a/designcoach.html
+++ b/designcoach.html
@@ -36,7 +36,9 @@
     .coach-kpi-card--missing  { border-left-color: #616161; }
     .coach-kpi-label { display: block; font-size: 0.78rem; color: var(--color-muted, #666); margin-bottom: 0.25rem; }
     .coach-kpi-value { display: block; font-size: 1.6rem; font-weight: 700; line-height: 1; }
-    .coach-controls { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
+    .coach-controls { display: flex; flex-wrap: wrap; gap: 0.5rem 0.75rem; align-items: center; margin-bottom: 1rem; }
+    .coach-status-summary { margin: -0.35rem 0 1rem; color: var(--color-muted, #666); font-size: 0.9rem; }
+    .coach-filter-check { display: inline-flex; align-items: center; gap: 0.35rem; }
     .coach-rec {
       border: 1px solid var(--color-border, #ddd);
       border-radius: 6px;
@@ -187,8 +189,12 @@
             <option value="missing_data">Missing Data only</option>
           </select>
         </label>
+        <label class="coach-filter-check" for="coach-open-only">
+          <input id="coach-open-only" type="checkbox" checked> Open items only
+        </label>
         <button id="coach-clear-dismissed-btn" class="btn">Clear Dismissed</button>
       </div>
+      <p id="coach-status-summary" class="coach-status-summary" role="status">Run the coach to see open, accepted, and dismissed recommendation counts.</p>
 
       <!-- Results -->
       <section id="coach-results" aria-live="polite" aria-atomic="false"></section>
@@ -207,6 +213,8 @@
       <p><strong>Accept / Dismiss:</strong> Use Accept to document an engineering basis for
       allowing a known violation. Use Dismiss to hide a recommendation you are not addressing
       in this project. Accepted records include reviewer name, date, and engineering note.</p>
+      <p><strong>Open items only:</strong> Keep this filter enabled to focus the action queue on
+      recommendations that still need a decision, or turn it off to review accepted and dismissed history.</p>
       <button id="close-help-btn" class="btn">Close</button>
     </div>
   </div>

--- a/docs/page-contract-audit.md
+++ b/docs/page-contract-audit.md
@@ -1101,15 +1101,15 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - src/designCoach.js:155 getCables()
+  - src/designCoach.js:158 getCables()
 - `oneLineDiagram`
   - src/crossProbe.js:139 getOneLine()
   - src/crossProbe.js:152 getOneLine()
   - src/crossProbe.js:201 getOneLine()
 - `settings.coachAuditTrail`
-  - src/designCoach.js:34 getCoachAuditTrail()
+  - src/designCoach.js:36 getCoachAuditTrail()
 - `studyResults`
-  - src/designCoach.js:157 getStudies()
+  - src/designCoach.js:160 getStudies()
 - `studyResults.arcFlash`
   - analysis/designCoach.mjs:476 studies.arcFlash
   - analysis/equipmentEvaluation.mjs:236 studies?.arcFlash
@@ -1125,14 +1125,14 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
   - analysis/designCoach.mjs:477 studies.shortCircuit
   - analysis/equipmentEvaluation.mjs:235 studies?.shortCircuit
 - `traySchedule`
-  - src/designCoach.js:156 getTrays()
+  - src/designCoach.js:159 getTrays()
 
 **Detected Writes**
 - `settings.coachAuditTrail`
-  - src/designCoach.js:142 setCoachAuditTrail()
-  - src/designCoach.js:149 setCoachAuditTrail()
-  - src/designCoach.js:54 setCoachAuditTrail()
-  - src/designCoach.js:73 setCoachAuditTrail()
+  - src/designCoach.js:145 setCoachAuditTrail()
+  - src/designCoach.js:152 setCoachAuditTrail()
+  - src/designCoach.js:57 setCoachAuditTrail()
+  - src/designCoach.js:76 setCoachAuditTrail()
 
 ### Spool Sheets (`spoolsheets.html`)
 

--- a/docs/page-contracts.md
+++ b/docs/page-contracts.md
@@ -846,7 +846,7 @@ Coverage: 77 contracts for 77 navigation routes.
 - Workflow step: studies
 
 **Standalone Inputs**
-- Manual coaching run selections and recommendation review notes.
+- Manual coaching run selections, severity/status filters, open-item queue toggle, and recommendation review notes.
 
 **Project Inputs**
 - `equipment` (schedule, required): Equipment tags, ratings, locations, and physical metadata.

--- a/src/designCoach.js
+++ b/src/designCoach.js
@@ -28,6 +28,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const runBtn            = document.getElementById('coach-run-btn');
   const severityFilter    = document.getElementById('coach-severity-filter');
   const clearDismissedBtn = document.getElementById('coach-clear-dismissed-btn');
+  const openOnlyToggle    = document.getElementById('coach-open-only');
+  const statusSummary     = document.getElementById('coach-status-summary');
   const resultsSection    = document.getElementById('coach-results');
 
   let lastResult   = null;
@@ -35,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   runBtn.addEventListener('click', runAndRender);
   severityFilter.addEventListener('change', () => { if (lastResult) renderResults(lastResult); });
+  openOnlyToggle.addEventListener('change', () => { if (lastResult) renderResults(lastResult); });
   clearDismissedBtn.addEventListener('click', async () => {
     const dismissed = auditTrail.filter(e => e.action === 'dismiss');
     if (!dismissed.length) return;
@@ -172,9 +175,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const filterVal   = severityFilter.value;
     const auditMap    = new Map(auditTrail.map(e => [e.id, e]));
 
-    const filtered = filterVal === 'all'
-      ? recommendations
-      : recommendations.filter(r => r.severity === filterVal);
+    const counts = recommendations.reduce((acc, rec) => {
+      const action = auditMap.get(rec.id)?.action;
+      if (action === 'accept') acc.accepted += 1;
+      else if (action === 'dismiss') acc.dismissed += 1;
+      else acc.open += 1;
+      return acc;
+    }, { open: 0, accepted: 0, dismissed: 0 });
+
+    const filtered = recommendations.filter(rec => {
+      if (filterVal !== 'all' && rec.severity !== filterVal) return false;
+      if (openOnlyToggle.checked && auditMap.has(rec.id)) return false;
+      return true;
+    });
+
+    statusSummary.textContent = `${counts.open} open, ${counts.accepted} accepted, ${counts.dismissed} dismissed recommendation${recommendations.length === 1 ? '' : 's'}. Showing ${filtered.length}.`;
+    clearDismissedBtn.disabled = counts.dismissed === 0;
 
     resultsSection.innerHTML = '';
 
@@ -182,7 +198,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const div = document.createElement('div');
       div.className = 'coach-empty';
       div.textContent = recommendations.length
-        ? 'No recommendations match the current filter.'
+        ? 'No recommendations match the current filter. Turn off Open items only to review accepted or dismissed recommendations.'
         : 'No recommendations found. Run studies and refresh to check your project.';
       resultsSection.appendChild(div);
       return;

--- a/src/pageContracts.js
+++ b/src/pageContracts.js
@@ -384,7 +384,7 @@ export const PAGE_CONTRACTS_BY_HREF = {
   }),
   'designcoach.html': contract({
     workflowStep: 'studies',
-    standaloneInputs: ['Manual coaching run selections and recommendation review notes.'],
+    standaloneInputs: ['Manual coaching run selections, severity/status filters, open-item queue toggle, and recommendation review notes.'],
     projectInputs: [equipment, oneLine, cables, trays, conduits, ductbanks, studies, designBasis],
     outputs: [
       output('settings.coachAuditTrail', 'setting', 'Design coach recommendation audit records.', ['projectreport.html']),


### PR DESCRIPTION
### Motivation
- Make the Design Coach easier to act on by surfacing an action-focused queue that hides already-accepted or dismissed recommendations by default. 
- Provide immediate status visibility so engineers can prioritize open safety/compliance/efficiency items without sifting through history.

### Description
- Add an "Open items only" checkbox and a live status summary to `designcoach.html` and wire the UI to `src/designCoach.js` so accepted/dismissed items are hidden when enabled. 
- Compute and display open/accepted/dismissed counts and disable the `Clear Dismissed` control when there are no dismissed items. 
- Update help copy and the page-contract source/docs (`src/pageContracts.js`, `docs/page-contracts.md`, `docs/page-contract-audit.md`) to document the new filter and status outputs. 

### Testing
- Ran targeted unit suites: `node tests/designCoach.test.mjs`, `node tests/htmlAssetReferences.test.mjs`, `node tests/pageContracts.test.mjs`, and `node tests/pageContractAudit.test.mjs`, all of which passed. 
- Performed a full build with `npm run build` which completed (Rollup warnings for unresolved externals remained unchanged and are expected). 
- Ran the full test collection with `npm test` which completed after regenerating page-contract docs; an attempt to capture a browser screenshot via Playwright failed because `npx playwright install chromium` was blocked with HTTP 403, so a preview SVG was generated instead at `/tmp/designcoach-preview.svg`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae98b9f20832496fd6018c2608ead)