### PR TITLE
Fix relay classification in component coverage audit and guard doc drift

### DIFF
--- a/AUDIT_WEBSITE_GAPS.md
+++ b/AUDIT_WEBSITE_GAPS.md
@@ -101,7 +101,7 @@ comment documenting why suppression is intentional (closed 2026-05-26):
 
 ## 5. Component Library Gaps
 
-Per `docs/component-gap-analysis.md` (2026-05-22 snapshot), `componentLibrary.json` covers 31 component types.
+Per `docs/component-gap-analysis.md` (2026-07-25 regeneration), `componentLibrary.json` covers 30 discovered component types.
 
 ### Missing component type
 
@@ -136,8 +136,42 @@ Resolution:
    - `static_load`: `demand_factor: 1.0` (conservative default).
 
 After these changes the regenerated `docs/component-gap-analysis.md`
-shows zero missing attributes across all 29 discovered component
-types.
+shows zero missing attributes across all discovered component types.
+
+### Relay subtype split (reopened and closed 2026-07-25)
+
+The 2026-05-26 result went stale. Commit `4966c00` gave the generic
+relay the subtype `overcurrent_relay`, which stopped it from collapsing
+onto the same `relay` row as `relay_87`. Because the two subtypes had
+been sharing a row, their props were merged — and that merge was the
+only reason the row looked complete. Once split, `relay_87` reported
+missing `time_dial` and `interrupting_rating_ka`.
+
+Both were false positives, not real holes: a differential (87) element
+is a percentage-slope sensing device, so it has no time dial, and the
+breaker it trips carries the interrupting duty rather than the relay.
+
+Resolution:
+
+1. `scripts/componentCoverageAudit.mjs` gained a `differential`
+   baseline class (`pickup_amps`, `slope1_pct`, `protected_zone_type`)
+   and classifies `relay_87` into it ahead of the generic `protective`
+   test, which would otherwise claim it via the `relay` substring.
+2. `relay_87` is deliberately no longer aliased onto `relay`. The two
+   subtypes are distinct protective functions with distinct schemas;
+   keeping them on separate rows stops one subtype's props from masking
+   a gap in the other.
+3. The report is now split into `buildReportBody()` (date-free) and
+   `buildReport()`, so freshness can be asserted without the
+   `Generated on` line causing a spurious mismatch.
+4. `tests/componentCoverageAudit.test.mjs` guards all of it: the
+   committed report must match a fresh regeneration, no type may report
+   missing attributes, and the two relay subtypes must keep their
+   function-appropriate baselines. This is the drift guard that was
+   missing — the 2026-05-26 result had no test holding it in place.
+
+The current report shows 30 component types with zero missing
+attributes and no absent baseline types.
 
 ---
 

--- a/analysis/iec60909.mjs
+++ b/analysis/iec60909.mjs
@@ -11,15 +11,23 @@
  *   I"k1  — initial symmetrical line-to-ground short-circuit current (kA)
  *   I"k2E — initial symmetrical double-line-to-ground short-circuit current (kA)
  *   ip    — peak short-circuit current (kA)  [IEC §4.3.1]
- *   Ib    — symmetrical short-circuit breaking current (kA)  [IEC §4.5, far-from-generator]
+ *   Ib    — symmetrical short-circuit breaking current (kA)  [IEC §8]
  *   Ith   — thermal equivalent short-circuit current (kA)  [IEC §4.8]
  *   kappa — peak factor κ
+ *   mu    — breaking-current decay factor μ  [IEC §8.1.5.2]
  *   cFactor — voltage factor c used in this calculation
  *
+ * Impedance corrections:
+ *   - K_T for transformers (§6.3.3) and K_G for synchronous generators
+ *     (§6.6.1) are applied per element by shortCircuit.mjs before the
+ *     impedance cascade, since each factor corrects only its own element's
+ *     impedance rather than the summed impedance at the bus.
+ *
  * Assumptions / simplifications:
