### PR TITLE
Manage governed manufacturer catalog rows in the catalog browser

### DIFF
--- a/analysis/catalogImport.mjs
+++ b/analysis/catalogImport.mjs
@@ -325,6 +325,100 @@ export function buildCatalogTemplateWorkbook(XLSX) {
 }
 
 // ---------------------------------------------------------------------------
+// Export (round-trips back through the import parser)
+// ---------------------------------------------------------------------------
+
+function exportCellValue(product, column) {
+  const direct = {
+    id: product.id,
+    manufacturer: product.manufacturer,
+    catalogNumber: product.catalogNumber,
+    category: product.category,
+    subcategory: product.subcategory,
+    description: product.description,
+    material: product.material,
+    finish: product.finish,
+    width_in: product.dimensions?.widthIn,
+    depth_in: product.dimensions?.depthIn,
+    weight_lb: product.dimensions?.weightLb,
+    unit: product.unit,
+    list_price_usd: product.commercial?.listPriceUsd,
+    load_class: product.ratings?.loadClass,
+    nec_listed: product.ratings?.necListed,
+    ul_classified: product.ratings?.ulClassified,
+    approved: product.approved,
+    approval_status: product.approval?.status,
+    approval_authority: product.approval?.authority,
+    approved_by: product.approval?.approvedBy,
+    approved_at: product.approval?.approvedAt,
+    source: product.source,
+    lastVerified: product.lastVerified,
+    datasheet_url: product.datasheetUrl
+  }[column.key];
+
+  if (direct === undefined || direct === null) return '';
+  if (column.type === 'boolean') return direct ? 'TRUE' : 'FALSE';
+  return direct;
+}
+
+/**
+ * Build export rows (header → value) for the same column spec used by the
+ * import template, so an exported catalog can be edited and re-imported.
+ *
+ * @param {object[]} products catalog products (normalized or raw)
+ * @returns {object[]}
+ */
+export function buildCatalogExportRows(products = []) {
+  return (Array.isArray(products) ? products : [])
+    .map(product => normalizeCatalogProduct(product))
+    .filter(Boolean)
+    .map((product) => {
+      const row = {};
+      for (const col of CATALOG_IMPORT_COLUMNS) {
+        row[col.header] = exportCellValue(product, col);
+      }
+      return row;
+    });
+}
+
+/**
+ * Serialize a catalog to CSV using the import template headers.
+ * @param {object[]} products
+ * @returns {string}
+ */
+export function buildCatalogExportCsv(products = []) {
+  const headers = CATALOG_IMPORT_COLUMNS.map(col => col.header);
+  const rows = buildCatalogExportRows(products);
+  const lines = [headers.map(csvEscape).join(',')];
+  for (const row of rows) {
+    lines.push(headers.map(h => csvEscape(row[h])).join(','));
+  }
+  return lines.join('\r\n') + '\r\n';
+}
+
+/**
+ * Build an XLSX workbook of the catalog (Products sheet + Reference sheet),
+ * matching the import template layout.
+ *
+ * @param {object} XLSX SheetJS module (browser global or imported)
+ * @param {object[]} products
+ * @returns {object} workbook
+ */
+export function buildCatalogExportWorkbook(XLSX, products = []) {
+  if (!XLSX || !XLSX.utils || typeof XLSX.utils.book_new !== 'function') {
+    throw new Error('XLSX module is required to build the catalog workbook.');
+  }
+  const wb = XLSX.utils.book_new();
+  const headers = CATALOG_IMPORT_COLUMNS.map(col => col.header);
+  const rows = buildCatalogExportRows(products);
+  const aoa = [headers, ...rows.map(row => headers.map(h => row[h] ?? ''))];
+  const sheet = XLSX.utils.aoa_to_sheet(aoa);
+  sheet['!cols'] = headers.map(h => ({ wch: Math.max(12, Math.min(h.length + 2, 32)) }));
+  XLSX.utils.book_append_sheet(wb, sheet, 'Products');
+  return wb;
+}
+
+// ---------------------------------------------------------------------------
 // CSV parsing (RFC 4180 — quoted strings, escaped quotes, CRLF tolerant)
 // ---------------------------------------------------------------------------
 

--- a/analysis/manufacturerCatalog.mjs
+++ b/analysis/manufacturerCatalog.mjs
@@ -375,12 +375,103 @@ export function mergeCatalogProducts(baseProducts = [], projectProducts = []) {
   return merged;
 }
 
