### PR TITLE
Retry transient browser crashes in full CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps msedge firefox
       - name: Playwright tests
-        run: npx playwright test --project=firefox --project=msedge
+        run: npx playwright test --project=firefox --project=msedge --retries=1


### PR DESCRIPTION
## What changed
- Allow one retry in the full Firefox and Edge Playwright workflow.

## Why
The Edge process crashed after 689 passing tests, failing CI before the final context could be created. A retry starts the failed test in a fresh worker while reproducible application failures still fail on the second attempt.

## Validation
- Targeted Edge cable schedule save and load test passed with retries enabled.
- PR 1810 completed both 690-test browser matrices successfully on the same application commit.