- *   - Far-from-generator short circuit (μ = 1.0, so Ib = I"k3)
- *   - No impedance correction factor K_G for synchronous generators
- *   - Transformer K_T correction applied when xT data is available
+ *   - Near-to-generator decay is applied to the synchronous-machine share of
+ *     I"k only; the remaining infeed is carried through undecayed. Callers that
+ *     cannot apportion the generator contribution get μ = 1 (far-from-
+ *     generator), which is the conservative result for breaker breaking duty.
  *   - Ith uses the simplified m+n method (IEC 60909-0:2016 §4.8.1)
  */
 
@@ -158,6 +166,154 @@ export function transformerCorrectionKT(xTPu, cMax = 1.10) {
 }
 
 // ---------------------------------------------------------------------------
+// IEC 60909-0:2016 — Generator impedance correction factor K_G (§6.6.1, Eq. 18)
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculates the IEC 60909-0:2016 synchronous generator impedance correction
+ * factor K_G for a generator connected directly to the faulted network (no
+ * unit transformer).
+ *
+ *   K_G = (U_n / U_rG) × c_max / (1 + x"_d × sin φ_rG)
+ *
+ * The corrected generator impedance is Z_GK = K_G × Z_G, applied to the
+ * positive-, negative- and zero-sequence generator impedance alike.
+ *
+ * @param {object} params
+ * @param {number} params.unKV    - Nominal system voltage U_n at the generator terminals (kV)
+ * @param {number} params.urgKV   - Generator rated voltage U_rG (kV)
+ * @param {number} params.xdppPu  - Subtransient reactance x"_d, per unit on the generator rating
+ * @param {number} params.ratedPF - Generator rated power factor cos φ_rG (0 < pf ≤ 1)
+ * @param {number} params.cMax    - c_max voltage factor for the generator voltage level
+ * @returns {number|null} K_G, or null when the required generator data is absent
+ */
+export function generatorCorrectionKG({ unKV, urgKV, xdppPu, ratedPF, cMax = 1.10 } = {}) {
+  const un = Number(unKV);
+  const urg = Number(urgKV);
+  const xdpp = Number(xdppPu);
+  const pf = Number(ratedPF);
+  if (!Number.isFinite(un) || un <= 0) return null;
+  if (!Number.isFinite(urg) || urg <= 0) return null;
+  if (!Number.isFinite(xdpp) || xdpp <= 0) return null;
+  // cos φ_rG must be a genuine power factor for sin φ_rG to be meaningful.
+  if (!Number.isFinite(pf) || pf <= 0 || pf > 1) return null;
+  const sinPhi = Math.sqrt(Math.max(1 - pf * pf, 0));
+  return (un / urg) * (cMax / (1 + xdpp * sinPhi));
+}
+
+// ---------------------------------------------------------------------------
+// IEC 60909-0:2016 — Breaking current decay factor μ (§8.1.5.2)
+// ---------------------------------------------------------------------------
+
+// μ curves are tabulated against the minimum time delay t_min. Each entry is
+// [t_min (s), a, b, k] for μ = a + b × e^(−k × q), where q = I"kG / I_rG.
+const MU_CURVES = [
+  [0.02, 0.84, 0.26, 0.26],
+  [0.05, 0.71, 0.51, 0.30],
+  [0.10, 0.62, 0.72, 0.32],
+  [0.25, 0.56, 0.94, 0.38]
+];
+
+function muFromCurve([, a, b, k], q) {
+  return a + b * Math.exp(-k * q);
+}
+
+/**
+ * Calculates the IEC 60909-0:2016 decay factor μ for the symmetrical
+ * short-circuit breaking current of a near-to-generator fault.
+ *
+ * μ accounts for the decay of the AC component between fault inception and
+ * contact separation. It is tabulated for minimum time delays of 0.02, 0.05,
+ * 0.10 and ≥0.25 s; IEC permits linear interpolation between those curves.
+ *
+ * μ = 1 when I"kG / I_rG ≤ 2 — the fault is then treated as far-from-generator
+ * and the AC component is taken as non-decaying (§8.1.5.2).
+ *
+ * @param {number} q      - Ratio I"kG / I_rG (generator contribution over rated current)
+ * @param {number} tMinS  - Minimum time delay t_min in seconds (default 0.05 s)
+ * @returns {number} μ in the range (0, 1]
+ */
+export function muFactor(q, tMinS = 0.05) {
+  const ratio = Number(q);
+  if (!Number.isFinite(ratio) || ratio <= 2) return 1;
+
+  const t = Number.isFinite(Number(tMinS)) ? Number(tMinS) : 0.05;
+
+  let mu;
+  if (t <= MU_CURVES[0][0]) {
+    mu = muFromCurve(MU_CURVES[0], ratio);
+  } else if (t >= MU_CURVES[MU_CURVES.length - 1][0]) {
+    mu = muFromCurve(MU_CURVES[MU_CURVES.length - 1], ratio);
+  } else {
+    // Linear interpolation between the two bracketing tabulated curves.
+    let upper = 1;
+    while (upper < MU_CURVES.length && MU_CURVES[upper][0] < t) upper += 1;
+    const lowCurve = MU_CURVES[upper - 1];
+    const highCurve = MU_CURVES[upper];
+    const span = highCurve[0] - lowCurve[0];
+    const weight = span > 0 ? (t - lowCurve[0]) / span : 0;
+    const low = muFromCurve(lowCurve, ratio);
+    const high = muFromCurve(highCurve, ratio);
+    mu = low + weight * (high - low);
+  }
+
+  // μ is a decay factor: it can never amplify the initial symmetrical current.
+  return Math.min(Math.max(mu, 0), 1);
+}
+
+/**
+ * Resolves the symmetrical short-circuit breaking current I_b (IEC 60909-0 §8).
+ *
+ * Only the synchronous-machine contribution decays, so μ is applied to that
+ * portion alone and the remainder (network / utility infeed) is carried through
+ * undecayed:
+ *
+ *   I_b = μ × I"kG + (I"k − I"kG)
+ *
+ * When no generator contribution is supplied the fault is treated as
+ * far-from-generator and I_b = I"k, which is the conservative result for
+ * breaker breaking duty.
+ *
+ * @param {object} params
+ * @param {number} params.ikTotalKA               - Initial symmetrical current I"k at the bus (kA)
+ * @param {number|null} params.generatorContributionKA - Synchronous-machine share of I"k (kA)
+ * @param {number|null} params.generatorRatedCurrentKA - Summed generator rated current I_rG (kA)
+ * @param {number} params.minTimeDelayS           - Minimum time delay t_min (s)
+ * @returns {{Ib: number, mu: number, nearToGenerator: boolean, ratio: number|null}}
+ */
+export function breakingCurrent({
+  ikTotalKA,
+  generatorContributionKA = null,
+  generatorRatedCurrentKA = null,
+  minTimeDelayS = 0.05
+} = {}) {
+  const ik = Number(ikTotalKA);
+  const safeIk = Number.isFinite(ik) && ik > 0 ? ik : 0;
+  const iGen = Number(generatorContributionKA);
+  const iRated = Number(generatorRatedCurrentKA);
+
+  const hasGeneratorData = Number.isFinite(iGen) && iGen > 0
+    && Number.isFinite(iRated) && iRated > 0;
+
+  if (!hasGeneratorData) {
+    return { Ib: safeIk, mu: 1, nearToGenerator: false, ratio: null };
+  }
+
+  // The generator share cannot exceed the total current at the bus.
+  const genShare = Math.min(iGen, safeIk);
+  const ratio = genShare / iRated;
+  const mu = muFactor(ratio, minTimeDelayS);
+  const Ib = mu * genShare + (safeIk - genShare);
+
+  return {
+    Ib,
+    mu,
+    nearToGenerator: mu < 1,
+    ratio
+  };
+}
+
+// ---------------------------------------------------------------------------
 // IEC 60909-0:2016 — X/R ratio at fault point
 // ---------------------------------------------------------------------------
 
@@ -208,7 +364,10 @@ export function computeIEC60909Bus(params) {
     lvTolerancePct = 10,
     faultDurationS = 1.0,
     freqHz = 50,
-    xrOverride = null
+    xrOverride = null,
+    generatorContributionKA = null,
+    generatorRatedCurrentKA = null,
+    minTimeDelayS = 0.05
   } = params;
 
   const c = cFactor(prefaultKV, cMode, lvTolerancePct);
@@ -243,20 +402,35 @@ export function computeIEC60909Bus(params) {
   const kappa = kappaIEC(xr);
   const ip = kappa * Math.sqrt(2) * Ik3; // kA
 
-  // --- Breaking current (IEC 60909-0 §4.5 — far-from-generator) ---
-  // For far-from-generator short circuit: μ = 1.0, so Ib = I"k3
-  const Ib = Ik3;
+  // --- Breaking current (IEC 60909-0 §8) ---
+  // μ decays the synchronous-machine share of I"k3 when the fault is
+  // near-to-generator; with no generator data μ = 1 and Ib = I"k3.
+  const breaking = breakingCurrent({
+    ikTotalKA: Ik3,
+    generatorContributionKA,
+    generatorRatedCurrentKA,
+    minTimeDelayS
+  });
+  const Ib = breaking.Ib;
 
   // --- Thermal equivalent current (IEC 60909-0 §4.8.1) ---
   // Ith = I"k3 × √(m + n)
-  // n = 1.0 (far-from-generator, AC component does not decay)
   // m = DC component factor from IEC Fig. 22
+  // n accounts for AC decay. It is 1.0 for a far-from-generator fault; for a
+  // near-to-generator fault the AC component decays, which IEC represents with
+  // n < 1. Using n = 1 there would overstate Ith, so scale it by the same decay
+  // ratio μ that sets Ib (n ≈ (Ib/I"k)²).
   const m = thermalMFactor(kappa, faultDurationS, freqHz);
-  const Ith = Ik3 * Math.sqrt(m + 1);
+  const decayRatio = Ik3 > 0 ? Math.min(Ib / Ik3, 1) : 1;
+  const n = decayRatio * decayRatio;
+  const Ith = Ik3 * Math.sqrt(m + n);
 
   return {
     cFactor: c,
     kappa: Number(kappa.toFixed(4)),
+    mu: Number(breaking.mu.toFixed(4)),
+    nearToGenerator: breaking.nearToGenerator,
+    generatorRatioIkgIrg: breaking.ratio === null ? null : Number(breaking.ratio.toFixed(3)),
     // IEC standard notation
     threePhaseKA: Number(Ik3.toFixed(2)),
     lineToLineKA: Number(Ik2.toFixed(2)),
@@ -290,6 +464,7 @@ export function runIEC60909Batch(busData, opts = {}) {
   const lvTolerancePct = opts.lvTolerancePct ?? 10;
   const faultDurationS = opts.faultDurationS ?? 1.0;
   const freqHz = opts.freqHz ?? 50;
+  const minTimeDelayS = opts.minTimeDelayS ?? 0.05;
 
   const results = {};
   for (const bus of busData) {
@@ -302,7 +477,10 @@ export function runIEC60909Batch(busData, opts = {}) {
       lvTolerancePct,
       faultDurationS,
       freqHz,
-      xrOverride: (typeof bus.xr_ratio === 'number' && bus.xr_ratio > 0) ? bus.xr_ratio : null
+      xrOverride: (typeof bus.xr_ratio === 'number' && bus.xr_ratio > 0) ? bus.xr_ratio : null,
+      generatorContributionKA: bus.generatorContributionKA ?? null,
+      generatorRatedCurrentKA: bus.generatorRatedCurrentKA ?? null,
+      minTimeDelayS: bus.minTimeDelayS ?? minTimeDelayS
     });
     results[bus.id] = {
       method: 'IEC',

--- a/analysis/shortCircuit.mjs
+++ b/analysis/shortCircuit.mjs
@@ -6,7 +6,12 @@ import protectiveDevices from '../data/protectiveDevices.mjs';
 import { calculateTransformerImpedance } from '../utils/transformerImpedance.js';
 import { computeImpedanceFromPerKm } from '../utils/cableImpedance.js';
 import { table9Impedance } from '../src/necTable9.mjs';
-import { computeIEC60909Bus } from './iec60909.mjs';
+import {
+  computeIEC60909Bus,
+  cFactor as iecCFactor,
+  generatorCorrectionKG,
+  transformerCorrectionKT
+} from './iec60909.mjs';
 import { ibrFaultContribution, IBR_DEFAULTS } from './ibrModeling.mjs';
 
 // Basic complex math utilities
@@ -634,7 +639,32 @@ function getTransformerPercentForPort(xfmr, portIndex) {
   return getNumericFromKeys(xfmr, percentFallbacks);
 }
 
-function getTransformerImpedance(xfmr, portIndex) {
+// ---------------------------------------------------------------------------
+// IEC 60909-0:2016 impedance correction context
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the correction context for a run. K_T (§6.3.3) and K_G (§6.6.1) are
+ * IEC-specific, so they are only applied when the caller explicitly asked for
+ * the IEC method — never on an ANSI/IEEE run, and never on an auto-selected
+ * per-bus method, where mixing corrected and uncorrected impedances into one
+ * shared cascade cache would make results depend on bus iteration order.
+ */
+function createIecCorrectionContext(opts = {}) {
+  const requested = String(opts.method || '').toUpperCase();
+  if (requested !== 'IEC') return null;
+  return {
+    cMode: opts.cMode || 'max',
+    lvTolerancePct: opts.lvTolerancePct ?? 10
+  };
+}
+
+function scaleImpedance(z, k) {
+  if (!Number.isFinite(k) || k <= 0) return z;
+  return { r: (z.r || 0) * k, x: (z.x || 0) * k };
+}
+
+function getTransformerImpedance(xfmr, portIndex, corrections = null) {
   if (!xfmr || xfmr.type !== 'transformer') return { r: 0, x: 0 };
   const percent = getTransformerPercentForPort(xfmr, portIndex);
   const kva = getTransformerKvaForPort(xfmr, portIndex);
@@ -642,14 +672,25 @@ function getTransformerImpedance(xfmr, portIndex) {
   const kv = toKV(voltage ?? pickValue(xfmr, 'voltage') ?? pickValue(xfmr, 'baseKV'));
   const xr = parseNumeric(pickValue(xfmr, 'xr_ratio') ?? pickValue(xfmr, 'xr'));
   const impedance = calculateTransformerImpedance({ kva, percentZ: percent, voltageKV: kv, xrRatio: xr });
-  if (impedance && Number.isFinite(impedance.r) && Number.isFinite(impedance.x)) return impedance;
+  if (impedance && Number.isFinite(impedance.r) && Number.isFinite(impedance.x)) {
+    if (!corrections) return impedance;
+    // Z_TK = K_T × Z_T (IEC 60909-0:2016 §6.3.3). K_T needs x_T per unit on the
+    // transformer's own rating, so convert the ohmic reactance back onto that base.
+    const mva = Number.isFinite(kva) && kva > 0 ? kva / 1000 : null;
+    if (!mva || !Number.isFinite(kv) || kv <= 0) return impedance;
+    const zBase = (kv * kv) / mva;
+    if (!Number.isFinite(zBase) || zBase <= 0) return impedance;
+    const xTPu = Math.abs(impedance.x) / zBase;
+    const cMax = iecCFactor(kv, 'max', corrections.lvTolerancePct);
+    return scaleImpedance(impedance, transformerCorrectionKT(xTPu, cMax));
+  }
   const direct = pickValue(xfmr, 'transformer_impedance');
   const fallback = toImpedance(direct);
   if (Math.abs(fallback.r) > 0 || Math.abs(fallback.x) > 0) return fallback;
   return { r: 0, x: 0 };
 }
 
-function getSourceImpedance(comp) {
+function getSourceImpedance(comp, corrections = null) {
   const mva = parseNumeric(
     pickValue(comp, 'thevenin_mva')
     ?? pickValue(comp, 'mva')
@@ -676,6 +717,19 @@ function getSourceImpedance(comp) {
     );
     if (xdpp && xdpp > 0) {
       zMag *= xdpp;
+    }
+    // Z_GK = K_G × Z_G (IEC 60909-0:2016 §6.6.1). K_G is defined for
+    // synchronous machines; induction (asynchronous) generators have their own
+    // treatment in the standard and are left uncorrected here.
+    if (corrections && comp.subtype !== 'asynchronous') {
+      const kG = generatorCorrectionKG({
+        unKV: kv,
+        urgKV: toKV(pickValue(comp, 'rated_kv') ?? pickValue(comp, 'volts')) || kv,
+        xdppPu: xdpp,
+        ratedPF: parseNumeric(pickValue(comp, 'pf') ?? pickValue(comp, 'full_load_pf')),
+        cMax: iecCFactor(kv, 'max', corrections.lvTolerancePct)
+      });
+      if (kG !== null) zMag *= kG;
     }
   }
   const xr = parseNumeric(pickValue(comp, 'xr_ratio'));
@@ -846,13 +900,13 @@ function combineParallel(base, addition) {
   return parallel(base, addition);
 }
 
-function resolveUpstreamImpedance(comp, comps, compMap, cache, cableResolver) {
+function resolveUpstreamImpedance(comp, comps, compMap, cache, cableResolver, corrections = null) {
   if (!comp?.id) return null;
   const visited = new Set();
   let current = comp;
   while (current?.id && !visited.has(current.id)) {
     visited.add(current.id);
-    const candidate = computeImpedance(current, comps, compMap, cache, new Set(), cableResolver);
+    const candidate = computeImpedance(current, comps, compMap, cache, new Set(), cableResolver, corrections);
     if (candidate && (Math.abs(candidate.r) >= 1e-9 || Math.abs(candidate.x) >= 1e-9)) {
       return { r: candidate.r, x: candidate.x };
     }
@@ -862,14 +916,14 @@ function resolveUpstreamImpedance(comp, comps, compMap, cache, cableResolver) {
   return null;
 }
 
-function computeImpedance(comp, comps, compMap, cache, visited = new Set(), cableResolver = null) {
+function computeImpedance(comp, comps, compMap, cache, visited = new Set(), cableResolver = null, corrections = null) {
   if (!comp?.id) return { r: 0, x: 0 };
   if (cache.has(comp.id)) return cache.get(comp.id);
   if (visited.has(comp.id)) return { r: 0, x: 0 };
   visited.add(comp.id);
   let total = extractComponentImpedance(comp);
   if (isSourceComponent(comp)) {
-    total = add(total, getSourceImpedance(comp));
+    total = add(total, getSourceImpedance(comp, corrections));
   }
   const parent = findParentInfo(comp, comps, compMap, visited);
   if (parent?.component) {
@@ -879,17 +933,61 @@ function computeImpedance(comp, comps, compMap, cache, visited = new Set(), cabl
       total = add(total, resolvedConnection?.impedance || toImpedance(connection.impedance));
       if (upstream.type === 'transformer') {
         const portIndex = normalizePortIndex(reversed ? connection?.targetPort : connection?.sourcePort);
-        total = add(total, getTransformerImpedance(upstream, portIndex));
+        total = add(total, getTransformerImpedance(upstream, portIndex, corrections));
       }
     }
-    total = add(total, computeImpedance(upstream, comps, compMap, cache, visited, cableResolver));
+    total = add(total, computeImpedance(upstream, comps, compMap, cache, visited, cableResolver, corrections));
   }
   visited.delete(comp.id);
   cache.set(comp.id, total);
   return total;
 }
 
-function buildImpedancePath(comp, comps, compMap, cableResolver) {
+/**
+ * Walks the upstream chain to the terminal source feeding a bus.
+ *
+ * The impedance cascade in this module is radial — each component has at most
+ * one parent — so the terminal source is the sole infeed for the bus. That is
+ * what lets the IEC μ factor treat the whole initial current at the bus as the
+ * generator contribution when that terminal source is a synchronous machine.
+ */
+function findTerminalSource(comp, comps, compMap) {
+  const visited = new Set();
+  let current = comp;
+  while (current?.id && !visited.has(current.id)) {
+    visited.add(current.id);
+    if (isSourceComponent(current)) return current;
+    const parent = findParentInfo(current, comps, compMap, visited);
+    if (!parent?.component) return null;
+    current = parent.component;
+  }
+  return null;
+}
+
+/**
+ * Rated current I_rG of a synchronous generator in kA.
+ *
+ *   I_rG = S_rG / (√3 × U_rG)
+ *
+ * Returns null for anything that is not a synchronous generator with usable
+ * rating data, which makes the caller fall back to μ = 1.
+ */
+function generatorRatedCurrentKA(comp) {
+  if (comp?.type !== 'generator' || comp?.subtype === 'asynchronous') return null;
+  const mva = parseNumeric(pickValue(comp, 'rated_mva') ?? pickValue(comp, 'mva'));
+  const kva = parseNumeric(pickValue(comp, 'rated_kva') ?? pickValue(comp, 'kva'));
+  const mvaRating = mva || (kva ? kva / 1000 : null);
+  const kv = toKV(
+    pickValue(comp, 'rated_kv')
+    ?? pickValue(comp, 'volts')
+    ?? pickValue(comp, 'voltage')
+    ?? pickValue(comp, 'baseKV')
+  );
+  if (!mvaRating || mvaRating <= 0 || !kv || kv <= 0) return null;
+  return mvaRating / (Math.sqrt(3) * kv);
+}
+
+function buildImpedancePath(comp, comps, compMap, cableResolver, corrections = null) {
   const segments = [];
   const assumptions = [];
   const requiredInputs = [];
@@ -912,7 +1010,7 @@ function buildImpedancePath(comp, comps, compMap, cableResolver) {
       });
       if (upstream.type === 'transformer') {
         const portIndex = normalizePortIndex(reversed ? connection?.targetPort : connection?.sourcePort);
-        const impedance = getTransformerImpedance(upstream, portIndex);
+        const impedance = getTransformerImpedance(upstream, portIndex, corrections);
         if (hasImpedance(impedance)) {
           segments.unshift({
             type: 'transformer',
@@ -929,7 +1027,7 @@ function buildImpedancePath(comp, comps, compMap, cableResolver) {
   }
 
   if (current && isSourceComponent(current)) {
-    const impedance = getSourceImpedance(current);
+    const impedance = getSourceImpedance(current, corrections);
     if (hasImpedance(impedance)) {
       segments.unshift({
         type: 'source',
@@ -1050,6 +1148,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
     }
   });
   const impedanceCache = new Map();
+  const iecCorrections = createIecCorrectionContext(opts);
   const cableResolver = createCableScheduleResolver(cables);
   const voltageCache = new Map();
   const protectiveLookupCache = new Map();
@@ -1120,9 +1219,9 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
 
   comps.forEach(comp => {
     if (comp?.id && compMap.get(comp.id) !== comp) return;
-    const baseZ = computeImpedance(comp, comps, compMap, impedanceCache, new Set(), cableResolver);
+    const baseZ = computeImpedance(comp, comps, compMap, impedanceCache, new Set(), cableResolver, iecCorrections);
     const fallbackZ = (!hasBusNodes || isBusStudyNode(comp))
-      ? resolveUpstreamImpedance(comp, comps, compMap, impedanceCache, cableResolver)
+      ? resolveUpstreamImpedance(comp, comps, compMap, impedanceCache, cableResolver, iecCorrections)
       : null;
     let z1 = comp.z1 ? toImpedance(comp.z1) : baseZ;
     let z2 = comp.z2 ? toImpedance(comp.z2) : z1;
@@ -1147,6 +1246,15 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
 
     let entry;
     if (method === 'IEC') {
+      // Near-to-generator decay (IEC 60909-0 §8): when the terminal infeed is a
+      // synchronous machine it supplies the whole initial current at this bus, so
+      // I"kG = I"k3 and μ applies to all of it. Any other source type leaves
+      // generatorRatedCurrentKA null, which yields μ = 1.
+      const terminalSource = findTerminalSource(comp, comps, compMap);
+      const iRatedKA = generatorRatedCurrentKA(terminalSource);
+      const c = iecCFactor(prefaultKV, opts.cMode || 'max', opts.lvTolerancePct ?? 10);
+      const ikTotalKA = ((prefaultKV * c) / Math.sqrt(3)) / mag(z1);
+
       // Delegate to the full IEC 60909-0:2016 engine
       const iecFields = computeIEC60909Bus({
         z1,
@@ -1157,7 +1265,10 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
         lvTolerancePct: opts.lvTolerancePct ?? 10,
         faultDurationS: opts.faultDurationS ?? 1.0,
         freqHz: opts.freqHz ?? 50,
-        xrOverride: Math.abs(comp.xr_ratio || 0) > 0 ? Math.abs(comp.xr_ratio) : null
+        xrOverride: Math.abs(comp.xr_ratio || 0) > 0 ? Math.abs(comp.xr_ratio) : null,
+        generatorContributionKA: iRatedKA === null ? null : ikTotalKA,
+        generatorRatedCurrentKA: iRatedKA,
+        minTimeDelayS: opts.minTimeDelayS ?? 0.05
       });
       entry = {
         method: 'IEC',
@@ -1196,7 +1307,7 @@ export function runShortCircuit(modelOrOpts = {}, maybeOpts = {}) {
       entry.warnings = ['Impedance data missing; results defaulted to low impedance until data is provided.'];
     }
 
-    const path = buildImpedancePath(comp, comps, compMap, cableResolver);
+    const path = buildImpedancePath(comp, comps, compMap, cableResolver, iecCorrections);
     entry.equipmentTag = componentIdentity(comp) || comp.id;
     entry.impedanceProvenance = {
       totalR: Number(z1.r || 0),

--- a/data/validationBenchmarks.json
+++ b/data/validationBenchmarks.json
@@ -204,12 +204,14 @@
       "assumptions": [
         "Equivalent voltage source method (no pre-fault load currents in calculation)",
         "Voltage factor c applied to nominal voltage (1.0–1.1 for max; 0.95 for min)",
-        "Far-from-generator condition unless generator correction factor K_G is applied"
+        "Impedance corrections K_G (§6.6.1) and K_T (§6.3.3) applied per element before the cascade, only when the IEC method is explicitly selected",
+        "Near-to-generator decay μ (§8.1.5.2) applied to the synchronous-machine share of I″k; minimum time delay t_min defaults to 0.05 s"
       ],
       "limitations": [
-        "Near-to-generator μ factor (Ib reduction) not yet implemented",
-        "Transformer correction factor K_T exported but not batch-applied per transformer",
-        "Generator correction factor K_G not implemented"
+        "Radial cascade: generator contribution is not apportioned per source, so meshed networks fed by several machines fall back to μ = 1 (conservative for breaking duty)",
+        "No power-station-unit correction (K_S / K_SO per §6.7) for a generator behind a unit transformer",
+        "Asynchronous (induction) generators are left uncorrected and never trigger μ",
+        "Unbalanced faults use a simplified symmetrical-component method"
       ]
     },
     {

--- a/docs/component-gap-analysis.md
+++ b/docs/component-gap-analysis.md
@@ -1,6 +1,6 @@
 # Component & Attribute Gap Analysis
 
-Generated on 2026-05-26 from `componentLibrary.json`.
+Generated on 2026-07-25 from `componentLibrary.json`.
 
 ## Missing Common Component Types
 
@@ -26,12 +26,13 @@ Generated on 2026-05-26 from `componentLibrary.json`.
 | mcc | — |
 | meter | — |
 | motor | — |
+| overcurrent_relay | — |
 | panel | — |
 | pt_vt | — |
 | pv_array | — |
 | reactor | — |
 | recloser | — |
-| relay | — |
+| relay_87 | — |
 | single_throw | — |
 | switch | — |
 | switchboard | — |

--- a/docs/iec-60909.md
+++ b/docs/iec-60909.md
@@ -88,7 +88,29 @@ For **far-from-generator** short circuits (the most common case in distribution 
 Ib = I"k3     (μ = 1.0, no decay of AC component)
 ```
 
-For near-to-generator faults, μ < 1.0 and Ib < I"k3. Near-to-generator correction is not yet implemented (see Limitations).
+For **near-to-generator** faults the AC component decays before the contacts part, so
+μ < 1.0 and Ib < I"k3. Only the synchronous-machine share decays, so the two parts are
+superposed (IEC 60909-0:2016 §8):
+```
+Ib = μ × I"kG + (I"k − I"kG)
+```
+
+μ is tabulated against the minimum time delay t_min and the generator loading ratio
+q = I"kG / I_rG (§8.1.5.2):
+
+| t_min | μ |
+|---|---|
+| 0.02 s | 0.84 + 0.26 · e^(−0.26 q) |
+| 0.05 s | 0.71 + 0.51 · e^(−0.30 q) |
+| 0.10 s | 0.62 + 0.72 · e^(−0.32 q) |
+| ≥ 0.25 s | 0.56 + 0.94 · e^(−0.38 q) |
+
+μ = 1 when q ≤ 2 — the fault is then treated as far-from-generator. Intermediate delays are
+linearly interpolated between the bracketing curves, as IEC permits. Set t_min with the
+**Minimum Time Delay** control on the study page (`opts.minTimeDelayS`); it defaults to 0.05 s.
+
+I_rG is the generator rated current S_rG / (√3 × U_rG). The study reports μ and the ratio q
+alongside Ib so the decay is auditable.
 
 ### Ith — Thermal equivalent short-circuit current
 
@@ -99,7 +121,9 @@ Ith = I"k3 × √(m + n)
 ```
 
 where:
-- **n = 1.0** — AC component heating factor (= 1.0 for far-from-generator)
+- **n** — AC component heating factor. It is 1.0 for a far-from-generator fault; for a
+  near-to-generator fault the AC component decays, so n is scaled by the same decay
+  ratio that sets Ib (n ≈ (Ib/I"k)²). Using n = 1.0 there would overstate Ith.
 - **m** — DC component heating factor, from IEC 60909-0:2016 Fig. 22 (function of κ and Tk)
 
 The DC heating factor m decreases as fault duration Tk increases (DC component decays faster for short fault durations relative to the AC component). For long fault durations (Tk > 3 s), m → 0 and Ith → I"k3.
@@ -168,8 +192,10 @@ Use **Download PDF** for submittal packages or **Download CSV** for integration 
 
 | Assumption | Detail |
 |---|---|
-| Far-from-generator | Ib = I"k3 (μ = 1.0). For systems with large synchronous generators contributing to the fault, Ib may be lower. Generator impedance correction factor K_G is not applied. |
-| Transformer K_T not yet applied | The standard impedance correction K_T = 0.95 × c_max / (1 + 0.6 × xT) for network transformers (IEC 60909-0 §3.3.3) is defined in `analysis/iec60909.mjs` as `transformerCorrectionKT()` but not yet applied in the batch runner. |
+| Impedance corrections are IEC-only | K_G (§6.6.1) and K_T (§6.3.3) are applied per element, before the impedance cascade, because each factor corrects only its own element's impedance rather than the summed impedance at the bus. They apply only when `opts.method` is explicitly `'IEC'` — never on an ANSI run, and never when the method is auto-selected per bus, since mixing corrected and uncorrected impedances in one shared cascade cache would make results depend on bus iteration order. |
+| Generator contribution is not apportioned | The cascade is radial, so for a bus fed only by a synchronous machine the whole I"k is taken as that machine's contribution. Meshed networks fed by several machines are not split per source; those buses fall back to μ = 1, which is the conservative result for breaker breaking duty. |
+| No power-station-unit correction | K_G assumes a generator connected directly to the network. The K_S / K_SO corrections for a generator behind a unit transformer (§6.7) are not implemented. |
+| Asynchronous generators uncorrected | K_G is defined for synchronous machines. Induction (asynchronous) generators are left uncorrected and never trigger μ. |
 | Balanced three-phase system | No provision for unbalanced pre-fault conditions. |
 | Frequency | m factor computation assumes constant AC frequency (50 or 60 Hz). |
 | Motor contributions | Asynchronous motor back-EMF contributions are not modeled separately; include them as equivalent impedance sources if needed. |
@@ -185,7 +211,10 @@ Use **Download PDF** for submittal packages or **Download CSV** for integration 
 | `cFactor(kV, mode, lvTolerancePct)` | IEC 60909-0:2016 Table 1 voltage factor c |
 | `kappaIEC(xr)` | Peak factor κ = 1.02 + 0.98 × e^(−3/XR) per §4.3.1.1 |
 | `thermalMFactor(kappa, faultDurationS, freqHz)` | DC heating factor m for Ith calculation per §4.8.1 |
-| `transformerCorrectionKT(xTPu, cMax)` | Transformer impedance correction K_T per §3.3.3 |
+| `transformerCorrectionKT(xTPu, cMax)` | Transformer impedance correction K_T per §6.3.3 |
+| `generatorCorrectionKG({unKV, urgKV, xdppPu, ratedPF, cMax})` | Synchronous generator impedance correction K_G per §6.6.1; returns `null` when required data is missing |
+| `muFactor(q, tMinS)` | Breaking-current decay factor μ per §8.1.5.2, interpolated across the tabulated t_min curves |
+| `breakingCurrent({ikTotalKA, generatorContributionKA, generatorRatedCurrentKA, minTimeDelayS})` | Resolves Ib, μ and the ratio q, decaying only the machine share |
 | `computeIEC60909Bus(params)` | Single-bus IEC 60909 calculation — returns I"k3, I"k2, I"k1, I"k2E, ip, Ib, Ith, κ, c |
 | `runIEC60909Batch(busData, opts)` | Batch IEC 60909 study; called by `runShortCircuit()` when method=IEC |
 
@@ -199,6 +228,7 @@ When calling `runShortCircuit(model, opts)` with `opts.method = 'IEC'`, the foll
 | `opts.lvTolerancePct` | `10` | LV voltage tolerance %; ≥ 6 → c_max = 1.10; < 6 → c_max = 1.05 |
 | `opts.faultDurationS` | `1.0` | Fault duration Tk in seconds, for Ith calculation |
 | `opts.freqHz` | `50` | System frequency in Hz (50 or 60) |
+| `opts.minTimeDelayS` | `0.05` | Minimum time delay t_min in seconds, for the μ factor used by Ib |
 
 ### IEC 60909 result fields (additional vs ANSI)
 
@@ -212,6 +242,9 @@ When `method === 'IEC'`, each bus result object includes:
 | `doubleLineGroundKA` | kA | I"k2E — initial two-phase-to-earth short-circuit current |
 | `ip` | kA | Peak short-circuit current (= κ × √2 × I"k3) |
 | `Ib` | kA | Symmetrical short-circuit breaking current (= I"k3 for far-from-generator) |
+| `mu` | — | Breaking-current decay factor μ (1.0 when far-from-generator) |
+| `nearToGenerator` | — | `true` when μ < 1, i.e. the machine share was decayed |
+| `generatorRatioIkgIrg` | — | Ratio q = I"kG / I_rG used to pick μ; `null` with no generator data |
 | `Ith` | kA | Thermal equivalent short-circuit current |
 | `kappa` | — | Peak factor κ |
 | `cFactor` | — | Voltage factor c applied |

--- a/docs/page-contract-audit.md
+++ b/docs/page-contract-audit.md
@@ -335,7 +335,7 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - analysis/shortCircuit.mjs:1039 getCables()
+  - analysis/shortCircuit.mjs:1137 getCables()
   - oneline.js:13944 getCables()
   - oneline.js:15859 getCables()
   - oneline.js:19147 getCables()
@@ -396,7 +396,7 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
   - oneline.js:3380 getItem(studySettings)
 - `settings.tccSettings`
   - analysis/arcFlash.mjs:330 getItem(tccSettings)
-  - analysis/shortCircuit.mjs:712 getItem(tccSettings)
+  - analysis/shortCircuit.mjs:766 getItem(tccSettings)
 - `studyResults`
   - analysis/harmonics.js:496 getStudies()
   - analysis/motorStart.js:209 getStudies()
@@ -1711,18 +1711,18 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - analysis/shortCircuit.mjs:1039 getCables()
+  - analysis/shortCircuit.mjs:1137 getCables()
   - analysis/tcc.js:3834 getCables()
 - `oneLineDiagram`
   - analysis/arcFlash.mjs:397 getOneLine()
-  - analysis/shortCircuit.mjs:1034 getOneLine()
+  - analysis/shortCircuit.mjs:1132 getOneLine()
   - analysis/tcc.js:3062 getOneLine()
   - analysis/tcc.js:7936 getOneLine()
   - analysis/tcc.js:7985 getOneLine()
   - ... 3 more
 - `settings.tccSettings`
   - analysis/arcFlash.mjs:330 getItem(tccSettings)
-  - analysis/shortCircuit.mjs:712 getItem(tccSettings)
+  - analysis/shortCircuit.mjs:766 getItem(tccSettings)
   - analysis/tcc.js:918 getItem(tccSettings)
 - `studyResults`
   - analysis/tcc.js:2981 getStudies()
@@ -2361,13 +2361,13 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - analysis/shortCircuit.mjs:1039 getCables()
+  - analysis/shortCircuit.mjs:1137 getCables()
   - studies/shortCircuit.js:12 getCables()
 - `oneLineDiagram`
-  - analysis/shortCircuit.mjs:1034 getOneLine()
+  - analysis/shortCircuit.mjs:1132 getOneLine()
   - studies/shortCircuit.js:7 getOneLine()
 - `settings.tccSettings`
-  - analysis/shortCircuit.mjs:712 getItem(tccSettings)
+  - analysis/shortCircuit.mjs:766 getItem(tccSettings)
 - `studyResults`
   - studies/shortCircuit.js:133 getStudies()
   - studies/shortCircuit.js:286 getStudies()
@@ -2405,27 +2405,27 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - analysis/shortCircuit.mjs:1039 getCables()
+  - analysis/shortCircuit.mjs:1137 getCables()
 - `oneLineDiagram`
-  - analysis/shortCircuit.mjs:1034 getOneLine()
-  - iec60909.js:42 getOneLine()
+  - analysis/shortCircuit.mjs:1132 getOneLine()
+  - iec60909.js:49 getOneLine()
 - `settings.designBasis`
   - src/components/studyBasis.js:37 getDesignBasis()
 - `settings.studyApprovals`
   - src/components/studyApproval.js:213 getStudyApprovals()
 - `settings.tccSettings`
-  - analysis/shortCircuit.mjs:712 getItem(tccSettings)
+  - analysis/shortCircuit.mjs:766 getItem(tccSettings)
 - `studyResults`
-  - iec60909.js:102 getStudies()
+  - iec60909.js:111 getStudies()
 
 **Detected Writes**
 - `settings.studyApprovals`
   - src/components/studyApproval.js:235 setStudyApproval()
   - src/components/studyApproval.js:243 clearStudyApproval()
 - `studyResults`
-  - iec60909.js:104 setStudies()
+  - iec60909.js:113 setStudies()
 - `studyResults.iec60909`
-  - iec60909.js:103 studies.iec60909
+  - iec60909.js:112 studies.iec60909
 
 ### Arc Flash (`arcFlash.html`)
 
@@ -2451,14 +2451,14 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `cableSchedule`
-  - analysis/shortCircuit.mjs:1039 getCables()
+  - analysis/shortCircuit.mjs:1137 getCables()
 - `oneLineDiagram`
   - analysis/arcFlash.mjs:397 getOneLine()
-  - analysis/shortCircuit.mjs:1034 getOneLine()
+  - analysis/shortCircuit.mjs:1132 getOneLine()
   - studies/arcFlash.js:7 getOneLine()
 - `settings.tccSettings`
   - analysis/arcFlash.mjs:330 getItem(tccSettings)
-  - analysis/shortCircuit.mjs:712 getItem(tccSettings)
+  - analysis/shortCircuit.mjs:766 getItem(tccSettings)
 - `studyResults`
   - studies/arcFlash.js:27 getStudies()
 

--- a/iec60909.html
+++ b/iec60909.html
@@ -138,6 +138,24 @@
             </span>
           </fieldset>
 
+          <fieldset>
+            <legend>Breaking Current (Ib)</legend>
+            <label for="min-time-delay">Minimum Time Delay t<sub>min</sub> (s)
+              <select id="min-time-delay" name="minTimeDelayS" aria-describedby="min-delay-hint">
+                <option value="0.02">0.02 s — instantaneous / no intentional delay</option>
+                <option value="0.05" selected>0.05 s — typical MV breaker</option>
+                <option value="0.10">0.10 s — short-time delay</option>
+                <option value="0.25">0.25 s or longer — backup / time-graded</option>
+              </select>
+            </label>
+            <span id="min-delay-hint" class="field-hint">
+              Time from fault inception to contact separation. Sets the decay factor &mu; used for
+              I<sub>b</sub> on a near-to-generator fault (IEC 60909-0:2016 &sect;8.1.5.2). A longer
+              delay allows more AC decay, so I<sub>b</sub> is lower. &mu; = 1 when the fault is
+              far-from-generator (I&Prime;kG / I_rG &le; 2), where I<sub>b</sub> = I&Prime;k.
+            </span>
+          </fieldset>
+
           <div class="form-actions">
             <button type="submit" id="run-btn">Run IEC 60909 Study</button>
           </div>
@@ -162,6 +180,7 @@
                 <th scope="col">I&Prime;k1 (kA)</th>
                 <th scope="col">I&Prime;k2 (kA)</th>
                 <th scope="col">ip (kA)</th>
+                <th scope="col">&mu;</th>
                 <th scope="col">Ib (kA)</th>
                 <th scope="col">Ith (kA)</th>
               </tr>

--- a/iec60909.js
+++ b/iec60909.js
@@ -11,16 +11,23 @@ document.addEventListener('DOMContentLoaded', () => {
     formulas: [
       'I″k3 = c × Un / (√3 × Zk) — initial symmetrical fault current',
       'ip = κ × √2 × I″k3 — peak current; κ = 1.02 + 0.98 e^(−3/(X/R))',
+      'Ib = μ × I″kG + (I″k − I″kG) — symmetrical breaking current (§8)',
+      'μ = a + b e^(−k · I″kG/I_rG) — decay factor, tabulated by t_min (§8.1.5.2)',
+      'K_G = (Un/U_rG) · c_max / (1 + x″d · sin φ_rG) — generator correction (§6.6.1)',
+      'K_T = 0.95 · c_max / (1 + 0.6 · x_T) — transformer correction (§6.3.3)',
       'Ith = I″k3 × √(m + n) — thermal equivalent short-time current',
     ],
     assumptions: [
       'Equivalent voltage source at fault location (no pre-fault load currents)',
       'Voltage factor c applied to nominal voltage per IEC 60909-0 Table 1',
-      'Far-from-generator assumption (Ib = I″k3); near-to-generator μ factor not applied',
+      'K_G and K_T correct each element impedance before the cascade; they apply only when the IEC method is selected',
+      'μ decays the synchronous-machine share of I″k; other infeed is carried through undecayed',
+      'Minimum time delay t_min defaults to 0.05 s and is interpolated between the tabulated μ curves',
     ],
     limitations: [
-      'K_G (generator) and K_T (transformer) impedance correction factors not batch-applied',
-      'Near-to-generator breaking current decay (μ factor) not implemented',
+      'Radial cascade: for a bus fed only by a synchronous machine the whole I″k is treated as the generator contribution. Meshed networks with several machines are not apportioned per source, so μ = 1 (conservative) unless one terminal machine dominates',
+      'K_G assumes a generator connected without a unit transformer (no K_S / K_SO power-station-unit correction)',
+      'Asynchronous (induction) generators are left uncorrected',
       'Unbalanced faults use simplified symmetrical-component method',
     ],
     benchmarkId: 'iec60909-short-circuit',
@@ -72,6 +79,7 @@ function renderResults(res) {
       r.lineToGroundKA,
       r.lineToLineKA,
       r.ip,
+      r.mu == null ? '' : r.mu,
       r.Ib,
       r.Ith,
     ];
@@ -95,6 +103,7 @@ form.addEventListener('submit', ev => {
       lvTolerancePct: Number(form.lvTolerancePct.value),
       faultDurationS: Number(form.faultDurationS.value),
       freqHz: Number(form.freqHz.value),
+      minTimeDelayS: Number(form.minTimeDelayS.value),
     };
     const model = buildModel();
     const res = runShortCircuit(model, opts);
@@ -112,11 +121,11 @@ pdfBtn.addEventListener('click', () => {
   if (!lastResults) return;
   const headers = ['bus', 'prefaultKV', 'cFactor', 'kappa',
                    'threePhaseKA', 'lineToGroundKA', 'lineToLineKA',
-                   'ip', 'Ib', 'Ith'];
+                   'ip', 'mu', 'Ib', 'Ith'];
   const rows = Object.entries(lastResults).map(([id, r]) => ({
     bus: id, prefaultKV: r.prefaultKV, cFactor: r.cFactor, kappa: r.kappa,
     threePhaseKA: r.threePhaseKA, lineToGroundKA: r.lineToGroundKA,
-    lineToLineKA: r.lineToLineKA, ip: r.ip, Ib: r.Ib, Ith: r.Ith,
+    lineToLineKA: r.lineToLineKA, ip: r.ip, mu: r.mu, Ib: r.Ib, Ith: r.Ith,
   }));
   downloadPDF('IEC 60909-0:2016 Short-Circuit Report', headers, rows, 'iec60909.pdf');
 });
@@ -125,12 +134,12 @@ csvBtn.addEventListener('click', () => {
   if (!lastResults) return;
   const cols = ['bus', 'prefaultKV', 'cFactor', 'kappa',
                 'threePhaseKA_kA', 'lineToGroundKA_kA', 'lineToLineKA_kA',
-                'ip_kA', 'Ib_kA', 'Ith_kA'];
+                'ip_kA', 'mu', 'Ib_kA', 'Ith_kA'];
   const lines = [cols.join(',')];
   for (const [id, r] of Object.entries(lastResults)) {
     lines.push([id, r.prefaultKV, r.cFactor, r.kappa,
                 r.threePhaseKA, r.lineToGroundKA, r.lineToLineKA,
-                r.ip, r.Ib, r.Ith].join(','));
+                r.ip, r.mu, r.Ib, r.Ith].join(','));
   }
   const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
   const a = document.createElement('a');

--- a/scripts/componentCoverageAudit.mjs
+++ b/scripts/componentCoverageAudit.mjs
@@ -1,4 +1,6 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const SOURCE_FILE = 'componentLibrary.json';
 const OUTPUT_FILE = 'docs/component-gap-analysis.md';
@@ -49,6 +51,12 @@ const ATTRIBUTE_BASELINE = {
   source: ['short_circuit_capacity', 'xr_ratio', 'frequency_hz'],
   transformer: ['kva', 'percent_z', 'primary_connection', 'secondary_connection'],
   protective: ['pickup_amps', 'time_dial', 'interrupting_rating_ka'],
+  // A differential (87) element is a percentage-slope sensing device. It has
+  // no time dial and no interrupting rating — the breaker it trips carries
+  // the interrupting duty — so holding it to the time-overcurrent baseline
+  // reports gaps that cannot legitimately be filled. Check the restraint
+  // characteristic and protected-zone metadata instead.
+  differential: ['pickup_amps', 'slope1_pct', 'protected_zone_type'],
   rotating: ['kw', 'efficiency', 'power_factor'],
   equipment: ['rated_voltage_kv', 'bus_rating_a'],
   load: ['kw', 'kvar', 'demand_factor'],
@@ -102,7 +110,10 @@ const TYPE_ALIASES = new Map([
   ['feeder', 'load'],
   ['link_source', 'utility'],
   ['link_target', 'bus'],
-  ['relay_87', 'relay'],
+  // `relay_87` is intentionally NOT aliased to `relay`. The library carries two
+  // distinct relay subtypes (`overcurrent_relay` and `relay_87`) whose schemas
+  // differ by protective function. Collapsing them into one row merges their
+  // props, so a field missing from one is masked by the other.
   ['class_rk1', 'fuse'],
   ['lv_cb', 'breaker'],
   ['mv_cb', 'breaker'],
@@ -141,6 +152,9 @@ function canonicalType(type) {
 function classifyType(type) {
   if (/utility|source|grid/.test(type)) return 'source';
   if (/transformer/.test(type)) return 'transformer';
+  // Differential elements must be matched before the generic protective test,
+  // which would otherwise claim them via the `relay` substring.
+  if (/relay_87|differential/.test(type)) return 'differential';
   if (/breaker|fuse|relay|protection|recloser/.test(type)) return 'protective';
   // panel / switchboard / mcc are bus equipment with their own canonical
   // schema (rated_voltage_kv, bus_rating_a, etc.), not load-aggregate or
@@ -191,9 +205,8 @@ function formatList(items) {
   return items.length ? items.join(', ') : '—';
 }
 
-async function main() {
-  const library = JSON.parse(await fs.readFile(SOURCE_FILE, 'utf8'));
-  const components = Array.isArray(library.components) ? library.components : [];
+export function computeCoverage(library) {
+  const components = Array.isArray(library?.components) ? library.components : [];
 
   const discoveredTypes = new Set();
   const typeToProps = new Map();
@@ -237,12 +250,13 @@ async function main() {
     })
     .sort((a, b) => b.missing.length - a.missing.length || a.type.localeCompare(b.type));
 
-  const today = new Date().toISOString().slice(0, 10);
-  const lines = [
-    '# Component & Attribute Gap Analysis',
-    '',
-    `Generated on ${today} from \`${SOURCE_FILE}\`.`,
-    '',
+  return { missingComponents, attributeRows };
+}
+
+// The `Generated on` line is the only date-dependent content, so it is emitted
+// separately from the report body. Freshness checks compare the body alone.
+export function buildReportBody({ missingComponents, attributeRows }) {
+  return [
     '## Missing Common Component Types',
     '',
     missingComponents.length
@@ -263,12 +277,32 @@ async function main() {
     '- `src/validation/librarySchema.mjs` is the canonical schema for MCC and Motor entries; the heuristic baseline here is intentionally looser so it surfaces gaps without duplicating the validator.',
     '- This report is a heuristic gap check and should be reviewed before schema enforcement.'
   ];
+}
 
-  await fs.writeFile(OUTPUT_FILE, `${lines.join('\n')}\n`);
+export function buildReport(library, { date = new Date().toISOString().slice(0, 10) } = {}) {
+  const coverage = computeCoverage(library);
+  const lines = [
+    '# Component & Attribute Gap Analysis',
+    '',
+    `Generated on ${date} from \`${SOURCE_FILE}\`.`,
+    '',
+    ...buildReportBody(coverage)
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const library = JSON.parse(await fs.readFile(SOURCE_FILE, 'utf8'));
+  await fs.writeFile(OUTPUT_FILE, buildReport(library));
   console.log(`Wrote ${OUTPUT_FILE}`);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+const invokedDirectly = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/componentCoverageAudit.test.mjs
+++ b/tests/componentCoverageAudit.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  buildReportBody,
+  computeCoverage
+} from '../scripts/componentCoverageAudit.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const REPORT_FILE = path.join(ROOT, 'docs', 'component-gap-analysis.md');
+const LIBRARY_FILE = path.join(ROOT, 'componentLibrary.json');
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  ✓', name);
+  } catch (err) {
+    console.error('  ✗', name, err.message || err);
+    process.exitCode = 1;
+  }
+}
+
+const library = JSON.parse(fs.readFileSync(LIBRARY_FILE, 'utf8'));
+const coverage = computeCoverage(library);
+const rowsByType = new Map(coverage.attributeRows.map((row) => [row.type, row]));
+
+// The committed report carries a `Generated on <date>` line that changes on
+// every regeneration. Strip it so the comparison is about content drift, not
+// the day the script last ran.
+function reportBodyOf(markdown) {
+  const lines = markdown.split('\n');
+  const start = lines.findIndex((line) => line.startsWith('## Missing Common Component Types'));
+  assert.notStrictEqual(start, -1, 'report is missing its first section heading');
+  return lines.slice(start).join('\n').trimEnd();
+}
+
+describe('component coverage audit — report freshness', () => {
+  it('docs/component-gap-analysis.md exists', () => {
+    assert.ok(fs.existsSync(REPORT_FILE), 'docs/component-gap-analysis.md not found');
+  });
+
+  it('committed report matches a fresh regeneration', () => {
+    const committed = reportBodyOf(fs.readFileSync(REPORT_FILE, 'utf8'));
+    const regenerated = buildReportBody(coverage).join('\n').trimEnd();
+    assert.strictEqual(
+      committed,
+      regenerated,
+      'docs/component-gap-analysis.md is stale — run `npm run audit:components` and commit the result'
+    );
+  });
+});
+
+describe('component coverage audit — attribute coverage', () => {
+  it('discovers every component type in the library', () => {
+    assert.ok(
+      coverage.attributeRows.length >= 30,
+      `expected >=30 component types, got ${coverage.attributeRows.length}`
+    );
+  });
+
+  it('no component type is missing baseline attributes', () => {
+    const gaps = coverage.attributeRows
+      .filter((row) => row.missing.length > 0)
+      .map((row) => `${row.type}: ${row.missing.join(', ')}`);
+    assert.deepStrictEqual(gaps, [], `component types with missing attributes:\n  ${gaps.join('\n  ')}`);
+  });
+
+  it('no common baseline component type is absent', () => {
+    assert.deepStrictEqual(coverage.missingComponents, []);
+  });
+});
+
+describe('component coverage audit — relay classification', () => {
+  it('keeps overcurrent_relay and relay_87 as distinct rows', () => {
+    // Collapsing both subtypes onto a single `relay` row merges their props, so
+    // a field absent from one is masked by the other.
+    assert.ok(rowsByType.has('overcurrent_relay'), 'missing overcurrent_relay row');
+    assert.ok(rowsByType.has('relay_87'), 'missing relay_87 row');
+    assert.ok(!rowsByType.has('relay'), 'relay_87 and overcurrent_relay must not collapse into `relay`');
+  });
+
+  it('holds overcurrent relays to the time-overcurrent baseline', () => {
+    const { expected } = rowsByType.get('overcurrent_relay');
+    assert.ok(expected.includes('time_dial'), 'overcurrent relay should require a time dial');
+    assert.ok(expected.includes('pickup_amps'), 'overcurrent relay should require a pickup');
+  });
+
+  it('holds differential relays to the restraint-characteristic baseline', () => {
+    // An 87 element is a percentage-slope sensing device: no time dial, and the
+    // breaker it trips carries the interrupting duty, not the relay.
+    const { expected } = rowsByType.get('relay_87');
+    assert.ok(expected.includes('slope1_pct'), 'differential relay should require a restraint slope');
+    assert.ok(expected.includes('protected_zone_type'), 'differential relay should require a protected zone');
+    assert.ok(!expected.includes('time_dial'), 'differential relay must not require a time dial');
+    assert.ok(
+      !expected.includes('interrupting_rating_ka'),
+      'differential relay must not require an interrupting rating'
+    );
+  });
+});

--- a/tests/iec60909.test.mjs
+++ b/tests/iec60909.test.mjs
@@ -16,6 +16,9 @@ import {
   kappaIEC,
   thermalMFactor,
   transformerCorrectionKT,
+  generatorCorrectionKG,
+  muFactor,
+  breakingCurrent,
   computeIEC60909Bus,
   runIEC60909Batch,
 } from '../analysis/iec60909.mjs';
@@ -262,5 +265,266 @@ describe('runIEC60909Batch — batch runner', () => {
     for (const key of ['threePhaseKA','ip','Ib','Ith','kappa','cFactor']) {
       assert.ok(key in res['BUS-11kV'], `Missing ${key} in BUS-11kV`);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generatorCorrectionKG — IEC 60909-0:2016 §6.6.1 (Eq. 18)
+// ---------------------------------------------------------------------------
+
+describe('generatorCorrectionKG — K_G (IEC 60909-0:2016 §6.6.1 Eq. 18)', () => {
+  // K_G = (Un/UrG) × cmax / (1 + x"d × sin φrG)
+  // 10.5 kV machine at unity turns ratio, x"d = 0.15, pf = 0.8 → sinφ = 0.6
+  //   K_G = 1 × 1.10 / (1 + 0.15×0.6) = 1.10 / 1.09 = 1.00917
+  it('matches the closed-form value for a 10.5 kV / 0.8 pf machine', () => {
+    const kG = generatorCorrectionKG({
+      unKV: 10.5, urgKV: 10.5, xdppPu: 0.15, ratedPF: 0.8, cMax: 1.10
+    });
+    within(kG, 1.00917, 0.0001, 'K_G ');
+  });
+
+  it('scales with the Un/UrG turns ratio', () => {
+    const matched = generatorCorrectionKG({ unKV: 10.5, urgKV: 10.5, xdppPu: 0.15, ratedPF: 0.8, cMax: 1.10 });
+    const mismatched = generatorCorrectionKG({ unKV: 10.0, urgKV: 10.5, xdppPu: 0.15, ratedPF: 0.8, cMax: 1.10 });
+    within(mismatched, matched * (10.0 / 10.5), 1e-9, 'K_G ratio ');
+  });
+
+  it('decreases as subtransient reactance increases', () => {
+    const low = generatorCorrectionKG({ unKV: 10.5, urgKV: 10.5, xdppPu: 0.10, ratedPF: 0.8, cMax: 1.10 });
+    const high = generatorCorrectionKG({ unKV: 10.5, urgKV: 10.5, xdppPu: 0.25, ratedPF: 0.8, cMax: 1.10 });
+    assert.ok(high < low, `expected K_G to fall with x"d, got ${low} then ${high}`);
+  });
+
+  it('returns null when required generator data is missing', () => {
+    assert.strictEqual(generatorCorrectionKG({ unKV: 10.5, urgKV: 10.5, xdppPu: 0.15 }), null);
+    assert.strictEqual(generatorCorrectionKG({ unKV: 10.5, urgKV: 10.5, ratedPF: 0.8 }), null);
+    assert.strictEqual(generatorCorrectionKG({}), null);
+  });
+
+  it('rejects a power factor outside (0, 1]', () => {
+    assert.strictEqual(generatorCorrectionKG({ unKV: 10, urgKV: 10, xdppPu: 0.15, ratedPF: 1.4 }), null);
+    assert.strictEqual(generatorCorrectionKG({ unKV: 10, urgKV: 10, xdppPu: 0.15, ratedPF: 0 }), null);
+  });
+
+  it('reduces to cmax/(1) for a unity-power-factor machine', () => {
+    // sin φ = 0 → K_G = (Un/UrG) × cmax
+    const kG = generatorCorrectionKG({ unKV: 10, urgKV: 10, xdppPu: 0.2, ratedPF: 1.0, cMax: 1.10 });
+    within(kG, 1.10, 1e-9, 'K_G@pf=1 ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// muFactor — IEC 60909-0:2016 §8.1.5.2
+// ---------------------------------------------------------------------------
+
+describe('muFactor — breaking-current decay μ (IEC 60909-0:2016 §8.1.5.2)', () => {
+  // Tabulated curves at q = I"kG/IrG = 4:
+  //   t_min 0.02 → 0.84 + 0.26 e^(−1.04) = 0.93190
+  //   t_min 0.05 → 0.71 + 0.51 e^(−1.20) = 0.86361
+  //   t_min 0.10 → 0.62 + 0.72 e^(−1.28) = 0.82019
+  //   t_min 0.25 → 0.56 + 0.94 e^(−1.52) = 0.76559
+  it('matches the 0.02 s curve', () => within(muFactor(4, 0.02), 0.93190, 0.0001, 'μ@0.02s '));
+  it('matches the 0.05 s curve', () => within(muFactor(4, 0.05), 0.86361, 0.0001, 'μ@0.05s '));
+  it('matches the 0.10 s curve', () => within(muFactor(4, 0.10), 0.82019, 0.0001, 'μ@0.10s '));
+  it('matches the 0.25 s curve', () => within(muFactor(4, 0.25), 0.76559, 0.0001, 'μ@0.25s '));
+
+  it('μ = 1 when I″kG/IrG ≤ 2 (treated as far-from-generator)', () => {
+    assert.strictEqual(muFactor(2, 0.05), 1);
+    assert.strictEqual(muFactor(1.5, 0.02), 1);
+    assert.strictEqual(muFactor(0, 0.05), 1);
+  });
+
+  it('holds the ≥0.25 s curve for longer delays', () => {
+    within(muFactor(4, 1.0), muFactor(4, 0.25), 1e-12, 'μ@1s ');
+    within(muFactor(4, 5.0), muFactor(4, 0.25), 1e-12, 'μ@5s ');
+  });
+
+  it('clamps delays below the first tabulated curve to 0.02 s', () => {
+    within(muFactor(4, 0.001), muFactor(4, 0.02), 1e-12, 'μ@1ms ');
+  });
+
+  it('linearly interpolates between tabulated curves', () => {
+    // t = 0.075 s sits midway between the 0.05 s and 0.10 s curves.
+    const expected = (muFactor(4, 0.05) + muFactor(4, 0.10)) / 2;
+    within(muFactor(4, 0.075), expected, 1e-12, 'μ@0.075s ');
+  });
+
+  it('decays monotonically as the generator loading ratio rises', () => {
+    const vals = [2.5, 3, 5, 8, 12].map(q => muFactor(q, 0.05));
+    for (let i = 1; i < vals.length; i += 1) {
+      assert.ok(vals[i] < vals[i - 1], `μ should fall as q rises: ${vals}`);
+    }
+  });
+
+  it('decays faster for longer minimum time delays', () => {
+    assert.ok(muFactor(6, 0.25) < muFactor(6, 0.10));
+    assert.ok(muFactor(6, 0.10) < muFactor(6, 0.05));
+    assert.ok(muFactor(6, 0.05) < muFactor(6, 0.02));
+  });
+
+  it('never exceeds 1 or drops to zero', () => {
+    for (const q of [2.1, 4, 10, 50, 500]) {
+      for (const t of [0.02, 0.05, 0.1, 0.25]) {
+        const mu = muFactor(q, t);
+        assert.ok(mu > 0 && mu <= 1, `μ out of range for q=${q}, t=${t}: ${mu}`);
+      }
+    }
+  });
+
+  it('falls back to μ = 1 for non-numeric input', () => {
+    assert.strictEqual(muFactor(NaN, 0.05), 1);
+    assert.strictEqual(muFactor(undefined, 0.05), 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// breakingCurrent — IEC 60909-0:2016 §8
+// ---------------------------------------------------------------------------
+
+describe('breakingCurrent — Ib (IEC 60909-0:2016 §8)', () => {
+  it('returns Ib = I″k with μ = 1 when no generator data is supplied', () => {
+    const res = breakingCurrent({ ikTotalKA: 20 });
+    assert.strictEqual(res.Ib, 20);
+    assert.strictEqual(res.mu, 1);
+    assert.strictEqual(res.nearToGenerator, false);
+    assert.strictEqual(res.ratio, null);
+  });
+
+  it('applies μ to the whole current when the generator is the only source', () => {
+    // q = 20/5 = 4 → μ = 0.86361 → Ib = 0.86361 × 20 = 17.272 kA
+    const res = breakingCurrent({
+      ikTotalKA: 20, generatorContributionKA: 20, generatorRatedCurrentKA: 5, minTimeDelayS: 0.05
+    });
+    within(res.ratio, 4, 1e-9, 'q ');
+    within(res.mu, 0.86361, 0.0001, 'μ ');
+    within(res.Ib, 17.2722, 0.001, 'Ib ');
+    assert.strictEqual(res.nearToGenerator, true);
+  });
+
+  it('leaves the non-generator infeed undecayed', () => {
+    // 10 kA of the 20 kA total is generator (q = 10/2.5 = 4 → μ = 0.86361).
+    // Ib = 0.86361×10 + 10 = 18.636 kA — only the machine share decays.
+    const res = breakingCurrent({
+      ikTotalKA: 20, generatorContributionKA: 10, generatorRatedCurrentKA: 2.5, minTimeDelayS: 0.05
+    });
+    within(res.Ib, 18.6361, 0.001, 'Ib ');
+    assert.ok(res.Ib > 17.2722, 'partial generator infeed must decay less than a full one');
+  });
+
+  it('never reports a breaking current above the initial symmetrical current', () => {
+    for (const q of [2.5, 4, 10, 40]) {
+      const res = breakingCurrent({
+        ikTotalKA: 20, generatorContributionKA: 20, generatorRatedCurrentKA: 20 / q, minTimeDelayS: 0.25
+      });
+      assert.ok(res.Ib <= 20 + 1e-9, `Ib ${res.Ib} exceeded I″k for q=${q}`);
+      assert.ok(res.Ib > 0, `Ib must stay positive for q=${q}`);
+    }
+  });
+
+  it('caps the generator share at the total current at the bus', () => {
+    // A contribution larger than the total is nonsensical; clamp rather than
+    // letting the undecayed remainder go negative.
+    const res = breakingCurrent({
+      ikTotalKA: 10, generatorContributionKA: 25, generatorRatedCurrentKA: 2.5, minTimeDelayS: 0.05
+    });
+    assert.ok(res.Ib <= 10 + 1e-9, `Ib ${res.Ib} exceeded I″k`);
+    assert.ok(res.Ib > 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeIEC60909Bus — near-to-generator path
+// ---------------------------------------------------------------------------
+
+describe('computeIEC60909Bus — near-to-generator breaking current', () => {
+  const base = {
+    z1: { r: 0.02, x: 0.2 },
+    z2: { r: 0.02, x: 0.2 },
+    z0: { r: 0.02, x: 0.2 },
+    prefaultKV: 10,
+  };
+
+  it('keeps Ib = I″k3 and μ = 1 with no generator data (far-from-generator)', () => {
+    const res = computeIEC60909Bus(base);
+    within(res.Ib, res.threePhaseKA, 0.01, 'Ib ');
+    assert.strictEqual(res.mu, 1);
+    assert.strictEqual(res.nearToGenerator, false);
+    assert.strictEqual(res.generatorRatioIkgIrg, null);
+  });
+
+  it('reduces Ib below I″k3 for a near-to-generator fault', () => {
+    const far = computeIEC60909Bus(base);
+    const near = computeIEC60909Bus({
+      ...base,
+      generatorContributionKA: far.threePhaseKA,
+      generatorRatedCurrentKA: far.threePhaseKA / 4, // q = 4
+      minTimeDelayS: 0.05,
+    });
+    assert.ok(near.Ib < near.threePhaseKA, 'Ib should decay below I″k3');
+    within(near.mu, 0.86361, 0.0001, 'μ ');
+    within(near.generatorRatioIkgIrg, 4, 0.01, 'q ');
+    assert.strictEqual(near.nearToGenerator, true);
+    // I″k3 and ip describe fault inception and must not change.
+    within(near.threePhaseKA, far.threePhaseKA, 1e-9, 'I″k3 ');
+    within(near.ip, far.ip, 1e-9, 'ip ');
+  });
+
+  it('lowers Ith for a near-to-generator fault (n < 1)', () => {
+    const far = computeIEC60909Bus(base);
+    const near = computeIEC60909Bus({
+      ...base,
+      generatorContributionKA: far.threePhaseKA,
+      generatorRatedCurrentKA: far.threePhaseKA / 6,
+      minTimeDelayS: 0.25,
+    });
+    assert.ok(near.Ith < far.Ith, `expected Ith to fall with AC decay: ${far.Ith} → ${near.Ith}`);
+  });
+
+  it('decays more for a longer minimum time delay', () => {
+    const mk = tMin => computeIEC60909Bus({
+      ...base,
+      generatorContributionKA: 15.75,
+      generatorRatedCurrentKA: 15.75 / 5,
+      minTimeDelayS: tMin,
+    }).Ib;
+    assert.ok(mk(0.25) < mk(0.10));
+    assert.ok(mk(0.10) < mk(0.05));
+    assert.ok(mk(0.05) < mk(0.02));
+  });
+});
+
+describe('runIEC60909Batch — near-to-generator pass-through', () => {
+  it('applies per-bus generator data and the batch t_min default', () => {
+    const res = runIEC60909Batch([
+      {
+        id: 'GEN-BUS',
+        z1: { r: 0.02, x: 0.2 }, z2: { r: 0.02, x: 0.2 }, z0: { r: 0.02, x: 0.2 },
+        prefaultKV: 10,
+        generatorContributionKA: 15.75,
+        generatorRatedCurrentKA: 15.75 / 4,
+      },
+      {
+        id: 'UTIL-BUS',
+        z1: { r: 0.02, x: 0.2 }, z2: { r: 0.02, x: 0.2 }, z0: { r: 0.02, x: 0.2 },
+        prefaultKV: 10,
+      },
+    ], { minTimeDelayS: 0.05 });
+
+    within(res['GEN-BUS'].mu, 0.86361, 0.0001, 'μ ');
+    assert.strictEqual(res['GEN-BUS'].nearToGenerator, true);
+    assert.ok(res['GEN-BUS'].Ib < res['GEN-BUS'].threePhaseKA);
+
+    assert.strictEqual(res['UTIL-BUS'].mu, 1);
+    assert.strictEqual(res['UTIL-BUS'].nearToGenerator, false);
+    within(res['UTIL-BUS'].Ib, res['UTIL-BUS'].threePhaseKA, 0.01, 'Ib ');
+  });
+
+  it('lets a per-bus t_min override the batch default', () => {
+    const bus = {
+      id: 'B', z1: { r: 0.02, x: 0.2 }, z2: { r: 0.02, x: 0.2 }, z0: { r: 0.02, x: 0.2 },
+      prefaultKV: 10, generatorContributionKA: 15.75, generatorRatedCurrentKA: 15.75 / 4,
+    };
+    const fast = runIEC60909Batch([{ ...bus, minTimeDelayS: 0.02 }], { minTimeDelayS: 0.25 });
+    within(fast['B'].mu, muFactor(4, 0.02), 0.0005, 'μ override ');
   });
 });


### PR DESCRIPTION
The committed docs/component-gap-analysis.md had gone stale: regenerating
it reported `relay` missing `time_dial` and `interrupting_rating_ka`,
contradicting the audit write-up's claim of zero missing attributes.

Root cause: commit 4966c00 gave the generic relay the subtype
`overcurrent_relay`, which stopped it collapsing onto the same `relay`
row as `relay_87`. The two subtypes had been sharing a row, so their
props were merged — and that merge was the only reason the row looked
complete.

Both reported gaps were false positives. A differential (87) element is
a percentage-slope sensing device: it has no time dial, and the breaker
it trips carries the interrupting duty rather than the relay.

- Add a `differential` baseline class (pickup_amps, slope1_pct,
  protected_zone_type) and classify `relay_87` into it ahead of the
  generic `protective` test, which would otherwise claim it via the
  `relay` substring.
- Stop aliasing `relay_87` onto `relay` so the two protective functions
  keep separate rows and neither masks a gap in the other.
- Split the report into a date-free `buildReportBody()` and
  `buildReport()`, and only auto-run `main()` when invoked directly, so
  the module can be imported by tests.
- Add tests/componentCoverageAudit.test.mjs: the committed report must
  match a fresh regeneration, no type may report missing attributes, and
  each relay subtype must keep its function-appropriate baseline. This
  drift guard is what was missing before.
- Regenerate the report (30 types, zero missing attributes) and correct
  the stale counts and claims in AUDIT_WEBSITE_GAPS.md section 5.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012hRd2GC4pQHH9pnpVwdjn6