+/**
+ * Insert or replace a product in a catalog list, matching on the governed
+ * manufacturer/catalog identity. Returns a new array; the input is untouched.
+ */
+export function upsertCatalogProduct(products = [], product) {
+  const normalized = normalizeCatalogProduct(product);
+  const list = (Array.isArray(products) ? products : [])
+    .map(row => normalizeCatalogProduct(row))
+    .filter(Boolean);
+  if (!normalized) return list;
+  const key = catalogIdentity(normalized);
+  const index = list.findIndex(row => catalogIdentity(row) === key);
+  if (index === -1) return [...list, normalized];
+  const next = [...list];
+  next[index] = mergeProduct(next[index], normalized);
+  return next;
+}
+
+/**
+ * Remove a product from a catalog list. `target` may be a product object, a
+ * catalog identity string (`manufacturer::catalogNumber`), or a row id.
+ */
+export function removeCatalogProduct(products = [], target) {
+  const list = (Array.isArray(products) ? products : [])
+    .map(row => normalizeCatalogProduct(row))
+    .filter(Boolean);
+  if (!target) return list;
+  const key = typeof target === 'string'
+    ? cleanText(target).toLowerCase()
+    : catalogIdentity(target);
+  if (!key) return list;
+  return list.filter(row => catalogIdentity(row) !== key && cleanText(row.id).toLowerCase() !== key);
+}
+
+/**
+ * Roll up catalog governance evidence across a product list so the catalog
+ * browser, audits, and reports can show how much of the catalog is usable for
+ * approved-part workflows.
+ */
+export function summarizeCatalogQuality(products = [], options = {}) {
+  const rows = (Array.isArray(products) ? products : [])
+    .map(product => normalizeCatalogProduct(product))
+    .filter(Boolean);
+
+  const byConfidence = {
+    [CATALOG_CONFIDENCE_STATUS.complete]: 0,
+    [CATALOG_CONFIDENCE_STATUS.review]: 0,
+    [CATALOG_CONFIDENCE_STATUS.incomplete]: 0
+  };
+  const byApprovalStatus = { approved: 0, conditional: 0, rejected: 0, unreviewed: 0 };
+  const missingCounts = new Map();
+  const staleCounts = new Map();
+  let approved = 0;
+  let scoreTotal = 0;
+  let staleRows = 0;
+
+  rows.forEach((product) => {
+    const confidence = buildCatalogConfidence(product, options);
+    byConfidence[confidence.status] = (byConfidence[confidence.status] || 0) + 1;
+    const status = product.approval?.status || 'unreviewed';
+    byApprovalStatus[status] = (byApprovalStatus[status] || 0) + 1;
+    if (product.approved) approved += 1;
+    scoreTotal += confidence.score;
+    confidence.missingEvidence.forEach((evidence) => {
+      missingCounts.set(evidence, (missingCounts.get(evidence) || 0) + 1);
+    });
+    if (confidence.staleEvidence.length) staleRows += 1;
+    confidence.staleEvidence.forEach((evidence) => {
+      staleCounts.set(evidence, (staleCounts.get(evidence) || 0) + 1);
+    });
+  });
+
+  const toSortedCounts = map => [...map.entries()]
+    .map(([evidence, count]) => ({ evidence, count }))
+    .sort((a, b) => b.count - a.count || a.evidence.localeCompare(b.evidence));
+
+  return {
+    total: rows.length,
+    approved,
+    averageScore: rows.length ? Math.round(scoreTotal / rows.length) : 0,
+    byConfidence,
+    byApprovalStatus,
+    missingEvidence: toSortedCounts(missingCounts),
+    staleEvidence: toSortedCounts(staleCounts),
+    staleRows
+  };
+}
+
 export function filterCatalogProducts(products = [], filters = {}) {
   return (Array.isArray(products) ? products : [])
     .map(product => normalizeCatalogProduct(product))
     .filter(Boolean)
     .filter((product) => {
       if (filters.approvedOnly && !product.approved) return false;
+      if (filters.approvalStatus && (product.approval?.status || 'unreviewed') !== filters.approvalStatus) return false;
+      if (filters.confidenceStatus
+        && buildCatalogConfidence(product, filters.confidenceOptions || {}).status !== filters.confidenceStatus) return false;
       if (filters.category && product.category !== filters.category) return false;
       if (filters.subcategory && product.subcategory !== filters.subcategory) return false;
       if (filters.manufacturer && !product.manufacturer.toLowerCase().includes(String(filters.manufacturer).toLowerCase())) return false;

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -94,6 +94,23 @@ merges `data/manufacturer_catalog.json` with the project's own catalog rows
   same column spec, so an exported catalog can be edited externally and
   re-imported without remapping headers.
 
+### Catalog governance audit
+
+`npm run audit:catalog` (`scripts/auditManufacturerCatalog.mjs`) runs the same
+validation and confidence roll-up headlessly, so catalog data can be checked in
+CI or before importing a vendor file:
+
+```
+node scripts/auditManufacturerCatalog.mjs [file] [--check] [--json] \
+  [--min-score=<0-100>] [--min-complete=<0-1>] [--today=YYYY-MM-DD]
+```
+
+It accepts either a `{ products: [...] }` payload or a bare product array,
+prints the confidence roll-up, ranked evidence gaps, and the lowest-confidence
+rows, and with `--check` exits non-zero on schema errors or unmet thresholds.
+The npm script uses `--check` with no thresholds, so it guards schema validity
+without pinning the seed catalog's current evidence coverage.
+
 The shipped seed rows in `data/manufacturer_catalog.json` are placeholders for
 approved-part workflows: they carry approval, source, and verification metadata
 but intentionally no datasheet URLs or EPD figures, so they report a **review**

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -63,3 +63,39 @@ score from identity, approval, source/date, datasheet, BIM, standards/listing,
 and EPD/CO2e evidence. Submittal XLSX exports include a **Catalog Traceability**
 sheet with the confidence score, missing evidence list, datasheet URL, BIM
 reference, standards, and EPD metadata for each schedule row.
+
+`summarizeCatalogQuality(products, options)` rolls the same evidence up across a
+whole catalog: totals by confidence status and approval status, the average
+evidence score, the most common missing-evidence gaps, and how many rows carry
+stale verification dates or expired EPDs.
+
+## Manufacturer Catalog Management
+
+The catalog browser mounted on the Tray Hardware BOM page (`src/catalogBrowser.js`)
+merges `data/manufacturer_catalog.json` with the project's own catalog rows
+(`settings.trayHardwareCatalogCustomProducts`) and manages the project rows:
+
+- **Add / edit / remove.** Project rows can be edited in place or removed
+  (remove requires a second confirming click). Base catalog rows are read-only,
+  and the table's **Origin** column shows which is which. Edits and adds are
+  keyed by governed identity (`manufacturer::catalogNumber`) through
+  `upsertCatalogProduct` / `removeCatalogProduct`, so a project row cannot
+  silently duplicate an existing catalog identity.
+- **Evidence fields.** The add/edit form captures the full governed set —
+  approval authority, source, last-verified date, datasheet URL, standards, BIM
+  family, EPD source/validity, and CO2e — so project rows can reach a
+  **complete** catalog confidence status.
+- **Filtering.** Rows can be filtered by category, manufacturer, material,
+  approval status, catalog confidence status, origin, and free text. A summary
+  above the table reports the confidence roll-up for the rows in view.
+- **Import / export.** Imports accept CSV or XLSX using the template columns in
+  `analysis/catalogImport.mjs`. Exports (`buildCatalogExportCsv`,
+  `buildCatalogExportWorkbook`, and a JSON export of the filtered view) use the
+  same column spec, so an exported catalog can be edited externally and
+  re-imported without remapping headers.
+
+The shipped seed rows in `data/manufacturer_catalog.json` are placeholders for
+approved-part workflows: they carry approval, source, and verification metadata
+but intentionally no datasheet URLs or EPD figures, so they report a **review**
+confidence status until a project replaces them with rows backed by real vendor
+documentation.

--- a/docs/page-contract-audit.md
+++ b/docs/page-contract-audit.md
@@ -990,13 +990,13 @@ The audit is intentionally conservative: `--check` fails on actionable drift and
 
 **Detected Reads**
 - `settings.trayHardwareCatalogCustomProducts`
-  - src/catalogBrowser.js:41 getTrayHardwareCatalogCustomProducts()
+  - src/catalogBrowser.js:54 getTrayHardwareCatalogCustomProducts()
 - `traySchedule`
   - src/trayhardwarebom.js:37 getTrays()
 
 **Detected Writes**
 - `settings.trayHardwareCatalogCustomProducts`
-  - src/catalogBrowser.js:50 setTrayHardwareCatalogCustomProducts()
+  - src/catalogBrowser.js:63 setTrayHardwareCatalogCustomProducts()
 
 ### Clash Detection (`clashdetect.html`)
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "e2e:heat-trace": "playwright test --config playwright.config.cjs playwright-tests/heatTrace.acceptance.spec.js",
     "e2e:heat-trace-dashboard": "playwright test --config playwright.config.cjs playwright-tests/heatTrace.acceptance.spec.js --grep \"AT-HT-0[1-5]\"",
     "e2e:heat-trace-export": "playwright test --config playwright.config.cjs playwright-tests/heatTrace.acceptance.spec.js --grep \"AT-HT-06\"",
+    "audit:catalog": "node scripts/auditManufacturerCatalog.mjs --check",
     "audit:components": "node scripts/componentCoverageAudit.mjs",
     "audit:symbol-continuity": "node scripts/auditOneLineSymbolContinuity.mjs",
     "audit:page-contracts": "node scripts/auditPageContracts.mjs",

--- a/playwright-tests/catalogBrowser.spec.js
+++ b/playwright-tests/catalogBrowser.spec.js
@@ -1,0 +1,223 @@
+/**
+ * E2E coverage for the manufacturer catalog browser on the Tray Hardware BOM
+ * page: governed evidence display, project-row add/edit/remove, filters, and
+ * catalog export.
+ *
+ * The browser fetches `data/manufacturer_catalog.json`, so these tests run
+ * against a static HTTP server rather than `file://`.
+ */
+import { test, expect } from '@playwright/test';
+import fs from 'fs/promises';
+import http from 'http';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, '..');
+
+async function startStaticServer() {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      const requested = decodeURIComponent(url.pathname === '/' ? '/index.html' : url.pathname);
+      const filePath = path.resolve(root, `.${requested}`);
+      if (!(filePath === root || filePath.startsWith(root + path.sep))) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+      }
+      const body = await fs.readFile(filePath);
+      const ext = path.extname(filePath).toLowerCase();
+      const type = {
+        '.html': 'text/html; charset=utf-8',
+        '.js': 'text/javascript; charset=utf-8',
+        '.mjs': 'text/javascript; charset=utf-8',
+        '.css': 'text/css; charset=utf-8',
+        '.json': 'application/json; charset=utf-8',
+        '.svg': 'image/svg+xml',
+        '.png': 'image/png',
+      }[ext] || 'application/octet-stream';
+      res.writeHead(200, { 'Content-Type': type });
+      res.end(body);
+    } catch {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  return {
+    url: file => new URL(file, `http://127.0.0.1:${port}/`).toString(),
+    close: () => new Promise(resolve => server.close(resolve)),
+  };
+}
+
+const PROJECT_ROW = {
+  id: 'PRJ-TRAY-18',
+  manufacturer: 'Project Vendor',
+  catalogNumber: 'PV-18-4',
+  description: 'Project approved 18 in tray',
+  material: 'aluminum',
+  width_in: '18',
+  depth_in: '4',
+  list_price_usd: '210.50',
+  approvalAuthority: 'Project EE',
+  source: 'Approved list rev C',
+  lastVerified: '2026-07-01',
+  datasheetUrl: 'https://example.com/pv-18-4.pdf',
+  standards: 'NEMA VE 1; UL classified',
+  bimFamilyName: 'Cable Tray - Ventilated',
+  epdSource: 'Vendor EPD 2026',
+  epdValidUntil: '2028-01-01',
+  co2eKgPerUnit: '5.5',
+};
+
+async function fillCatalogForm(page, values) {
+  for (const [name, value] of Object.entries(values)) {
+    await page.fill(`.catalog-add-form [name="${name}"]`, String(value));
+  }
+}
+
+async function addProjectRow(page, overrides = {}) {
+  const values = { ...PROJECT_ROW, ...overrides };
+  await fillCatalogForm(page, values);
+  await page.check('.catalog-add-form [name="approved"]');
+  await page.selectOption('.catalog-add-form [name="category"]', 'tray');
+  await page.click('.catalog-add-submit');
+  return values;
+}
+
+function rowFor(page, partNumber) {
+  return page.locator(`.catalog-table tbody tr[data-product-id="${partNumber}"]`);
+}
+
+test.describe('Manufacturer catalog browser', () => {
+  let staticSite;
+
+  test.beforeAll(async () => {
+    staticSite = await startStaticServer();
+  });
+
+  test.afterAll(async () => {
+    await staticSite.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    await page.goto(staticSite.url('trayhardwarebom.html?e2e=1&e2e_reset=1'));
+    await expect(page.locator('.catalog-table tbody tr').first()).toBeVisible();
+  });
+
+  test('renders seed catalog rows with governance evidence', async ({ page }) => {
+    const rows = page.locator('.catalog-table tbody tr');
+    expect(await rows.count()).toBeGreaterThanOrEqual(20);
+
+    await expect(page.locator('.catalog-quality-counts')).toContainText('approved');
+    await expect(page.locator('.catalog-quality-gaps')).toContainText('Top evidence gaps');
+
+    const firstRow = rows.first();
+    await expect(firstRow).toHaveAttribute('data-catalog-origin', 'base');
+    await expect(firstRow.locator('.catalog-confidence')).toBeVisible();
+  });
+
+  test('base catalog rows are read-only', async ({ page }) => {
+    const firstRow = page.locator('.catalog-table tbody tr').first();
+    await expect(firstRow.locator('.catalog-row-edit')).toHaveCount(0);
+    await expect(firstRow.locator('.catalog-row-remove')).toHaveCount(0);
+  });
+
+  test('adds a fully governed project row at complete confidence', async ({ page }) => {
+    await addProjectRow(page);
+
+    await expect(page.locator('.catalog-add-status')).toContainText('Added PRJ-TRAY-18');
+    const row = rowFor(page, 'PRJ-TRAY-18');
+    await expect(row).toHaveAttribute('data-catalog-origin', 'project');
+    await expect(row.locator('.catalog-confidence')).toHaveText('Complete 100%');
+    await expect(row).toContainText('$210.50');
+  });
+
+  test('rejects a duplicate manufacturer/catalog identity', async ({ page }) => {
+    await addProjectRow(page);
+    const before = await page.locator('.catalog-table tbody tr').count();
+
+    await addProjectRow(page, { id: 'PRJ-TRAY-18-COPY', description: 'Duplicate identity attempt' });
+
+    await expect(page.locator('.catalog-add-status')).toContainText('already exists');
+    expect(await page.locator('.catalog-table tbody tr').count()).toBe(before);
+  });
+
+  test('edits a project row in place', async ({ page }) => {
+    await addProjectRow(page);
+    const before = await page.locator('.catalog-table tbody tr').count();
+
+    await rowFor(page, 'PRJ-TRAY-18').locator('.catalog-row-edit').click();
+    await expect(page.locator('.catalog-add-submit')).toHaveText('Save Changes');
+    await expect(page.locator('.catalog-add-form [name="epdSource"]')).toHaveValue('Vendor EPD 2026');
+
+    await page.fill('.catalog-add-form [name="description"]', 'Project approved 18 in tray (rev D)');
+    await page.fill('.catalog-add-form [name="list_price_usd"]', '225');
+    await page.click('.catalog-add-submit');
+
+    await expect(page.locator('.catalog-add-status')).toContainText('Updated PRJ-TRAY-18');
+    expect(await page.locator('.catalog-table tbody tr').count()).toBe(before);
+    const row = rowFor(page, 'PRJ-TRAY-18');
+    await expect(row).toContainText('rev D');
+    await expect(row).toContainText('$225.00');
+    await expect(page.locator('.catalog-add-submit')).toHaveText('Add Item');
+  });
+
+  test('removes a project row only after a confirming click', async ({ page }) => {
+    await addProjectRow(page);
+    const before = await page.locator('.catalog-table tbody tr').count();
+
+    const removeBtn = rowFor(page, 'PRJ-TRAY-18').locator('.catalog-row-remove');
+    await removeBtn.click();
+    await expect(removeBtn).toHaveText('Confirm remove');
+    expect(await page.locator('.catalog-table tbody tr').count()).toBe(before);
+
+    await removeBtn.click();
+    await expect(page.locator('.catalog-add-status')).toContainText('Removed PRJ-TRAY-18');
+    await expect(rowFor(page, 'PRJ-TRAY-18')).toHaveCount(0);
+  });
+
+  test('filters by origin and catalog confidence', async ({ page }) => {
+    await addProjectRow(page);
+
+    await page.selectOption('[data-catalog-filter="origin"]', 'project');
+    await expect(page.locator('.catalog-table tbody tr')).toHaveCount(1);
+    await expect(rowFor(page, 'PRJ-TRAY-18')).toBeVisible();
+
+    await page.selectOption('[data-catalog-filter="origin"]', '');
+    await page.selectOption('[data-catalog-filter="confidence"]', 'complete');
+    await expect(page.locator('.catalog-table tbody tr')).toHaveCount(1);
+
+    await page.selectOption('[data-catalog-filter="confidence"]', 'incomplete');
+    await expect(page.locator('.catalog-empty')).toBeVisible();
+  });
+
+  test('exports the current view as CSV using the import template columns', async ({ page }) => {
+    await addProjectRow(page);
+    await page.selectOption('[data-catalog-filter="origin"]', 'project');
+    await expect(page.locator('.catalog-table tbody tr')).toHaveCount(1);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('.catalog-export-csv'),
+    ]);
+    const stream = await download.createReadStream();
+    const chunks = [];
+    for await (const chunk of stream) chunks.push(chunk);
+    const csv = Buffer.concat(chunks).toString('utf8');
+
+    const [header, firstDataRow] = csv.split('\r\n');
+    expect(header).toContain('Part Number');
+    expect(header).toContain('Last Verified');
+    expect(header).toContain('Datasheet URL');
+    expect(firstDataRow).toContain('PRJ-TRAY-18');
+    expect(firstDataRow).toContain('Approved list rev C');
+    await expect(page.locator('.catalog-import-status')).toContainText('Exported 1 row(s) to CSV');
+  });
+});

--- a/scripts/auditManufacturerCatalog.mjs
+++ b/scripts/auditManufacturerCatalog.mjs
@@ -1,0 +1,185 @@
+/**
+ * Manufacturer catalog governance audit.
+ *
+ * Validates a catalog file against the governed schema and reports the
+ * catalog-confidence roll-up used by BOM, submittal, cost, and BIM export
+ * flows. Works on the shipped seed catalog and on any exported/imported
+ * project catalog that uses the same `{ products: [...] }` shape.
+ *
+ *   node scripts/auditManufacturerCatalog.mjs [file] [options]
+ *
+ *   --check              exit non-zero on validation errors or threshold misses
+ *   --min-score=<0-100>  minimum average evidence score for --check
+ *   --min-complete=<n>   minimum share (0-1) of rows at complete confidence
+ *   --today=YYYY-MM-DD   evaluation date for staleness checks
+ *   --json               emit the audit as JSON instead of text
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  buildCatalogConfidence,
+  summarizeCatalogQuality,
+  validateCatalog
+} from '../analysis/manufacturerCatalog.mjs';
+
+const DEFAULT_FILE = 'data/manufacturer_catalog.json';
+
+export function parseAuditArgs(argv = []) {
+  const options = {
+    file: DEFAULT_FILE,
+    check: false,
+    json: false,
+    minScore: null,
+    minCompleteRatio: null,
+    today: ''
+  };
+  for (const arg of argv) {
+    if (arg === '--check') options.check = true;
+    else if (arg === '--json') options.json = true;
+    else if (arg.startsWith('--min-score=')) options.minScore = Number(arg.split('=')[1]);
+    else if (arg.startsWith('--min-complete=')) options.minCompleteRatio = Number(arg.split('=')[1]);
+    else if (arg.startsWith('--today=')) options.today = arg.split('=')[1];
+    else if (!arg.startsWith('--')) options.file = arg;
+  }
+  return options;
+}
+
+function readProducts(catalog) {
+  if (Array.isArray(catalog)) return catalog;
+  if (Array.isArray(catalog?.products)) return catalog.products;
+  return [];
+}
+
+/**
+ * Audit a parsed catalog payload.
+ * @param {object|object[]} catalog `{ products: [...] }` or a bare array
+ * @param {object} [options] `today`, `minScore`, `minCompleteRatio`, `verificationMaxAgeDays`
+ */
+export function auditCatalog(catalog, options = {}) {
+  const products = readProducts(catalog);
+  const validation = validateCatalog(products, { requireApprovalAuthority: false });
+  const confidenceOptions = {
+    today: options.today || undefined,
+    verificationMaxAgeDays: options.verificationMaxAgeDays
+  };
+  const summary = summarizeCatalogQuality(validation.products, confidenceOptions);
+
+  const rows = validation.products.map((product) => {
+    const confidence = buildCatalogConfidence(product, confidenceOptions);
+    return {
+      id: product.id,
+      manufacturer: product.manufacturer,
+      catalogNumber: product.catalogNumber,
+      approvalStatus: product.approval?.status || 'unreviewed',
+      score: confidence.score,
+      status: confidence.status,
+      missingEvidence: confidence.missingEvidence,
+      staleEvidence: confidence.staleEvidence
+    };
+  });
+
+  const completeRatio = summary.total ? summary.byConfidence.complete / summary.total : 0;
+  const failures = [];
+  validation.errors.forEach(error => failures.push({
+    code: 'schema-error',
+    message: `${error.path}: ${error.message}`
+  }));
+  if (options.minScore != null && Number.isFinite(options.minScore)
+    && summary.averageScore < options.minScore) {
+    failures.push({
+      code: 'below-min-score',
+      message: `Average evidence score ${summary.averageScore} is below the required ${options.minScore}.`
+    });
+  }
+  if (options.minCompleteRatio != null && Number.isFinite(options.minCompleteRatio)
+    && completeRatio < options.minCompleteRatio) {
+    failures.push({
+      code: 'below-min-complete',
+      message: `Complete-confidence share ${completeRatio.toFixed(2)} is below the required `
+        + `${Number(options.minCompleteRatio).toFixed(2)}.`
+    });
+  }
+
+  return {
+    valid: failures.length === 0,
+    summary,
+    completeRatio,
+    rows,
+    errors: validation.errors,
+    warnings: validation.warnings,
+    failures
+  };
+}
+
+export function renderAuditReport(audit, { file = DEFAULT_FILE } = {}) {
+  const { summary, rows } = audit;
+  const lines = [
+    `Manufacturer catalog audit — ${file}`,
+    `  Rows: ${summary.total} (${summary.approved} approved)`,
+    `  Confidence: ${summary.byConfidence.complete} complete, `
+      + `${summary.byConfidence.review} review, ${summary.byConfidence.incomplete} incomplete`,
+    `  Average evidence score: ${summary.averageScore}%`
+  ];
+
+  if (summary.missingEvidence.length) {
+    lines.push('  Evidence gaps:');
+    summary.missingEvidence.forEach(item => lines.push(`    - ${item.evidence}: ${item.count} row(s)`));
+  }
+  if (summary.staleRows) {
+    lines.push(`  Stale evidence: ${summary.staleRows} row(s)`);
+    summary.staleEvidence.forEach(item => lines.push(`    - ${item.evidence}: ${item.count} row(s)`));
+  }
+
+  const weakest = rows
+    .filter(row => row.status !== 'complete')
+    .sort((a, b) => a.score - b.score)
+    .slice(0, 10);
+  if (weakest.length) {
+    lines.push('  Lowest-confidence rows:');
+    weakest.forEach(row => lines.push(
+      `    - ${row.id} (${row.score}%, ${row.status}): missing ${row.missingEvidence.join(', ') || 'nothing'}`
+    ));
+  }
+
+  if (audit.errors.length) {
+    lines.push(`  Schema errors: ${audit.errors.length}`);
+    audit.errors.slice(0, 20).forEach(error => lines.push(`    - ${error.path}: ${error.message}`));
+  }
+  if (audit.warnings.length) {
+    lines.push(`  Schema warnings: ${audit.warnings.length}`);
+  }
+  if (audit.failures.length) {
+    lines.push('  FAILURES:');
+    audit.failures.forEach(failure => lines.push(`    - ${failure.message}`));
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const options = parseAuditArgs(process.argv.slice(2));
+  const catalog = JSON.parse(await fs.readFile(options.file, 'utf8'));
+  const audit = auditCatalog(catalog, options);
+
+  if (options.json) {
+    console.log(JSON.stringify(audit, null, 2));
+  } else {
+    process.stdout.write(renderAuditReport(audit, { file: options.file }));
+  }
+
+  if (options.check && !audit.valid) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedDirectly = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/src/catalogBrowser.js
+++ b/src/catalogBrowser.js
@@ -3,13 +3,20 @@ import {
   setTrayHardwareCatalogCustomProducts
 } from '../dataStore.mjs';
 import {
+  buildCatalogConfidence,
+  catalogIdentity,
   filterCatalogProducts,
   getCatalogOptionsFromProducts,
   mergeCatalogProducts,
   normalizeCatalogProduct,
+  removeCatalogProduct,
+  summarizeCatalogQuality,
+  upsertCatalogProduct,
   validateCatalogProduct
 } from '../analysis/manufacturerCatalog.mjs';
 import {
+  buildCatalogExportCsv,
+  buildCatalogExportWorkbook,
   buildCatalogTemplateCsv,
   buildCatalogTemplateWorkbook,
   parseCatalogCsv,
@@ -24,6 +31,12 @@ import {
  *   - filterProducts(filters)  — query products by category, manufacturer, width, etc.
  *   - renderCatalogTable(container, products) — render a filterable product table
  *   - getCatalogProduct(id)    — look up a single product by SKU
+ *
+ * The mounted browser also manages the project's custom catalog rows: add,
+ * edit, remove, bulk import, and export. Governed evidence (approval, source,
+ * verification date, datasheet, BIM, standards, EPD) is surfaced per row as a
+ * catalog confidence status so unusable rows are visible before they reach BOM,
+ * submittal, cost, and BIM export flows.
  *
  * Intended for use by the Tray Hardware BOM wizard and the Submittal Package
  * generator to select real manufacturer part numbers and list prices.
@@ -80,6 +93,8 @@ export async function loadCatalog() {
  * @param {number}   [filters.widthIn]      - exact tray width in inches
  * @param {number}   [filters.depthIn]      - exact tray depth in inches
  * @param {string}   [filters.material]     - 'steel' | 'aluminum' | 'fiberglass' etc.
+ * @param {string}   [filters.approvalStatus]   - 'approved' | 'conditional' | 'rejected' | 'unreviewed'
+ * @param {string}   [filters.confidenceStatus] - 'complete' | 'review' | 'incomplete'
  * @param {string}   [filters.search]       - free-text search across description, id, series
  * @returns {Promise<object[]>}
  */
@@ -112,19 +127,49 @@ export async function getCatalogOptions(field) {
 // UI helpers
 // ---------------------------------------------------------------------------
 
+const CONFIDENCE_LABELS = {
+  complete: 'Complete',
+  review: 'Review',
+  incomplete: 'Incomplete'
+};
+
+function confidenceLabel(confidence) {
+  const label = CONFIDENCE_LABELS[confidence.status] || confidence.status;
+  return `${label} ${confidence.score}%`;
+}
+
+function confidenceTitle(confidence) {
+  const parts = [];
+  if (confidence.missingEvidence.length) parts.push(`Missing: ${confidence.missingEvidence.join(', ')}`);
+  if (confidence.staleEvidence.length) parts.push(`Stale: ${confidence.staleEvidence.join(', ')}`);
+  return parts.join(' — ') || 'All governed catalog evidence present.';
+}
+
 /**
  * Render a catalog product table into a container element.
  *
  * Supports:
  *   - Column headers: Part Number, Manufacturer, Description, Width, Depth, Material, List Price
  *   - onSelect(product) callback when a row is clicked or Enter is pressed
+ *   - Origin + catalog confidence columns, and edit/remove actions for the
+ *     project's own catalog rows
  *
  * @param {HTMLElement} container
  * @param {object[]}    products
  * @param {object}      [opts]
  * @param {function}    [opts.onSelect] - callback(product) when user selects a row
+ * @param {Set<string>} [opts.projectIdentities] - identities owned by the project catalog
+ * @param {function}    [opts.onEdit]   - callback(product) for project rows
+ * @param {function}    [opts.onRemove] - callback(product) for project rows
+ * @param {object}      [opts.confidenceOptions] - options passed to buildCatalogConfidence
  */
-export function renderCatalogTable(container, products, { onSelect } = {}) {
+export function renderCatalogTable(container, products, {
+  onSelect,
+  projectIdentities,
+  onEdit,
+  onRemove,
+  confidenceOptions
+} = {}) {
   if (!container) return;
   container.innerHTML = '';
 
@@ -135,6 +180,9 @@ export function renderCatalogTable(container, products, { onSelect } = {}) {
     container.appendChild(p);
     return;
   }
+
+  const owned = projectIdentities instanceof Set ? projectIdentities : new Set();
+  const showActions = typeof onEdit === 'function' || typeof onRemove === 'function';
 
   const table = document.createElement('table');
   table.className = 'catalog-table';
@@ -153,7 +201,10 @@ export function renderCatalogTable(container, products, { onSelect } = {}) {
     { key: 'unit', label: 'Unit' },
     { key: 'commercial.listPriceUsd', label: 'List Price' },
     { key: 'approval.status', label: 'Approval' },
+    { key: 'confidence', label: 'Catalog Confidence' },
+    { key: 'origin', label: 'Origin' },
   ];
+  if (showActions) columns.push({ key: 'actions', label: 'Actions' });
   for (const col of columns) {
     const th = document.createElement('th');
     th.scope = 'col';
@@ -165,19 +216,82 @@ export function renderCatalogTable(container, products, { onSelect } = {}) {
 
   const tbody = document.createElement('tbody');
   for (const product of products) {
+    const identity = catalogIdentity(product);
+    const isProjectRow = owned.has(identity);
+    const confidence = buildCatalogConfidence(product, confidenceOptions || {});
     const tr = document.createElement('tr');
     tr.tabIndex = 0;
     tr.setAttribute('role', 'button');
     tr.setAttribute('aria-label', `Select ${product.description}`);
     tr.dataset.productId = product.id;
+    tr.dataset.catalogIdentity = identity;
+    tr.dataset.catalogOrigin = isProjectRow ? 'project' : 'base';
 
     for (const col of columns) {
       const td = document.createElement('td');
+      if (col.key === 'confidence') {
+        const badge = document.createElement('span');
+        badge.className = `catalog-confidence catalog-confidence-${confidence.status}`;
+        badge.textContent = confidenceLabel(confidence);
+        badge.title = confidenceTitle(confidence);
+        td.appendChild(badge);
+        if (confidence.missingEvidence.length) {
+          const detail = document.createElement('span');
+          detail.className = 'catalog-confidence-detail';
+          detail.textContent = `Missing ${confidence.missingEvidence.length}`;
+          td.appendChild(detail);
+        }
+        tr.appendChild(td);
+        continue;
+      }
+      if (col.key === 'origin') {
+        td.textContent = isProjectRow ? 'Project' : 'Base catalog';
+        tr.appendChild(td);
+        continue;
+      }
+      if (col.key === 'actions') {
+        if (isProjectRow) {
+          td.className = 'catalog-row-actions';
+          if (typeof onEdit === 'function') {
+            const editBtn = document.createElement('button');
+            editBtn.type = 'button';
+            editBtn.className = 'catalog-row-edit';
+            editBtn.textContent = 'Edit';
+            editBtn.setAttribute('aria-label', `Edit ${product.id}`);
+            editBtn.addEventListener('click', (e) => {
+              e.stopPropagation();
+              onEdit(product);
+            });
+            td.appendChild(editBtn);
+          }
+          if (typeof onRemove === 'function') {
+            const removeBtn = document.createElement('button');
+            removeBtn.type = 'button';
+            removeBtn.className = 'catalog-row-remove';
+            removeBtn.textContent = 'Remove';
+            removeBtn.setAttribute('aria-label', `Remove ${product.id}`);
+            removeBtn.addEventListener('click', (e) => {
+              e.stopPropagation();
+              if (removeBtn.dataset.confirm !== 'true') {
+                removeBtn.dataset.confirm = 'true';
+                removeBtn.textContent = 'Confirm remove';
+                return;
+              }
+              onRemove(product);
+            });
+            td.appendChild(removeBtn);
+          }
+        } else {
+          td.textContent = '—';
+        }
+        tr.appendChild(td);
+        continue;
+      }
       const val = col.key.split('.').reduce((value, key) => value?.[key], product);
       if (col.key === 'commercial.listPriceUsd') {
         td.textContent = val != null ? `$${Number(val).toFixed(2)}` : '—';
       } else {
-        td.textContent = val != null ? String(val) : '—';
+        td.textContent = val != null && val !== '' ? String(val) : '—';
       }
       tr.appendChild(td);
     }
@@ -196,9 +310,196 @@ export function renderCatalogTable(container, products, { onSelect } = {}) {
 }
 
 /**
+ * Render a governance roll-up for the products currently in view.
+ *
+ * @param {HTMLElement} container
+ * @param {object[]} products
+ * @param {object} [options] - forwarded to summarizeCatalogQuality
+ */
+export function renderCatalogQuality(container, products, options = {}) {
+  if (!container) return;
+  const summary = summarizeCatalogQuality(products, options);
+  container.innerHTML = '';
+
+  const counts = document.createElement('p');
+  counts.className = 'catalog-quality-counts';
+  counts.textContent = summary.total === 0
+    ? 'No catalog rows in view.'
+    : `${summary.total} row(s) · ${summary.approved} approved · `
+      + `${summary.byConfidence.complete} complete, ${summary.byConfidence.review} review, `
+      + `${summary.byConfidence.incomplete} incomplete · average evidence score ${summary.averageScore}%`;
+  container.appendChild(counts);
+
+  if (summary.missingEvidence.length) {
+    const gaps = document.createElement('p');
+    gaps.className = 'catalog-quality-gaps';
+    gaps.textContent = `Top evidence gaps: ${summary.missingEvidence
+      .slice(0, 3)
+      .map(item => `${item.evidence} (${item.count})`)
+      .join(', ')}`;
+    container.appendChild(gaps);
+  }
+
+  if (summary.staleRows) {
+    const stale = document.createElement('p');
+    stale.className = 'catalog-quality-stale';
+    stale.textContent = `${summary.staleRows} row(s) carry stale verification or expired EPD evidence.`;
+    container.appendChild(stale);
+  }
+
+  return summary;
+}
+
+const ADD_FORM_FIELDS = `
+  <fieldset class="catalog-form-group">
+    <legend>Identity</legend>
+    <label class="catalog-filter-label">Part Number <input class="catalog-filter-input" name="id" required></label>
+    <label class="catalog-filter-label">Manufacturer <input class="catalog-filter-input" name="manufacturer" required></label>
+    <label class="catalog-filter-label">Catalog No. <input class="catalog-filter-input" name="catalogNumber" placeholder="defaults to part number"></label>
+    <label class="catalog-filter-label">Category
+      <select class="catalog-filter-select" name="category">
+        <option value="tray">tray</option>
+        <option value="fitting">fitting</option>
+        <option value="conduit">conduit</option>
+        <option value="accessory">accessory</option>
+      </select>
+    </label>
+    <label class="catalog-filter-label">Subcategory <input class="catalog-filter-input" name="subcategory" placeholder="straight, elbow, cover…"></label>
+    <label class="catalog-filter-label">Description <input class="catalog-filter-input" name="description" required></label>
+  </fieldset>
+  <fieldset class="catalog-form-group">
+    <legend>Physical &amp; commercial</legend>
+    <label class="catalog-filter-label">Material <input class="catalog-filter-input" name="material" placeholder="steel"></label>
+    <label class="catalog-filter-label">Finish <input class="catalog-filter-input" name="finish" placeholder="pre-galvanized"></label>
+    <label class="catalog-filter-label">Width (in) <input class="catalog-filter-input" name="width_in" type="number" min="0" step="0.25"></label>
+    <label class="catalog-filter-label">Depth (in) <input class="catalog-filter-input" name="depth_in" type="number" min="0" step="0.25"></label>
+    <label class="catalog-filter-label">Weight (lb) <input class="catalog-filter-input" name="weight_lb" type="number" min="0" step="0.1"></label>
+    <label class="catalog-filter-label">Load Class <input class="catalog-filter-input" name="load_class" placeholder="20A"></label>
+    <label class="catalog-filter-label">Unit
+      <select class="catalog-filter-select" name="unit">
+        <option value="EA">EA</option>
+        <option value="FT">FT</option>
+        <option value="LF">LF</option>
+      </select>
+    </label>
+    <label class="catalog-filter-label">List Price (USD) <input class="catalog-filter-input" name="list_price_usd" type="number" min="0" step="0.01" value="0"></label>
+  </fieldset>
+  <fieldset class="catalog-form-group">
+    <legend>Governed evidence</legend>
+    <label class="catalog-filter-label">Approved <input name="approved" type="checkbox"></label>
+    <label class="catalog-filter-label">Approval Authority <input class="catalog-filter-input" name="approvalAuthority" placeholder="Project EE"></label>
+    <label class="catalog-filter-label">Source <input class="catalog-filter-input" name="source" placeholder="approved list, quote, or datasheet"></label>
+    <label class="catalog-filter-label">Last Verified <input class="catalog-filter-input" name="lastVerified" type="date"></label>
+    <label class="catalog-filter-label">Datasheet URL <input class="catalog-filter-input" name="datasheetUrl" type="url" placeholder="https://…"></label>
+    <label class="catalog-filter-label">Standards <input class="catalog-filter-input" name="standards" placeholder="NEMA VE 1; UL classified"></label>
+    <label class="catalog-filter-label">BIM Family <input class="catalog-filter-input" name="bimFamilyName" placeholder="Cable Tray - Ventilated"></label>
+    <label class="catalog-filter-label">EPD Source <input class="catalog-filter-input" name="epdSource" placeholder="Vendor EPD reference"></label>
+    <label class="catalog-filter-label">EPD Valid Until <input class="catalog-filter-input" name="epdValidUntil" type="date"></label>
+    <label class="catalog-filter-label">CO2e (kg/unit) <input class="catalog-filter-input" name="co2eKgPerUnit" type="number" min="0" step="0.01"></label>
+  </fieldset>
+  <div class="catalog-add-actions">
+    <button type="submit" class="catalog-add-submit">Add Item</button>
+    <button type="button" class="catalog-add-cancel" hidden>Cancel Edit</button>
+  </div>
+`;
+
+function formValue(formData, name) {
+  return String(formData.get(name) || '').trim();
+}
+
+function formNumber(formData, name) {
+  const raw = formValue(formData, name);
+  if (raw === '') return null;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : null;
+}
+
+function productFromForm(formData) {
+  const productId = formValue(formData, 'id');
+  const catalogNumber = formValue(formData, 'catalogNumber') || productId;
+  const standards = formValue(formData, 'standards')
+    .split(/[;,]/)
+    .map(item => item.trim())
+    .filter(Boolean);
+  return {
+    id: productId,
+    catalogNumber,
+    manufacturer: formValue(formData, 'manufacturer'),
+    series: 'Custom',
+    category: formValue(formData, 'category') || 'accessory',
+    subcategory: formValue(formData, 'subcategory') || 'custom',
+    description: formValue(formData, 'description'),
+    width_in: formNumber(formData, 'width_in'),
+    depth_in: formNumber(formData, 'depth_in'),
+    weight_lb: formNumber(formData, 'weight_lb'),
+    angle_deg: null,
+    material: formValue(formData, 'material') || 'steel',
+    finish: formValue(formData, 'finish') || 'none',
+    load_class: formValue(formData, 'load_class') || null,
+    unit: formValue(formData, 'unit') || 'EA',
+    list_price_usd: formNumber(formData, 'list_price_usd') ?? 0,
+    standards,
+    nec_listed: standards.some(item => /nec/i.test(item)),
+    ul_classified: standards.some(item => /\bul\b/i.test(item)),
+    datasheetUrl: formValue(formData, 'datasheetUrl'),
+    bimRef: {
+      familyName: formValue(formData, 'bimFamilyName'),
+      typeName: catalogNumber,
+      classification: formValue(formData, 'category')
+    },
+    epd: {
+      source: formValue(formData, 'epdSource'),
+      validUntil: formValue(formData, 'epdValidUntil'),
+      co2eKgPerUnit: formNumber(formData, 'co2eKgPerUnit')
+    },
+    approved: formData.get('approved') === 'on',
+    approval: {
+      status: formData.get('approved') === 'on' ? 'approved' : 'unreviewed',
+      authority: formValue(formData, 'approvalAuthority')
+    },
+    source: formValue(formData, 'source'),
+    lastVerified: formValue(formData, 'lastVerified')
+  };
+}
+
+function fillFormFromProduct(form, product) {
+  const setValue = (name, value) => {
+    const field = form.elements.namedItem(name);
+    if (!field) return;
+    if (field.type === 'checkbox') field.checked = Boolean(value);
+    else field.value = value == null ? '' : String(value);
+  };
+  setValue('id', product.id);
+  setValue('manufacturer', product.manufacturer);
+  setValue('catalogNumber', product.catalogNumber);
+  setValue('category', product.category || 'accessory');
+  setValue('subcategory', product.subcategory);
+  setValue('description', product.description);
+  setValue('material', product.material);
+  setValue('finish', product.finish);
+  setValue('width_in', product.dimensions?.widthIn);
+  setValue('depth_in', product.dimensions?.depthIn);
+  setValue('weight_lb', product.dimensions?.weightLb);
+  setValue('load_class', product.ratings?.loadClass);
+  setValue('unit', product.unit || 'EA');
+  setValue('list_price_usd', product.commercial?.listPriceUsd ?? 0);
+  setValue('approved', product.approved);
+  setValue('approvalAuthority', product.approval?.authority);
+  setValue('source', product.source);
+  setValue('lastVerified', product.lastVerified);
+  setValue('datasheetUrl', product.datasheetUrl);
+  setValue('standards', (product.standards || []).join('; '));
+  setValue('bimFamilyName', product.bimRef?.familyName);
+  setValue('epdSource', product.epdSource);
+  setValue('epdValidUntil', product.epdValidUntil);
+  setValue('co2eKgPerUnit', product.co2eKgPerUnit ?? '');
+}
+
+/**
  * Build and mount a self-contained catalog browser widget.
  *
- * Renders filter controls + product table inside `container`.
+ * Renders governance summary, add/edit form, import/export controls, filter
+ * controls, and the product table inside `container`.
  *
  * @param {HTMLElement} container
  * @param {object}      [opts]
@@ -215,6 +516,15 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
     container.innerHTML = `<p class="catalog-error">Failed to load catalog: ${err.message}</p>`;
     return;
   }
+
+  let projectIdentities = new Set(getCustomProducts().map(catalogIdentity));
+  let editingIdentity = '';
+  let filteredProducts = [];
+
+  const qualitySection = document.createElement('section');
+  qualitySection.className = 'catalog-quality';
+  qualitySection.setAttribute('aria-live', 'polite');
+  qualitySection.setAttribute('aria-label', 'Catalog governance summary');
 
   // Build filter bar
   const filterBar = document.createElement('div');
@@ -244,6 +554,8 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
   const mfrFilter = makeSelect('Manufacturer', getDistinctOptions('manufacturer'));
   const matFilter = makeSelect('Material', getDistinctOptions('material'));
   const approvalFilter = makeSelect('Approval', ['', 'approved', 'conditional', 'rejected', 'unreviewed']);
+  const confidenceFilter = makeSelect('Confidence', ['', 'complete', 'review', 'incomplete']);
+  const originFilter = makeSelect('Origin', ['', 'base', 'project']);
 
   const searchLabel = document.createElement('label');
   searchLabel.className = 'catalog-filter-label';
@@ -258,6 +570,8 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
   filterBar.appendChild(mfrFilter.label);
   filterBar.appendChild(matFilter.label);
   filterBar.appendChild(approvalFilter.label);
+  filterBar.appendChild(confidenceFilter.label);
+  filterBar.appendChild(originFilter.label);
   filterBar.appendChild(searchLabel);
 
   const resultsDiv = document.createElement('div');
@@ -265,46 +579,25 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
 
   const addSection = document.createElement('section');
   addSection.className = 'catalog-add';
-  addSection.innerHTML = '<h3>Add Catalog Item</h3><p class="catalog-add-help">Add custom manufacturer items for this project scenario.</p>';
+  addSection.innerHTML = '<h3 class="catalog-add-heading">Add Catalog Item</h3><p class="catalog-add-help">Add custom manufacturer items for this project scenario. Governed evidence fields drive the catalog confidence score used by BOM, submittal, cost, and BIM export flows.</p>';
 
+  const addHeading = addSection.querySelector('.catalog-add-heading');
   const addForm = document.createElement('form');
   addForm.className = 'catalog-add-form';
-  addForm.innerHTML = `
-    <label class="catalog-filter-label">Part Number <input class="catalog-filter-input" name="id" required></label>
-    <label class="catalog-filter-label">Manufacturer <input class="catalog-filter-input" name="manufacturer" required></label>
-    <label class="catalog-filter-label">Category
-      <select class="catalog-filter-select" name="category">
-        <option value="tray">tray</option>
-        <option value="fitting">fitting</option>
-        <option value="conduit">conduit</option>
-        <option value="accessory">accessory</option>
-      </select>
-    </label>
-    <label class="catalog-filter-label">Description <input class="catalog-filter-input" name="description" required></label>
-    <label class="catalog-filter-label">Material <input class="catalog-filter-input" name="material" placeholder="steel"></label>
-    <label class="catalog-filter-label">Source <input class="catalog-filter-input" name="source" placeholder="approved list, quote, or datasheet"></label>
-    <label class="catalog-filter-label">Last Verified <input class="catalog-filter-input" name="lastVerified" type="date"></label>
-    <label class="catalog-filter-label">Approved <input name="approved" type="checkbox"></label>
-    <label class="catalog-filter-label">Unit
-      <select class="catalog-filter-select" name="unit">
-        <option value="EA">EA</option>
-        <option value="FT">FT</option>
-        <option value="LF">LF</option>
-      </select>
-    </label>
-    <label class="catalog-filter-label">List Price (USD) <input class="catalog-filter-input" name="list_price_usd" type="number" min="0" step="0.01" value="0"></label>
-    <button type="submit">Add Item</button>
-  `;
+  addForm.innerHTML = ADD_FORM_FIELDS;
+  const addSubmitBtn = addForm.querySelector('.catalog-add-submit');
+  const addCancelBtn = addForm.querySelector('.catalog-add-cancel');
   const addStatus = document.createElement('p');
   addStatus.className = 'catalog-add-status';
+  addStatus.setAttribute('aria-live', 'polite');
   addSection.appendChild(addForm);
   addSection.appendChild(addStatus);
 
   const importSection = document.createElement('section');
   importSection.className = 'catalog-import';
   importSection.innerHTML = `
-    <h3>Bulk Import (CSV / XLSX)</h3>
-    <p class="catalog-add-help">Download a template, fill it in with project-approved catalog items, and import. Imports save to this project's custom catalog.</p>
+    <h3>Bulk Import / Export (CSV / XLSX)</h3>
+    <p class="catalog-add-help">Download a template, fill it in with project-approved catalog items, and import. Imports save to this project's custom catalog. Exports use the same columns, so an exported catalog can be edited and re-imported.</p>
     <div class="catalog-import-actions">
       <button type="button" class="catalog-import-template-csv">Download CSV Template</button>
       <button type="button" class="catalog-import-template-xlsx">Download XLSX Template</button>
@@ -312,6 +605,12 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
         Import file
         <input type="file" class="catalog-import-file" accept=".csv,.xlsx" />
       </label>
+    </div>
+    <div class="catalog-export-actions">
+      <span class="catalog-export-label">Export current view:</span>
+      <button type="button" class="catalog-export-csv">CSV</button>
+      <button type="button" class="catalog-export-xlsx">XLSX</button>
+      <button type="button" class="catalog-export-json">JSON</button>
     </div>
     <div class="catalog-import-preview" aria-live="polite"></div>
     <div class="catalog-import-confirm" hidden>
@@ -328,8 +627,12 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
   const importSaveBtn = importSection.querySelector('.catalog-import-save');
   const importCancelBtn = importSection.querySelector('.catalog-import-cancel');
   const importStatusEl = importSection.querySelector('.catalog-import-status');
+  const exportCsvBtn = importSection.querySelector('.catalog-export-csv');
+  const exportXlsxBtn = importSection.querySelector('.catalog-export-xlsx');
+  const exportJsonBtn = importSection.querySelector('.catalog-export-json');
 
   container.innerHTML = '';
+  container.appendChild(qualitySection);
   container.appendChild(addSection);
   container.appendChild(importSection);
   container.appendChild(filterBar);
@@ -434,6 +737,43 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
     }
   });
 
+  const exportStamp = () => new Date().toISOString().slice(0, 10);
+
+  exportCsvBtn?.addEventListener('click', () => {
+    const csv = buildCatalogExportCsv(filteredProducts);
+    downloadBlob(new Blob([csv], { type: 'text/csv;charset=utf-8' }), `manufacturer-catalog-${exportStamp()}.csv`);
+    importStatusEl.textContent = `Exported ${filteredProducts.length} row(s) to CSV.`;
+  });
+
+  exportXlsxBtn?.addEventListener('click', () => {
+    try {
+      const xlsx = getXlsx();
+      const wb = buildCatalogExportWorkbook(xlsx, filteredProducts);
+      const out = xlsx.write(wb, { type: 'array', bookType: 'xlsx' });
+      downloadBlob(
+        new Blob([out], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+        `manufacturer-catalog-${exportStamp()}.xlsx`
+      );
+      importStatusEl.textContent = `Exported ${filteredProducts.length} row(s) to XLSX.`;
+    } catch (err) {
+      importStatusEl.textContent = err.message || String(err);
+    }
+  });
+
+  exportJsonBtn?.addEventListener('click', () => {
+    const payload = {
+      _version: '2.0',
+      _description: 'Manufacturer catalog export',
+      _exportedAt: new Date().toISOString(),
+      products: filteredProducts
+    };
+    downloadBlob(
+      new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }),
+      `manufacturer-catalog-${exportStamp()}.json`
+    );
+    importStatusEl.textContent = `Exported ${filteredProducts.length} row(s) to JSON.`;
+  });
+
   importFileInput?.addEventListener('change', () => {
     const file = importFileInput.files?.[0];
     if (file) handleImportFile(file);
@@ -451,10 +791,7 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
     const current = getCustomProducts();
     const merged = mergeCatalogProducts(current, incoming);
     setCustomProducts(merged);
-    allProducts = await loadCatalog();
-    repopulateSelect(catFilter.select, getDistinctOptions('category'));
-    repopulateSelect(mfrFilter.select, getDistinctOptions('manufacturer'));
-    repopulateSelect(matFilter.select, getDistinctOptions('material'));
+    await reloadProducts();
     importStatusEl.textContent = `Saved ${pendingImport.accepted.length} new and updated ${pendingImport.duplicates.length} existing product(s).`;
     clearPreview();
     if (importFileInput) importFileInput.value = '';
@@ -473,73 +810,106 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
     select.value = options.includes(previous) ? previous : '';
   }
 
+  async function reloadProducts() {
+    allProducts = await loadCatalog();
+    projectIdentities = new Set(getCustomProducts().map(catalogIdentity));
+    repopulateSelect(catFilter.select, getDistinctOptions('category'));
+    repopulateSelect(mfrFilter.select, getDistinctOptions('manufacturer'));
+    repopulateSelect(matFilter.select, getDistinctOptions('material'));
+  }
+
+  function exitEditMode() {
+    editingIdentity = '';
+    addForm.reset();
+    addHeading.textContent = 'Add Catalog Item';
+    addSubmitBtn.textContent = 'Add Item';
+    addCancelBtn.hidden = true;
+  }
+
+  function enterEditMode(product) {
+    editingIdentity = catalogIdentity(product);
+    fillFormFromProduct(addForm, product);
+    addHeading.textContent = `Edit ${product.id}`;
+    addSubmitBtn.textContent = 'Save Changes';
+    addCancelBtn.hidden = false;
+    addStatus.textContent = `Editing project catalog row ${product.id}.`;
+    addSection.scrollIntoView?.({ block: 'nearest' });
+  }
+
+  async function removeProjectProduct(product) {
+    const remaining = removeCatalogProduct(getCustomProducts(), product);
+    setCustomProducts(remaining);
+    if (editingIdentity === catalogIdentity(product)) exitEditMode();
+    await reloadProducts();
+    addStatus.textContent = `Removed ${product.id} from this project catalog.`;
+    await refresh();
+  }
+
   async function refresh() {
     let filtered = await filterProducts({
       category: catFilter.select.value || undefined,
       manufacturer: mfrFilter.select.value || undefined,
       material: matFilter.select.value || undefined,
-      approvedOnly: approvalFilter.select.value === 'approved',
+      approvalStatus: approvalFilter.select.value || undefined,
+      confidenceStatus: confidenceFilter.select.value || undefined,
       search: searchInput.value.trim() || undefined,
     });
-    if (approvalFilter.select.value && approvalFilter.select.value !== 'approved') {
-      filtered = filtered.filter(product => product.approval?.status === approvalFilter.select.value);
+    if (originFilter.select.value === 'project') {
+      filtered = filtered.filter(product => projectIdentities.has(catalogIdentity(product)));
+    } else if (originFilter.select.value === 'base') {
+      filtered = filtered.filter(product => !projectIdentities.has(catalogIdentity(product)));
     }
-    renderCatalogTable(resultsDiv, filtered, { onSelect });
+    filteredProducts = filtered;
+    renderCatalogQuality(qualitySection, filtered);
+    renderCatalogTable(resultsDiv, filtered, {
+      onSelect,
+      projectIdentities,
+      onEdit: enterEditMode,
+      onRemove: removeProjectProduct
+    });
   }
 
   catFilter.select.addEventListener('change', refresh);
   mfrFilter.select.addEventListener('change', refresh);
   matFilter.select.addEventListener('change', refresh);
   approvalFilter.select.addEventListener('change', refresh);
+  confidenceFilter.select.addEventListener('change', refresh);
+  originFilter.select.addEventListener('change', refresh);
   searchInput.addEventListener('input', refresh);
+  addCancelBtn.addEventListener('click', () => {
+    exitEditMode();
+    addStatus.textContent = 'Edit cancelled.';
+  });
   addForm.addEventListener('submit', async e => {
     e.preventDefault();
     const formData = new FormData(addForm);
-    const productId = String(formData.get('id') || '').trim();
-    if (!productId) return;
-    const existing = await getCatalogProduct(productId);
-    if (existing) {
-      addStatus.textContent = `Part number ${productId} already exists in the catalog.`;
-      return;
-    }
-    const nextProduct = {
-      id: productId,
-      catalogNumber: productId,
-      manufacturer: String(formData.get('manufacturer') || '').trim(),
-      series: 'Custom',
-      category: String(formData.get('category') || 'accessory').trim(),
-      subcategory: 'custom',
-      description: String(formData.get('description') || '').trim(),
-      width_in: null,
-      depth_in: null,
-      angle_deg: null,
-      material: String(formData.get('material') || '').trim() || 'steel',
-      finish: 'none',
-      load_class: null,
-      unit: String(formData.get('unit') || 'EA').trim() || 'EA',
-      list_price_usd: Number(formData.get('list_price_usd')) || 0,
-      weight_lb: null,
-      nec_listed: false,
-      ul_classified: false,
-      url: null,
-      approved: formData.get('approved') === 'on',
-      source: String(formData.get('source') || '').trim(),
-      lastVerified: String(formData.get('lastVerified') || '').trim(),
-    };
+    const nextProduct = productFromForm(formData);
+    if (!nextProduct.id) return;
+
     const validation = validateCatalogProduct(nextProduct, { requireApprovalAuthority: false });
     if (!validation.valid) {
       addStatus.textContent = validation.errors.map(error => error.message).join(' ');
       return;
     }
-    const custom = getCustomProducts();
-    custom.push(validation.product);
-    setCustomProducts(custom);
-    allProducts = await loadCatalog();
-    repopulateSelect(catFilter.select, getDistinctOptions('category'));
-    repopulateSelect(mfrFilter.select, getDistinctOptions('manufacturer'));
-    repopulateSelect(matFilter.select, getDistinctOptions('material'));
-    addStatus.textContent = `Added ${nextProduct.id} to this project catalog.`;
-    addForm.reset();
+
+    const nextIdentity = catalogIdentity(validation.product);
+    const collides = allProducts.some(product => catalogIdentity(product) === nextIdentity
+      && catalogIdentity(product) !== editingIdentity);
+    if (collides) {
+      addStatus.textContent = `${nextProduct.manufacturer} ${nextProduct.catalogNumber} already exists in the catalog.`;
+      return;
+    }
+
+    const current = editingIdentity
+      ? removeCatalogProduct(getCustomProducts(), editingIdentity)
+      : getCustomProducts();
+    setCustomProducts(upsertCatalogProduct(current, validation.product));
+    const wasEditing = Boolean(editingIdentity);
+    await reloadProducts();
+    exitEditMode();
+    addStatus.textContent = wasEditing
+      ? `Updated ${nextProduct.id} in this project catalog.`
+      : `Added ${nextProduct.id} to this project catalog.`;
     await refresh();
   });
 

--- a/src/catalogBrowser.js
+++ b/src/catalogBrowser.js
@@ -534,12 +534,14 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
     return ['', ...[...new Set(allProducts.map(p => p[field]).filter(Boolean))].sort()];
   }
 
-  function makeSelect(labelText, options) {
+  function makeSelect(labelText, options, filterKey) {
     const label = document.createElement('label');
     label.className = 'catalog-filter-label';
     label.textContent = labelText + ' ';
     const sel = document.createElement('select');
     sel.className = 'catalog-filter-select';
+    sel.dataset.catalogFilter = filterKey;
+    sel.setAttribute('aria-label', `Filter catalog by ${labelText.toLowerCase()}`);
     for (const opt of options) {
       const o = document.createElement('option');
       o.value = opt;
@@ -550,12 +552,12 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
     return { label, select: sel };
   }
 
-  const catFilter = makeSelect('Category', getDistinctOptions('category'));
-  const mfrFilter = makeSelect('Manufacturer', getDistinctOptions('manufacturer'));
-  const matFilter = makeSelect('Material', getDistinctOptions('material'));
-  const approvalFilter = makeSelect('Approval', ['', 'approved', 'conditional', 'rejected', 'unreviewed']);
-  const confidenceFilter = makeSelect('Confidence', ['', 'complete', 'review', 'incomplete']);
-  const originFilter = makeSelect('Origin', ['', 'base', 'project']);
+  const catFilter = makeSelect('Category', getDistinctOptions('category'), 'category');
+  const mfrFilter = makeSelect('Manufacturer', getDistinctOptions('manufacturer'), 'manufacturer');
+  const matFilter = makeSelect('Material', getDistinctOptions('material'), 'material');
+  const approvalFilter = makeSelect('Approval', ['', 'approved', 'conditional', 'rejected', 'unreviewed'], 'approval');
+  const confidenceFilter = makeSelect('Confidence', ['', 'complete', 'review', 'incomplete'], 'confidence');
+  const originFilter = makeSelect('Origin', ['', 'base', 'project'], 'origin');
 
   const searchLabel = document.createElement('label');
   searchLabel.className = 'catalog-filter-label';
@@ -563,6 +565,7 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
   const searchInput = document.createElement('input');
   searchInput.type = 'search';
   searchInput.className = 'catalog-filter-input';
+  searchInput.dataset.catalogFilter = 'search';
   searchInput.placeholder = 'Part number or keyword…';
   searchLabel.appendChild(searchInput);
 
@@ -833,7 +836,9 @@ export async function mountCatalogBrowser(container, { onSelect } = {}) {
     addSubmitBtn.textContent = 'Save Changes';
     addCancelBtn.hidden = false;
     addStatus.textContent = `Editing project catalog row ${product.id}.`;
-    addSection.scrollIntoView?.({ block: 'nearest' });
+    // `behavior: 'instant'` opts out of the site-wide smooth scrolling so the
+    // form does not keep moving under the pointer after the Edit click.
+    addSection.scrollIntoView?.({ block: 'nearest', behavior: 'instant' });
   }
 
   async function removeProjectProduct(product) {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -879,9 +879,109 @@
 
 .catalog-add-form {
   display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 0.75rem);
+}
+
+.catalog-form-group {
+  display: flex;
   flex-wrap: wrap;
   gap: var(--space-3, 0.75rem);
   align-items: flex-end;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3, 0.75rem);
+  margin: 0;
+}
+
+.catalog-form-group legend {
+  padding: 0 var(--space-2, 0.5rem);
+  font-size: var(--font-size-sm, 0.8rem);
+  font-weight: 600;
+  color: var(--color-text-muted, #6c757d);
+}
+
+.catalog-add-actions,
+.catalog-export-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2, 0.5rem);
+  align-items: center;
+}
+
+.catalog-export-actions {
+  margin-top: var(--space-2, 0.5rem);
+}
+
+.catalog-export-label {
+  font-size: var(--font-size-sm, 0.8rem);
+  color: var(--color-text-muted, #6c757d);
+}
+
+.catalog-quality {
+  margin-bottom: var(--space-4, 1rem);
+  padding: var(--space-3, 0.75rem);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-strong, var(--color-surface));
+}
+
+.catalog-quality p {
+  margin: 0 0 var(--space-1, 0.25rem);
+  font-size: var(--font-size-sm, 0.8rem);
+}
+
+.catalog-quality-counts {
+  font-weight: 600;
+}
+
+.catalog-quality-gaps,
+.catalog-quality-stale {
+  color: var(--color-text-muted, #6c757d);
+}
+
+.catalog-confidence {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 99px;
+  font-size: 0.72rem;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+
+.catalog-confidence-complete {
+  background: color-mix(in srgb, var(--color-success, #198754) 15%, transparent);
+  color: var(--color-success, #198754);
+  border-color: color-mix(in srgb, var(--color-success, #198754) 30%, transparent);
+}
+
+.catalog-confidence-review {
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 18%, transparent);
+  color: var(--color-warning-text, #92400e);
+  border-color: color-mix(in srgb, var(--color-warning, #f59e0b) 35%, transparent);
+}
+
+.catalog-confidence-incomplete {
+  background: color-mix(in srgb, var(--color-error, #dc3545) 15%, transparent);
+  color: var(--color-error, #dc3545);
+  border-color: color-mix(in srgb, var(--color-error, #dc3545) 30%, transparent);
+}
+
+.catalog-confidence-detail {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--color-text-muted, #6c757d);
+}
+
+.catalog-row-actions {
+  display: flex;
+  gap: var(--space-2, 0.5rem);
+  white-space: nowrap;
+}
+
+.catalog-row-actions button {
+  font-size: 0.72rem;
+  padding: 0.1rem 0.5rem;
 }
 
 .catalog-add-status {

--- a/tests/manufacturerCatalog.test.mjs
+++ b/tests/manufacturerCatalog.test.mjs
@@ -15,11 +15,18 @@ import {
 } from '../analysis/manufacturerCatalog.mjs';
 import {
   CATALOG_IMPORT_COLUMNS,
+  buildCatalogExportCsv,
+  buildCatalogExportRows,
   buildCatalogTemplateCsv,
   buildCatalogTemplateRows,
   importCatalogRows,
   parseCatalogCsv
 } from '../analysis/catalogImport.mjs';
+import {
+  removeCatalogProduct,
+  summarizeCatalogQuality,
+  upsertCatalogProduct
+} from '../analysis/manufacturerCatalog.mjs';
 import { validateLibraryPayload } from '../src/validation/librarySchema.mjs';
 
 function describe(name, fn) {
@@ -148,6 +155,189 @@ describe('manufacturer catalog merge and filters', () => {
       { id: 'B', manufacturer: 'M', category: 'tray', description: 'B', approved: false }
     ], { approvedOnly: true });
     assert.deepEqual(rows.map(row => row.id), ['A']);
+  });
+});
+
+describe('project catalog editing helpers', () => {
+  const base = {
+    id: 'TRAY-12',
+    manufacturer: 'ACME',
+    catalogNumber: 'TRAY-12',
+    category: 'tray',
+    description: 'Base tray',
+    unit: 'EA',
+    list_price_usd: 100
+  };
+
+  it('upserts by manufacturer/catalog identity instead of appending duplicates', () => {
+    const first = upsertCatalogProduct([], base);
+    assert.equal(first.length, 1);
+    const updated = upsertCatalogProduct(first, {
+      ...base,
+      id: 'TRAY-12-REV-B',
+      description: 'Revised tray',
+      list_price_usd: 118,
+      approved: true,
+      source: 'Approved list rev B',
+      lastVerified: '2026-05-22'
+    });
+    assert.equal(updated.length, 1);
+    assert.equal(updated[0].description, 'Revised tray');
+    assert.equal(updated[0].commercial.listPriceUsd, 118);
+    assert.equal(updated[0].approved, true);
+  });
+
+  it('appends products with a different identity', () => {
+    const list = upsertCatalogProduct([base], { ...base, id: 'TRAY-24', catalogNumber: 'TRAY-24' });
+    assert.deepEqual(list.map(row => row.catalogNumber).sort(), ['TRAY-12', 'TRAY-24']);
+  });
+
+  it('removes products by product object, identity string, or row id', () => {
+    const list = [base, { ...base, id: 'TRAY-24', catalogNumber: 'TRAY-24' }];
+    assert.deepEqual(removeCatalogProduct(list, base).map(row => row.id), ['TRAY-24']);
+    assert.deepEqual(removeCatalogProduct(list, 'acme::tray-24').map(row => row.id), ['TRAY-12']);
+    assert.deepEqual(removeCatalogProduct(list, 'TRAY-24').map(row => row.id), ['TRAY-12']);
+    assert.equal(removeCatalogProduct(list, '').length, 2);
+  });
+});
+
+describe('catalog quality summary and filters', () => {
+  const complete = {
+    id: 'FULL-1',
+    manufacturer: 'ACME',
+    catalogNumber: 'FULL-1',
+    category: 'tray',
+    description: 'Fully governed tray',
+    approved: true,
+    source: 'Owner approved list',
+    lastVerified: '2026-05-22',
+    datasheetUrl: 'https://example.com/full-1.pdf',
+    bimRef: { familyName: 'ACME Tray', typeName: 'FULL-1', classification: 'tray' },
+    standards: ['NEMA VE 1'],
+    co2eKgPerUnit: 3.4,
+    epdSource: 'ACME EPD 2026',
+    epdValidUntil: '2027-12-31'
+  };
+  const partial = {
+    id: 'PART-1',
+    manufacturer: 'ACME',
+    catalogNumber: 'PART-1',
+    category: 'fitting',
+    description: 'Partly governed elbow',
+    approved: true,
+    source: 'Owner approved list',
+    lastVerified: '2026-05-22',
+    standards: ['NEMA VE 1']
+  };
+  const ungoverned = {
+    id: 'GEN-1',
+    manufacturer: 'Generic',
+    catalogNumber: '',
+    category: 'accessory',
+    description: 'Placeholder accessory'
+  };
+
+  it('rolls up confidence, approval, and evidence gaps', () => {
+    const summary = summarizeCatalogQuality([complete, partial, ungoverned], { today: '2026-06-02' });
+    assert.equal(summary.total, 3);
+    assert.equal(summary.approved, 2);
+    assert.equal(summary.byConfidence.complete, 1);
+    assert.equal(summary.byConfidence.review, 1);
+    assert.equal(summary.byConfidence.incomplete, 1);
+    assert.equal(summary.byApprovalStatus.approved, 2);
+    assert.equal(summary.byApprovalStatus.unreviewed, 1);
+    const datasheetGap = summary.missingEvidence.find(item => item.evidence === 'datasheet URL');
+    assert.equal(datasheetGap.count, 2);
+    assert.ok(summary.averageScore > 0 && summary.averageScore <= 100);
+  });
+
+  it('counts stale verification and expired EPD evidence', () => {
+    const summary = summarizeCatalogQuality([
+      { ...complete, lastVerified: '2024-01-01' }
+    ], { today: '2026-06-02', verificationMaxAgeDays: 365 });
+    assert.equal(summary.staleRows, 1);
+    assert.ok(summary.staleEvidence.some(item => item.evidence === 'catalog verification date'));
+  });
+
+  it('filters by approval status and confidence status', () => {
+    const products = [complete, partial, ungoverned];
+    assert.deepEqual(
+      filterCatalogProducts(products, { approvalStatus: 'unreviewed' }).map(row => row.id),
+      ['GEN-1']
+    );
+    assert.deepEqual(
+      filterCatalogProducts(products, {
+        confidenceStatus: CATALOG_CONFIDENCE_STATUS.complete,
+        confidenceOptions: { today: '2026-06-02' }
+      }).map(row => row.id),
+      ['FULL-1']
+    );
+  });
+});
+
+describe('catalog export', () => {
+  const product = {
+    id: 'EXP-1',
+    manufacturer: 'ACME',
+    catalogNumber: 'EXP-1',
+    category: 'tray',
+    subcategory: 'straight',
+    description: 'Exportable tray',
+    material: 'steel',
+    finish: 'pre-galvanized',
+    width_in: 12,
+    depth_in: 4,
+    weight_lb: 24.5,
+    unit: 'EA',
+    list_price_usd: 142,
+    load_class: '20A',
+    nec_listed: true,
+    ul_classified: true,
+    approved: true,
+    approval: { status: 'approved', authority: 'Project EE', approvedBy: 'D. Mitz', approvedAt: '2026-05-22' },
+    source: 'Approved list rev B',
+    lastVerified: '2026-05-22',
+    datasheetUrl: 'https://example.com/exp-1.pdf'
+  };
+
+  it('maps governed fields onto the import template headers', () => {
+    const [row] = buildCatalogExportRows([product]);
+    assert.equal(row['Part Number'], 'EXP-1');
+    assert.equal(row['Catalog No.'], 'EXP-1');
+    assert.equal(row['Width (in)'], 12);
+    assert.equal(row['List Price (USD)'], 142);
+    assert.equal(row['Approved'], 'TRUE');
+    assert.equal(row['Approval Status'], 'approved');
+    assert.equal(row['Last Verified'], '2026-05-22');
+    assert.equal(row['Datasheet URL'], 'https://example.com/exp-1.pdf');
+    Object.keys(row).forEach(header => {
+      assert.ok(CATALOG_IMPORT_COLUMNS.some(col => col.header === header), `unexpected header ${header}`);
+    });
+  });
+
+  it('round-trips exported CSV back through the import parser', () => {
+    const csv = buildCatalogExportCsv([product]);
+    const { products, errors } = parseCatalogCsv(csv);
+    assert.equal(errors.length, 0, `unexpected parse errors: ${JSON.stringify(errors)}`);
+    assert.equal(products.length, 1);
+    assert.equal(products[0].catalogNumber, 'EXP-1');
+    assert.equal(products[0].approved, true);
+    assert.equal(products[0].source, 'Approved list rev B');
+    assert.equal(products[0].lastVerified, '2026-05-22');
+    assert.equal(products[0].dimensions.widthIn, 12);
+    assert.equal(products[0].commercial.listPriceUsd, 142);
+  });
+
+  it('escapes commas and quotes so descriptions survive the round trip', () => {
+    const csv = buildCatalogExportCsv([{
+      ...product,
+      id: 'EXP-2',
+      catalogNumber: 'EXP-2',
+      description: 'Tray, 12" wide, "special" order'
+    }]);
+    const { products, errors } = parseCatalogCsv(csv);
+    assert.equal(errors.length, 0);
+    assert.equal(products[0].description, 'Tray, 12" wide, "special" order');
   });
 });
 

--- a/tests/manufacturerCatalogAudit.test.mjs
+++ b/tests/manufacturerCatalogAudit.test.mjs
@@ -1,0 +1,164 @@
+import assert from 'assert';
+import { spawnSync } from 'node:child_process';
+import {
+  auditCatalog,
+  parseAuditArgs,
+  renderAuditReport
+} from '../scripts/auditManufacturerCatalog.mjs';
+
+function describe(name, fn) {
+  console.log(name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log('  ✓', name);
+  } catch (err) {
+    console.error('  ✗', name, err.message || err);
+    process.exitCode = 1;
+  }
+}
+
+const COMPLETE_ROW = {
+  id: 'FULL-1',
+  manufacturer: 'ACME',
+  catalogNumber: 'FULL-1',
+  category: 'tray',
+  description: 'Fully governed tray',
+  unit: 'EA',
+  approved: true,
+  source: 'Owner approved list',
+  lastVerified: '2026-05-22',
+  datasheetUrl: 'https://example.com/full-1.pdf',
+  bimRef: { familyName: 'ACME Tray', typeName: 'FULL-1', classification: 'tray' },
+  standards: ['NEMA VE 1'],
+  co2eKgPerUnit: 3.4,
+  epdSource: 'ACME EPD 2026',
+  epdValidUntil: '2027-12-31'
+};
+
+const REVIEW_ROW = {
+  id: 'PART-1',
+  manufacturer: 'ACME',
+  catalogNumber: 'PART-1',
+  category: 'fitting',
+  description: 'Partly governed elbow',
+  unit: 'EA',
+  approved: true,
+  source: 'Owner approved list',
+  lastVerified: '2026-05-22',
+  standards: ['NEMA VE 1']
+};
+
+describe('catalog audit argument parsing', () => {
+  it('defaults to the seed catalog with no flags set', () => {
+    const options = parseAuditArgs([]);
+    assert.equal(options.file, 'data/manufacturer_catalog.json');
+    assert.equal(options.check, false);
+    assert.equal(options.json, false);
+    assert.equal(options.minScore, null);
+  });
+
+  it('parses file, check, threshold, and date flags', () => {
+    const options = parseAuditArgs([
+      'catalogs/project.json', '--check', '--json', '--min-score=85', '--min-complete=0.5', '--today=2026-06-02'
+    ]);
+    assert.equal(options.file, 'catalogs/project.json');
+    assert.equal(options.check, true);
+    assert.equal(options.json, true);
+    assert.equal(options.minScore, 85);
+    assert.equal(options.minCompleteRatio, 0.5);
+    assert.equal(options.today, '2026-06-02');
+  });
+});
+
+describe('catalog audit', () => {
+  it('summarizes confidence for a valid catalog', () => {
+    const audit = auditCatalog({ products: [COMPLETE_ROW, REVIEW_ROW] }, { today: '2026-06-02' });
+    assert.equal(audit.valid, true);
+    assert.equal(audit.summary.total, 2);
+    assert.equal(audit.summary.byConfidence.complete, 1);
+    assert.equal(audit.summary.byConfidence.review, 1);
+    assert.equal(audit.completeRatio, 0.5);
+    assert.equal(audit.rows.length, 2);
+    assert.ok(audit.rows.find(row => row.id === 'PART-1').missingEvidence.includes('datasheet URL'));
+  });
+
+  it('accepts a bare product array as well as a wrapped catalog', () => {
+    const audit = auditCatalog([COMPLETE_ROW], { today: '2026-06-02' });
+    assert.equal(audit.summary.total, 1);
+    assert.equal(audit.valid, true);
+  });
+
+  it('fails on schema errors such as approved rows without evidence', () => {
+    const audit = auditCatalog({
+      products: [{ ...COMPLETE_ROW, source: '', lastVerified: '' }]
+    }, { today: '2026-06-02' });
+    assert.equal(audit.valid, false);
+    assert.ok(audit.failures.some(failure => failure.code === 'schema-error'));
+    assert.ok(audit.errors.some(error => error.path.includes('source')));
+  });
+
+  it('enforces average-score and complete-share thresholds', () => {
+    const catalog = { products: [COMPLETE_ROW, REVIEW_ROW] };
+    assert.equal(auditCatalog(catalog, { today: '2026-06-02', minScore: 80 }).valid, true);
+
+    const lowScore = auditCatalog(catalog, { today: '2026-06-02', minScore: 95 });
+    assert.equal(lowScore.valid, false);
+    assert.ok(lowScore.failures.some(failure => failure.code === 'below-min-score'));
+
+    const lowComplete = auditCatalog(catalog, { today: '2026-06-02', minCompleteRatio: 0.9 });
+    assert.equal(lowComplete.valid, false);
+    assert.ok(lowComplete.failures.some(failure => failure.code === 'below-min-complete'));
+  });
+
+  it('reports stale verification dates against the evaluation date', () => {
+    const audit = auditCatalog({
+      products: [{ ...COMPLETE_ROW, lastVerified: '2024-01-01' }]
+    }, { today: '2026-06-02', verificationMaxAgeDays: 365 });
+    assert.equal(audit.summary.staleRows, 1);
+    assert.ok(audit.rows[0].staleEvidence.includes('catalog verification date'));
+  });
+
+  it('renders a readable report with gaps and failures', () => {
+    const audit = auditCatalog({ products: [COMPLETE_ROW, REVIEW_ROW] }, { today: '2026-06-02', minScore: 95 });
+    const report = renderAuditReport(audit, { file: 'data/manufacturer_catalog.json' });
+    assert.ok(report.includes('Manufacturer catalog audit'));
+    assert.ok(report.includes('Rows: 2 (2 approved)'));
+    assert.ok(report.includes('Evidence gaps:'));
+    assert.ok(report.includes('Lowest-confidence rows:'));
+    assert.ok(report.includes('FAILURES:'));
+  });
+});
+
+describe('catalog audit CLI', () => {
+  it('passes --check against the shipped seed catalog', () => {
+    const result = spawnSync(process.execPath, ['scripts/auditManufacturerCatalog.mjs', '--check'], {
+      encoding: 'utf8'
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(/Manufacturer catalog audit/.test(result.stdout));
+  });
+
+  it('exits non-zero when a threshold is not met', () => {
+    const result = spawnSync(process.execPath, [
+      'scripts/auditManufacturerCatalog.mjs', '--check', '--min-score=100'
+    ], { encoding: 'utf8' });
+    assert.equal(result.status, 1);
+    assert.ok(/below the required 100/.test(result.stdout));
+  });
+
+  it('emits machine-readable JSON with --json', () => {
+    const result = spawnSync(process.execPath, ['scripts/auditManufacturerCatalog.mjs', '--json'], {
+      encoding: 'utf8'
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.ok(parsed.summary.total >= 20);
+    assert.ok(Array.isArray(parsed.rows));
+  });
+});
+
+console.log('manufacturer catalog audit tests complete');


### PR DESCRIPTION
The catalog browser could only add project rows and bulk-import them:
rows could never be corrected or removed, and the catalog confidence
scoring that BOM, submittal, cost, and BIM export flows rely on was
never visible while selecting parts.

- Add `upsertCatalogProduct`, `removeCatalogProduct`, and
  `summarizeCatalogQuality` to the catalog helper, plus `approvalStatus`
  and `confidenceStatus` filters for `filterCatalogProducts`.
- Add catalog export helpers (`buildCatalogExportRows`,
  `buildCatalogExportCsv`, `buildCatalogExportWorkbook`) that reuse the
  import template column spec, so an exported catalog round-trips back
  through the import parser.
- Surface per-row catalog confidence and origin (base vs project) in the
  browser table, add a governance roll-up above it, and add confidence,
  approval-status, and origin filters.
- Let project rows be edited in place or removed (two-step confirm);
  base catalog rows stay read-only. Adds/edits are keyed by governed
  manufacturer/catalog identity so they cannot duplicate an existing row.
- Expand the add/edit form with the full evidence set (approval
  authority, datasheet URL, standards, BIM family, EPD source/validity,
  CO2e) so project rows can reach complete catalog confidence.
- Add CSV/XLSX/JSON export of the filtered view.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V7eYNSYGr92jwJaPDRCpqm